### PR TITLE
Preserve state in setup flow when navigating away

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
@@ -31,7 +31,7 @@ public static class ServiceExtensions
         services.AddSummary();
 
         // View-models
-        services.AddTransient<SetupFlowViewModel>();
+        services.AddSingleton<SetupFlowViewModel>();
 
         // Services
         services.AddSingleton<ISetupFlowStringResource, SetupFlowStringResource>();


### PR DESCRIPTION
## Summary of the pull request

Preserve the state of the Setup flow when going to the dashboard, settings, or any other page. This is done simply by making the setup page service a Singleton instead of Transient

![DevHome_CsnAS8jGMl](https://user-images.githubusercontent.com/14323496/231025577-351efd04-ae88-4786-88c2-8613f0f24573.gif)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
