### PR TITLE
Enable 'editing' widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -12,6 +12,7 @@
     <None Remove="Assets\HostConfigDark.json" />
     <None Remove="Assets\HostConfigLight.json" />
     <None Remove="Views\AddWidgetDialog.xaml" />
+    <None Remove="Views\CustomizeWidgetDialog.xaml" />
     <None Remove="Views\DashboardView.xaml" />
     <None Remove="Views\WidgetControl.xaml" />
   </ItemGroup>
@@ -42,6 +43,9 @@
 
   <ItemGroup>
     <Page Update="Views\AddWidgetDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\CustomizeWidgetDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Update="Views\DashboardView.xaml">

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -86,6 +86,14 @@
     <value>Pin Widgets</value>
     <comment>Title for "Pin Widgets" dialog</comment>
   </data>
+  <data name="PinButton.Content" xml:space="preserve">
+    <value>Pin</value>
+    <comment>Label for button that pins the widget</comment>
+  </data>
+  <data name="UpdateWidgetButton.Content" xml:space="preserve">
+    <value>Update</value>
+    <comment>Label for button that updates the widget</comment>
+  </data>
   <data name="RemoveWidgetMenuText" xml:space="preserve">
     <value>Remove widget</value>
     <comment>Menu item that will remove the Widget from being displayed on the dashboard if it is selected</comment>
@@ -101,5 +109,9 @@
   <data name="SmallWidgetMenuText" xml:space="preserve">
     <value>Small</value>
     <comment>The size of a small widget</comment>
+  </data>
+  <data name="CustomizeWidgetMenuText" xml:space="preserve">
+    <value>Customize</value>
+    <comment>A menu option that will bring up a dialog that lets the user customize the widget</comment>
   </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -34,6 +34,9 @@ public partial class WidgetViewModel : ObservableObject
     [ObservableProperty]
     private Microsoft.UI.Xaml.Media.Brush _widgetBackground;
 
