### PR TITLE
Don't allow trying to add widgets if no widget service is installed

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -44,6 +44,13 @@ public sealed partial class AddWidgetDialog : ContentDialog
     {
         AddWidgetNavigationView.MenuItems.Clear();
 
+        if (_widgetCatalog is null)
+        {
+            // We should never have gotten here if we don't have a WidgetCatalog.
+            Log.Logger()?.ReportError("AddWidgetDialog", $"Opened the AddWidgetDialog, but WidgetCatalog is null.");
+            return;
+        }
+
         var providerDefs = _widgetCatalog.GetProviderDefinitions();
         var widgetDefs = _widgetCatalog.GetWidgetDefinitions();
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -68,6 +68,7 @@ public partial class DashboardView : ToolPage
         else
         {
             // TODO: show error
+            AddWidgetButton.IsEnabled = false;
         }
 
 #if DEBUG
@@ -95,7 +96,7 @@ public partial class DashboardView : ToolPage
         }
         catch (Exception ex)
         {
-            Log.Logger()?.ReportError("DashboardView", "Error in InitializeWidgetHost", ex);
+            Log.Logger()?.ReportError("DashboardView", "Exception in InitializeWidgetHost:", ex);
             return false;
         }
 


### PR DESCRIPTION
## Summary of the pull request
Once we ship with our own widget service, this should never happen, but if one is not installed (or we were otherwise unable to register with it), disable the AddWidgetButton so the user can't try to add a widget. If they do somehow open the dialog, log an error.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
