### PR TITLE
Remove tabs from DevHome code

### DIFF
--- a/settings/DevHome.Settings.UnitTest/DevHome.SetupFlow.UnitTest.csproj
+++ b/settings/DevHome.Settings.UnitTest/DevHome.SetupFlow.UnitTest.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-	<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
   </PropertyGroup>
   <ItemGroup>

--- a/settings/DevHome.Settings/Helpers/AdaptiveCardRendererHelper.cs
+++ b/settings/DevHome.Settings/Helpers/AdaptiveCardRendererHelper.cs
@@ -13,11 +13,11 @@ public static class AdaptiveCardRendererHelper
 
         var hostConfigJSON = @"
 {
-	""supportsInteractivity"": true,
-	""actions"": {
-		""actionsOrientation"": ""vertical"",
-		""actionAlignment"": ""stretch""
-	}
+    ""supportsInteractivity"": true,
+    ""actions"": {
+        ""actionsOrientation"": ""vertical"",
+        ""actionAlignment"": ""stretch""
+    }
 }
 ";
         var hostConfig = AdaptiveHostConfig.FromJsonString(hostConfigJSON);

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -191,43 +191,43 @@
   <data name="Settings_Accounts_AddAccountButton.Content" xml:space="preserve">
     <value>Add Account</value>
   </data>
-	<data name="Settings_Accounts_AddAccountText.Text" xml:space="preserve">
+  <data name="Settings_Accounts_AddAccountText.Text" xml:space="preserve">
     <value>Add Account</value>
   </data>
-	<data name="Settings_Accounts_AfterLogoutContentDialog_Content" xml:space="preserve">
+  <data name="Settings_Accounts_AfterLogoutContentDialog_Content" xml:space="preserve">
     <value>has successfully logged out of Dev Home.</value>
   </data>
-	<data name="Settings_Accounts_AfterLogoutContentDialog_PrimaryButtonText" xml:space="preserve">
+  <data name="Settings_Accounts_AfterLogoutContentDialog_PrimaryButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
-	<data name="Settings_Accounts_AfterLogoutContentDialog_Title" xml:space="preserve">
+  <data name="Settings_Accounts_AfterLogoutContentDialog_Title" xml:space="preserve">
     <value>Logout Successful!</value>
   </data>
-	<data name="Settings_Accounts_ConfirmLogoutContentDialog_Content" xml:space="preserve">
+  <data name="Settings_Accounts_ConfirmLogoutContentDialog_Content" xml:space="preserve">
     <value>Dev Home will no longer be able to access online resources that use this account.</value>
   </data>
-	<data name="Settings_Accounts_ConfirmLogoutContentDialog_PrimaryButtonText" xml:space="preserve">
+  <data name="Settings_Accounts_ConfirmLogoutContentDialog_PrimaryButtonText" xml:space="preserve">
     <value>Yes</value>
   </data>
-	<data name="Settings_Accounts_ConfirmLogoutContentDialog_SecondaryButtonText" xml:space="preserve">
+  <data name="Settings_Accounts_ConfirmLogoutContentDialog_SecondaryButtonText" xml:space="preserve">
     <value>No</value>
   </data>
-	<data name="Settings_Accounts_ConfirmLogoutContentDialog_Title" xml:space="preserve">
+  <data name="Settings_Accounts_ConfirmLogoutContentDialog_Title" xml:space="preserve">
     <value>Are you sure?</value>
   </data>
-	<data name="Settings_Accounts_LogoutButton.Content" xml:space="preserve">
+  <data name="Settings_Accounts_LogoutButton.Content" xml:space="preserve">
     <value>Logout</value>
   </data>
-	<data name="Settings_Accounts_NoProvidersContentDialog_Content" xml:space="preserve">
+  <data name="Settings_Accounts_NoProvidersContentDialog_Content" xml:space="preserve">
     <value>Please install a Dev Home Plugin and restart Dev Home to add an account.</value>
   </data>
-	<data name="Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText" xml:space="preserve">
+  <data name="Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
-	<data name="Settings_Accounts_NoProvidersContentDialog_Title" xml:space="preserve">
+  <data name="Settings_Accounts_NoProvidersContentDialog_Title" xml:space="preserve">
     <value>No Dev Home Plugins found!</value>
   </data>
-	<data name="Settings_Accounts_SubTitle.Text" xml:space="preserve">
+  <data name="Settings_Accounts_SubTitle.Text" xml:space="preserve">
     <value>Accounts</value>
   </data>
 </root>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -2,80 +2,80 @@
 <!-- Licensed under the MIT License. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<RootNamespace>DevHome</RootNamespace>
