### PR TITLE
Fix the signing command build.ps1 tells you at the end.

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -135,9 +135,9 @@ WARNING: Cert signing requires admin privileges.  To sign, run the following in 
 "@ -ForegroundColor GREEN
   foreach ($platform in $env:Build_Platform.Split(",")) {
     foreach ($configuration in $env:Build_Configuration.Split(",")) {
-      $appxPackageDir = (Join-Path $env:Build_RootDirectory "AppxPackages\$platform\$configuration")
+      $appxPackageFile = (Join-Path $env:Build_RootDirectory "AppxPackages\$configuration\DevHome-$platform.msix")
         Write-Host @"
-powershell -command "& { . build\scripts\CertSignAndInstall.ps1; Invoke-SignPackage $appxPackageDir\DevHome.msix }"
+powershell -command "& { . build\scripts\CertSignAndInstall.ps1; Invoke-SignPackage $appxPackageFile }"
 "@ -ForegroundColor GREEN
     }
   }


### PR DESCRIPTION
## Summary of the pull request
Small tweak so the command to sign (if you're not running admin) is correct and you can just copy/paste it.