### PR TITLE
Removing items does not change anything else.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
@@ -80,20 +80,12 @@ public partial class RepoConfigViewModel : SetupPageViewModelBase
     public void RemoveCloningInformation(CloningInformation cloningInformation)
     {
         RepoReviewItems.Remove(cloningInformation);
-        UpdateCollection();
+        _taskGroup.SaveSetupTaskInformation(RepoReviewItems.ToList());
 
         if (RepoReviewItems.Count == 0)
         {
             ShouldShowNoRepoMessage = Visibility.Visible;
         }
-    }
-
-    // Assumes an item in the list has been changed via reference.
-    public void UpdateCollection()
-    {
-        List<CloningInformation> repoReviewItems = new (RepoReviewItems);
-        RepoReviewItems = new ObservableCollection<CloningInformation>(repoReviewItems);
-        _taskGroup.SaveSetupTaskInformation(repoReviewItems);
     }
 
     public void UpdateCloneLocation(CloningInformation cloningInformation)
@@ -102,7 +94,7 @@ public partial class RepoConfigViewModel : SetupPageViewModelBase
         if (location != -1)
         {
             RepoReviewItems[location] = cloningInformation;
-            UpdateCollection();
+            _taskGroup.SaveSetupTaskInformation(RepoReviewItems.ToList());
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
Removing items, and sometimes editing the clone path of one repo item would change other repo items.  This is no more!

## References and relevant issues
[Ado item](https://microsoft.visualstudio.com/OS/_workitems/edit/44093166)

## Detailed description of the pull request / Additional comments
Why did this happen?  In the earlier times I used a DataGrid from the Community Toolkit.  The DataGrid is, in fact, not a well cared Win UI control.  When I changed an item in the observable collection the DataGrid did not update the UI.  I "fixed" this issue by assigning the ObservableCollection to a new ObservableCollection.

Another issue with DataGrids was the poor cell border control.  This was an issue that could not be fixed.  I switched to an ItemsRepeater.

With an ItemsRepeater it DID update the UI when I changed the item inside an ObservableCollection.

Before this PR I was changing the item in the ObservableCollection AND replacing the whole collection with itself.

Moral of the story.  Don't use DataGrid.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Before bug fix: 
![BugInRepoItems](https://user-images.githubusercontent.com/2517139/230699106-e47c2f1b-aba1-4259-9cd6-eb0d98c6d37d.gif)

After bug fix:
![RemoveRepoItemsNoMoreBugs](https://user-images.githubusercontent.com/2517139/230699112-384ec027-e4ff-4f46-9ec1-e6b68d621c03.gif)
