### PR TITLE
Add all should only select non-installed packages

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogViewModel.cs
@@ -50,7 +50,11 @@ public partial class PackageCatalogViewModel : ObservableObject
         Log.Logger?.ReportInfo(Log.Component.AppManagement, $"Adding all packages from catalog {Name} to selection");
         foreach (var package in Packages)
         {
-            package.IsSelected = true;
+            // Select all non-installed packages
+            if (!package.IsInstalled)
+            {
+                package.IsSelected = true;
+            }
         }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
@@ -90,7 +90,6 @@
                                                     <Setter Target="Image.Opacity" Value="0.4"/>
                                                     <Setter Target="Title.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}"/>
                                                     <Setter Target="Version.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}"/>
-                                                    <Setter Target="LearnMoreButton.IsEnabled" Value="False"/>
                                                 </VisualState.Setters>
                                             </VisualState>
                                         </VisualStateGroup>


### PR DESCRIPTION
## Summary of the pull request
- Updated "Add all" command to only select non-installed packages
- Always enable the learn more button during search

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
