### PR TITLE
Single instancing & protocol activation

### DIFF
--- a/common/Services/INavigationService.cs
+++ b/common/Services/INavigationService.cs
@@ -20,6 +20,11 @@ public interface INavigationService
         get; set;
     }
 
+    string DefaultPage
+    {
+        get; set;
+    }
+
     bool NavigateTo(string pageKey, object? parameter = null, bool clearNavigation = false);
 
     bool GoBack();

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -17,13 +17,17 @@ using DevHome.ViewModels;
 using DevHome.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppLifecycle;
 
 namespace DevHome;
 
 // To learn more about WinUI 3, see https://docs.microsoft.com/windows/apps/winui/winui3/.
 public partial class App : Application, IApp
 {
+    private readonly DispatcherQueue _dispatcherQueue;
+
     // The .NET Generic Host provides dependency injection, configuration, logging, and other services.
     // https://docs.microsoft.com/dotnet/core/extensions/generic-host
     // https://docs.microsoft.com/dotnet/core/extensions/dependency-injection
@@ -44,6 +48,7 @@ public partial class App : Application, IApp
     public App()
     {
         InitializeComponent();
+        _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
         Host = Microsoft.Extensions.Hosting.Host.
         CreateDefaultBuilder().
@@ -51,9 +56,10 @@ public partial class App : Application, IApp
         ConfigureServices((context, services) =>
         {
             // Default Activation Handler
-            services.AddTransient<ActivationHandler<LaunchActivatedEventArgs>, DefaultActivationHandler>();
+            services.AddTransient<ActivationHandler<Microsoft.UI.Xaml.LaunchActivatedEventArgs>, DefaultActivationHandler>();
 
             // Other Activation Handlers
+            services.AddTransient<IActivationHandler, ProtocolActivationHandler>();
 
             // Services
             services.AddSingleton<ILocalSettingsService, LocalSettingsService>();
@@ -97,6 +103,7 @@ public partial class App : Application, IApp
         Build();
 
         UnhandledException += App_UnhandledException;
+        AppInstance.GetCurrent().Activated += OnActivated;
     }
 
     private async void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
@@ -106,11 +113,19 @@ public partial class App : Application, IApp
         await GetService<IPluginService>().SignalStopPluginsAsync();
     }
 
-    protected async override void OnLaunched(LaunchActivatedEventArgs args)
+    protected async override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
     {
         base.OnLaunched(args);
 
-        await GetService<IActivationService>().ActivateAsync(args);
+        await GetService<IActivationService>().ActivateAsync(AppInstance.GetCurrent().GetActivatedEventArgs().Data);
         await GetService<IAccountsService>().InitializeAsync();
+    }
+
+    private void OnActivated(object? sender, AppActivationArguments args)
+    {
+        _dispatcherQueue.TryEnqueue(async () =>
+        {
+            await GetService<IActivationService>().ActivateAsync(args.Data);
+        });
     }
 }

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -71,4 +71,23 @@
     <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
         <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
     </PropertyGroup>
+	
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+	</PropertyGroup>
 </Project>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -25,6 +25,11 @@
             <uap3:Name>com.microsoft.devhome</uap3:Name>
           </uap3:AppExtensionHost>
         </uap3:Extension>
+		<uap:Extension Category="windows.protocol">
+		  <uap:Protocol Name="ms-devhome">
+		    <uap:DisplayName>Dev Home</uap:DisplayName>
+		  </uap:Protocol>
+		</uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.Windows.AppLifecycle;
+using Windows.ApplicationModel.Activation;
+
+namespace DevHome;
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+
+        var isRedirect = DecideRedirection().GetAwaiter().GetResult();
+
+        if (!isRedirect)
+        {
+            Microsoft.UI.Xaml.Application.Start((p) =>
+            {
+                var dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+                var context = new DispatcherQueueSynchronizationContext(dispatcherQueue);
+                SynchronizationContext.SetSynchronizationContext(context);
+                var app = new App();
+            });
+        }
+    }
+
+    private static async Task<bool> DecideRedirection()
+    {
+        var mainInstance = Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey("main");
+        var activatedEventArgs = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
+
+        if (!mainInstance.IsCurrent)
+        {
+            // Redirect the activation (and args) to the "main" instance, and exit.
+            await mainInstance.RedirectActivationToAsync(activatedEventArgs);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Services/NavigationService.cs
+++ b/src/Services/NavigationService.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
 using DevHome.Contracts.ViewModels;
+using DevHome.Dashboard.ViewModels;
 using DevHome.Helpers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -18,6 +19,7 @@ public class NavigationService : INavigationService
     private readonly IPageService _pageService;
     private object? _lastParameterUsed;
     private Frame? _frame;
+    private string? _defaultPage;
 
     public event NavigatedEventHandler? Navigated;
 
@@ -40,6 +42,12 @@ public class NavigationService : INavigationService
             _frame = value;
             RegisterFrameEvents();
         }
+    }
+
+    public string DefaultPage
+    {
+        get => _defaultPage ?? typeof(DashboardViewModel).FullName ?? string.Empty;
+        set => _defaultPage = value;
     }
 
     [MemberNotNullWhen(true, nameof(Frame), nameof(_frame))]

--- a/src/Services/ProtocolActivationHandler.cs
+++ b/src/Services/ProtocolActivationHandler.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHome.Activation;
+using DevHome.Common.Services;
+using DevHome.Settings.ViewModels;
+using Windows.ApplicationModel.Activation;
+
+namespace DevHome.Services;
+public class ProtocolActivationHandler : ActivationHandler<ProtocolActivatedEventArgs>
+{
+    private const string SettingsAccountsUri = "settings/accounts";
+
+    private readonly INavigationService _navigationService;
+
+    public ProtocolActivationHandler(INavigationService navigationService)
+    {
+        this._navigationService = navigationService;
+    }
+
+    protected override Task HandleInternalAsync(ProtocolActivatedEventArgs args)
+    {
+        if (args.Uri.AbsolutePath == SettingsAccountsUri)
+        {
+            _navigationService.DefaultPage = typeof(AccountsViewModel).FullName!;
+            _navigationService.NavigateTo(_navigationService.DefaultPage);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -52,7 +52,7 @@ public class ShellViewModel : ObservableRecipient
     {
         if (await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstRun))
         {
-            NavigationService.NavigateTo(typeof(DashboardViewModel).FullName!);
+            NavigationService.NavigateTo(NavigationService.DefaultPage);
         }
         else
         {


### PR DESCRIPTION
This PR makes the following changes to Dev Home:

1. Makes the app single instanced instead of the default multi instanced
2. Allows protocol activation with "ms-devhome" uri host.
3. Allows protocol activation to go to "settings > accounts" using uri "ms-devhome:settings/accounts"
