### PR TITLE
Allow widgets to be scrolled vertically

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
@@ -17,7 +17,8 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <ContentPresenter Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}" Grid.Row="1" />
+
+        <!-- Widget header: icon, title, menu -->
         <Grid Grid.Row="0">
             <StackPanel Orientation="Horizontal" Margin="15,10,15,5">
                 <Rectangle Width="16" Height="16" Margin="0,0,8,0"
@@ -34,5 +35,10 @@
                 </Button.Flyout>
             </Button>
         </Grid>
+
+        <!-- Widget content -->
+        <ScrollViewer Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}" Grid.Row="1" 
+                      VerticalScrollBarVisibility="Hidden" HorizontalScrollMode="Disabled"/>
+
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary of the pull request
Widgets may give us more content than a widget has room to display, so they should be allowed to scroll vertically. This change puts the adaptive card content of the widget into a ScrollViewer, instead of a non-scrollable ContentPresenter. The header of the widget (icon, title, "..." menu) stays put at the top. The actual scroll bar is not visible. This aligns with one of the mockups from Design. If they end up wanting a scroll bar, we can add it later.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
