### PR TITLE
Update nuget version

### DIFF
--- a/build/NugetWrapper.cmd
+++ b/build/NugetWrapper.cmd
@@ -5,12 +5,12 @@ if "%VisualStudioVersion%" == "" set VisualStudioVersion=15.0
 
 if defined NUGETEXETOOLPATH goto :AzurePipelines
 
-if not exist %TEMP%\nuget.5.8.0-preview.2.exe (
+if not exist %TEMP%\nuget.6.4.0.exe (
     echo Nuget.exe not found in the temp dir, downloading.
-    powershell -Command "& { Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v5.8.0-preview.2/nuget.exe -outfile $env:TEMP\nuget.5.8.0-preview.2.exe }"
+    powershell -Command "& { Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v6.4.0/nuget.exe -outfile $env:TEMP\nuget.6.4.0.exe }"
 )
 
-%TEMP%\nuget.5.8.0-preview.2.exe %*
+%TEMP%\nuget.6.4.0.exe %*
 
 exit /B %ERRORLEVEL%
 


### PR DESCRIPTION
## Summary of the pull request
Updating to a recent NuGet version

## Detailed description of the pull request / Additional comments

When I first ran a build using build.cmd, NuGet was asking me credentials for the internal feed.  This shouldn't be needed if it used azure artifacts provider which recent versions of NuGet does.

## Validation steps performed

Build.cmd runs without issues

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
