### PR TITLE
Skipping to repo page if all conditions are filled

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -110,7 +110,7 @@ public partial class AddRepoViewModel : ObservableObject
     private bool? _isUrlAccountButtonChecked;
 
     /// <summary>
-    /// COntrols if the primary button is enabled.  Turns true if everything is correct.
+    /// Controls if the primary button is enabled.  Turns true if everything is correct.
     /// </summary>
     [ObservableProperty]
     private bool _shouldPrimaryButtonBeEnabled;
@@ -153,7 +153,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// 1. DevHome has only 1 provider installed.
     /// 2. The provider has only 1 logged in account.
     /// </remarks>
-    public bool CanSkipToRepoPage
+    public bool CanSkipAccountConnection
     {
         get;
         private set;
@@ -178,7 +178,6 @@ public partial class AddRepoViewModel : ObservableObject
         ShouldPrimaryButtonBeEnabled = false;
         ShowErrorTextBox = Visibility.Collapsed;
         EverythingToClone = new ();
-        CanSkipToRepoPage = false;
     }
 
     /// <summary>
@@ -231,7 +230,7 @@ public partial class AddRepoViewModel : ObservableObject
             var accounts = _providers.GetAllLoggedInAccounts(ProviderNames[0]);
             if (accounts.Count() == 1)
             {
-                CanSkipToRepoPage = true;
+                CanSkipAccountConnection = true;
             }
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -96,9 +96,9 @@ internal partial class AddRepoDialog
         FolderPickerViewModel.CloseFolderPicker();
         EditDevDriveViewModel.HideDevDriveUI();
 
-        // If the DevHome has 1 provider installed and the provider has 1 logged in account
+        // If DevHome has 1 provider installed and the provider has 1 logged in account
         // switch to the repo page.
-        if (AddRepoViewModel.CanSkipToRepoPage)
+        if (AddRepoViewModel.CanSkipAccountConnection)
         {
             RepositoryProviderComboBox.SelectedValue = AddRepoViewModel.ProviderNames[0];
             SwitchToRepoPage(AddRepoViewModel.ProviderNames[0]);


### PR DESCRIPTION
## Summary of the pull request
To reduce the number of clicks, the repo tool will skip from the account page to the repo page if
1. DevHome has only 1 provider installed
2. 1 account is already logged into the provider.

## References and relevant issues
[ADO](https://microsoft.visualstudio.com/OS/_workitems/edit/44119701)

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manual testing.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![SkippingToRepoPage](https://user-images.githubusercontent.com/2517139/234417797-258d348d-c314-48cd-8b57-6bb1a2ac2e2d.gif)