-		<ApplicationIcon>Assets/DevHome.ico</ApplicationIcon>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
-		<Platforms>x86;x64;arm64</Platforms>
-		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-		<PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<UseWinUI>true</UseWinUI>
-		<EnableMsixTooling>true</EnableMsixTooling>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+        <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+        <RootNamespace>DevHome</RootNamespace>
+        <ApplicationIcon>Assets/DevHome.ico</ApplicationIcon>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
+        <Platforms>x86;x64;arm64</Platforms>
+        <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+        <PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <UseWinUI>true</UseWinUI>
+        <EnableMsixTooling>true</EnableMsixTooling>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<Manifest Include="$(ApplicationManifest)" />
-	</ItemGroup>
+    <ItemGroup>
+        <Manifest Include="$(ApplicationManifest)" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
-		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="System.Management" Version="7.0.0" />
-		<PackageReference Include="WinUIEx" Version="1.8.0" />
-		<PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Management" Version="7.0.0" />
+        <PackageReference Include="WinUIEx" Version="1.8.0" />
+        <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\common\DevHome.Common.csproj" />
-		<ProjectReference Include="..\settings\DevHome.Settings\DevHome.Settings.csproj" />
-		<ProjectReference Include="..\tools\SampleTool\src\SampleTool.csproj" />
-		<ProjectReference Include="..\tools\Dashboard\DevHome.Dashboard\DevHome.Dashboard.csproj" />
-		<ProjectReference Include="..\tools\SetupFlow\DevHome.SetupFlow\DevHome.SetupFlow.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Update="appsettings.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<None Update="navConfig.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-		<Page Update="Styles\Feedback_ThemeResources.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\common\DevHome.Common.csproj" />
+        <ProjectReference Include="..\settings\DevHome.Settings\DevHome.Settings.csproj" />
+        <ProjectReference Include="..\tools\SampleTool\src\SampleTool.csproj" />
+        <ProjectReference Include="..\tools\Dashboard\DevHome.Dashboard\DevHome.Dashboard.csproj" />
+        <ProjectReference Include="..\tools\SetupFlow\DevHome.SetupFlow\DevHome.SetupFlow.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="navConfig.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <Page Update="Styles\Feedback_ThemeResources.xaml">
+            <Generator>MSBuild:Compile</Generator>
+        </Page>
+    </ItemGroup>
 
-	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-		<ProjectCapability Include="Msix" />
-	</ItemGroup>
+    <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+        <ProjectCapability Include="Msix" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<None Remove="Styles\Feedback_ThemeResources.xaml" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Remove="Styles\Feedback_ThemeResources.xaml" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<Folder Include="Assets\Tiles\" />
-	</ItemGroup>
+    <ItemGroup>
+        <Folder Include="Assets\Tiles\" />
+    </ItemGroup>
 
-	<PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-		<HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+        <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
+    </PropertyGroup>
 
-	<!-- In the setup flow there is a WinRT component that gets consumed by project reference
-	     in some places and by referencing the .winmd in others. This results in multiple
-	     projects having the .winmd as output, which causes a build error. We disable that
-	     check for now, but we should find a solution that doesn't require it. -->
-	<PropertyGroup>
-		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-	</PropertyGroup>
+    <!-- In the setup flow there is a WinRT component that gets consumed by project reference
+         in some places and by referencing the .winmd in others. This results in multiple
+         projects having the .winmd as output, which causes a build error. We disable that
+         check for now, but we should find a solution that doesn't require it. -->
+    <PropertyGroup>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    </PropertyGroup>
 </Project>

--- a/src/Properties/launchsettings.json
+++ b/src/Properties/launchsettings.json
@@ -1,10 +1,10 @@
 ﻿{
-    "profiles": {
-      "DevHome (Package)": {
-        "commandName": "MsixPackage"
-      },
-      "DevHome (Unpackaged)": {
-        "commandName": "Project"
-      }
+  "profiles": {
+    "DevHome (Package)": {
+      "commandName": "MsixPackage"
+    },
+    "DevHome (Unpackaged)": {
+      "commandName": "Project"
     }
+  }
 }

--- a/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.SetupFlow.UnitTest.csproj
+++ b/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.SetupFlow.UnitTest.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-	<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/SetupFlow/DevHome.SetupFlow.UnitTest/DevHome.SetupFlow.UnitTest.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.UnitTest/DevHome.SetupFlow.UnitTest.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-	<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
We use spaces. We should be consistent, especially before going open source. This change does not remove tabs from .sln files, where they are the norm. Also update launchsettings.json to use the default indentation.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
