### PR TITLE
Disable widget pin button when configuring widget

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}">
 
@@ -19,6 +20,7 @@
         <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
         <Thickness x:Key="ContentDialogPadding">0,0,0,0</Thickness>
         <Thickness x:Key="NavigationViewContentMargin">0,0,0,0</Thickness>
+        <converters:BoolNegationConverter x:Key="BoolNegation"/>
     </ContentDialog.Resources>
 
     <StackPanel>
@@ -69,6 +71,7 @@
                     <Button x:Name="PinButton" x:Uid="PinButton"
                             VerticalAlignment="Bottom" HorizontalAlignment="Center"
                             Visibility="Collapsed"
+                            IsEnabled="{x:Bind ViewModel.Configuring, Mode=OneWay, Converter={StaticResource BoolNegation}}"
                             Height="32" Width="118"
                             Click="PinButton_Click"
                             Margin="0,40" />

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -206,6 +206,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
             Log.Logger()?.ReportInfo("AddWidgetDialog", $"Created Widget {widget.Id}");
 
             ViewModel.Widget = widget;
+            ViewModel.IsInAddMode = true;
             PinButton.Visibility = Visibility.Visible;
 
             clearWidgetTask.Wait();

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}">
 
@@ -18,6 +19,7 @@
         <x:Double x:Key="ContentDialogMaxHeight">684</x:Double>
         <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
         <Thickness x:Key="ContentDialogPadding">0,0,0,0</Thickness>
+        <converters:BoolNegationConverter x:Key="BoolNegation"/>
     </ContentDialog.Resources>
 
     <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
@@ -47,6 +49,7 @@
             <Button x:Name="UpdateWidgetButton" x:Uid="UpdateWidgetButton"
                     VerticalAlignment="Bottom" HorizontalAlignment="Center"
                     Visibility="Visible"
+                    IsEnabled="{x:Bind ViewModel.Configuring, Mode=OneWay, Converter={StaticResource BoolNegation}}"
                     Height="32" Width="118"
                     Click="UpdateWidgetButton_Click"
                     Grid.Row="1"


### PR DESCRIPTION
## Summary of the pull request
Widgets shouldn't be able to be pinned when in an invalid state, like when they're still being configured, or while the loading screen is up. Widgets can specify `"configuring" = true` (subject to API review) to indicate this state.

Associated extension PR: https://github.com/microsoft/devhomegithubextension/pull/28

## References and relevant issues
http://task.ms/44119671

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
