### PR TITLE
Fix widgets sometimes not launching browser

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -20,6 +20,8 @@ public partial class WidgetViewModel : ObservableObject
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
     private readonly AdaptiveCardRenderer _renderer;
 
+    private RenderedAdaptiveCard _renderedCard;
+
     [ObservableProperty]
     private Widget _widget;
 
@@ -136,11 +138,16 @@ public partial class WidgetViewModel : ObservableObject
         {
             try
             {
-                var renderedCard = _renderer.RenderAdaptiveCard(card.AdaptiveCard);
-                if (renderedCard != null && renderedCard.FrameworkElement != null)
+                if (_renderedCard != null)
                 {
-                    renderedCard.Action += HandleAdaptiveAction;
-                    WidgetFrameworkElement = renderedCard.FrameworkElement;
+                    _renderedCard.Action -= HandleAdaptiveAction;
+                }
+
+                _renderedCard = _renderer.RenderAdaptiveCard(card.AdaptiveCard);
+                if (_renderedCard != null && _renderedCard.FrameworkElement != null)
+                {
+                    _renderedCard.Action += HandleAdaptiveAction;
+                    WidgetFrameworkElement = _renderedCard.FrameworkElement;
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
## Summary of the pull request
In order for a widget to open a URL in browser, we respond to the AdaptiveOpenUrlAction on the rendered card. Sometimes the event wasn't being raised -- I think it's because we weren't saving the rendered card and the subscription was going away. 

## References and relevant issues
http://task.ms/44162551

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
