### PR TITLE
Rename to Microsoft.WindowsPackageManager.Configuration nuget

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.3" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.5" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta">
       <PrivateAssets>all</PrivateAssets>

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
-    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.3" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.*-*" />
-    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.3" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.5" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" GeneratePathProperty="true">
       <IncludeAssets>contentFiles</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Rename Microsoft.Management.Configuration to Microsoft.WindowsPackageManager.Configuration. 

This is the public available name that is published into [nuget.org]([NuGet Gallery | Microsoft.WindowsPackageManager.Configuration 0.0.3](https://www.nuget.org/packages/Microsoft.WindowsPackageManager.Configuration))