### PR TITLE
Handle winget ElevationRequirement=ElevatesSelf

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
@@ -80,11 +80,11 @@ public class WinGetPackage : IWinGetPackage
             // TODO Use the API contract version to check if this method can be
             // called instead of a try/catch
             Log.Logger?.ReportInfo(Log.Component.AppManagement, $"Getting applicable installer info for package {Id}");
-            var appInstaller = _package.DefaultInstallVersion.GetApplicableInstaller(options);
-            if (appInstaller != null)
+            var applicableInstaller = _package.DefaultInstallVersion.GetApplicableInstaller(options);
+            if (applicableInstaller != null)
             {
-                Log.Logger?.ReportInfo(Log.Component.AppManagement, $"Elevation requirement = {appInstaller.ElevationRequirement} for package {Id}");
-                return appInstaller.ElevationRequirement == ElevationRequirement.ElevationRequired;
+                Log.Logger?.ReportInfo(Log.Component.AppManagement, $"Elevation requirement = {applicableInstaller.ElevationRequirement} for package {Id}");
+                return applicableInstaller.ElevationRequirement == ElevationRequirement.ElevationRequired || applicableInstaller.ElevationRequirement == ElevationRequirement.ElevatesSelf;
             }
             else
             {


### PR DESCRIPTION
## Summary of the pull request

When we determine if a an app needs elevation to install we get the metadata from winget about ElevationRequirement. We only considered ElevationRequirement=ElevationRequired, but not ElevationRequirement=ElevatesSelf. This caused us to get individual UAC prompts for packages with that elevation requirement, instead of it being included in the single prompt.

This changes to also consider ElevatesSelf