### PR TITLE
Add padding around widget content to fix scrollbars

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
@@ -50,8 +50,12 @@
         </Grid>
 
         <!-- Widget content -->
-        <ScrollViewer x:Name="WidgetScrollViewer" Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}" Grid.Row="1" 
-                      VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" />
+        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridLeft" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="5"
+                      HorizontalAlignment="Left" />
+        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridRight" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="5"
+                      HorizontalAlignment="Right" />
+        <ScrollViewer Grid.Row="1" x:Name="WidgetScrollViewer" Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}"
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" Padding="5,0" />
 
     </Grid>
 </UserControl>

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -18,8 +18,6 @@ public sealed partial class WidgetControl : UserControl
     public WidgetControl()
     {
         this.InitializeComponent();
-
-        WidgetScrollViewer.RegisterPropertyChangedCallback(ScrollViewer.ComputedVerticalScrollBarVisibilityProperty, OnWidgetScrollBarVisibilityChanged);
     }
 
     public WidgetViewModel WidgetSource
@@ -30,21 +28,6 @@ public sealed partial class WidgetControl : UserControl
 
     public static readonly DependencyProperty WidgetSourceProperty = DependencyProperty.Register(
         nameof(WidgetSource), typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
-
-    private void OnWidgetScrollBarVisibilityChanged(DependencyObject sender, DependencyProperty dp)
-    {
-        var padding = new Thickness(0, 0, 0, 0);
-
-        if (sender as ScrollViewer is ScrollViewer sv)
-        {
-            if (sv.ComputedVerticalScrollBarVisibility == Visibility.Visible)
-            {
-                padding.Right = 13;
-            }
-        }
-
-        WidgetScrollViewer.Padding = padding;
-    }
 
     private void OpenWidgetMenu(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## Summary of the pull request
Widget scrollbars had an issue where their background was truly transparent (not the same transparency as the rest of the widget background. This was due to adding padding to the widget content when the scroll bars were visible, so they wouldn't cover content. Additionally, the widget side margins were smaller than specified by the Figma.

Fix both these problems by adding a 5 pixel padding to the content, and putting grids in those positions with the correct background. The larger padding means the content doesn't need to resize when the scroll bar appears, and the scrollbar no longer has a bad background.

![image](https://user-images.githubusercontent.com/47155823/235722251-f63a760d-68de-49dc-bf18-ef5885a9a437.png)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
