### PR TITLE
Show scroll bars inside widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
@@ -23,11 +23,11 @@
             <StackPanel Orientation="Horizontal" Margin="15,10,15,5">
                 <Rectangle Width="16" Height="16" Margin="0,0,8,0"
                            Fill="{x:Bind views:DashboardView.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme),Mode=OneWay}"/>
-                <TextBlock Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}" VerticalAlignment="Center" FontSize="{ThemeResource CaptionTextBlockFontSize}"/>
+                <TextBlock Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}" VerticalAlignment="Center" FontSize="{ThemeResource CaptionTextBlockFontSize}" />
             </StackPanel>
             <Button Tag="{x:Bind}" Content="&#xE712;" 
                     FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{ThemeResource CaptionTextBlockFontSize}"
-                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="15,10,15,5" BorderThickness="0"
+                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="15,10,15,5" BorderThickness="0" Padding="5"
                     Background="Transparent"
                     Click="OpenWidgetMenu">
                 <Button.Flyout>
@@ -37,8 +37,8 @@
         </Grid>
 
         <!-- Widget content -->
-        <ScrollViewer Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}" Grid.Row="1" 
-                      VerticalScrollBarVisibility="Hidden" HorizontalScrollMode="Disabled"/>
+        <ScrollViewer x:Name="WidgetScrollViewer" Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}" Grid.Row="1" 
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" />
 
     </Grid>
 </UserControl>

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -18,6 +18,8 @@ public sealed partial class WidgetControl : UserControl
     public WidgetControl()
     {
         this.InitializeComponent();
+
+        WidgetScrollViewer.RegisterPropertyChangedCallback(ScrollViewer.ComputedVerticalScrollBarVisibilityProperty, OnWidgetScrollBarVisibilityChanged);
     }
 
     public WidgetViewModel WidgetSource
@@ -28,6 +30,21 @@ public sealed partial class WidgetControl : UserControl
 
     public static readonly DependencyProperty WidgetSourceProperty = DependencyProperty.Register(
         nameof(WidgetSource), typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
+
+    private void OnWidgetScrollBarVisibilityChanged(DependencyObject sender, DependencyProperty dp)
+    {
+        var padding = new Thickness(0, 0, 0, 0);
+
+        if (sender as ScrollViewer is ScrollViewer sv)
+        {
+            if (sv.ComputedVerticalScrollBarVisibility == Visibility.Visible)
+            {
+                padding.Right = 13;
+            }
+        }
+
+        WidgetScrollViewer.Padding = padding;
+    }
 
     private void OpenWidgetMenu(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## Summary of the pull request
Widgets that can scroll need their scroll bars to be visible for accessibility. When we can see the scroll bar, put a padding on the right side of the widget content so that the bar doesn't cover any content.

## References and relevant issues
http://task.ms/44123286

## Detailed description of the pull request / Additional comments
![image](https://user-images.githubusercontent.com/47155823/231199098-b2059bce-624a-4872-92b3-7d2c2543b315.png)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
