### PR TITLE
List real widgets in Add Widget dialog

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -21,6 +21,7 @@
     </ContentDialog.Resources>
 
     <StackPanel>
+        <!-- Title and Close button -->
         <Grid>
             <TextBlock x:Uid="PinWidgetsTitle" HorizontalAlignment="Left" />
             <Button HorizontalAlignment="Right" Click="CancelButton_Click" BorderThickness="0" >
@@ -30,7 +31,8 @@
             </Button>
         </Grid>
 
-        <NavigationView x:Name="widgetConfigurationNavigationView"
+        <!-- Widgets available to pin-->
+        <NavigationView x:Name="AddWidgetNavigationView"
                         x:Uid="AllWidgetsList"
                         PaneDisplayMode="Left"
                         IsTabStop="False"
@@ -39,15 +41,11 @@
                         IsPaneToggleButtonVisible="False"
                         IsTitleBarAutoPaddingEnabled="False"
                         OpenPaneLength="180"
-                        SelectionChanged="WidgetConfigurationNavigationView_SelectionChanged">
+                        SelectionChanged="AddWidgetNavigationView_SelectionChanged">
             <NavigationView.MenuItems>
-                <NavigationViewItem Content="GitHub Placeholder" Icon="Contact" ToolTipService.ToolTip="GitHub" Tag="GitHub" IsExpanded="True">
-                    <NavigationViewItem.MenuItems>
-                        <NavigationViewItem Content="Pull requests Placeholder" ToolTipService.ToolTip="Pull requests" Tag="PullRequests"/>
-                        <NavigationViewItem Content="Issues Placeholder" ToolTipService.ToolTip="Issues" Tag="Issues"/>
-                    </NavigationViewItem.MenuItems>
-                </NavigationViewItem>
             </NavigationView.MenuItems>
+
+            <!-- Widget configuration UI -->
             <Frame x:Name="configurationContentFrame" />
         </NavigationView>
     </StackPanel>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -1,18 +1,66 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Views;
 public sealed partial class AddWidgetDialog : ContentDialog
 {
-    public AddWidgetDialog()
+    private readonly WidgetCatalog _widgetCatalog;
+
+    public AddWidgetDialog(WidgetCatalog catalog)
     {
         this.InitializeComponent();
+
+        _widgetCatalog = catalog;
+
         configurationContentFrame.Content = new WidgetConfigurationContent();
+
+        FillAvailableWidgets();
     }
 
-    private void WidgetConfigurationNavigationView_SelectionChanged(
+    private void FillAvailableWidgets()
+    {
+        AddWidgetNavigationView.MenuItems.Clear();
+
+        // Fill NavigationView Menu with Widget Providers, and group widgets under each provider
+        foreach (var provider in _widgetCatalog.GetProviderDefinitions())
+        {
+            if (IsIncludedWidgetProvider(provider))
+            {
+                var navItem = new NavigationViewItem
+                {
+                    IsExpanded = true,
+                    Tag = provider,
+                    Content = provider.DisplayName,
+                };
+
+                foreach (var widget in _widgetCatalog.GetWidgetDefinitions())
+                {
+                    if (widget.ProviderDefinition.Id.Equals(provider.Id, StringComparison.Ordinal))
+                    {
+                        var subItem = new NavigationViewItem
+                        {
+                            Tag = widget,
+                            Content = widget.DisplayTitle,
+                        };
+                        navItem.MenuItems.Add(subItem);
+                    }
+                }
+
+                AddWidgetNavigationView.MenuItems.Add(navItem);
+            }
+        }
+    }
+
+    private bool IsIncludedWidgetProvider(WidgetProviderDefinition provider)
+    {
+        return provider.Id.StartsWith("Microsoft.Windows.DevHome", StringComparison.CurrentCulture);
+    }
+
+    private void AddWidgetNavigationView_SelectionChanged(
         NavigationView sender,
         NavigationViewSelectionChangedEventArgs args)
     {

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -5,28 +5,32 @@ using System;
 using DevHome.Common;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Dashboard.Views;
-using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard;
 
-/// <summary>
-/// An empty page that can be used on its own or navigated to within a Frame.
-/// </summary>
 public partial class DashboardView : ToolPage
 {
     public override string ShortName => "Dashboard";
 
     public DashboardViewModel ViewModel { get; }
 
+    private readonly WidgetHost _widgetHost;
+    private readonly WidgetCatalog _widgetCatalog;
+
     public DashboardView()
     {
         ViewModel = new DashboardViewModel();
         this.InitializeComponent();
+
+        // GUID is your personal Host GUID that widget platform will use to identify you
+        _widgetHost = WidgetHost.Register(new WidgetHostContext("BAA93438-9B07-4554-AD09-7ACCD7D4F031"));
+        _widgetCatalog = WidgetCatalog.GetDefault();
     }
 
     private async void AddWidgetButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        var dialog = new AddWidgetDialog
+        var dialog = new AddWidgetDialog(_widgetCatalog)
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app
             XamlRoot = this.XamlRoot,


### PR DESCRIPTION
## Summary of the pull request
List widgets available to pin in Add Widget dialog.

## References and relevant issues
http://task.ms/43375393

## Detailed description of the pull request / Additional comments
This change registers the Dashboard as a widget host. The Add Widget dialog uses the WidgetCatalog to display all widgets available for pinning, grouped by provider. We limit providers to those created for DevHome specifically (done by a simple name comparison) but that can be enhanced in the future. While this change doesn't quite follow the MVVM model, it could easily be changed in the future. I don't want to spend too much time switching now, especially if we ever want to swap the NavigationView for something else (we might, since NavigationView puts a header at the top that we don't really want).

## Validation steps performed
Validated locally with DevHome GitHub and other widgets installed.

## PR checklist
- [X] Closes #43375393
- [ ] Tests added/passed
- [ ] Documentation updated
