### PR TITLE
Make widget host persist between instances of the Dashboard

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -121,14 +121,14 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
         // Load selected widget configuration.
         var selectedTag = (sender.SelectedItem as NavigationViewItem).Tag;
-        if (selectedTag == null)
+        if (selectedTag is null)
         {
+            Log.Logger()?.ReportError("AddWidgetDialog", $"Selected widget description did not have a tag");
             return;
         }
 
         // If the user has selected a widget, show configuration UI. If they selected a provider, leave space blank.
-        var selectedWidgetDefinition = selectedTag as WidgetDefinition;
-        if (selectedWidgetDefinition != null)
+        if (selectedTag as WidgetDefinition is WidgetDefinition selectedWidgetDefinition)
         {
             var size = WidgetHelpers.GetLargetstCapabilitySize(selectedWidgetDefinition.GetWidgetCapabilities());
 
@@ -143,16 +143,12 @@ public sealed partial class AddWidgetDialog : ContentDialog
             clearWidgetTask.Wait();
             _currentWidget = widget;
         }
-        else
+        else if (selectedTag as WidgetProviderDefinition is not null)
         {
-            var selectedWidgetProviderDefintion = selectedTag as WidgetProviderDefinition;
-            if (selectedWidgetProviderDefintion != null)
-            {
-                // Null out the view model background so we don't bind to the old one
-                ViewModel.WidgetBackground = null;
-                ConfigurationContentFrame.Content = null;
-                PinButton.Visibility = Visibility.Collapsed;
-            }
+            // Null out the view model background so we don't bind to the old one
+            ViewModel.WidgetBackground = null;
+            ConfigurationContentFrame.Content = null;
+            PinButton.Visibility = Visibility.Collapsed;
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
The Dashboard page is initialized on app launch, and then again each time it is navigated to. We don't want to re-register with the widget host each time, so make the widget host and the widget catalog, etc, static so they persist.

Display an error in more situations where we can't display the widget's adaptive card for various reasons. Simple message should be swapped out with nice UI in the future (already just a message, not a regression).

Logging and code cleanup added.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
