### PR TITLE
Update vsconfig to include 22000 SDK

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -7,8 +7,9 @@
     "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
     "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
     "Microsoft.VisualStudio.Component.NuGet",
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.Component.Windows10SDK",
+    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22000",
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs",
     "Microsoft.VisualStudio.Workload.ManagedDesktop"


### PR DESCRIPTION
## Summary of the pull request
Title says it all.  Most of the projects are built against the 22000 sdk now, but we still have some 19041 that we'll need to clean up in there.  Will open issue for that.
