### PR TITLE
Staging/Release branches will publish to store now

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -333,8 +333,8 @@ stages:
             artifactName: MsixBundle_${{ configuration }}
             targetPath: AppxBundles\${{ configuration }}
 
-- stage: Build_MsixBundle
-  dependsOn: Build_DevHome
+- stage: Store_Publish
+  dependsOn: Build_MsixBundle
   jobs:
   - job: Store_Publish
     steps:
@@ -346,7 +346,7 @@ stages:
 
     - task: MS-RDX-MRO.windows-store-publish-dev.publish-task.store-publish@2
       displayName: 'Publish Staging build to store - NEEDS TO BE CHANGED TO CANARY STORE ENTRY WHEN AVAILABLE'
-      condition: ne('$(BuildingBranch)', 'staging')
+      condition: eq('$(BuildingBranch)', 'staging')
       inputs:
         serviceEndpoint: 'DevHome StoreBroker'
         appId: 9N8MHTPHNGVV
@@ -356,7 +356,7 @@ stages:
 
     - task: MS-RDX-MRO.windows-store-publish-dev.publish-task.store-publish@2
       displayName: 'Publish Release build to store'
-      condition: ne('$(BuildingBranch)', 'release')
+      condition: eq('$(BuildingBranch)', 'release')
       inputs:
         serviceEndpoint: 'DevHome StoreBroker'
         appId: 9N8MHTPHNGVV


### PR DESCRIPTION
## Summary of the pull request
This will enable single action for publishing staging/release builds.  We just need to do a PR from main>staging or staging>release.  After the PR is done, a build will be auto triggered using the mirrored ADO repos.  Once sucessful, the msixbundle_release will be published to the store.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
