### PR TITLE
Use "add" more than "pin" for widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -59,12 +59,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddWidget.Content" xml:space="preserve">
-    <value>+ Add Widget</value>
-    <comment>Label for "Add Widget" button"</comment>
-  </data>
-  <data name="AllWidgetsList.PaneTitle" xml:space="preserve">
-    <value>All widgets</value>
-    <comment>PaneTitle for the list of Widgets in the NavigationView</comment>
+    <value>+ Add widget</value>
+    <comment>Label for "Add widget" button"</comment>
   </data>
   <data name="DashboardBanner.Title" xml:space="preserve">
     <value>Monitor your GitHub Issues and Pull Requests</value>
@@ -82,9 +78,9 @@
     <value>Dashboard</value>
     <comment>Navigation pane content</comment>
   </data>
-  <data name="PinWidgetsTitle.Text" xml:space="preserve">
-    <value>Pin Widgets</value>
-    <comment>Title for "Pin Widgets" dialog</comment>
+  <data name="AddWidgetsTitle.Text" xml:space="preserve">
+    <value>Add widgets</value>
+    <comment>Title for "Add widgets" dialog</comment>
   </data>
   <data name="PinButtonText.Text" xml:space="preserve">
     <value>Pin</value>
@@ -118,13 +114,13 @@
     <value>Dashboard</value>
     <comment>Header label for the Dashboard page</comment>
   </data>
-  <data name="NoWidgetsPinned.Text" xml:space="preserve">
-    <value>Pin a widget here</value>
-    <comment>Shown when no widgets are pinned</comment>
+  <data name="NoWidgetsAdded.Text" xml:space="preserve">
+    <value>No widgets added yet</value>
+    <comment>Message shown when no widgets have been added to the Dashboard</comment>
   </data>
   <data name="AddFirstWidgetLink.Content" xml:space="preserve">
     <value>+ Add new widget</value>
-    <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't pinned any widgets.</comment>
+    <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't added any widgets.</comment>
   </data>
   <data name="WidgetErrorCardDisplayText" xml:space="preserve">
     <value>This widget could not be displayed</value>
@@ -139,7 +135,7 @@
     <comment>Second part of message shown when the user tries to create a widet but the widget provider is not installed.</comment>
   </data>
   <data name="WidgetErrorCardNoWidgetsText" xml:space="preserve">
-    <value>There are no widgets available to pin</value>
+    <value>There are no widgets available to add</value>
     <comment>Message shown when the user tries to create a widet but there are no installed widgets.</comment>
   </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -26,7 +26,7 @@
     <StackPanel>
         <!-- Title and Close button -->
         <Grid>
-            <TextBlock x:Uid="PinWidgetsTitle" HorizontalAlignment="Left" Margin="16,10,0,0" />
+            <TextBlock x:Uid="AddWidgetsTitle" HorizontalAlignment="Left" Margin="16,10,0,0" />
             <Button HorizontalAlignment="Right" Click="CancelButton_Click"
                     BorderThickness="0" Background="Transparent" Padding="10">
                 <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -80,7 +80,7 @@
                 </GridView>
 
                 <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
-                    <TextBlock x:Uid="NoWidgetsPinned" HorizontalAlignment="Center" />
+                    <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
                     <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" Click="AddWidgetButton_Click" HorizontalAlignment="Center" />
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
## Summary of the pull request
We mix Pin and Add. Design wants us to lean towards Add. Remove unnecessary "second title" in add widget dialog.
![image](https://user-images.githubusercontent.com/47155823/236889278-0b3223f7-056f-49bc-b6f0-9e17a836ad22.png)
![image](https://user-images.githubusercontent.com/47155823/236889309-5fb092ef-9e39-42ab-b4b1-a1eef4befb64.png)
![image](https://user-images.githubusercontent.com/47155823/236889423-1acbf01d-823b-4b28-bbbe-bc810a21166a.png)
![image](https://user-images.githubusercontent.com/47155823/236889662-34bccea2-a75f-4b9e-92ec-83ed9905cc1b.png)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