+    [ObservableProperty]
+    private bool _isInEditMode;
+
     partial void OnWidgetChanging(Widget value)
     {
         if (Widget != null)

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -61,7 +61,7 @@
                             Content="{x:Bind ViewModel.WidgetFrameworkElement, Mode=OneWay}" />
                 </ScrollViewer>
 
-                <Button x:Name="PinButton" x:Uid="PinButton" Content="Pin"
+                <Button x:Name="PinButton" x:Uid="PinButton"
                         VerticalAlignment="Bottom" HorizontalAlignment="Center"
                         Visibility="Collapsed"
                         Height="32" Width="118"

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -1,0 +1,57 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<ContentDialog
+    x:Class="DevHome.Dashboard.Views.CustomizeWidgetDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
+
+    <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
+    <ContentDialog.Resources>
+        <x:Double x:Key="ContentDialogMinWidth">434</x:Double>
+        <x:Double x:Key="ContentDialogMinHeight">684</x:Double>
+        <x:Double x:Key="ContentDialogMaxWidth">434</x:Double>
+        <x:Double x:Key="ContentDialogMaxHeight">684</x:Double>
+        <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
+        <Thickness x:Key="ContentDialogPadding">0,0,0,0</Thickness>
+    </ContentDialog.Resources>
+
+    <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
+        <!-- Close button -->
+        <Grid>
+            <Button HorizontalAlignment="Right" Click="CancelButton_Click"
+                    BorderThickness="0" Background="Transparent" Margin="5">
+                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                           FontSize="{ThemeResource BodyTextBlockFontSize}" 
+                           Text="&#xE10A;" />
+            </Button>
+        </Grid>
+
+        <!-- Widget configuration UI -->
+        <Grid x:Name="ConfigurationContentGrid" Margin="40,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="auto" />
+            </Grid.RowDefinitions>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch" Grid.Row="0"
+                            MinHeight="520" MaxHeight="520">
+                <Frame x:Name="ConfigurationContentFrame" 
+                        Content="{x:Bind ViewModel.WidgetFrameworkElement, Mode=OneWay}" />
+            </ScrollViewer>
+
+            <Button x:Name="UpdateWidgetButton" x:Uid="UpdateWidgetButton"
+                    VerticalAlignment="Bottom" HorizontalAlignment="Center"
+                    Visibility="Visible"
+                    Height="32" Width="118"
+                    Click="UpdateWidgetButton_Click"
+                    Grid.Row="1"
+                    Margin="0,40" />
+        </Grid>
+    </StackPanel>
+</ContentDialog>

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using AdaptiveCards.Rendering.WinUI3;
+using DevHome.Dashboard.Helpers;
+using DevHome.Dashboard.ViewModels;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.Widgets.Hosts;
+
+namespace DevHome.Dashboard.Views;
+public sealed partial class CustomizeWidgetDialog : ContentDialog
+{
+    public Widget EditedWidget { get; set; }
+
+    public WidgetViewModel ViewModel { get; set; }
+
+    private readonly WidgetDefinition _widgetDefinition;
+    private readonly WidgetHost _widgetHost;
+
+    public CustomizeWidgetDialog(WidgetHost host, AdaptiveCardRenderer renderer, DispatcherQueue dispatcher, WidgetDefinition widgetDefinition)
+    {
+        ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, renderer, dispatcher);
+        this.InitializeComponent();
+
+        _widgetHost = host;
+        _widgetDefinition = widgetDefinition;
+
+        this.Loaded += InitializeWidgetCustomization;
+    }
+
+    private async void InitializeWidgetCustomization(object sender, RoutedEventArgs e)
+    {
+        var size = WidgetHelpers.GetLargetstCapabilitySize(_widgetDefinition.GetWidgetCapabilities());
+
+        // Create the widget for configuration. We will need to delete it if
+        var widget = await _widgetHost.CreateWidgetAsync(_widgetDefinition.Id, size);
+        Log.Logger()?.ReportInfo("CustomizeWidgetDialog", $"Created Widget {widget.Id}");
+
+        ViewModel.Widget = widget;
+    }
+
+    private void UpdateWidgetButton_Click(object sender, RoutedEventArgs e)
+    {
+        Log.Logger()?.ReportDebug("CustomizeWidgetDialog", $"Exiting dialog, updated widget");
+        EditedWidget = ViewModel.Widget;
+        this.Hide();
+    }
+
+    private async void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        Log.Logger()?.ReportDebug("CustomizeWidgetDialog", $"Exiting dialog, cancel button clicked");
+        var widgetIdToDelete = ViewModel.Widget.Id;
+        await ViewModel.Widget.DeleteAsync();
+        Log.Logger()?.ReportInfo("CustomizeWidgetDialog", $"Deleted Widget {widgetIdToDelete}");
+
+        EditedWidget = null;
+        this.Hide();
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -7,6 +7,7 @@ using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
@@ -26,7 +27,7 @@ public sealed partial class WidgetControl : UserControl
     }
 
     public static readonly DependencyProperty WidgetSourceProperty = DependencyProperty.Register(
-        "WidgetSource", typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
+        nameof(WidgetSource), typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
 
     private void OpenWidgetMenu(object sender, RoutedEventArgs e)
     {
@@ -41,14 +42,33 @@ public sealed partial class WidgetControl : UserControl
                 {
                     var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
 
-                    AddRemoveToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
                     AddSizesToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
+                    widgetMenuFlyout.Items.Add(new MenuFlyoutSeparator());
+                    AddCustomizeToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
+                    AddRemoveToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
                 }
             }
         }
     }
 
-    private async void DeleteWidgetClick(object sender, RoutedEventArgs e)
+    private void AddRemoveToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
+    {
+        var removeWidgetText = resourceLoader.GetString("RemoveWidgetMenuText");
+        var icon = new FontIcon()
+        {
+            FontFamily = new FontFamily("Segoe MDL2 Assets"),
+            Glyph = "\uE77A;",
+        };
+        var menuItemClose = new MenuFlyoutItem
+        {
+            Tag = widgetViewModel,
+            Text = removeWidgetText,
+        };
+        menuItemClose.Click += OnRemoveWidgetClick;
+        widgetMenuFlyout.Items.Add(menuItemClose);
+    }
+
+    private async void OnRemoveWidgetClick(object sender, RoutedEventArgs e)
     {
         if (sender is MenuFlyoutItem deleteMenuItem)
         {
@@ -65,18 +85,6 @@ public sealed partial class WidgetControl : UserControl
         }
     }
 
