### PR TITLE
[SetupFlow] On review page, immediately show tab with content

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/DevDriveTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/DevDriveTaskGroup.cs
@@ -80,5 +80,6 @@ public class DevDriveTaskGroup : ISetupTaskGroup
 
     public SetupPageViewModelBase GetSetupPageViewModel() => null;
 
-    public ReviewTabViewModelBase GetReviewTabViewModel() => _devDriveReviewViewModel.Value;
+    // Only show this tab when we are actually creating a dev drive
+    public ReviewTabViewModelBase GetReviewTabViewModel() => SetupTasks.Any() ? _devDriveReviewViewModel.Value : null;
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -39,16 +39,16 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
     /// <summary>
     /// Gets all the tasks to execute during the loading screen.
     /// </summary>
-    public IEnumerable<ISetupTask> SetupTasks => _cloneTasks;
+    public IEnumerable<ISetupTask> SetupTasks => CloneTasks;
+
+    /// <summary>
+    /// Gets all tasks that need to be ran.
+    /// </summary>
+    public IList<CloneRepoTask> CloneTasks { get; } = new List<CloneRepoTask>();
 
     public SetupPageViewModelBase GetSetupPageViewModel() => _repoConfigViewModel.Value;
 
-    public ReviewTabViewModelBase GetReviewTabViewModel() => _host.CreateInstance<RepoConfigReviewViewModel>(_cloneTasks);
-
-    /// <summary>
-    /// All tasks that need to be ran.
-    /// </summary>
-    private readonly IList<CloneRepoTask> _cloneTasks = new List<CloneRepoTask>();
+    public ReviewTabViewModelBase GetReviewTabViewModel() => _repoConfigReviewViewModel.Value;
 
     /// <summary>
     /// Converts CloningInformation to a CloneRepoTask.
@@ -57,7 +57,7 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
     public void SaveSetupTaskInformation(List<CloningInformation> cloningInformations)
     {
         Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Saving cloning information to task group");
-        _cloneTasks.Clear();
+        CloneTasks.Clear();
         foreach (var cloningInformation in cloningInformations)
         {
             // if the repo was added via URL.
@@ -76,7 +76,7 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
                 task.DependsOnDevDriveToBeInstalled = true;
             }
 
-            _cloneTasks.Add(task);
+            CloneTasks.Add(task);
         }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AppManagementReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AppManagementReviewViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.ObjectModel;
+using System.Linq;
 using DevHome.SetupFlow.Services;
 
 namespace DevHome.SetupFlow.ViewModels;
@@ -12,6 +13,8 @@ public partial class AppManagementReviewViewModel : ReviewTabViewModelBase
     private readonly PackageProvider _packageProvider;
 
     public ReadOnlyObservableCollection<PackageViewModel> ReviewPackages => _packageProvider.SelectedPackages;
