### PR TITLE
add checks to prevent crashing

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
@@ -146,7 +146,7 @@ public class DevDriveManager : IDevDriveManager
         if (result == DevDriveValidationResult.Successful)
         {
             var taskGroups = _host.GetService<SetupFlowOrchestrator>().TaskGroups;
-            var group = taskGroups.Single(x => x.GetType() == typeof(DevDriveTaskGroup));
+            var group = taskGroups.SingleOrDefault(x => x.GetType() == typeof(DevDriveTaskGroup));
             if (group is DevDriveTaskGroup driveTaskGroup)
             {
                 ViewModel.TaskGroup = driveTaskGroup;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -33,7 +33,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         {
             var repositoriesCloned = new ObservableCollection<KeyValuePair<string, string>>();
             var taskGroup = _host.GetService<SetupFlowOrchestrator>().TaskGroups;
-            var group = taskGroup.Single(x => x.GetType() == typeof(RepoConfigTaskGroup));
+            var group = taskGroup.SingleOrDefault(x => x.GetType() == typeof(RepoConfigTaskGroup));
             if (group is RepoConfigTaskGroup repoTaskGroup)
             {
                 foreach (var task in repoTaskGroup.SetupTasks)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Contracts.Services;
@@ -44,7 +45,7 @@ public sealed partial class RepoConfigView : UserControl
         }
 
         var everythingToClone = addRepoDialog.AddRepoViewModel.EverythingToClone;
-        if (result == ContentDialogResult.Primary)
+        if (result == ContentDialogResult.Primary && everythingToClone.Any())
         {
             // We currently only support adding either a local path or a new Dev Drive as the cloning location. Only one can be selected
             // during the add repo dialog flow. So if multiple repositories are selected and the user chose to clone them to a Dev Drive
@@ -60,7 +61,7 @@ public sealed partial class RepoConfigView : UserControl
                 // The cloning location may have changed e.g The original Drive clone path for Dev Drives was the F: drive for items
                 // on the add repo page, but during the Add repo dialog flow the user chose to change this location to the D: drive.
                 // we need to reflect this for all the old items currently in the add repo page.
-                ViewModel.UpdateCollectionWithDevDriveInfo(everythingToClone[0]);
+                ViewModel.UpdateCollectionWithDevDriveInfo(everythingToClone.First());
                 ViewModel.DevDriveManager.IncreaseRepositoriesCount(everythingToClone.Count);
                 ViewModel.DevDriveManager.ConfirmChangesToDevDrive();
             }


### PR DESCRIPTION
## Summary of the pull request
Fixes crashing on other summary page by changing use of Single to SingleOrDefault
changed other usage of Single to SingleOrDefault
Fixes null exception on repo page when "everything to clone" list is empty

video for summary page installing python

https://user-images.githubusercontent.com/105318831/230512913-93e58ce8-3f61-485d-976c-e28060ec697a.mp4


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually tested
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
