### PR TITLE
Add icons to settings page

### DIFF
--- a/settings/DevHome.Settings/Models/Setting.cs
+++ b/settings/DevHome.Settings/Models/Setting.cs
@@ -21,6 +21,8 @@ public class Setting
 
     public string Description { get; }
 
+    public string Glyph { get; }
+
     public bool HasToggleSwitch { get; }
 
     public bool IsExtensionEnabled
@@ -61,12 +63,13 @@ public class Setting
         }
     }
 
-    public Setting(string path, string classId, string header, string description, bool hasToggleSwitch)
+    public Setting(string path, string classId, string header, string description, string glyph, bool hasToggleSwitch)
     {
         Path = path;
         ClassId = classId;
         Header = header;
         Description = description;
+        Glyph = glyph;
         HasToggleSwitch = hasToggleSwitch;
 
         _isExtensionEnabled = GetIsExtensionEnabled();

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -63,7 +63,7 @@
     <comment>Navigation pane content</comment>
   </data>
   <data name="Settings_Preferences_Description" xml:space="preserve">
-    <value>Description: Preferences</value>
+    <value>Theme, on startup, get started content</value>
     <comment>Body text description for a card than when clicked takes the user to the Preferences settings page</comment>
   </data>
   <data name="Settings_Preferences_Header" xml:space="preserve">
@@ -71,7 +71,7 @@
     <comment>Header for a card than when clicked takes the user to the Preferences settings page</comment>
   </data>
   <data name="Settings_Accounts_Description" xml:space="preserve">
-    <value>Description: Accounts</value>
+    <value>Add accounts, sign in or out</value>
     <comment>Body text description for a card than when clicked takes the user to the Accounts settings page</comment>
   </data>
   <data name="Settings_Accounts_Header" xml:space="preserve">
@@ -79,7 +79,7 @@
     <comment>Header for a card than when clicked takes the user to the Accounts settings page</comment>
   </data>
   <data name="Settings_Extensions_Description" xml:space="preserve">
-    <value>Description: Extensions</value>
+    <value>Add or remove, manage</value>
     <comment>Body text description for a card than when clicked takes the user to the Extensions settings page</comment>
   </data>
   <data name="Settings_Extensions_Header" xml:space="preserve">
@@ -87,7 +87,7 @@
     <comment>Header for a card than when clicked takes the user to the Extensions settings page</comment>
   </data>
   <data name="Settings_About_Description" xml:space="preserve">
-    <value>Description: About</value>
+    <value>App info, Privacy statement, Terms of Use</value>
     <comment>Body text description for a card than when clicked takes the user to the About settings page</comment>
   </data>
   <data name="Settings_About_Header" xml:space="preserve">

--- a/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
@@ -77,7 +77,7 @@ public partial class ExtensionsViewModel : ObservableRecipient
 
         foreach (var pluginWrapper in pluginWrappers)
         {
-            var setting = new Setting("Plugins/" + pluginWrapper.PluginClassId, pluginWrapper.PluginClassId, pluginWrapper.Name, string.Empty, true);
+            var setting = new Setting("Plugins/" + pluginWrapper.PluginClassId, pluginWrapper.PluginClassId, pluginWrapper.Name, string.Empty, string.Empty, true);
             SettingsList.Add(new ExtensionViewModel(setting, this));
         }
     }

--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -29,6 +29,8 @@ public partial class SettingViewModel : ObservableRecipient
 
     public string Description => _setting.Description;
 
+    public string Glyph => _setting.Glyph;
+
     public bool HasToggleSwitch => _setting.HasToggleSwitch;
 
     [RelayCommand]
@@ -49,10 +51,10 @@ public partial class SettingsViewModel : ObservableRecipient
 
         var settings = new[]
         {
-            new Setting("Preferences", string.Empty, stringResource.GetLocalized("Settings_Preferences_Header"), stringResource.GetLocalized("Settings_Preferences_Description"), false),
-            new Setting("Accounts", string.Empty, stringResource.GetLocalized("Settings_Accounts_Header"), stringResource.GetLocalized("Settings_Accounts_Description"), false),
-            new Setting("Extensions", string.Empty, stringResource.GetLocalized("Settings_Extensions_Header"), stringResource.GetLocalized("Settings_Extensions_Description"), false),
-            new Setting("About", string.Empty, stringResource.GetLocalized("Settings_About_Header"), stringResource.GetLocalized("Settings_About_Description"), false),
+            new Setting("Preferences", string.Empty, stringResource.GetLocalized("Settings_Preferences_Header"), stringResource.GetLocalized("Settings_Preferences_Description"), "\ue713", false),
+            new Setting("Accounts", string.Empty, stringResource.GetLocalized("Settings_Accounts_Header"), stringResource.GetLocalized("Settings_Accounts_Description"), "\ue77b", false),
+            new Setting("Extensions", string.Empty, stringResource.GetLocalized("Settings_Extensions_Header"), stringResource.GetLocalized("Settings_Extensions_Description"), "\ued35", false),
+            new Setting("About", string.Empty, stringResource.GetLocalized("Settings_About_Header"), stringResource.GetLocalized("Settings_About_Description"), "\ue946", false),
         };
 
         foreach (var setting in settings)

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -44,6 +44,9 @@
 
             <StackPanel x:Name="AddAccountMainStackPanel" Margin="{StaticResource XSmallTopMargin}">
                 <labs:SettingsCard x:Uid="Settings_Accounts_AddAccount">
+                    <labs:SettingsCard.HeaderIcon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8fa;"/>
+                    </labs:SettingsCard.HeaderIcon>
                     <Button x:Uid="Settings_Accounts_AddAccountButton" HorizontalAlignment="Right">
                         <Button.Flyout>
                             <Flyout Placement="Bottom">

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -20,7 +20,11 @@
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:SettingViewModel">
                         <labs:SettingsCard Header="{x:Bind Header}" Description="{x:Bind Description}"
-                                       IsClickEnabled="True" Command="{x:Bind NavigateSettingsCommand}" Margin="0 0 0 5" />
+                                       IsClickEnabled="True" Command="{x:Bind NavigateSettingsCommand}" Margin="0 0 0 5">
+                            <labs:SettingsCard.HeaderIcon>
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="{x:Bind Glyph}"/>
+                            </labs:SettingsCard.HeaderIcon>
+                        </labs:SettingsCard>
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>


### PR DESCRIPTION
## Summary of the pull request
Adding icons to Settings page and Accounts page to match Figma docs.  This does not add the GitHub icon as that would need to come from the extension.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
