### PR TITLE
fix crashing for review page and repo page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveReviewViewModel.cs
@@ -3,9 +3,12 @@
 
 using System.Collections.ObjectModel;
 using System.Linq;
+using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Services;
+using DevHome.SetupFlow.TaskGroups;
 using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Xaml;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -13,17 +16,17 @@ public partial class DevDriveReviewViewModel : ReviewTabViewModelBase
 {
     private readonly IHost _host;
     private readonly ISetupFlowStringResource _stringResource;
-    private readonly IDevDriveManager _devDriveManager;
+    private readonly DevDriveTaskGroup _devDriveTaskGroup;
 
-    public DevDriveReviewViewModel(IHost host, ISetupFlowStringResource stringResource, IDevDriveManager devDriveManager)
+    public DevDriveReviewViewModel(IHost host, ISetupFlowStringResource stringResource, DevDriveTaskGroup devDriveTaskGroup)
     {
         _host = host;
         _stringResource = stringResource;
-        _devDriveManager = devDriveManager;
         TabTitle = stringResource.GetLocalized(StringResourceKey.DevDriveReviewTitle);
+        _devDriveTaskGroup = devDriveTaskGroup;
     }
 
-    public override bool HasItems => _devDriveManager.DevDrivesMarkedForCreation.Any();
+    public override bool HasItems => Application.Current.GetService<IDevDriveManager>().DevDrivesMarkedForCreation.Any();
 
     /// <summary>
     /// Gets the a collection of <see cref="DevDriveReviewTabItem"/> to be displayed on the Basics review tab in the
@@ -34,9 +37,10 @@ public partial class DevDriveReviewViewModel : ReviewTabViewModelBase
         get
         {
             ObservableCollection<DevDriveReviewTabItem> devDriveReviewTabItem = new ();
-            if (_devDriveManager.RepositoriesUsingDevDrive > 0)
+            var manager = Application.Current.GetService<IDevDriveManager>();
+            if (manager.RepositoriesUsingDevDrive > 0)
             {
-                foreach (var devDrive in _devDriveManager.DevDrivesMarkedForCreation)
+                foreach (var devDrive in manager.DevDrivesMarkedForCreation)
                 {
                     devDriveReviewTabItem.Add(new DevDriveReviewTabItem(devDrive));
                 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
@@ -159,12 +159,15 @@ public partial class FolderPickerViewModel : ObservableObject
             return false;
         }
 
-        var fileAttributes = File.GetAttributes(CloneLocation);
-        if (!fileAttributes.HasFlag(FileAttributes.Directory))
+        if (!InDevDriveScenario)
         {
-            FolderPickerErrorMessage = _stringResource.GetLocalized(StringResourceKey.ClonePathNotFolder);
-            ShowFolderPickerError = true;
-            return false;
+            var fileAttributes = File.GetAttributes(CloneLocation);
+            if (!fileAttributes.HasFlag(FileAttributes.Directory))
+            {
+                FolderPickerErrorMessage = _stringResource.GetLocalized(StringResourceKey.ClonePathNotFolder);
+                ShowFolderPickerError = true;
+                return false;
+            }
         }
 
         ShowFolderPickerError = false;


### PR DESCRIPTION
## Summary of the pull request

- Fixes crashes in the add and edit repo page due to   File.GetAttributes(CloneLocation);, For Dev Drives, the drive isnt created yet so we shouldn't attempt to check the attributes.
- Updated the DevDriveReviewViewModel constructor to take DevDriveTaskGroup as a parameter 
- removed IDevDriveManager  as a parameter since we can just call it with Application.Current.GetService<IDevDriveManager>().
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually confirmed no crashes when clicking the dev drive checkmark, and that I can get to the review page, see the dev drive tab and create a Dev Drive.
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
