### PR TITLE
Add border to widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
@@ -46,12 +46,12 @@
   },
   "containerStyles": {
     "default": {
-      "backgroundColor": "#B3FFFFFF",
-      "borderColor": "#B3FFFFFF",
+      "backgroundColor": "#B4FFFFFF",
+      "borderColor": "#B4FFFFFF",
       "foregroundColors": {
         "default": {
-          "default": "#000000",
-          "subtle": "#606060"
+          "default": "#E6000000",
+          "subtle": "#99000000"
         },
         "accent": {
           "default": "#0063B1",
@@ -72,12 +72,12 @@
       }
     },
     "emphasis": {
-      "backgroundColor": "#B3FFFFFF",
-      "borderColor": "#B3FFFFFF",
+      "backgroundColor": "#80F6F6F6",
+      "borderColor": "#80F6F6F6",
       "foregroundColors": {
         "default": {
-          "default": "#000000",
-          "subtle": "#606060"
+          "default": "#E6000000",
+          "subtle": "#99000000"
         },
         "accent": {
           "default": "#2E89FC",

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
@@ -11,8 +11,21 @@
     xmlns:helpers="using:DevHome.Dashboard.Helpers"
     mc:Ignorable="d">
 
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <Color x:Key="WidgetBorderColor">#0F000000</Color>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="WidgetBorderColor">#1A000000</Color>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
     <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize), Mode=OneWay}" 
-          CornerRadius="7">
+          CornerRadius="7" BorderBrush="{ThemeResource WidgetBorderColor}" BorderThickness="1">
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />


### PR DESCRIPTION
## Summary of the pull request
Figma specifies a 1px border around widgets. Also tweak light theme host config to match Figma.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
