### PR TITLE
Put icons in widget menu

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -15,6 +15,8 @@ using Microsoft.Windows.Widgets.Hosts;
 namespace DevHome.Dashboard.Views;
 public sealed partial class WidgetControl : UserControl
 {
+    private MenuFlyoutItem _currentSelectedSize;
+
     public WidgetControl()
     {
         this.InitializeComponent();
@@ -73,13 +75,13 @@ public sealed partial class WidgetControl : UserControl
         var removeWidgetText = resourceLoader.GetString("RemoveWidgetMenuText");
         var icon = new FontIcon()
         {
-            FontFamily = new FontFamily("Segoe MDL2 Assets"),
-            Glyph = "\uE77A;",
+            Glyph = "\xE77A",
         };
         var menuItemClose = new MenuFlyoutItem
         {
             Tag = widgetViewModel,
             Text = removeWidgetText,
+            Icon = icon,
         };
         menuItemClose.Click += OnRemoveWidgetClick;
         widgetMenuFlyout.Items.Add(menuItemClose);
@@ -137,6 +139,23 @@ public sealed partial class WidgetControl : UserControl
         };
         menuItemLarge.Click += OnMenuItemSizeClick;
         widgetMenuFlyout.Items.Add(menuItemLarge);
+
+        // Mark current widget size.
+        var size = widgetViewModel.WidgetSize;
+        switch (size)
+        {
+            case WidgetSize.Small:
+                _currentSelectedSize = menuItemSmall;
+                break;
+            case WidgetSize.Medium:
+                _currentSelectedSize = menuItemMedium;
+                break;
+            case WidgetSize.Large:
+                _currentSelectedSize = menuItemLarge;
+                break;
+        }
+
+        MarkSize(_currentSelectedSize);
     }
 
     private async void OnMenuItemSizeClick(object sender, RoutedEventArgs e)
@@ -145,11 +164,31 @@ public sealed partial class WidgetControl : UserControl
         {
             if (menuSizeItem.DataContext is WidgetViewModel widgetViewModel)
             {
+                // Unset mark on current size.
+                if (_currentSelectedSize is not null)
+                {
+                    _currentSelectedSize.Icon = null;
+                }
+
+                // Resize widget.
                 var size = (WidgetSize)menuSizeItem.Tag;
                 widgetViewModel.WidgetSize = size;
                 await widgetViewModel.Widget.SetSizeAsync(size);
+
+                // Set mark on new size.
+                _currentSelectedSize = menuSizeItem;
+                MarkSize(_currentSelectedSize);
             }
         }
+    }
+
+    private void MarkSize(MenuFlyoutItem menuSizeItem)
+    {
+        var fontIcon = new FontIcon
+        {
+            Glyph = "\xE915",
+        };
+        menuSizeItem.Icon = fontIcon;
     }
 
     private void AddCustomizeToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
@@ -157,13 +196,13 @@ public sealed partial class WidgetControl : UserControl
         var customizeWidgetText = resourceLoader.GetString("CustomizeWidgetMenuText");
         var icon = new FontIcon()
         {
-            FontFamily = new FontFamily("Segoe MDL2 Assets"),
-            Glyph = "\uE70F;",
+            Glyph = "\xE70F",
         };
         var menuItemCustomize = new MenuFlyoutItem
         {
             Tag = widgetViewModel,
             Text = customizeWidgetText,
+            Icon = icon,
         };
         menuItemCustomize.Click += OnCustomizeWidgetClick;
         widgetMenuFlyout.Items.Add(menuItemCustomize);


### PR DESCRIPTION
## Summary of the pull request
Put dot next to current size of the widget, as well as icons for "Customize" and "Remove widget".
![image](https://user-images.githubusercontent.com/47155823/236030060-fb66eaa2-b43d-4511-b2b1-1991d4fc2402.png)

## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/44123297

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
