### PR TITLE
Minor UI improvements for setup flow

### DIFF
--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -9,28 +9,32 @@
         <Grid.Background>
             <ImageBrush Stretch="UniformToFill" ImageSource="{x:Bind ImageSource, Mode=OneWay}" />
         </Grid.Background>
-        <Button HorizontalAlignment="Right" VerticalAlignment="Top" 
-                BorderThickness="0" Background="Transparent"
-                Command="{x:Bind HideButtonCommand, Mode=OneWay}"
-                Visibility="{x:Bind HideButtonVisibility, Mode=OneWay}">
-            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                       FontSize="{ThemeResource BodyTextBlockFontSize}" 
+        <Grid HorizontalAlignment="Right" VerticalAlignment="Top" Height="60" Width="60">
+            <Button HorizontalAlignment="Center" VerticalAlignment="Center"
+                    BorderThickness="0" Background="Transparent"
+                    Command="{x:Bind HideButtonCommand, Mode=OneWay}"
+                    Visibility="{x:Bind HideButtonVisibility, Mode=OneWay}">
+                <!-- Text = close symbol -->
+                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                       FontSize="{ThemeResource BodyTextBlockFontSize}"
                        Text="&#xE10A;" />
-        </Button>
+            </Button>
+        </Grid>
         <StackPanel VerticalAlignment="Center" Margin="38 0 0 0" Spacing="12">
             <TextBlock
-                Width="250"
+                Width="{x:Bind TextWidth}"
                 HorizontalAlignment="Left"
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 Text="{x:Bind Title, Mode=OneWay}"/>
             <TextBlock
-                Width="500"
+                Width="{x:Bind TextWidth}"
                 HorizontalAlignment="Left"
                 TextWrapping="Wrap"
                 Text="{x:Bind Description, Mode=OneWay}"/>
             <Button
                 Margin="0 15 0 0"
                 Padding="25 4 25 6"
+                MinWidth="120"
                 Command="{x:Bind ButtonCommand, Mode=OneWay}"
                 Content="{x:Bind ButtonText, Mode=OneWay}"/>
         </StackPanel>

--- a/common/Views/Banner.xaml.cs
+++ b/common/Views/Banner.xaml.cs
@@ -20,6 +20,12 @@ public sealed partial class Banner : UserControl
         set => SetValue(DescriptionProperty, value);
     }
 
