### PR TITLE
Fixing up event handlers to break some cycles that can cause leaks

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -33,7 +33,7 @@ internal class WidgetIconCache
     /// <summary>
     /// Caches icons for all widgets in the WidgetCatalog that are included in Dev Home.
     /// </summary>
-    public async Task CacheAllWidgetIcons(WidgetCatalog widgetCatalog, DispatcherQueue dispatcher)
+    public static async Task CacheAllWidgetIcons(WidgetCatalog widgetCatalog, DispatcherQueue dispatcher)
     {
         var widgetDefs = widgetCatalog.GetWidgetDefinitions();
         foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
@@ -45,7 +45,7 @@ internal class WidgetIconCache
     /// <summary>
     /// Caches two icons for each widget, one for light theme and one for dark theme.
     /// </summary>
-    public async Task AddIconsToCache(WidgetDefinition widgetDef, DispatcherQueue dispatcher)
+    public static async Task AddIconsToCache(WidgetDefinition widgetDef, DispatcherQueue dispatcher)
     {
         // Only cache icons for providers that we're including.
         if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
@@ -81,7 +81,7 @@ internal class WidgetIconCache
         }
     }
 
-    public void RemoveIconsFromCache(string definitionId)
+    public static void RemoveIconsFromCache(string definitionId)
     {
         _widgetLightIconCache.Remove(definitionId);
         _widgetDarkIconCache.Remove(definitionId);

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -94,11 +94,11 @@ public partial class WidgetViewModel : ObservableObject
     {
         _renderer = renderer;
         _dispatcher = dispatcher;
+        _widgetHandler = new WidgetHandler(this);
 
         Widget = widget;
         WidgetSize = widgetSize;
         WidgetDefinition = widgetDefintion;
-        _widgetHandler = new WidgetHandler(this);
     }
 
     public void Render()

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -174,7 +174,7 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
 
         // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
+        await WidgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
 
         await ConfigureWidgetRenderer(_renderer);
 
@@ -269,7 +269,7 @@ public partial class DashboardView : ToolPage
             if (_widgetServiceHelper.EnsureWebExperiencePack())
             {
                 _widgetHostInitialized = InitializeWidgetHost();
-                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
+                await WidgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
                 await ConfigureWidgetRenderer(_renderer);
             }
             else
@@ -366,7 +366,7 @@ public partial class DashboardView : ToolPage
     private static async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-        await _widgetIconCache.AddIconsToCache(args.Definition, _dispatcher);
+        await WidgetIconCache.AddIconsToCache(args.Definition, _dispatcher);
     }
 
     private static async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
@@ -437,7 +437,7 @@ public partial class DashboardView : ToolPage
             }
         });
 
-        _widgetIconCache.RemoveIconsFromCache(definitionId);
+        WidgetIconCache.RemoveIconsFromCache(definitionId);
     }
 
     // Listen for widgets being added or removed, so we can add or remove listeners on the WidgetViewModels' properties.

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -353,23 +353,23 @@ public partial class DashboardView : ToolPage
         }
     }
 
-    private void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args)
+    private static void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionAdded {args.ProviderDefinition.Id}");
     }
 
-    private void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args)
+    private static void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionDeleted {args.ProviderDefinitionId}");
     }
 
-    private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
+    private static async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
         await _widgetIconCache.AddIconsToCache(args.Definition, _dispatcher);
     }
 
-    private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
+    private static async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
     {
         var updatedDefinitionId = args.Definition.Id;
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionUpdated {updatedDefinitionId}");
@@ -421,7 +421,7 @@ public partial class DashboardView : ToolPage
     }
 
     // Remove widget(s) from the Dashboard if the provider deletes the widget definition, or the provider is uninstalled.
-    private void WidgetCatalog_WidgetDefinitionDeleted(WidgetCatalog sender, WidgetDefinitionDeletedEventArgs args)
+    private static void WidgetCatalog_WidgetDefinitionDeleted(WidgetCatalog sender, WidgetDefinitionDeletedEventArgs args)
     {
         var definitionId = args.DefinitionId;
         _dispatcher.TryEnqueue(async () =>


### PR DESCRIPTION
## Summary of the pull request

Addressing an issue where a couple of events are contributing to the WidgetViewModel and the dashboard leaking through the cycles that get formed when non static event handlers are added.  Note that even with this change, the WidgetViewModel is leaking which is being investigated but this reduces the sources contributing to it leaking.

## References and relevant issues

Contributes to ADO#44532978

## Detailed description of the pull request / Additional comments

When instance level event handlers are added to an event, the instance that the event is from is kept alive for the lifetime of the event handler.  In the WidgetViewModel, we were holding onto an instance of the Widget model and setting up an event handler from it to subscribe to widget notifications.  This meant we had a cycle where the Widget model is holding onto a CCW for an event handler belonging to the WidgetViewModel while at the same time the WidgetViewModel is keeping the Widget alive.  The .NET GC cannot detect such cycles especially for non XAML scenarios and thereby it contributes to the view model leaking.  Addressed by introducing another class which is used to achieve weak event handlers.

On the dashboard page, we also had a couple of instance event handlers we were adding to events on static objects.  This meant the event handlers were keeping the first dashboard instance alive for the lifetime of the static object which is forever.

## Validation steps performed

Validated scenarios continue to work, but note we still do have other things still causing the leak to happen.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
