### PR TITLE
Resize banner text and banner gets smaller

### DIFF
--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -12,7 +12,7 @@
 
         <!-- Set Min sizes so that image gets clipped as window narrows, rather than scaling down -->
         <Image Stretch="Uniform" Source="{x:Bind OverlaySource, Mode=OneWay}" 
-               Margin="0 0 0 0" Height="214" Width="924" MinHeight="214" MinWidth="924"/>
+               Margin="0 0 0 0" MinHeight="214" MinWidth="{ThemeResource MaxPageContentWidth}"/>
 
         <!-- Hide Banner Button -->
         <Button HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10"
@@ -25,12 +25,12 @@
         </Button>
         <StackPanel VerticalAlignment="Center" Margin="38 0 0 0" Spacing="12">
             <TextBlock
-                Width="{x:Bind TextWidth}"
+                MaxWidth="{x:Bind TextWidth}"
                 HorizontalAlignment="Left"
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 Text="{x:Bind Title}"/>
             <TextBlock
-                Width="{x:Bind TextWidth}"
+                MaxWidth="{x:Bind TextWidth}"
                 HorizontalAlignment="Left"
                 TextWrapping="Wrap"
                 Text="{x:Bind Description}"/>

--- a/common/Views/Banner.xaml.cs
+++ b/common/Views/Banner.xaml.cs
@@ -8,60 +8,106 @@ using Microsoft.UI.Xaml.Controls;
 namespace DevHome.Common.Views;
 public sealed partial class Banner : UserControl
 {
+    /// <summary>
+    /// Gets or sets the title to display on the Banner.
+    /// </summary>
     public string Title
     {
         get => (string)GetValue(TitleProperty);
         set => SetValue(TitleProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the description to display on the Banner.
+    /// </summary>
     public string Description
     {
         get => (string)GetValue(DescriptionProperty);
         set => SetValue(DescriptionProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the maximum width of the Title and Description text.
+    /// </summary>
+    /// <remarks>
+    /// This value should be set so that the text does not overlap with the Overlay image.
+    /// </remarks>
     public int TextWidth
     {
         get => (int)GetValue(TextWidthProperty);
         set => SetValue(TextWidthProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the path to the image resource used as the background image on the banner.
+    /// </summary>
+    /// <remarks>
+    /// This image will be scaled to the maximum size of the Banner. It is expected to have content for the entire size
+    /// of the banner.
+    /// </remarks>
     public string BackgroundSource
     {
         get => (string)GetValue(BackgroundSourceProperty);
         set => SetValue(BackgroundSourceProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the path to the image resource used as the overlaid image on the banner.
+    /// </summary>
+    /// <remarks>
+    /// This image will be scaled to the maximum size of the Banner. It is expected that the left side will not have
+    /// content, as to not overlap the Banner text. It should also have a transparent background, to let the Background
+    /// image show through.
+    /// </remarks>
     public string OverlaySource
     {
         get => (string)GetValue(OverlaySourceProperty);
         set => SetValue(OverlaySourceProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the text displayed on the Banner's action buttton.
+    /// </summary>
     public string ButtonText
     {
         get => (string)GetValue(ButtonTextProperty);
         set => SetValue(ButtonTextProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the command that will be executed when the Banner's action button is invoked.
+    /// </summary>
     public ICommand ButtonCommand
     {
         get => (ICommand)GetValue(ButtonCommandProperty);
         set => SetValue(ButtonCommandProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the Button's hide button is shown.
+    /// </summary>
     public bool HideButtonVisibility
     {
         get => (bool)GetValue(HideButtonVisibilityProperty);
         set => SetValue(HideButtonVisibilityProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the command that will be executed when the Banner's hide button is invoked.
+    /// </summary>
     public ICommand HideButtonCommand
     {
         get => (ICommand)GetValue(HideButtonCommandProperty);
         set => SetValue(HideButtonCommandProperty, value);
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Banner"/> class.
+    /// </summary>
+    /// <remarks>
+    /// Use this control to put a banner at the top of your Dev Home page. It can optionally be dismissed and not shown
+    /// again on subsequent app launches.
+    /// </remarks>
     public Banner()
     {
         this.InitializeComponent();
@@ -74,6 +120,6 @@ public sealed partial class Banner : UserControl
     public static readonly DependencyProperty OverlaySourceProperty = DependencyProperty.Register(nameof(OverlaySource), typeof(string), typeof(Banner), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty ButtonTextProperty = DependencyProperty.Register(nameof(ButtonText), typeof(string), typeof(Banner), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty ButtonCommandProperty = DependencyProperty.Register(nameof(ButtonCommand), typeof(ICommand), typeof(Banner), new PropertyMetadata(null));
-    public static readonly DependencyProperty HideButtonVisibilityProperty = DependencyProperty.Register(nameof(HideButtonVisibility), typeof(bool), typeof(Banner), new PropertyMetadata(false));
+    public static readonly DependencyProperty HideButtonVisibilityProperty = DependencyProperty.Register(nameof(HideButtonVisibility), typeof(bool), typeof(Banner), new PropertyMetadata(true));
     public static readonly DependencyProperty HideButtonCommandProperty = DependencyProperty.Register(nameof(HideButtonCommand), typeof(ICommand), typeof(Banner), new PropertyMetadata(null));
 }

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -13,7 +13,7 @@
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     </Page.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto"  MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <StackPanel Margin="{StaticResource XSmallTopMargin}">
             <Grid x:Name="Settings_Breadcrumbs" Margin="{StaticResource SettingsPageSubTitleMargin}">
                 <Grid.ColumnDefinitions>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -38,7 +38,7 @@
         </DataTemplate>
     </Page.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto"  MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <StackPanel x:Name="AccountsContentArea">
             <Grid x:Name="Settings_Breadcrumbs" Margin="{StaticResource SettingsPageSubTitleMargin}">
                 <Grid.ColumnDefinitions>

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetBoard.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetBoard.cs
@@ -44,7 +44,7 @@ public sealed class WidgetBoard : Panel
     }
 
     /// <summary>
-    /// Identifies the <see cref="WidgetWidth"/> dependency property. The defaultt value is 300.
+    /// Identifies the <see cref="WidgetWidth"/> dependency property. The default value is 300.
     /// </summary>
     /// <returns>The identifier for the <see cref="WidgetWidth"/> dependency property.</returns>
     public static readonly DependencyProperty WidgetWidthProperty = DependencyProperty.Register(


### PR DESCRIPTION
## Summary of the pull request
If the app window is resized smaller, the text in the banner should wrap rather than being cut off. Do this by setting MaxWidth, rather than Width.

## References and relevant issues
http://task.ms/44123340

## Detailed description of the pull request / Additional comments
- Fixed some whitespace in Settings pages
- Use themeresource rather than magic number for banner overlay image width
- Add comments to Banner properties
- Change HideButtonVisibilityProperty default to true, since it is true in all current uses.
- Fixed typo in WidgetBoard comment

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
