### PR TITLE
Fix letter capitalization bug

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -618,7 +618,7 @@
     <comment>Content for the primary button in the edit clone path dialog.</comment>
   </data>
   <data name="LoadingPage_HeaderBottomRow.Text" xml:space="preserve">
-    <value>stay tuned for the magic...</value>
+    <value>Stay tuned for the magic...</value>
     <comment>Bottom row of the header for the loading page.</comment>
   </data>
   <data name="LoadingPage_HeaderTopRow.Text" xml:space="preserve">


### PR DESCRIPTION
Fixes the latter capitalization bug in setup tool page. "Stay tuned for magic" instead of "stay tuned for magic"
