### PR TITLE
Modified the default text value of the ssh widget configuration JSON so users will no longer have to manua…

### DIFF
--- a/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
@@ -39,7 +39,7 @@
       "spacing": "Medium",
       "style": "Url",
       "placeholder": "${$root.configuration.defaultConfigFile}",
-      "value": "${$root.configuration.configFile}"
+      "value": "${$root.configuration.defaultConfigFile}"
     },
     {
       "type": "Container",


### PR DESCRIPTION
…lly type in the string that is currently the placeholder

## Summary of the pull request

In the SSH Keychain widget, the current behavior is for the placeholder text to appear showing a user what they likely will want to input as a value, but there is no way for the user to just accept that value. In order to enter the config they want, the user must manually type in the string that is shown as the placeholder value. This is no fun!


![sshkeychain1](https://github.com/microsoft/devhome/assets/98557455/6f5c769f-a974-4171-81a6-12c605d15205)



This PR simply changes the text behavior so users can quickly set up their SSH configuration. Much better!

![sshkeychain2](https://github.com/microsoft/devhome/assets/98557455/3ae1afcd-b396-43a8-9d4b-cf671ccb399d)



## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

I did a few sanity checks to make sure this did not impact any other behavior: 

1. Input an invalid file path --> "File not found" 
2. Input a valid file path with no valid ssh hosts --> 0 hosts found
3. Input a valid file path that is not the default file path --> widget properly created with the relevant ssh connections for the respective file

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
