### PR TITLE
Align Dashboard title and Add Widget button

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -114,4 +114,8 @@
     <value>Customize</value>
     <comment>A menu option that will bring up a dialog that lets the user customize the widget</comment>
   </data>
+  <data name="DashboardPage_Title.Text" xml:space="preserve">
+    <value>Dashboard</value>
+    <comment>Header label for the Dashboard page</comment>
+  </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -11,6 +11,8 @@
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:vm="using:DevHome.Dashboard.ViewModels"
     xmlns:views="using:DevHome.Dashboard.Views"
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
     <Grid>
@@ -19,9 +21,13 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="0">
-            <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right" Click="AddWidgetButton_Click"/>
-        </StackPanel>
+        <!-- Header - Title and Add Widget button -->
+        <Grid Grid.Row="0" Margin="0,10,0,22">
+            <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource TitleTextBlockStyle}" HorizontalAlignment="Left"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right" Click="AddWidgetButton_Click"/>
+            </StackPanel>
+        </Grid>
 
         <ScrollViewer VerticalScrollBarVisibility="Auto" Grid.Row="1">
             <StackPanel>
@@ -34,7 +40,7 @@
                     ButtonCommand="{x:Bind ViewModel.DashboardBannerButtonCommand,Mode=OneWay}"
                     x:Uid="ms-resource:///DevHome.Dashboard/Resources/DashboardBanner"
                     ImageSource="ms-appx:///DevHome.Dashboard/Assets/DashboardBanner.png"
-                    Margin="0, 20"/>
+                    Margin="0,0,0,12" />
 
                 <!-- Widget grid -->
                 <GridView x:Name="MainGridView" ItemsSource="{x:Bind views:DashboardView.PinnedWidgets}"


### PR DESCRIPTION
## Summary of the pull request
Moves the Add Widget button up so it's on the same level as the Dashboard title, rather than being below it. Do this by removing the default header (`HeaderMode="Never"`) and replicating it in the page itself.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
