### PR TITLE
Widget CustomizeDialog's update button should be disabled for non-configured widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
     public CustomizeWidgetDialog(WidgetHost host, WidgetCatalog catalog, AdaptiveCardRenderer renderer, DispatcherQueue dispatcher, WidgetDefinition widgetDefinition)
     {
         ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, null, renderer, dispatcher);
+        ViewModel.IsInEditMode = true;
         this.InitializeComponent();
 
         _widgetHost = host;
@@ -75,6 +76,7 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
     {
         Application.Current.GetService<WindowEx>().Closed -= OnMainWindowClosed;
         _widgetCatalog.WidgetDefinitionDeleted -= WidgetCatalog_WidgetDefinitionDeleted;
+        ViewModel.IsInEditMode = false;
 
         this.Hide();
     }


### PR DESCRIPTION
## Summary of the pull request
When the widget customization dialog is open, set IsInEditMode to true so that we will check for the customization flag in the widget data, and enable/disable the update button accordingly.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
