### PR TITLE
Change Add Widget dialog's theme if app's theme changes

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -6,6 +6,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common;
+using DevHome.Common.Extensions;
+using DevHome.Contracts.Services;
 using DevHome.Dashboard.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -63,10 +65,12 @@ public partial class DashboardView : ToolPage
 
     private async void AddWidgetButton_Click(object sender, RoutedEventArgs e)
     {
+        var themeService = Application.Current.GetService<IThemeSelectorService>();
         var dialog = new AddWidgetDialog(_widgetHost, _widgetCatalog, _renderer, _dispatcher)
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.
             XamlRoot = this.XamlRoot,
+            RequestedTheme = themeService.Theme,
         };
         _ = await dialog.ShowAsync();
 


### PR DESCRIPTION
## Summary of the pull request
Since ContentDialog's root is different from the rest of the app, it doesn't get theme changes the same way, and we need to request the theme explicitly. 

## References and relevant issues

## Detailed description of the pull request / Additional comments
There are still issues with theming ContentDialogs (see https://github.com/microsoft/microsoft-ui-xaml/issues/7405) but this gets us at least part of the way there.

## Validation steps performed
Validated locally.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
