### PR TITLE
Update AdaptiveCards packages to 0.0.3

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -21,10 +21,10 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.8" />
     <PackageReference Include="WinUIEx" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-	<PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
-    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="0.0.1" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="0.0.1" />
-	<PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
+    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="0.0.3" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="0.0.3" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
The AdaptiveCards.ObjectModel.WinUI3 and AdaptiveCards.Rendering.WinUI3 version 0.0.3 packages are built using x64 Release bits, so should avoid problems running DevHome on machines that don't have debug dlls. These packages do not include arm or arm64 bits, so do not enable those machines yet.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
