### PR TITLE
Page backgrounds should be the same as the NavigationView Pane background

### DIFF
--- a/src/Views/ShellPage.xaml
+++ b/src/Views/ShellPage.xaml
@@ -46,8 +46,8 @@
                             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource NavigationViewExpandedPaneBackground}" />
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="HighContrast">
-                            <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{ThemeResource NavigationViewExpandedPaneBackground}" />
-                            <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{ThemeResource NavigationViewExpandedPaneBackground}" />
+                            <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{ThemeResource SystemColorWindowColor}" />
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request
Set colors on the ShellPage Navigation view. Works in light, dark, and high contrast themes.

## References and relevant issues

## Detailed description of the pull request / Additional comments
![image](https://user-images.githubusercontent.com/47155823/233484880-0112b8b2-793c-463f-a588-6e73b46dea1a.png)


## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
