### PR TITLE
Don't show provider icons in AddWidgetDialog

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -64,15 +64,12 @@ public sealed partial class AddWidgetDialog : ContentDialog
         {
             if (WidgetHelpers.IsIncludedWidgetProvider(providerDef))
             {
-                var itemContent = BuildProviderNavItem(providerDef);
                 var navItem = new NavigationViewItem
                 {
                     IsExpanded = true,
                     Tag = providerDef,
-                    Content = itemContent,
+                    Content = providerDef.DisplayName,
                 };
-
-                navItem.Content = itemContent;
 
                 foreach (var widgetDef in widgetDefs)
                 {
@@ -99,12 +96,6 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
     }
 
-    private StackPanel BuildProviderNavItem(WidgetProviderDefinition providerDefinition)
-    {
-        var image = DashboardView.GetProviderIcon(providerDefinition);
-        return BuildNavItem(image, providerDefinition.DisplayName);
-    }
-
     private StackPanel BuildWidgetNavItem(WidgetDefinition widgetDefinition)
     {
         var image = DashboardView.GetWidgetIconForTheme(widgetDefinition, ActualTheme);
@@ -122,12 +113,13 @@ public sealed partial class AddWidgetDialog : ContentDialog
         {
             var itemSquare = new Rectangle()
             {
-                MinWidth = 20,
-                MinHeight = 20,
+                Width = 16,
+                Height = 16,
                 Margin = new Thickness(0, 0, 10, 0),
                 Fill = new ImageBrush
                 {
                     ImageSource = image,
+                    Stretch = Stretch.Uniform,
                 },
             };
 


### PR DESCRIPTION
## Summary of the pull request
Provider icons can't be themed. They don't work well in our AddWidgetDialog, so don't show them.
Any resulting margin weirdness can be decided on by Design later.

## References and relevant issues

## Detailed description of the pull request / Additional comments
![image](https://user-images.githubusercontent.com/47155823/231921594-4c68359f-71ce-4cf1-93c8-7d0cb639c88e.png)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
