### PR TITLE
Make "Add" button in "Add repo" dialog the default

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -16,6 +16,7 @@
                x:Name="AddRepoContentDialog"
                PrimaryButtonClick="AddRepoContentDialog_PrimaryButtonClick"
                IsPrimaryButtonEnabled="{x:Bind AddRepoViewModel.ShouldPrimaryButtonBeEnabled, Mode=OneWay}"
+               DefaultButton="Primary"
                Style="{StaticResource DefaultContentDialogStyle}"
                PrimaryButtonText="{x:Bind AddRepoViewModel.PrimaryButtonText, Mode=OneWay}"
                CornerRadius="8">


### PR DESCRIPTION
## Summary of the pull request

Make "Add" button in "Add repo" dialog the default

## References and relevant issues

https://task.ms/44117861

## Detailed description of the pull request / Additional comments

Making it the default button does two things:
1. Gives the button the accent button style
2. Makes it react to Enter on the dialog

![image](https://github.com/microsoft/devhome/assets/14323496/95ed6b79-f5e5-4875-a86e-f4f8013c1522)


## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
