### PR TITLE
Remove SampleTool reference from DevHome

### DIFF
--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -42,7 +42,6 @@
         <ProjectReference Include="..\common\DevHome.Common.csproj" />
         <ProjectReference Include="..\CoreWidgetProvider\CoreWidgetProvider.csproj" />
         <ProjectReference Include="..\settings\DevHome.Settings\DevHome.Settings.csproj" />
-        <ProjectReference Include="..\tools\SampleTool\src\SampleTool.csproj" />
         <ProjectReference Include="..\tools\Dashboard\DevHome.Dashboard\DevHome.Dashboard.csproj" />
         <ProjectReference Include="..\tools\SetupFlow\DevHome.SetupFlow\DevHome.SetupFlow.csproj" />
     </ItemGroup>


### PR DESCRIPTION
This PR removes the unnecessary reference to SampleTool dll in DevHome core.