### PR TITLE
Show message when no widgets are pinned

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -118,4 +118,12 @@
     <value>Dashboard</value>
     <comment>Header label for the Dashboard page</comment>
   </data>
+  <data name="NoWidgetsPinned.Text" xml:space="preserve">
+    <value>Pin a widget here</value>
+    <comment>Shown when no widgets are pinned</comment>
+  </data>
+  <data name="AddFirstWidgetLink.Content" xml:space="preserve">
+    <value>+ Add new widget</value>
+    <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't pinned any widgets.</comment>
+  </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -78,6 +78,11 @@
                         </Style>
                     </GridView.ItemContainerStyle>
                 </GridView>
+
+                <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                    <TextBlock x:Uid="NoWidgetsPinned" HorizontalAlignment="Center" />
+                    <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" Click="AddWidgetButton_Click" HorizontalAlignment="Center" />
+                </StackPanel>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -69,6 +69,7 @@ public partial class DashboardView : ToolPage
         {
             // TODO: show error
             AddWidgetButton.IsEnabled = false;
+            AddFirstWidgetLink.IsEnabled = false;
         }
 
 #if DEBUG
@@ -321,6 +322,7 @@ public partial class DashboardView : ToolPage
         else
         {
             Log.Logger()?.ReportInfo("DashboardView", $"Found 0 widgets for this host");
+            NoWidgetsStackPanel.Visibility = Visibility.Visible;
         }
     }
 
@@ -469,6 +471,8 @@ public partial class DashboardView : ToolPage
                 item.PropertyChanged += PinnedWidgetsPropertyChanged;
             }
         }
+
+        NoWidgetsStackPanel.Visibility = (PinnedWidgets.Count > 0) ? Visibility.Collapsed : Visibility.Visible;
     }
 
     private async void PinnedWidgetsPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request
Show a message and link to pin a widget if no widgets are pinned. Disable the link if there's no widget service. CommunityToolkit CollectionVisibilityConverter wouldn't work, so just do it manually.

## References and relevant issues

## Detailed description of the pull request / Additional comments
![image](https://user-images.githubusercontent.com/47155823/232857519-66b5948c-03de-4299-902e-0a537b1baa44.png)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
