### PR TITLE
Hide elevated process window

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Elevation/IPCSetup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Elevation/IPCSetup.cs
@@ -190,7 +190,7 @@ public static class IPCSetup
             {
                 FileName = serverPath,
                 Arguments = serverArgs,
-                //// CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
                 UseShellExecute = true,
                 Verb = "runas",
             };


### PR DESCRIPTION
## Summary of the pull request

This prevents the elevated helper process from showing a console window during setup.