### PR TITLE
Delete widgets when their provider is deleted

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -82,10 +82,18 @@ public sealed partial class WidgetControl : UserControl
                 // Remove the widget from the list before deleting, otherwise the widget will
                 // have changed and the collection won't be able to find it to remove it.
                 var widgetIdToDelete = widgetViewModel.Widget.Id;
+                var widgetToDelete = widgetViewModel.Widget;
                 Log.Logger()?.ReportDebug("WidgetControl", $"User removed widget, delete widget {widgetIdToDelete}");
                 DashboardView.PinnedWidgets.Remove(widgetViewModel);
-                await widgetViewModel.Widget.DeleteAsync();
-                Log.Logger()?.ReportInfo("WidgetControl", $"Deleted Widget {widgetIdToDelete}");
+                try
+                {
+                    await widgetToDelete.DeleteAsync();
+                    Log.Logger()?.ReportInfo("WidgetControl", $"Deleted Widget {widgetIdToDelete}");
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger()?.ReportError("WidgetControl", $"Didn't delete Widget {widgetIdToDelete}", ex);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary of the pull request
The widget service does not delete created widgets when the widget definition is deleted (as in, the provider is uninstalled) and instead relies on the host to decide what to do. We will delete any created widgets that have that definition.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
