### PR TITLE
Style error card shown when widget can't be displayed

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -126,4 +126,8 @@
     <value>+ Add new widget</value>
     <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't pinned any widgets.</comment>
   </data>
+  <data name="WidgetErrorCardText" xml:space="preserve">
+    <value>This widget could not be displayed</value>
+    <comment>Message that shows in the widget if the widget was given bad data and can't be rendered.</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
If the widget can't be rendered due to bad data from the widget provider, we show an error message. This change styles that error message so it looks a little nicer and wraps the text so it's not cut off.

## References and relevant issues
http://task.ms/44156158

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
