### PR TITLE
Update the build check for the Dev Drive feature 

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
@@ -69,14 +69,17 @@ public static class DevDriveUtil
     // numbers start at 22000.
     private const ushort DevDriveMajorVersion = 10;
     private const ushort DevDriveMinorVersion = 0;
-    private const ushort DevDriveMinBuild = 23000;
-    private const ushort DevDriveMaxBuild = 23999;
+    private const ushort DevDriveMinBuildForDevChannel = 23451;
+    private const ushort DevDriveMaxBuildForDevChannel = 23999;
+    private const ushort DevDriveMinBuildForCanaryChannel = 25846;
 
     /// <summary>
     /// Gets a value indicating whether the system has the ability to create Dev Drives
-    /// and whether the ability is enabled. Win10 machines will not have this ability.
-    /// This is temporary and will be replaced by an API call once it is created.
+    /// and whether the ability is enabled. Windows 10 or below machines will not have this ability.
     /// </summary>
+    /// <remarks>
+    /// The body of this function is temporary and will be replaced by an API call once it is created.
+    /// </remarks>
     /// <returns>
     /// Returns true if Dev Drive creation functionality is present on the machine
     /// </returns>
@@ -84,18 +87,26 @@ public static class DevDriveUtil
     {
         get
         {
-            // Windows Insiders dev channel now uses the 23000 series for its build numbers.
-            // The Dev Drive Feature is only be enabled there currently and will eventually go into a full retail
+            // Windows Insiders dev channel now uses the 23000 series for its build numbers. The Canary channel
+            // where the feature is enabled start on build number 25846.
+            // The Dev Drive Feature is only be enabled on these builds currently and will eventually go into a full retail
             // release. We expect the API to be created before the full retail release of the Dev Drive feature
             // in which case we will not be checking windows build numbers, but will be checking the results of the
             // API call.
             var osVersion = ToolKitHelpers.SystemInformation.Instance.OperatingSystemVersion;
-            if (osVersion.Major == DevDriveMajorVersion &&
-                osVersion.Minor == DevDriveMinorVersion &&
-                osVersion.Build >= DevDriveMinBuild &&
-                osVersion.Build <= DevDriveMaxBuild)
+            if (osVersion.Major == DevDriveMajorVersion && osVersion.Minor == DevDriveMinorVersion)
             {
-                return true;
+                // Check if on an acceptable Windows 11 Dev insider channel
+                if (osVersion.Build >= DevDriveMinBuildForDevChannel && osVersion.Build <= DevDriveMaxBuildForDevChannel)
+                {
+                    return true;
+                }
+
+                // Check if on an acceptable Windows 11 Canary insider channel that supports Dev Drive.
+                if (osVersion.Build >= DevDriveMinBuildForCanaryChannel)
+                {
+                    return true;
+                }
             }
 
             Log.Logger?.ReportInfo(Log.Component.DevDrive, $"Dev Drive feature is not available on this build of Windows: {osVersion}");


### PR DESCRIPTION
## Summary of the pull request
[Please read ADO bug for even more context for this change](https://microsoft.visualstudio.com/OS/_workitems/edit/44574661)
- See Windows insider build number changes https://blogs.windows.com/windows-insider/2023/03/06/whats-coming-for-the-windows-insider-program-in-2023/
- Currently we check if the Dev Drive feature is available via a build check, while we wait for the storage team to create an API for us to check if the feature is available. See[ ADO task](https://microsoft.visualstudio.com/OS/_workitems/edit/43936780)
- The Dev Drive feature was originally intended to go into the Canary insiders channel only, but after some internal changes, it is now set to be enabled in the Dev Channel (23000 series) and also the Canary channel (25000) series.
- This change updates the build check with this information.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated