### PR TITLE
Add some more lines of logging for DevDriveStorageOperator and make DevDriveFormatter public sealed

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevDriveFormatter/DevDriveFormatter.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevDriveFormatter/DevDriveFormatter.cs
@@ -15,7 +15,7 @@ namespace DevHome.SetupFlow.Common.DevDriveFormatter;
 /// this was moved out of the DevDriveStorageOperator class in that project. This is a work around for
 /// now until that is fixed.
 /// </summary>
-public class DevDriveFormatter
+public sealed class DevDriveFormatter
 {
     /// <summary>
     /// Uses WMI to and the storage Api to format the drive as a Dev Drive. Note: the implementation

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/DevDriveStorageOperator.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/DevDriveStorageOperator.cs
@@ -557,6 +557,11 @@ public sealed class DevDriveStorageOperator
     {
         Log.Logger?.ReportInfo(nameof(DevDriveStorageOperator), $"{nameof(FormatPartitionAsDevDrive)}: Creating DevDriveFormatter");
         var devDriveFormatter = new DevDriveFormatter();
-        return devDriveFormatter.FormatPartitionAsDevDrive(curDriveLetter, driveLabel);
+
+        Log.Logger?.ReportInfo(nameof(DevDriveStorageOperator), $"{nameof(FormatPartitionAsDevDrive)}: DevDriveFormatter created");
+        var result = devDriveFormatter.FormatPartitionAsDevDrive(curDriveLetter, driveLabel);
+
+        Log.Logger?.ReportInfo(nameof(DevDriveStorageOperator), $"{nameof(FormatPartitionAsDevDrive)}: {nameof(DevDriveFormatter)} FormatPartitionAsDevDrive resulted in return code: {result:X}");
+        return result;
     }
 }


### PR DESCRIPTION
## Summary of the pull request
This PR should fix a weird issue where some machine don't can't format a drive as a dev drive. Looks like the issue is that users would experience the following error when attempting to create a Dev Drive: 

- `The system cannot find the file specified. (0x80070002)`

Now that we have logging the issue happens [here ](https://github.com/microsoft/devhome/blob/main/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/DevDriveStorageOperator.cs#:~:text=var%20devDriveFormatter%20%3D,%2C%20driveLabel) . It seems that the Dev Drive formatter throws upon creation and we catch this [here](https://github.com/microsoft/devhome/blob/main/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs#:~:text=Log.Logger%3F.ReportError(nameof(CreateDevDriveTask)%2C%20%24%22Failed%20to%20create%20Dev%20Drive.%20Due%20to%20Exception%20ErrorCode%3A%200x%7Bex.HResult%3AX%7D%2C%20Msg%3A%20%7Bex.Message%7D%22)) . I tested this on a separate machine other than my original dev machine (where the original code actually works) to confirm it works on another machine. But will have to get others to verify on there machines.

**Video of me going through the flow on my laptop, BEFORE change:**

https://user-images.githubusercontent.com/105318831/230748986-313fbea9-9f41-41b9-90f4-63b58120197c.mp4

**Video of me going though the flow on my laptop, AFTER change:**

https://user-images.githubusercontent.com/105318831/230749006-c6c76af6-3d45-439a-96c5-b1a6eadbd604.mp4


## References and relevant issues

## Detailed description of the pull request / Additional comments
For context, originally this all worked and the code inside the DevDriveFormatter class was actually inside the DevDriveStorageOperator.cs class just like the rest of the code to create a Dev Drive. However since this code has to live in the ElevatedComponent project in the SetupFlow issues arose since there are weird build errors that pop up due to multiple dll's getting produced because of the ElevatedComponent project. 

This affected the DevDriveStorageOperator class because to format a Dev Drive we're using the System.Management assembly which adds the System.Management.dll to the project. To prevent the multiple dll issue, the System.Management WMI code to format the Dev Drive was moved to its own class. In the future, depending on this fix we will need to solve the multiple dll issue that happens for the elevated component project or use another method to format the Dev Drive, which is not ideal as the other way is private and not public.

Also for future reference, here is the error that gets produced when you add a package reference to System.Management 7.0.0 in the ElevatedComponent Project in the settings flow as of today.


```
"C:\Users\bbonaby\repos\devhome\DevHome.sln" (default target) (1:2) ->
"C:\Users\bbonaby\repos\devhome\src\DevHome.csproj.metaproj" (default target) (22) ->
"C:\Users\bbonaby\repos\devhome\src\DevHome.csproj" (default target) (2:10) ->
(_ComputeAppxPackagePayload target) ->
  C:\Users\bbonaby\repos\devhome\packages\microsoft.windowsappsdk\1.2.230118.102\buildTransitive\Microsoft.Build.Msix.P
ackaging.targets(1504,5): error APPX1101: Payload contains two or more files with the same destination path 'System.Man
agement.dll'. Source files:  [C:\Users\bbonaby\repos\devhome\src\DevHome.csproj]
C:\Users\bbonaby\repos\devhome\packages\microsoft.windowsappsdk\1.2.230118.102\buildTransitive\Microsoft.Build.Msix.Pac
kaging.targets(1504,5): error APPX1101: C:\Users\bbonaby\repos\devhome\src\obj\x64\Release\net6.0-windows10.0.19041.0\w
in10-x64\R2R\System.Management.dll [C:\Users\bbonaby\repos\devhome\src\DevHome.csproj]
C:\Users\bbonaby\repos\devhome\packages\microsoft.windowsappsdk\1.2.230118.102\buildTransitive\Microsoft.Build.Msix.Pac
kaging.targets(1504,5): error APPX1101: C:\Users\bbonaby\repos\devhome\packages\system.management\7.0.0\lib\net6.0\Syst
em.Management.dll [C:\Users\bbonaby\repos\devhome\src\DevHome.csproj]
```


## Validation steps performed
Manually tested 
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