+    public int TextWidth
+    {
+        get => (int)GetValue(TextWidthProperty);
+        set => SetValue(TextWidthProperty, value);
+    }
+
     public string ImageSource
     {
         get => (string)GetValue(ImageSourceProperty);
@@ -57,6 +63,7 @@ public sealed partial class Banner : UserControl
 
     public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(nameof(Title), typeof(string), typeof(Banner), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(nameof(Description), typeof(string), typeof(Banner), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty TextWidthProperty = DependencyProperty.Register(nameof(TextWidth), typeof(int), typeof(Banner), new PropertyMetadata(null));
     public static readonly DependencyProperty ImageSourceProperty = DependencyProperty.Register(nameof(ImageSource), typeof(string), typeof(Banner), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty ButtonTextProperty = DependencyProperty.Register(nameof(ButtonText), typeof(string), typeof(Banner), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty ButtonCommandProperty = DependencyProperty.Register(nameof(ButtonCommand), typeof(ICommand), typeof(Banner), new PropertyMetadata(null));

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -27,6 +27,7 @@
             <StackPanel>
                 <!-- Top Banner - Default/First run experience - shown until user dismissed -->
                 <commonviews:Banner x:Name="DashboardBanner"
+                    TextWidth="500"
                     Visibility="{x:Bind ViewModel.ShowDashboardBanner,Mode=OneWay}"
                     HideButtonVisibility="true"
                     HideButtonCommand="{x:Bind ViewModel.HideDashboardBannerButtonCommand,Mode=OneWay}"

--- a/tools/SetupFlow/DevHome.SetupFlow.MainPage/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.MainPage/ViewModels/MainPageViewModel.cs
@@ -7,14 +7,12 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
-using DevHome.Common.Services;
 using DevHome.SetupFlow.AppManagement;
 using DevHome.SetupFlow.Common.Models;
 using DevHome.SetupFlow.Common.Services;
 using DevHome.SetupFlow.Common.ViewModels;
 using DevHome.SetupFlow.ConfigurationFile;
 using DevHome.SetupFlow.DevDrive;
-using DevHome.SetupFlow.DevDrive.Models;
 using DevHome.SetupFlow.DevDrive.Utilities;
 using DevHome.SetupFlow.RepoConfig;
 using DevHome.Telemetry;
@@ -33,6 +31,9 @@ public partial class MainPageViewModel : SetupPageViewModelBase
 {
     private readonly ILogger _logger;
     private readonly IHost _host;
+
+    [ObservableProperty]
+    private bool _showBanner = true;
 
     [ObservableProperty]
     private bool _showDevDriveItem;
@@ -57,6 +58,12 @@ public partial class MainPageViewModel : SetupPageViewModelBase
         IsNavigationBarVisible = false;
         IsStepPage = false;
         ShowDevDriveItem = DevDriveUtil.IsDevDriveFeatureEnabled;
+    }
+
+    [RelayCommand]
+    private void HideBanner()
+    {
+        ShowBanner = false;
     }
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow.MainPage/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow.MainPage/Views/MainPageView.xaml
@@ -33,8 +33,11 @@
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Spacing="30">
-            <!--TODO: Add x button to banner -->
             <commonviews:Banner
+                TextWidth="400"
+                HideButtonVisibility="True"
+                HideButtonCommand="{x:Bind ViewModel.HideBannerCommand}"
+                Visibility="{x:Bind ViewModel.ShowBanner, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                 ButtonCommand="{x:Bind ViewModel.BannerButtonCommand,Mode=OneWay}"
                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DefaultBanner"
                 ImageSource="{ThemeResource Setup_Banner}" />

--- a/tools/SetupFlow/DevHome.SetupFlow.Review/ViewModels/ReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Review/ViewModels/ReviewViewModel.cs
@@ -55,7 +55,7 @@ public partial class ReviewViewModel : SetupPageViewModelBase
     protected async override Task OnEachNavigateToAsync()
     {
         IsRebootRequired = _orchestrator.TaskGroups.Any(taskGroup => taskGroup.SetupTasks.Any(task => task.RequiresReboot));
-        NextPageButtonToolTipText = HasTasksToSetUp ? string.Empty : StringResource.GetLocalized(StringResourceKey.ReviewNothingToSetUpToolTip);
+        NextPageButtonToolTipText = HasTasksToSetUp ? null : StringResource.GetLocalized(StringResourceKey.ReviewNothingToSetUpToolTip);
         await Task.CompletedTask;
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow.UITest/SetupFlowScenarioStandard.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.UITest/SetupFlowScenarioStandard.cs
@@ -16,7 +16,7 @@ public class SetupFlowScenarioStandard : SetupFlowSession
     [TestMethod]
     public void SetupFlowTest1()
     {
-        session.FindElementByName("Dev Setup tool").Click();
+        session.FindElementByName("Machine Configuration").Click();
         WindowsElement title = session.FindElementByName("Add packages");
         Assert.AreEqual("Add packages", title.Text);
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -178,7 +178,7 @@
     <comment>Title text of an instruction banner section for setting up a development machine</comment>
   </data>
   <data name="DefaultBanner.Description" xml:space="preserve">
-    <value>Find out how you can use Dev Home to get your development machine set up quickly.</value>
+    <value>Find out how you can use Dev Home to set up your development machine more quickly.</value>
     <comment>{Locked="Dev Home"}Description text of an instruction banner section for setting up a development machine</comment>
   </data>
   <data name="DefaultBanner.ButtonText" xml:space="preserve">
@@ -330,7 +330,7 @@
     <comment>Text shown if no applications were selected to install</comment>
   </data>
   <data name="NavigationPane.Content" xml:space="preserve">
-    <value>Dev Setup tool</value>
+    <value>Machine Configuration</value>
     <comment>Navigation pane content</comment>
   </data>
   <data name="NoApplicationsSelected.Text" xml:space="preserve">
@@ -414,7 +414,7 @@
     <comment>Text indicating that a reboot may be needed to finish the setup</comment>
   </data>
   <data name="ReviewNothingToSetUpToolTip" xml:space="preserve">
-    <value>Nothing to set up</value>
+    <value>There's nothing to set up​</value>
     <comment>Text shown on a tool tip for a "Start set up" button if there is noting to set up</comment>
   </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -105,11 +105,20 @@
                         MinWidth="120"
                         Visibility="{x:Bind ViewModel.Orchestrator.HasPreviousPage, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
                         x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Previous" />
-                <Button Command="{x:Bind ViewModel.Orchestrator.GoToNextPageCommand, Mode=OneWay}"
-                        Style="{StaticResource AccentButtonStyle}"
-                        MinWidth="120"
-                        Content="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonText, Mode=OneWay}"
-                        ToolTipService.ToolTip="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonToolTipText, Mode=OneWay}" />
+
+                <!-- We sometimes want to show a tooltip on the button when it is disabled,
+                     but tooltips only show on enabled controls. As a hacky workaround,
+                     put the button in a container and the tooltip in the container.
+                     But for some reason the tooltip doesn't show up if the button is the
+                     only control, so add an empty control... -->
+                <Grid ToolTipService.ToolTip="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonToolTipText, Mode=OneWay}">
+                    <TextBlock IsTabStop="False" />
+                    <Button Command="{x:Bind ViewModel.Orchestrator.GoToNextPageCommand, Mode=OneWay}"
+                            Style="{StaticResource AccentButtonStyle}"
+                            MinWidth="120"
+                            Content="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonText, Mode=OneWay}"
+                            ToolTipService.ToolTip="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonToolTipText, Mode=OneWay}" />
+                </Grid>
             </StackPanel>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Summary of the pull request

Updated some strings to latest per content designers; and fixed some minor UI issues.

## References and relevant issues

## Detailed description of the pull request / Additional comments

* Fixed positioning of "hide banner" button (away from edge) and added code to hide banner on setup flow
* Added max width to text blocks in banner to prevent overlapping with banner images
![image](https://user-images.githubusercontent.com/14323496/229219979-88447ae0-0ac7-4ec2-a27f-30c10d5ba28c.png)

* Fixed tooltip on review page when there's nothing to set up. (Can't take screenshot of tooltip :( )

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
