### PR TITLE
Move Widget code into its own control

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -13,6 +13,7 @@
     <None Remove="Assets\HostConfigLight.json" />
     <None Remove="Views\AddWidgetDialog.xaml" />
     <None Remove="Views\DashboardView.xaml" />
+    <None Remove="Views\WidgetControl.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,6 +37,12 @@
     <Content Update="Assets\HostConfigDark.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Views\WidgetControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -11,7 +11,6 @@
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:vm="using:DevHome.Dashboard.ViewModels"
     xmlns:views="using:DevHome.Dashboard.Views"
-    xmlns:helpers="using:DevHome.Dashboard.Helpers"
     mc:Ignorable="d">
 
     <Grid>
@@ -39,16 +38,7 @@
                 <GridView x:Name="MainGridView" ItemsSource="{x:Bind views:DashboardView.PinnedWidgets}">
                     <GridView.ItemTemplate>
                         <DataTemplate x:DataType="vm:WidgetViewModel">
-                            <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSize), Mode=OneWay}">
-                                <ContentPresenter Content="{x:Bind WidgetUIElement, Mode=OneWay}"/>
-                                <Button Tag="{x:Bind}" FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xE712;" 
-                                        VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0 30 3 0" BorderThickness="0"
-                                        Click="OpenWidgetMenu">
-                                    <Button.Flyout>
-                                        <MenuFlyout/>
-                                    </Button.Flyout>
-                                </Button>
-                            </Grid>
+                            <views:WidgetControl WidgetSource="{x:Bind}" />
                         </DataTemplate>
                     </GridView.ItemTemplate>
                     <GridView.ItemsPanel>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -130,44 +130,6 @@ public partial class DashboardView : ToolPage
         PinnedWidgets.Add(wvm);
     }
 
-    private void OpenWidgetMenu(object sender, RoutedEventArgs e)
-    {
-        if (sender as Button is Button widgetMenuButton)
-        {
-            var widgetMenuFlyout = widgetMenuButton.Flyout as MenuFlyout;
-            widgetMenuFlyout.Placement = Microsoft.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.BottomEdgeAlignedLeft;
-            if (widgetMenuFlyout?.Items.Count == 0)
-            {
-                if (widgetMenuButton?.Tag is WidgetViewModel widgetViewModel)
-                {
-                    var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
-                    var text = resourceLoader.GetString("RemoveWidgetMenuText");
-                    var menuItemClose = new MenuFlyoutItem
-                    {
-                        Tag = widgetViewModel,
-                        Text = text,
-                    };
-                    menuItemClose.Click += DeleteWidgetClick;
-                    widgetMenuFlyout.Items.Add(menuItemClose);
-                }
-            }
-        }
-    }
-
-    private async void DeleteWidgetClick(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuFlyoutItem deleteMenuItem)
-        {
-            if (deleteMenuItem?.Tag is WidgetViewModel widgetViewModel)
-            {
-                // Remove the widget from the list before deleting, otherwise the widget will
-                // have changed and the collection won't be able to find it to remove it.
-                PinnedWidgets.Remove(widgetViewModel);
-                await widgetViewModel.Widget.DeleteAsync();
-            }
-        }
-    }
-
     // Remove widget(s) from the Dashboard if the provider deletes the widget definition, or the provider is uninstalled.
     private void WidgetCatalog_WidgetDefinitionDeleted(WidgetCatalog sender, WidgetDefinitionDeletedEventArgs args)
     {

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
@@ -1,0 +1,24 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<UserControl
+    x:Class="DevHome.Dashboard.Views.WidgetControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DevHome.Dashboard.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:helpers="using:DevHome.Dashboard.Helpers"
+    mc:Ignorable="d">
+
+    <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize), Mode=OneWay}">
+        <ContentPresenter Content="{x:Bind WidgetSource.WidgetUIElement, Mode=OneWay}"/>
+        <Button Tag="{x:Bind}" FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xE712;" 
+                VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0 30 3 0" BorderThickness="0"
+                Click="OpenWidgetMenu">
+            <Button.Flyout>
+                <MenuFlyout/>
+            </Button.Flyout>
+        </Button>
+    </Grid>
+</UserControl>

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using DevHome.Dashboard.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace DevHome.Dashboard.Views;
+public sealed partial class WidgetControl : UserControl
+{
+    public WidgetControl()
+    {
+        this.InitializeComponent();
+    }
+
+    public WidgetViewModel WidgetSource
+    {
+        get => (WidgetViewModel)GetValue(WidgetSourceProperty);
+        set => SetValue(WidgetSourceProperty, value);
+    }
+
+    public static readonly DependencyProperty WidgetSourceProperty = DependencyProperty.Register(
+        "WidgetSource", typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
+
+    private void OpenWidgetMenu(object sender, RoutedEventArgs e)
+    {
+        if (sender as Button is Button widgetMenuButton)
+        {
+            var widgetMenuFlyout = widgetMenuButton.Flyout as MenuFlyout;
+            widgetMenuFlyout.Placement = Microsoft.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.BottomEdgeAlignedLeft;
+            if (widgetMenuFlyout?.Items.Count == 0)
+            {
+                var widgetControl = widgetMenuButton.Tag as WidgetControl;
+                if (widgetControl != null && widgetControl.WidgetSource is WidgetViewModel widgetViewModel)
+                {
+                    var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
+                    var text = resourceLoader.GetString("RemoveWidgetMenuText");
+                    var menuItemClose = new MenuFlyoutItem
+                    {
+                        Tag = widgetViewModel,
+                        Text = text,
+                    };
+                    menuItemClose.Click += DeleteWidgetClick;
+                    widgetMenuFlyout.Items.Add(menuItemClose);
+                }
+            }
+        }
+    }
+
+    private async void DeleteWidgetClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem deleteMenuItem)
+        {
+            if (deleteMenuItem?.Tag is WidgetViewModel widgetViewModel)
+            {
+                // Remove the widget from the list before deleting, otherwise the widget will
+                // have changed and the collection won't be able to find it to remove it.
+                DashboardView.PinnedWidgets.Remove(widgetViewModel);
+                await widgetViewModel.Widget.DeleteAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
Create a UserControl called WidgetControl. Fix a small issue where the Dashboard wasn't scrolling properly.

## References and relevant issues

## Detailed description of the pull request / Additional comments
As the widgets get more complicated, having the code for the WidgetControl separated out will help keep the code cleaner. This part of the PR is about moving code, not changing it, so it should be functionally the same.

Also, there was an issue where the Dashboard wouldn't scroll if content went longer than the window. This is because it was in a StackPanel, which does not constrict itself to the size of the container. Change to Grid, which does. Also, we put AddWidgetButton in a horizontally aligned StackPanel, so Debug buttons like the banner reset button can be put next to it.

## Validation steps performed
Local validation.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
