### PR TITLE
Add attach at reboot flag to AttachVirtualDisk call in DevDriveStorageOperator

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/DevDriveStorageOperator.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/DevDriveStorageOperator.cs
@@ -168,7 +168,7 @@ public sealed class DevDriveStorageOperator
         // when passed an attach virt disk flag that it does not support. This failure is not a deal breaker as we should still be able to attach the virtual
         // disk without the AttachVirtualDiskFlagAtBoot flag. Users would just have to manually remount their virtual disk file instead of the system
         // doing it for them at boot time. Once the api changes have propagated we will update this to remove the loop and use both flags in a single
-        // call with no fallback. We only make 2 attempts, first with the new flag and one second without.
+        // call with no fallback. We only make 2 attempts, first with the new flag and then a second attempt without the new flag.
         var numberOfAttemptsToAttachVirtDisk = 0;
         while (++numberOfAttemptsToAttachVirtDisk <= 2)
         {


### PR DESCRIPTION
## Summary of the pull request
- For context you should see [ ADO entry here ](https://microsoft.visualstudio.com/OS/_workitems/edit/44236659/) as to why this change is being made
- This is temporary for now, as the api changes on the storage side have not propagated up yet.
- The change adds the attach on boot flag to the AttachVirtualDisk call. Without this flag users would have to manually remount the virtual disk that the Dev Drive is created on after each reboot. 
## References and relevant issues

## Detailed description of the pull request / Additional comments

Since we're entering code complete for build, we won't have the ability to add this until post build, if this change doesn't go in. 
The change on the storage side would have to be on the users build of windows for them to have this updated api ability. However, since the api update hasn't propagated yet we don't want to wait until it does since we may not be able to add in in time for the build cut off. We want this to work out of the box without us having to add it in later, the storage changes should be in the build users can use at Build and post Build.

## Validation steps performed

**Confirmed Dev Drives can still be created after this change**

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
