### PR TITLE
Use text from main page as title in setup flows

### DIFF
--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -11,7 +11,7 @@
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-        <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
+        <PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UseWinUI>true</UseWinUI>

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
@@ -8,7 +8,7 @@
     <ApplicationIcon>$(SolutionDir)\src\Assets\DevHome.ico</ApplicationIcon>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfileFullPath>$(SolutionDir)\src\Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfileFullPath>
+    <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfileFullPath>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>DevHome.SetupFlow.ElevatedServer.Program</StartupObject>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -29,8 +29,8 @@
             <TextBlock
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 TextWrapping="WrapWholeWords"
-                Visibility="{x:Bind UseDefaultTitle, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SetupShell_EndToEndTitle" />
+                Visibility="{x:Bind UseOrchestratorTitle, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                Text="{x:Bind Orchestrator.FlowTitle}" />
             <TextBlock
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 TextWrapping="WrapWholeWords"

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml.cs
@@ -45,7 +45,7 @@ public sealed partial class SetupShell : UserControl
         set => SetValue(OrchestratorProperty, value);
     }
 
-    public bool UseDefaultTitle => string.IsNullOrEmpty(Title);
+    public bool UseOrchestratorTitle => string.IsNullOrEmpty(Title);
 
     public SetupShell()
     {

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/SetupFlowOrchestrator.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/SetupFlowOrchestrator.cs
@@ -47,6 +47,9 @@ public partial class SetupFlowOrchestrator
     [NotifyCanExecuteChangedFor(nameof(GoToNextPageCommand))]
     private SetupPageViewModelBase _currentPageViewModel;
 
+    [ObservableProperty]
+    private string _flowTitle;
+
     /// <summary>
     /// Occurrs right before a page changes
     /// </summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -489,10 +489,6 @@
     <value>Search for apps and packages to install or select them below.</value>
     <comment>Description for the application management page</comment>
   </data>
-  <data name="SetupShell_EndToEndTitle.Text" xml:space="preserve">
-    <value>End-to-end setup</value>
-    <comment>Title for all the pages during an end-to-end setup flow</comment>
-  </data>
   <data name="SetupShell_RepoConfig.Description" xml:space="preserve">
     <value>Add private or public repositories to clone to you computer.</value>
     <comment>Description for the application management page</comment>
@@ -520,10 +516,6 @@
   <data name="MainPage_RepoReviewDescription.Text" xml:space="preserve">
     <value>Add private or public repositories to clone to your compuer</value>
     <comment>Description for the repo review page</comment>
-  </data>
-  <data name="MainPage_RepoReviewHeader.Text" xml:space="preserve">
-    <value>End-to-end flow</value>
-    <comment>Header for the repo review page</comment>
   </data>
   <data name="MainPage_RepoReview_AddRepository.Content" xml:space="preserve">
     <value>+ Add repository</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
@@ -24,7 +24,6 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
     /// Configuration file
     /// </summary>
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(TitleText))]
     [NotifyPropertyChangedFor(nameof(Content))]
     private Configuration _configuration;
 
@@ -52,11 +51,6 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         CanGoToNextPage = value;
         Orchestrator.NotifyNavigationCanExecuteChanged();
     }
-
-    /// <summary>
-    /// Gets the title for the configuration page
-    /// </summary>
-    public string TitleText => StringResource.GetLocalized(StringResourceKey.ConfigurationViewTitle, _configuration.Name);
 
     /// <summary>
     /// Gets the configuration file content
