### PR TITLE
Added placeholder flow for Connect To Github button

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -74,7 +74,8 @@
 
                     <Button
                         Margin="0 10"
-                        Padding="30 7">
+                        Padding="30 7"
+                        Click="ConnectToGitHubButton_Click">
 
                         <StackPanel Orientation="Horizontal">
                             <TextBlock

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using CommunityToolkit.WinUI.UI;
 using DevHome.Common.Extensions;
-using DevHome.Helpers;
 using DevHome.Models;
+using DevHome.Services;
+using DevHome.Telemetry;
 using DevHome.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Windows.System;
+using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.Views;
 
@@ -39,6 +39,62 @@ public sealed partial class WhatsNewPage : Page
             }
 
             ViewModel.AddCard(card);
+        }
+    }
+
+    private async void ConnectToGitHubButton_Click(object sender, RoutedEventArgs e)
+    {
+        var pluginService = new PluginService();
+        var plugins = pluginService.GetInstalledPluginsAsync(ProviderType.DevId).Result;
+
+        var plugin = plugins.Where(p => p.Name.Contains("Github")).FirstOrDefault();
+
+        if (plugin is null)
+        {
+            // Nothing to do if there are no plugins for GitHub
+            return;
+        }
+
+        if (!plugin.IsRunning())
+        {
+            await plugin.StartPlugin();
+        }
+
+        var pluginObj = plugin.GetPluginObject();
+        var devIdProvider = pluginObj?.GetProvider(ProviderType.DevId);
+
+        if (devIdProvider is IDevIdProvider iDevIdProvider)
+        {
+            if (iDevIdProvider.GetLoggedInDeveloperIds().Any())
+            {
+                // DevId already connected
+                var connectToGitHubContentDialog = new ContentDialog
+                {
+                    Title = "You are already connected to GitHub!",
+                    CloseButtonText = "OK",
+                    XamlRoot = XamlRoot,
+                };
+                _ = await connectToGitHubContentDialog.ShowAsync();
+                return;
+            }
+
+            try
+            {
+                // TODO: Replace this flow with LoginUI
+                var devId = await iDevIdProvider.LoginNewDeveloperIdAsync();
+
+                var connectToGitHubSuccessContentDialog = new ContentDialog
+                {
+                    Title = $"{devId.LoginId()} has connected to GitHub!",
+                    CloseButtonText = "OK",
+                    XamlRoot = XamlRoot,
+                };
+                _ = await connectToGitHubSuccessContentDialog.ShowAsync();
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.Get<ILogger>().LogError<string>($"ConnectToGitHubButton_Click_Failure", LogLevel.Local, $"Error: {ex}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Added call to "LoginNewDevIdAsync()" for Connect button.

## References and relevant issues
https://github.com/microsoft/devhome/issues/76

## Detailed description of the pull request / Additional comments
When the button is clicked, a new DevId flow is triggered, if there are no connected accounts. Otherwise, a CD pops to say an account is already connected. This is currently just placeholder flow, until the AdaptiveCards loginUi is added.

## Validation steps performed
Tested locally.

## PR checklist
- [X] Closes #76
- [ ] Tests added/passed
- [ ] Documentation updated