-    private void AddRemoveToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
-    {
-        var removeWidgetText = resourceLoader.GetString("RemoveWidgetMenuText");
-        var menuItemClose = new MenuFlyoutItem
-        {
-            Tag = widgetViewModel,
-            Text = removeWidgetText,
-        };
-        menuItemClose.Click += DeleteWidgetClick;
-        widgetMenuFlyout.Items.Add(menuItemClose);
-    }
-
     private void AddSizesToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
     {
         var widgetDefinition = WidgetCatalog.GetDefault().GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
@@ -89,7 +97,7 @@ public sealed partial class WidgetControl : UserControl
             Text = resourceLoader.GetString("SmallWidgetMenuText"),
             IsEnabled = capabilities.Any(cap => cap.Size == WidgetSize.Small),
         };
-        menuItemSmall.Click += MenuItemSize_Click;
+        menuItemSmall.Click += OnMenuItemSizeClick;
         widgetMenuFlyout.Items.Add(menuItemSmall);
 
         var menuItemMedium = new MenuFlyoutItem
@@ -98,7 +106,7 @@ public sealed partial class WidgetControl : UserControl
             Text = resourceLoader.GetString("MediumWidgetMenuText"),
             IsEnabled = capabilities.Any(cap => cap.Size == WidgetSize.Medium),
         };
-        menuItemMedium.Click += MenuItemSize_Click;
+        menuItemMedium.Click += OnMenuItemSizeClick;
         widgetMenuFlyout.Items.Add(menuItemMedium);
 
         var menuItemLarge = new MenuFlyoutItem
@@ -107,11 +115,11 @@ public sealed partial class WidgetControl : UserControl
             Text = resourceLoader.GetString("LargeWidgetMenuText"),
             IsEnabled = capabilities.Any(cap => cap.Size == WidgetSize.Large),
         };
-        menuItemLarge.Click += MenuItemSize_Click;
+        menuItemLarge.Click += OnMenuItemSizeClick;
         widgetMenuFlyout.Items.Add(menuItemLarge);
     }
 
-    private async void MenuItemSize_Click(object sender, RoutedEventArgs e)
+    private async void OnMenuItemSizeClick(object sender, RoutedEventArgs e)
     {
         if (sender is MenuFlyoutItem menuSizeItem)
         {
@@ -120,6 +128,34 @@ public sealed partial class WidgetControl : UserControl
                 var size = (WidgetSize)menuSizeItem.Tag;
                 widgetViewModel.WidgetSize = size;
                 await widgetViewModel.Widget.SetSizeAsync(size);
+            }
+        }
+    }
+
+    private void AddCustomizeToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
+    {
+        var customizeWidgetText = resourceLoader.GetString("CustomizeWidgetMenuText");
+        var icon = new FontIcon()
+        {
+            FontFamily = new FontFamily("Segoe MDL2 Assets"),
+            Glyph = "\uE70F;",
+        };
+        var menuItemCustomize = new MenuFlyoutItem
+        {
+            Tag = widgetViewModel,
+            Text = customizeWidgetText,
+        };
+        menuItemCustomize.Click += OnCustomizeWidgetClick;
+        widgetMenuFlyout.Items.Add(menuItemCustomize);
+    }
+
+    private void OnCustomizeWidgetClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem customizeMenuItem)
+        {
+            if (customizeMenuItem?.Tag is WidgetViewModel widgetViewModel)
+            {
+                widgetViewModel.IsInEditMode = true;
             }
         }
     }


### PR DESCRIPTION
## Summary of the pull request
This change adds a "customize" option to the widget menu, to edit widgets once they have been pinned. A new `CustomizeWidgetDialog` is added for this UI.

## References and relevant issues

## Detailed description of the pull request / Additional comments
We can't really update widgets yet, since we don't have the customization APIs. For now simulate editing a widget by removing and adding a new widget in its place. We can't carry the state of the widget between implementations, but the new "edited" widget will be in the same location and have the same size.

If the user leaves the CustomizeWidgetDialog without "updating" the widget, delete the newly created widget and leave the old one in place.

In order to tell the list of PinnedWidgets that a widget needs to be updated, this adds a `IsInUpdateMode` property on the WidgetViewModel that the Dashboard can subscribe to and show the editing UI accordingly.

## Validation steps performed
Locally validated.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
