### PR TITLE
Don't allow adding more than one widget where AllowMultiple == false

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -57,15 +57,17 @@ public sealed partial class AddWidgetDialog : ContentDialog
                 {
                     if (widgetDef.ProviderDefinition.Id.Equals(providerDef.Id, StringComparison.Ordinal))
                     {
-                        if (IsPinnable(widgetDef))
+                        var subItem = new NavigationViewItem
                         {
-                            var subItem = new NavigationViewItem
-                            {
-                                Tag = widgetDef,
-                                Content = widgetDef.DisplayTitle,
-                            };
-                            navItem.MenuItems.Add(subItem);
+                            Tag = widgetDef,
+                            Content = widgetDef.DisplayTitle,
+                        };
+                        if (AlreadyPinnedSingleInstance(widgetDef))
+                        {
+                            subItem.IsEnabled = false;
                         }
+
+                        navItem.MenuItems.Add(subItem);
                     }
                 }
 
@@ -77,7 +79,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
     }
 
-    private bool IsPinnable(WidgetDefinition widgetDef)
+    private bool AlreadyPinnedSingleInstance(WidgetDefinition widgetDef)
     {
         // If a WidgetDefinition has AllowMultiple = false, only one of that widget can be pinned at one time.
         if (!widgetDef.AllowMultiple)
@@ -89,13 +91,13 @@ public sealed partial class AddWidgetDialog : ContentDialog
                 {
                     if (pinnedWidget.DefinitionId == widgetDef.Id)
                     {
-                        return false;
+                        return true;
                     }
                 }
             }
         }
 
-        return true;
+        return false;
     }
 
     private bool IsIncludedWidgetProvider(WidgetProviderDefinition provider)


### PR DESCRIPTION
## Summary of the pull request
A widget author can specify in their WidgetDescription AllowMultiple = false, which means only one instance of that widget may be pinned to a host at one time. If such a widget has already been added, disable the listing for that widget in the Add Widgets dialog so the user cannot add it. Design suggests this solution for usability and to align with the Windows Dashboard UX.

## References and relevant issues
http://task.ms/43375393

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated locally, test should be added.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
