### PR TITLE
Use internal cloning if no providers can clone a url.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -34,7 +34,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
     <ProjectReference Include="..\..\..\logging\DevHome.Logging.csproj" />
-    <ProjectReference Include="..\..\Dashboard\DevHome.Dashboard\DevHome.Dashboard.csproj" />
     <ProjectReference Include="..\DevHome.SetupFlow.Common\DevHome.SetupFlow.Common.csproj" />
     <ProjectReference Include="..\DevHome.SetupFlow.ElevatedComponent.Projection\DevHome.SetupFlow.ElevatedComponent.Projection.csproj">
       <Aliases>Projection</Aliases>

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/GenericRepository.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/GenericRepository.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using DevHome.Dashboard.Helpers;
+using DevHome.SetupFlow.Common.Helpers;
 using LibGit2Sharp;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Foundation;
@@ -48,22 +48,22 @@ internal class GenericRepository : Microsoft.Windows.DevHome.SDK.IRepository
                 }
                 catch (RecurseSubmodulesException recurseException)
                 {
-                    Log.Logger()?.ReportError("GenericRepository", "Could not clone all sub modules", recurseException);
+                    Log.Logger?.ReportError("GenericRepository", "Could not clone all sub modules", recurseException);
                     throw;
                 }
                 catch (UserCancelledException userCancelledException)
                 {
-                    Log.Logger()?.ReportError("GenericRepository", "The user stoped the clone operation", userCancelledException);
+                    Log.Logger?.ReportError("GenericRepository", "The user stoped the clone operation", userCancelledException);
                     throw;
                 }
                 catch (NameConflictException nameConflictException)
                 {
-                    Log.Logger()?.ReportError("GenericRepository", nameConflictException);
+                    Log.Logger?.ReportError("GenericRepository", nameConflictException);
                     throw;
                 }
                 catch (Exception e)
                 {
-                    Log.Logger()?.ReportError("GenericRepository", "Could not clone the repository", e);
+                    Log.Logger?.ReportError("GenericRepository", "Could not clone the repository", e);
                     throw;
                 }
             }


### PR DESCRIPTION
## Summary of the pull request
Letting users enter any URL gave the impression that any git url can be provided.  This code allows that to happen if no other extension can clone the url.

However, this works only with public repos.  Trying to clone a private repo will not work.

## References and relevant issues
[ADO](https://microsoft.visualstudio.com/OS/_queries/edit/44119819/?triage=true)

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually tested.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated


Movie!
![CloningAGitlabRepo](https://user-images.githubusercontent.com/2517139/231872119-1df50dc8-1915-4008-b45c-3be3941db81d.gif)
