### PR TITLE
Remove duplicate name from repo path

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.RepoConfig/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.RepoConfig/Views/AddRepoDialog.xaml.cs
@@ -277,7 +277,7 @@ internal sealed partial class AddRepoDialog
         {
             foreach (var repository in repositories)
             {
-                repositoriesToShow.Add(loginId + "/" + repository.DisplayName());
+                repositoriesToShow.Add(repository.DisplayName());
             }
 
             avalibleRepositoresToSelectFrom = repositories.ToList();


### PR DESCRIPTION
## Summary of the pull request
Remove duplicate name from repo path in Add Repo dialog.

## References and relevant issues
https://github.com/microsoft/devhome/issues/44

## Detailed description of the pull request / Additional comments
We were displaying LoginId\[repoName] but repoName already starts with ID.

## Validation steps performed
Tested with local build.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
