### PR TITLE
Update DevHome configuration to v0.2.0

### DIFF
--- a/.configurations/configuration.dsc.yaml
+++ b/.configurations/configuration.dsc.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   assertions:
     - resource: Microsoft.Windows.Developer/OsVersion


### PR DESCRIPTION
Updated the `configuration.dsc.yaml` file to v0.2.0

- Includes allowPrerelease for all powershell modules now publicly available in PSGallery.
- Changes the resource name to be module/dscResource for performance improvements.
- Updated with root variable for correct relative path to vsconfig file.

Only verified with winget configure, will update comment once I verify with DevHome.