### PR TITLE
Prevent scrollbar overlap on add repo page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -31,7 +31,8 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </ContentDialog.Resources>
-    <ScrollViewer VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
+    <!-- ContentDialog has a padding of 24 on left/right. Extend the ScrollViewer there so that we can show the scroll bar at the edge of the dialog. -->
+    <ScrollViewer VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto" Padding="24,0" Margin="-24,0">
         <StackPanel x:Name="AddRepoStackPanel" Orientation="Vertical" Spacing="5" MinWidth="450" MinHeight="550">
             <StackPanel.Resources>
                 <ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request

Prevent the scrollbar in the add repo page from overlapping with the controls by moving it to the edge of the dialog.

## References and relevant issues

https://task.ms/44533330

## Detailed description of the pull request / Additional comments

![image](https://github.com/microsoft/devhome/assets/14323496/b3273b73-7e0b-430f-b6a2-718e3130a2c7)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