+
+    public override bool HasItems => _packageProvider.SelectedPackages.Any();
 
     public AppManagementReviewViewModel(
         ISetupFlowStringResource stringResource,

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveReviewViewModel.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license.
 
 using System.Collections.ObjectModel;
-using DevHome.Common.Extensions;
+using System.Linq;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Services;
-using DevHome.SetupFlow.TaskGroups;
 using Microsoft.Extensions.Hosting;
 
 namespace DevHome.SetupFlow.ViewModels;
@@ -14,13 +13,17 @@ public partial class DevDriveReviewViewModel : ReviewTabViewModelBase
 {
     private readonly IHost _host;
     private readonly ISetupFlowStringResource _stringResource;
+    private readonly IDevDriveManager _devDriveManager;
 
-    public DevDriveReviewViewModel(IHost host, ISetupFlowStringResource stringResource, DevDriveTaskGroup taskGroup)
+    public DevDriveReviewViewModel(IHost host, ISetupFlowStringResource stringResource, IDevDriveManager devDriveManager)
     {
         _host = host;
         _stringResource = stringResource;
+        _devDriveManager = devDriveManager;
         TabTitle = stringResource.GetLocalized(StringResourceKey.DevDriveReviewTitle);
     }
+
+    public override bool HasItems => _devDriveManager.DevDrivesMarkedForCreation.Any();
 
     /// <summary>
     /// Gets the a collection of <see cref="DevDriveReviewTabItem"/> to be displayed on the Basics review tab in the
@@ -30,11 +33,10 @@ public partial class DevDriveReviewViewModel : ReviewTabViewModelBase
     {
         get
         {
-            var manager = _host.GetService<IDevDriveManager>();
             ObservableCollection<DevDriveReviewTabItem> devDriveReviewTabItem = new ();
-            if (manager.RepositoriesUsingDevDrive > 0)
+            if (_devDriveManager.RepositoriesUsingDevDrive > 0)
             {
-                foreach (var devDrive in manager.DevDrivesMarkedForCreation)
+                foreach (var devDrive in _devDriveManager.DevDrivesMarkedForCreation)
                 {
                     devDriveReviewTabItem.Add(new DevDriveReviewTabItem(devDrive));
                 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigReviewViewModel.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
 
@@ -13,24 +11,17 @@ namespace DevHome.SetupFlow.ViewModels;
 public partial class RepoConfigReviewViewModel : ReviewTabViewModelBase
 {
     private readonly ISetupFlowStringResource _stringResource;
-    private readonly RepoConfigTaskGroup _taskGroup;
     private readonly ReadOnlyObservableCollection<string> _repositoriesToClone;
 
     public ReadOnlyObservableCollection<string> RepositoriesToClone => _repositoriesToClone;
 
+    public override bool HasItems => _repositoriesToClone.Any();
+
     public RepoConfigReviewViewModel(ISetupFlowStringResource stringResource, RepoConfigTaskGroup taskGroup)
     {
         _stringResource = stringResource;
-        _taskGroup = taskGroup;
-
-        TabTitle = stringResource.GetLocalized(StringResourceKey.Repository);
-    }
-
-    public RepoConfigReviewViewModel(ISetupFlowStringResource stringResource, List<CloneRepoTask> cloningTasks)
-    {
-        _stringResource = stringResource;
         _repositoriesToClone = new ReadOnlyObservableCollection<string>(
-            new ObservableCollection<string>(cloningTasks.Select(x => x.CloneLocation.FullName)));
+            new ObservableCollection<string>(taskGroup.CloneTasks.Select(x => x.CloneLocation.FullName)));
 
         TabTitle = stringResource.GetLocalized(StringResourceKey.Repository);
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewTabViewModelBase.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewTabViewModelBase.cs
@@ -8,11 +8,16 @@ namespace DevHome.SetupFlow.ViewModels;
 /// <summary>
 /// Base view model class for all the tabs we show in the Review page of the Setup flow.
 /// </summary>
-public partial class ReviewTabViewModelBase : ObservableObject
+public abstract partial class ReviewTabViewModelBase : ObservableObject
 {
     /// <summary>
     /// Title shown on the tabs bar.
     /// </summary>
     [ObservableProperty]
     private string _tabTitle = string.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether the tab has any items to display
+    /// </summary>
+    public abstract bool HasItems { get; }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
@@ -64,15 +64,19 @@ public partial class ReviewViewModel : SetupPageViewModelBase
 
     protected async override Task OnEachNavigateToAsync()
     {
+        // We re-compute the list of tabs as it can change depending on the current selections
+        // Specifically we don't need to show Dev Drive if it wasn't selected
+        ReviewTabs =
+            Orchestrator.TaskGroups
+            .Select(taskGroup => taskGroup.GetReviewTabViewModel())
+            .Where(tab => tab is not null)
+            .ToList();
+
+        // Show the first tab that has any content, or the first one if they're all empty
+        SelectedReviewTab = ReviewTabs.FirstOrDefault(reviewTab => reviewTab.HasItems) ?? ReviewTabs.FirstOrDefault();
+
         NextPageButtonToolTipText = HasTasksToSetUp ? null : StringResource.GetLocalized(StringResourceKey.ReviewNothingToSetUpToolTip);
         UpdateCanGoToNextPage();
-        await Task.CompletedTask;
-    }
-
-    protected async override Task OnFirstNavigateToAsync()
-    {
-        ReviewTabs = Orchestrator.TaskGroups.Select(taskGroup => taskGroup.GetReviewTabViewModel()).ToList();
-        SelectedReviewTab = ReviewTabs.FirstOrDefault();
         await Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary of the pull request

On the review page we have multiple tabs showing what is to be done for the setup. We used to always show the first tab by default, even if it didn't have content. This PR changes it so that we show the first tab that has any content. This also hides the tab for Dev Drive if it wasn't selected.

## References and relevant issues

## Detailed description of the pull request / Additional comments

* Added a new property to the review tab view model that says whether it has any content
* Changed the selection of the tab to show to happen each time we get to the review page instead of only the first one, as the selections can change
* Used the new property from the tab view models to drive which tab to show
* Changed the review page to hide tabs that are null, the same way we hide pages that are null from the whole flow. This allows us to skip the dev drive tab if not needed.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