@@ -107,6 +101,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
             {
                 Log.Logger?.ReportInfo(Log.Component.Configuration, $"Selected file: {file.Path}");
                 Configuration = new (file.Path);
+                Orchestrator.FlowTitle = StringResource.GetLocalized(StringResourceKey.ConfigurationViewTitle, Configuration.Name);
                 var task = new ConfigureTask(StringResource, file);
                 await task.OpenConfigurationSetAsync();
                 TaskList.Add(task);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -38,7 +38,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     /// The orchestrator for the whole flow subscribes to this event to handle
     /// all the work needed at that point.
     /// </summary>
-    public event EventHandler<IList<ISetupTaskGroup>> StartSetupFlow;
+    public event EventHandler<(string, IList<ISetupTaskGroup>)> StartSetupFlow;
 
     public MainPageViewModel(
         ISetupFlowStringResource stringResource,
@@ -62,20 +62,27 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     /// <summary>
     /// Starts the setup flow including the pages for the given task groups.
     /// </summary>
+    /// <param name="flowTitle">Title to show in the flow; will use the SetupShell.Title property if empty</param>
     /// <param name="taskGroups">The task groups that will be included in this setup flow.</param>
+    private void StartSetupFlowForTaskGroups(string flowTitle, params ISetupTaskGroup[] taskGroups)
+    {
+        StartSetupFlow.Invoke(null, (flowTitle, taskGroups));
+    }
+
     private void StartSetupFlowForTaskGroups(params ISetupTaskGroup[] taskGroups)
     {
-        StartSetupFlow.Invoke(null, taskGroups);
+        StartSetupFlowForTaskGroups(string.Empty, taskGroups);
     }
 
     /// <summary>
     /// Starts a full setup flow, with all the possible task groups.
     /// </summary>
     [RelayCommand]
-    private void StartSetup()
+    private void StartSetup(string flowTitle)
     {
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Starting end-to-end setup");
         StartSetupFlowForTaskGroups(
+            flowTitle,
             _host.GetService<DevDriveTaskGroup>(),
             _host.GetService<RepoConfigTaskGroup>(),
             _host.GetService<AppManagementTaskGroup>());
@@ -85,10 +92,11 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     /// Starts a setup flow that only includes repo config.
     /// </summary>
     [RelayCommand]
-    private void StartRepoConfig()
+    private void StartRepoConfig(string flowTitle)
     {
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Starting flow for repo config");
         StartSetupFlowForTaskGroups(
+            flowTitle,
             _host.GetService<DevDriveTaskGroup>(),
             _host.GetService<RepoConfigTaskGroup>());
     }
@@ -97,10 +105,10 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     /// Starts a setup flow that only includes app management.
     /// </summary>
     [RelayCommand]
-    private void StartAppManagement()
+    private void StartAppManagement(string flowTitle)
     {
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Starting flow for app management");
-        StartSetupFlowForTaskGroups(_host.GetService<AppManagementTaskGroup>());
+        StartSetupFlowForTaskGroups(flowTitle,  _host.GetService<AppManagementTaskGroup>());
     }
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -34,8 +34,17 @@ public partial class SetupFlowViewModel : ObservableObject
             _mainPageViewModel,
         };
 
-        _mainPageViewModel.StartSetupFlow += (object sender, IList<ISetupTaskGroup> taskGroups) =>
+        _mainPageViewModel.StartSetupFlow += (object sender, (string, IList<ISetupTaskGroup>) args) =>
         {
+            var flowTitle = args.Item1;
+            var taskGroups = args.Item2;
+
+            // Don't reset the title when we get an empty string; we may have set it earlier to what we want
+            if (!string.IsNullOrEmpty(flowTitle))
+            {
+                Orchestrator.FlowTitle = flowTitle;
+            }
+
             Orchestrator.TaskGroups = taskGroups;
             SetFlowPagesFromCurrentTaskGroups();
         };

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
@@ -31,7 +31,7 @@
             </SplitButton.Flyout>
         </ToggleSplitButton>
     </setupFlowBehaviors:SetupFlowNavigationBehavior.NextTemplate>
-    <controls:SetupShell Title="{x:Bind ViewModel.TitleText, Mode=OneWay}">
+    <controls:SetupShell Orchestrator="{x:Bind ViewModel.Orchestrator}">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -59,7 +59,9 @@
                     <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_EnvironmentSetup" />
                     <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
                                        Style="{StaticResource MainPageCardStyle}"
-                                       IsClickEnabled="True" Command="{x:Bind ViewModel.StartSetupCommand}"
+                                       IsClickEnabled="True"
+                                       Command="{x:Bind ViewModel.StartSetupCommand}"
+                                       CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                        ActionIcon="{x:Null}" >
                         <labs:SettingsCard.HeaderIcon>
                             <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_EndToEnd.png" />
@@ -67,7 +69,9 @@
                     </labs:SettingsCard>
                     <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_ConfigurationFile"
                                        Style="{StaticResource MainPageCardStyle}"
-                                       IsClickEnabled="True" Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
+                                       IsClickEnabled="True"
+                                       Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
+                                       CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                        ActionIcon="{x:Null}" >
                         <labs:SettingsCard.HeaderIcon>
                             <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_ConfigurationFile.png" />
@@ -79,7 +83,9 @@
                     <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_QuickConfiguration" />
                     <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
                                        Style="{StaticResource MainPageCardStyle}"
-                                       IsClickEnabled="True" Command="{x:Bind ViewModel.StartRepoConfigCommand}"
+                                       IsClickEnabled="True"
+                                       Command="{x:Bind ViewModel.StartRepoConfigCommand}"
+                                       CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                        ActionIcon="{x:Null}" >
                         <labs:SettingsCard.HeaderIcon>
                             <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
@@ -87,7 +93,9 @@
                     </labs:SettingsCard>
                     <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
                                        Style="{StaticResource MainPageCardStyle}"
-                                       IsClickEnabled="True" Command="{x:Bind ViewModel.StartAppManagementCommand}"
+                                       IsClickEnabled="True"
+                                       Command="{x:Bind ViewModel.StartAppManagementCommand}"
+                                       CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                        ActionIcon="{x:Null}" >
                         <labs:SettingsCard.HeaderIcon>
                             <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_AppManagement.png" />


### PR DESCRIPTION
## Summary of the pull request

This changes the title in the setup flows to be the same text as in the setup flow home page.

## References and relevant issues

## Detailed description of the pull request / Additional comments

Changed the default title text in the SetupShell to use a new FlowTitle property from the orchestrator. Then, updated the cards that start each possible flow to pass their Header as a parameter to the command which starts the flow, which then sets it in the Orchestrator.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
