### PR TITLE
Update scope for getting the elevation field value

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
@@ -146,7 +146,7 @@ public class InstallPackageTask : ISetupTask
     private bool RequiresElevation()
     {
         var options = _wingetFactory.CreateInstallOptions();
-        options.PackageInstallScope = PackageInstallScope.User;
+        options.PackageInstallScope = PackageInstallScope.Any;
         return _package.RequiresElevation(options);
     }
 }


### PR DESCRIPTION
# 🚀 What was done?
- Issue: Not all packages define a `user` scope in the manifest
- Instead, use the `Any` option to get `scope: ` `machine` / `user`