### PR TITLE
Add/Edit widget dialog fixes

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -57,9 +57,10 @@
                 </Grid.RowDefinitions>
 
                 <ScrollViewer Grid.Row="0"
+                              Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}"
                               VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch"
                               MinHeight="530" MaxHeight="530">
-                    <Frame x:Name="ConfigurationContentFrame" 
+                    <Frame x:Name="ConfigurationContentFrame" Margin="45,45,45,0"
                            Content="{x:Bind ViewModel.WidgetFrameworkElement, Mode=OneWay}" />
                 </ScrollViewer>
 
@@ -70,7 +71,7 @@
                             Visibility="Collapsed"
                             Height="32" Width="118"
                             Click="PinButton_Click"
-                            Margin="0,43" />
+                            Margin="0,40" />
                 </Grid>
             </Grid>
         </NavigationView>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -29,13 +29,17 @@ public sealed partial class AddWidgetDialog : ContentDialog
         WidgetHost host,
         WidgetCatalog catalog,
         AdaptiveCardRenderer renderer,
-        DispatcherQueue dispatcher)
+        DispatcherQueue dispatcher,
+        ElementTheme theme)
     {
         ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, null, renderer, dispatcher);
         this.InitializeComponent();
 
         _widgetHost = host;
         _widgetCatalog = catalog;
+
+        // Strange behavior: setting the requested theme in the constructor isn't enough, so do it here.
+        RequestedTheme = theme;
 
         FillAvailableWidgets();
         SelectFirstWidgetByDefault();

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -8,8 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Style="{StaticResource DefaultContentDialogStyle}"
-    Background="{StaticResource NavigationViewContentBackground}">
+    Style="{StaticResource DefaultContentDialogStyle}">
 
     <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
     <ContentDialog.Resources>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -103,16 +103,27 @@ public partial class DashboardView : ToolPage
         return true;
     }
 
+    private async Task<AdaptiveCardRenderer> GetConfigurationRendererAsync()
+    {
+        // When we render a card in an add or edit dialog, we need to have a different Hostonfig,
+        // so create a new renderer for those situations. We can't just temporarily edit the existing
+        // renderer, because a pinned widget might get re-rendered the wrong way while the dialog is open.
+        var configRenderer = new AdaptiveCardRenderer();
+        await SetHostConfigOnWidgetRenderer(configRenderer);
+        configRenderer.HostConfig.ContainerStyles.Default.BackgroundColor = Microsoft.UI.Colors.Transparent;
+        return configRenderer;
+    }
+
     private async void OnActualThemeChanged(FrameworkElement sender, object args)
     {
         // Widgets may have different icons for light vs dark theme, so if the theme changes, update the icons.
         CacheWidgetIcons();
 
         // The app uses a different host config to render widgets (adaptive cards) in light and dark themes.
-        await SetHostConfigOnWidgetRenderer();
+        await SetHostConfigOnWidgetRenderer(_renderer);
     }
 
-    private async Task SetHostConfigOnWidgetRenderer()
+    private async Task SetHostConfigOnWidgetRenderer(AdaptiveCardRenderer renderer)
     {
         var hostConfigContents = string.Empty;
         var hostConfigFileName = (ActualTheme == ElementTheme.Light) ? "HostConfigLight.json" : "HostConfigDark.json";
@@ -132,7 +143,7 @@ public partial class DashboardView : ToolPage
         {
             if (!string.IsNullOrEmpty(hostConfigContents))
             {
-                _renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
+                renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
             }
             else
             {
@@ -287,7 +298,7 @@ public partial class DashboardView : ToolPage
     private async void RestorePinnedWidgets(object sender, RoutedEventArgs e)
     {
         // TODO: Ideally there would be some sort of visual loading indicator while the renderer gets set up.
-        await SetHostConfigOnWidgetRenderer();
+        await SetHostConfigOnWidgetRenderer(_renderer);
 
         Log.Logger()?.ReportInfo("DashboardView", "Get widgets for current host");
         var pinnedWidgets = _widgetHost.GetWidgets();
@@ -325,7 +336,8 @@ public partial class DashboardView : ToolPage
 
     private async void AddWidgetButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddWidgetDialog(_widgetHost, _widgetCatalog, _renderer, _dispatcher)
+        var configurationRenderer = await GetConfigurationRendererAsync();
+        var dialog = new AddWidgetDialog(_widgetHost, _widgetCatalog, configurationRenderer, _dispatcher, ActualTheme)
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.
             XamlRoot = this.XamlRoot,
@@ -492,7 +504,8 @@ public partial class DashboardView : ToolPage
         var originalSize = widgetViewModel.WidgetSize;
         var widgetDef = _widgetCatalog.GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
 
-        var dialog = new CustomizeWidgetDialog(_widgetHost, _renderer, _dispatcher, widgetDef)
+        var configurationRenderer = await GetConfigurationRendererAsync();
+        var dialog = new CustomizeWidgetDialog(_widgetHost, configurationRenderer, _dispatcher, widgetDef)
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.
             XamlRoot = this.XamlRoot,


### PR DESCRIPTION
## Summary of the pull request
Give nice padding to the AddWidgetDialog adaptive card content. In order to do that, we need to set the background to the widget's desired background color, and render the widget transparent -- otherwise, the transparencies layer and the adaptive card has a different background than desired, and it doesn't look good.

To render the widget in those scenarios with a different background, we create a renderer on demand for those dialogs. We can't just re-use the old one with different settings, because a widget may re-render while the dialog is open, and then that pinned widget will have no background.

Work around a bug where widget icons in the AddWidgetDialog were using the wrong theme -- setting the theme in the constructor actually sets the ActualTheme, whereas setting it when we new up the AddWidgetDialog doesn't.

Fix bug where CustomizeWidgetDialog had bad background.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
