### PR TITLE
Added modules path to config API

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Configuration/ConfigurationFileHelper.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Configuration/ConfigurationFileHelper.cs
@@ -54,10 +54,11 @@ public class ConfigurationFileHelper
     {
         try
         {
-            var modulesPath = Path.Combine(AppContext.BaseDirectory, "ExternalModules");
+            var modulesPath = Path.Combine(AppContext.BaseDirectory, @"runtimes\win\lib\net6.0\Modules");
+            var externalModulesPath = Path.Combine(AppContext.BaseDirectory, "ExternalModules");
             var properties = new ConfigurationProcessorFactoryProperties();
             properties.Policy = ConfigurationProcessorPolicy.Unrestricted;
-            properties.AdditionalModulePaths = new List<string>() { modulesPath };
+            properties.AdditionalModulePaths = new List<string>() { modulesPath, externalModulesPath };
             Log.Logger?.ReportInfo(Log.Component.Configuration, $"Additional module paths: {string.Join(", ", properties.AdditionalModulePaths)}");
             var factory = new ConfigurationSetProcessorFactory(ConfigurationProcessorType.Hosted, properties);
 


### PR DESCRIPTION
## Summary of the pull request
- Packaged version did not find the `Modules` directory which is required by the configuration API.
- Explicitly adding the path as input to the Configuration API.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
