### PR TITLE
Fix link bindings in the summary page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -32,10 +32,10 @@
                                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_NextSteps"
                                 Style="{ThemeResource BodyStrongTextBlockStyle}"
                                 Padding="0,20,0,25" />
-                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_SetUpAnotherProject" Command="{Binding ViewModel.GoToMainPageCommand}"/>
-                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ChangeDevHomeSettings" Command="{Binding ViewModel.GoToDevHomeSettingsCommand}"/>
-                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ChangeDeveloperSettingsInWindows" Command="{Binding ViewModel.GoToForDevelopersSettingsPageCommand}"/>
-                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_LearnMoreAboutDevHome" Command="{Binding ViewModel.LearnMoreCommand}"/>
+                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_SetUpAnotherProject" Command="{Binding GoToMainPageCommand}"/>
+                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ChangeDevHomeSettings" Command="{Binding GoToDevHomeSettingsCommand}"/>
+                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ChangeDeveloperSettingsInWindows" Command="{Binding GoToForDevelopersSettingsPageCommand}"/>
+                            <HyperlinkButton x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_LearnMoreAboutDevHome" Command="{Binding LearnMoreCommand}"/>
                         </StackPanel>
                     </ControlTemplate>
                 </ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request
- `Binding` by default uses the `DataContext` of the control, hence no need to specify `ViewModel` path, which was required when using `x:Bind`.

## References and relevant issues
[ADO entry](https://dev.azure.com/microsoft/OS/_workitems/edit/44682436)
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
