### PR TITLE
Don't cache widget icons on UI thread

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -105,9 +105,6 @@ public partial class DashboardView : ToolPage
 
     private async void OnActualThemeChanged(FrameworkElement sender, object args)
     {
-        // Widgets may have different icons for light vs dark theme, so if the theme changes, update the icons.
-        CacheWidgetIcons();
-
         // The app uses a different host config to render widgets (adaptive cards) in light and dark themes.
         await SetHostConfigOnWidgetRenderer();
     }
@@ -143,104 +140,97 @@ public partial class DashboardView : ToolPage
         return;
     }
 
-    private void OnLoaded(object sender, RoutedEventArgs e)
-    {
-        // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-        CacheWidgetIcons();
-        RestorePinnedWidgets(null, null);
-        CacheProviderIcons();
-    }
-
-    private void CacheWidgetIcons()
+    private async void OnLoaded(object sender, RoutedEventArgs e)
     {
         _widgetLightIconCache = new SortedDictionary<string, BitmapImage>();
         _widgetDarkIconCache = new SortedDictionary<string, BitmapImage>();
+        _providerIconCache = new SortedDictionary<string, BitmapImage>();
 
+        // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
+        await CacheWidgetIcons();
+        RestorePinnedWidgets(null, null);
+        await CacheProviderIcons();
+    }
+
+    private async Task CacheWidgetIcons()
+    {
         var widgetDefs = _widgetCatalog.GetWidgetDefinitions();
         foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
         {
-            CacheWidgetIcon(widgetDef);
+            await CacheWidgetIcon(widgetDef);
         }
     }
 
-    private void CacheWidgetIcon(WidgetDefinition widgetDef)
+    private async Task CacheWidgetIcon(WidgetDefinition widgetDef)
     {
         // Only cache icons for providers that we're including.
         if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
         {
-            _dispatcher.TryEnqueue(async () =>
+            var widgetDefId = widgetDef.Id;
+            try
             {
-                var widgetDefId = widgetDef.Id;
-                try
+                Log.Logger()?.ReportDebug("DashboardView", $"Cache widget icon for {widgetDefId}");
+                var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
+                var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
+
+                // There is a widget bug where Definition update events are being raised as added events.
+                // If we already have an icon for this key, just remove and add again.
+                if (_widgetLightIconCache.ContainsKey(widgetDefId))
                 {
-                    Log.Logger()?.ReportDebug("DashboardView", $"Cache widget icon for {widgetDefId}");
-                    var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
-                    var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
-
-                    // There is a widget bug where Definition update events are being raised as added events.
-                    // If we already have an icon for this key, just remove and add again.
-                    if (_widgetLightIconCache.ContainsKey(widgetDefId))
-                    {
-                        _widgetLightIconCache.Remove(widgetDefId);
-                    }
-
-                    if (_widgetDarkIconCache.ContainsKey(widgetDefId))
-                    {
-                        _widgetDarkIconCache.Remove(widgetDefId);
-                    }
-
-                    _widgetLightIconCache.Add(widgetDefId, itemLightImage);
-                    _widgetDarkIconCache.Add(widgetDefId, itemDarkImage);
+                    _widgetLightIconCache.Remove(widgetDefId);
                 }
-                catch (Exception ex)
+
+                if (_widgetDarkIconCache.ContainsKey(widgetDefId))
                 {
-                    Log.Logger()?.ReportError("DashboardView", $"Exception in CacheWidgetIcons:", ex);
-                    _widgetLightIconCache.Add(widgetDefId, null);
-                    _widgetDarkIconCache.Add(widgetDefId, null);
+                    _widgetDarkIconCache.Remove(widgetDefId);
                 }
-            });
+
+                _widgetLightIconCache.Add(widgetDefId, itemLightImage);
+                _widgetDarkIconCache.Add(widgetDefId, itemDarkImage);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportError("DashboardView", $"Exception in CacheWidgetIcons:", ex);
+                _widgetLightIconCache.Add(widgetDefId, null);
+                _widgetDarkIconCache.Add(widgetDefId, null);
+            }
         }
     }
 
-    private void CacheProviderIcons()
+    private async Task CacheProviderIcons()
     {
-        _providerIconCache = new SortedDictionary<string, BitmapImage>();
-
         var providerDefs = _widgetCatalog.GetProviderDefinitions();
         foreach (var providerDef in providerDefs)
         {
-            CacheProviderIcon(providerDef);
+            await CacheProviderIcon(providerDef);
         }
     }
 
-    private void CacheProviderIcon(WidgetProviderDefinition providerDef)
+    private async Task CacheProviderIcon(WidgetProviderDefinition providerDef)
     {
         // Only cache icons for providers that we're including.
         if (WidgetHelpers.IsIncludedWidgetProvider(providerDef))
         {
             var providerDefId = providerDef.Id;
-            _dispatcher.TryEnqueue(async () =>
+            try
             {
-                try
-                {
-                    Log.Logger()?.ReportDebug("DashboardView", $"Cache widget provider icon for {providerDefId}");
-                    var itemImage = await WidgetIconToBitmapImage(providerDef.Icon);
+                Log.Logger()?.ReportDebug("DashboardView", $"Cache widget provider icon for {providerDefId}");
+                var itemImage = await WidgetIconToBitmapImage(providerDef.Icon);
 
-                    // There is a widget bug where Definition update events are being raised as added events.
-                    // If we already have an icon for this key, just remove and add again.
-                    if (_providerIconCache.ContainsKey(providerDefId))
-                    {
-                        _providerIconCache.Remove(providerDefId);
-                    }
-
-                    _providerIconCache.Add(providerDefId, itemImage);
-                }
-                catch (Exception ex)
+                // There is a widget bug where Definition update events are being raised as added events.
+                // If we already have an icon for this key, just remove and add again.
+                if (_providerIconCache.ContainsKey(providerDefId))
                 {
-                    Log.Logger()?.ReportError("DashboardView", $"Exception in CacheProviderIcon:", ex);
-                    _providerIconCache.Add(providerDefId, null);
+                    _providerIconCache.Remove(providerDefId);
                 }
-            });
+
+                _providerIconCache.Add(providerDefId, itemImage);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportError("DashboardView", $"Exception in CacheProviderIcon:", ex);
+                _providerIconCache.Add(providerDefId, null);
+            }
         }
     }
 
@@ -371,9 +361,9 @@ public partial class DashboardView : ToolPage
         }
     }
 
-    private void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args)
+    private async void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args)
     {
-        CacheProviderIcon(args.ProviderDefinition);
+        await CacheProviderIcon(args.ProviderDefinition);
     }
 
     private void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args)
@@ -381,9 +371,9 @@ public partial class DashboardView : ToolPage
         _providerIconCache.Remove(args.ProviderDefinitionId);
     }
 
-    private void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
+    private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
-        CacheWidgetIcon(args.Definition);
+        await CacheWidgetIcon(args.Definition);
     }
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)


### PR DESCRIPTION
## Summary of the pull request
Widget icons shouldn't need to be cached on the UI thread. If we don't do that, we also don't have the bug where icons aren't showing up on previously-pinned widgets. Also, don't CacheWidgetIcons() OnActualThemeChanged. This was leftover from a version where I only cached the icons for the current theme. (We only have two widgets, soon to be 4. It's not a big deal to cache both themes. We can adjust for the future.) 

## References and relevant issues
http://task.ms/44119640

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
