### PR TITLE
Fix telemetry calls

### DIFF
--- a/src/Helpers/LoggingHelper.cs
+++ b/src/Helpers/LoggingHelper.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.Helpers;
@@ -28,7 +28,11 @@ public static class LoggingHelper
         }
 
         // TODO: Instead of LoginId, hash a globally unique id of DeveloperId (like url)
-        LoggerFactory.Get<ILogger>().Log($"{eventName}", LogLevel.Critical, $"{telemetryMessage}");
+        LoggerFactory.Get<ILogger>().Log($"{eventName}", LogLevel.Critical, new
+        {
+            PartA_PrivTags = PrivTags.ProductAndServiceUsage,
+            field1 = $"{telemetryMessage}",
+        });
     }
 
     public static void AccountEvent(string eventName, string providerName, string loginId)
@@ -44,6 +48,10 @@ public static class LoggingHelper
         var hashedLoginIdString = BitConverter.ToString(hashedLoginId).Replace("-", string.Empty);
 
         // TODO: Instead of LoginId, hash a globally unique id of DeveloperId (like url)
-        LoggerFactory.Get<ILogger>().Log($"{eventName}", LogLevel.Critical, $" developerId: {hashedLoginIdString}_{providerName}");
+        LoggerFactory.Get<ILogger>().Log($"{eventName}", LogLevel.Critical, new
+        {
+            PartA_PrivTags = PrivTags.ProductAndServiceUsage,
+            field1 = $" developerId: {hashedLoginIdString}_{providerName}",
+        });
     }
 }

--- a/telemetry/DevHome.Telemetry/TelemetryEventSource.cs
+++ b/telemetry/DevHome.Telemetry/TelemetryEventSource.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+#define TELEMETRYEVENTSOURCE_PUBLIC
+
 #if TELEMETRYEVENTSOURCE_USE_NUGET
 using Microsoft.Diagnostics.Tracing;
 #else


### PR DESCRIPTION
## Summary of the pull request
Fixes Telemetry calls for DevId. 

## References and relevant issues
#86 

## Detailed description of the pull request / Additional comments
Telemetry write calls should have Tagging as a field to be uploaded to Microsoft servers. Without tagging, the events will be blocked locally.

## Validation steps performed
Ran Unstub.ps1 and ran TRTT locally to verify that the events show up locally.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
