### PR TITLE
Remove widget from Dashboard if its provider deleted the widget, or provider was uninstalled

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common;
 using DevHome.Dashboard.ViewModels;
@@ -125,17 +126,12 @@ public partial class DashboardView : ToolPage
     // Remove widget(s) from the Dashboard if the provider deletes the widget definition, or the provider is uninstalled.
     private void WidgetCatalog_WidgetDefinitionDeleted(WidgetCatalog sender, WidgetDefinitionDeletedEventArgs args)
     {
-        var defId = args.DefinitionId;
-        if (defId != null)
+        _dispatcher.TryEnqueue(() =>
         {
-            for (var widgetIndex = PinnedWidgets.Count - 1; widgetIndex <= 0; widgetIndex--)
+            foreach (var widgetToRemove in PinnedWidgets.Where(x => x.Widget.DefinitionId == args.DefinitionId).ToList())
             {
-                var widget = PinnedWidgets[widgetIndex];
-                if (widget.Widget.DefinitionId == defId)
-                {
-                    PinnedWidgets.RemoveAt(widgetIndex);
-                }
+                PinnedWidgets.Remove(widgetToRemove);
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Subscribe to the WidgetCatalog.WidgetDefinitionDeleted event. If a widget's provider is uninstalled, or the provider deletes a widget, we remove those widget(s) from the Dashboard.

## References and relevant issues
http://task.ms/43799964

## Detailed description of the pull request / Additional comments
There is a bug that's been fixed in the Widget Platform, but that we haven't picked up yet, where widgets deleted by the provider will stay in the WidgetHost.GetWidgets() list. Until we pick up the fix, any widgets that get stranded this way will need to be cleared by deleting the Widget Service's AppData.

At this time, none of the other similar events to WidgetDefinitionDeleted (WidgetDefinitionAdded, WidgetDefinition updated, and there corresponding WidgetProvider events) seem relevant to subscribe to.

## Validation steps performed
Local validation.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
