### PR TITLE
Pre-select a widget in the add widget dialog

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -38,6 +38,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         _widgetCatalog = catalog;
 
         FillAvailableWidgets();
+        SelectFirstWidgetByDefault();
     }
 
     private void FillAvailableWidgets()
@@ -161,6 +162,19 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
 
         return false;
+    }
+
+    private void SelectFirstWidgetByDefault()
+    {
+        if (AddWidgetNavigationView.MenuItems.Count > 0)
+        {
+            var firstProvider = AddWidgetNavigationView.MenuItems[0] as NavigationViewItem;
+            if (firstProvider.MenuItems.Count > 0)
+            {
+                var firstWidget = firstProvider.MenuItems[0] as NavigationViewItem;
+                AddWidgetNavigationView.SelectedItem = firstWidget;
+            }
+        }
     }
 
     private async void AddWidgetNavigationView_SelectionChanged(


### PR DESCRIPTION
## Summary of the pull request
Currently we make a user select a widget in the Add Widget dialog before they see anything. Select the first one (the Issues widget) for them.

## References and relevant issues
http://task.ms/44162415

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
