### PR TITLE
change default Dev Drive folder location from roaming folder to users my documents folder

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
@@ -128,8 +128,15 @@ internal class CreateDevDriveTask : ISetupTask
                     return TaskFinishedState.Failure;
                 }
 
+                var defaultFolderName = Path.Combine(DevDrive.DriveLocation, _stringResource.GetLocalized(StringResourceKey.DevDriveDefaultFolderName));
+
+                if (!Directory.Exists(defaultFolderName))
+                {
+                    Directory.CreateDirectory(defaultFolderName);
+                }
+
                 var storageOperator = elevatedComponentFactory.CreateDevDriveStorageOperator();
-                var virtDiskPath = Path.Combine(DevDrive.DriveLocation, DevDrive.DriveLabel + ".vhdx");
+                var virtDiskPath = Path.Combine(defaultFolderName, DevDrive.DriveLabel + ".vhdx");
                 var result = storageOperator.CreateDevDrive(virtDiskPath, DevDrive.DriveSizeInBytes, DevDrive.DriveLetter, DevDrive.DriveLabel);
                 if (result != 0)
                 {

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
@@ -275,16 +275,14 @@ public class DevDriveManager : IDevDriveManager
             devDrive.DriveUnitOfMeasure = ByteUnit.GB;
             devDrive.DriveLocation = location;
             uint count = 1;
-            var fileName = $"{_defaultVhdxName}";
-            var folderWithFile = Path.Combine(_defaultVhdxLocation, fileName);
-            var fullPath = Path.Combine(location, folderWithFile);
+            var fullPath = Path.Combine(location, $"{_defaultVhdxName}.vhdx");
+            var fileName = _defaultVhdxName;
 
             // If original default file name exists we'll increase the number next to the filename
             while (File.Exists(fullPath) && count <= 1000)
             {
                 fileName = $"{_defaultVhdxName} {count}";
-                folderWithFile = Path.Combine(_defaultVhdxLocation, $"{fileName}.vhdx");
-                fullPath = Path.Combine(location, folderWithFile);
+                fullPath = Path.Combine(location, $"{fileName}.vhdx");
                 count++;
             }
 


### PR DESCRIPTION
## Summary of the pull request
- Changed the default save folder from appdata  to users my documents folder. After speaking with PM confirmed we no longer want the vhdx file that is created put in the roaming folder. 
- This also seemed to fix an issue where Dev Drives weren't being created on the latest build, (this change along with previous others earlier today may have fixed this). I'll continue to investigate but I confirmed (see video) with this change you can create a Dev Drive in dev Home again.

**Video with latest changes from main, showing me create a dev Drive , with the O drive letter in the my documents folder**


https://user-images.githubusercontent.com/105318831/230524102-776589af-2015-4647-a1b5-95cde5ba80b1.mp4





## References and relevant issues

## Detailed description of the pull request / Additional comments
I believe there is also a bug for when you select the edit button and then change the location of an item in the grid of the repository config page. It seems that multiple items get updated to the current selected on. Could be due to the use of references. Will have to investigate more

## Validation steps performed
Manually tested
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
