### PR TITLE
Add VCLib dependency as AdaptiveCardRender has a dependency on it

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -9,6 +9,7 @@
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />


### PR DESCRIPTION
## Summary of the pull request

The add GitHub account button fails to launch the GitHub login UI on fresh Windows images.  This looks to be due to AdaptiveCards has a dependency on the vclibs, but we don't declare our dependency on it.

## References and relevant issues

Fixes ADO#44470117

## Detailed description of the pull request / Additional comments

Added dependency on vclibs framework package.  Also going to start an email thread to see if AdaptiveCards in the future can follow a model similar to WinAppSDK which avoids that need.  This issue wasn't seen outside of a fresh VM because most folks already have the vc redist installed via other apps that they are using or by VS.

## Validation steps performed

Tested GitHub add account flow on a new VM

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
