### PR TITLE
Prevent crash in CacheProviderIcons

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -232,7 +232,6 @@ public partial class DashboardView : ToolPage
             try
             {
                 Log.Logger()?.ReportDebug("DashboardView", $"Cache widget provider icon for {providerDefId}");
-                var itemImage = await WidgetIconToBitmapImage(providerDef.Icon);
 
                 // There is a widget bug where Definition update events are being raised as added events.
                 // If we already have an icon for this key, just remove and add again.
@@ -241,6 +240,7 @@ public partial class DashboardView : ToolPage
                     _providerIconCache.Remove(providerDefId);
                 }
 
+                var itemImage = await WidgetIconToBitmapImage(providerDef.Icon);
                 _providerIconCache.Add(providerDefId, itemImage);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary of the pull request
Occasionally caching icons throws an exception because it's not running on the UI thread. When this happens, we can accidentally try to cache "null" more than once, which causes a crash. The real fix is to run the caching on the UI thread. The 5-minute fix is to remove the key if it exists, so we don't crash.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
