### PR TITLE
SettingsCard design improvements

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -94,8 +94,11 @@
     <value>About</value>
     <comment>Header for a card than when clicked takes the user to the About settings page</comment>
   </data>
-  <data name="Settings_Theme.Text" xml:space="preserve">
-    <value>Theme</value>
+  <data name="Settings_Theme.Header" xml:space="preserve">
+    <value>App theme</value>
+  </data>
+	<data name="Settings_Theme.Description" xml:space="preserve">
+    <value>Select which theme to display</value>
   </data>
   <data name="Settings_Theme_Light.Content" xml:space="preserve">
     <value>Light</value>
@@ -104,7 +107,8 @@
     <value>Dark</value>
   </data>
   <data name="Settings_Theme_Default.Content" xml:space="preserve">
-    <value>Default</value>
+    <value>Windows default</value>
+	  <comment>Windows refers to the Operating system</comment>
   </data>
   <data name="Settings_About.Text" xml:space="preserve">
     <value>About this application</value>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -97,7 +97,7 @@
   <data name="Settings_Theme.Header" xml:space="preserve">
     <value>App theme</value>
   </data>
-	<data name="Settings_Theme.Description" xml:space="preserve">
+  <data name="Settings_Theme.Description" xml:space="preserve">
     <value>Select which theme to display</value>
   </data>
   <data name="Settings_Theme_Light.Content" xml:space="preserve">

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -108,7 +108,7 @@
   </data>
   <data name="Settings_Theme_Default.Content" xml:space="preserve">
     <value>Windows default</value>
-	  <comment>Windows refers to the Operating system</comment>
+    <comment>Windows refers to the Operating system</comment>
   </data>
   <data name="Settings_About.Text" xml:space="preserve">
     <value>About this application</value>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -19,22 +19,16 @@
 
         <DataTemplate x:Key="AccountsProviderViewTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
             <StackPanel>
-                <StackPanel>
-                    <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="{StaticResource XSmallTopMargin}"/>
-                </StackPanel>
-                <StackPanel>
-                    <ItemsRepeater ItemsSource="{x:Bind LoggedInAccounts}" ItemTemplate="{StaticResource AccountsViewTemplate}"
+                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}"/>
+                <ItemsRepeater ItemsSource="{x:Bind LoggedInAccounts}" ItemTemplate="{StaticResource AccountsViewTemplate}"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" />
-                </StackPanel>
             </StackPanel>
         </DataTemplate>
 
         <DataTemplate x:Key="AccountsViewTemplate" x:DataType="models:Account">
-            <StackPanel Margin="{StaticResource XSmallTopMargin}">
-                <labs:SettingsCard Header="{x:Bind LoginId}">
-                    <Button Tag="{x:Bind}" x:Uid="Settings_Accounts_LogoutButton" Click="Logout_Click"/>
-                </labs:SettingsCard>
-            </StackPanel>
+            <labs:SettingsCard Header="{x:Bind LoginId}" Margin="{StaticResource SettingsCardMargin}">
+                <Button Tag="{x:Bind}" x:Uid="Settings_Accounts_LogoutButton" Click="Logout_Click"/>
+            </labs:SettingsCard>
         </DataTemplate>
     </Page.Resources>
 

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -27,9 +27,10 @@
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:ExtensionViewModel">
                         <labs:SettingsCard Header="{x:Bind Header}"
-                                   IsClickEnabled="False" Command="{x:Bind NavigateSettingsCommand}">
+                                           Margin="{ThemeResource SettingsCardMargin}"
+                                           IsClickEnabled="False" Command="{x:Bind NavigateSettingsCommand}">
                             <ToggleSwitch Visibility="{x:Bind HasToggleSwitch, Converter={StaticResource BoolToVisibilityConverter}}"
-                                      IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                          IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
                         </labs:SettingsCard>
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -2,55 +2,68 @@
     x:Class="DevHome.Settings.Views.PreferencesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:helpers="using:DevHome.Common.Helpers"
-    xmlns:xaml="using:Microsoft.UI.Xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:DevHome.Common.Helpers"
+    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xaml="using:Microsoft.UI.Xaml"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     </Page.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <ScrollViewer
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{ThemeResource ContentPageMargin}"
+        VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="ContentArea">
-            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
+            <BreadcrumbBar
+                x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+                ItemClicked="BreadcrumbBar_ItemClicked"
+                ItemsSource="{x:Bind Breadcrumbs}" />
 
             <StackPanel Margin="{StaticResource SmallTopBottomMargin}">
-                <TextBlock x:Uid="Settings_Theme" />
-                <StackPanel Margin="{StaticResource XSmallTopMargin}">
-                    <RadioButton
-                        x:Uid="Settings_Theme_Light"
-                        Command="{x:Bind ViewModel.SwitchThemeCommand}"
-                        IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}"
-                        FontSize="15"
-                        GroupName="AppTheme">
-                        <RadioButton.CommandParameter>
-                            <xaml:ElementTheme>Light</xaml:ElementTheme>
-                        </RadioButton.CommandParameter>
-                    </RadioButton>
-                    <RadioButton
-                        x:Uid="Settings_Theme_Dark"
-                        Command="{x:Bind ViewModel.SwitchThemeCommand}"
-                        IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}"
-                        FontSize="15"
-                        GroupName="AppTheme">
-                        <RadioButton.CommandParameter>
-                            <xaml:ElementTheme>Dark</xaml:ElementTheme>
-                        </RadioButton.CommandParameter>
-                    </RadioButton>
-                    <RadioButton
-                        x:Uid="Settings_Theme_Default"
-                        Command="{x:Bind ViewModel.SwitchThemeCommand}"
-                        IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Default, Mode=OneWay}"
-                        FontSize="15"
-                        GroupName="AppTheme">
-                        <RadioButton.CommandParameter>
-                            <xaml:ElementTheme>Default</xaml:ElementTheme>
-                        </RadioButton.CommandParameter>
-                    </RadioButton>
-                </StackPanel>
+                <labs:SettingsExpander x:Uid="Settings_Theme" IsExpanded="True">
+                    <labs:SettingsExpander.HeaderIcon>
+                        <FontIcon Glyph="&#xE790;" />
+                    </labs:SettingsExpander.HeaderIcon>
+                    <labs:SettingsExpander.Items>
+                        <labs:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
+                            <StackPanel>
+                                <RadioButton
+                                    x:Uid="Settings_Theme_Light"
+                                    Command="{x:Bind ViewModel.SwitchThemeCommand}"
+                                    GroupName="AppTheme"
+                                    IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}">
+                                    <RadioButton.CommandParameter>
+                                        <xaml:ElementTheme>Light</xaml:ElementTheme>
+                                    </RadioButton.CommandParameter>
+                                </RadioButton>
+                                <RadioButton
+                                    x:Uid="Settings_Theme_Dark"
+                                    Command="{x:Bind ViewModel.SwitchThemeCommand}"
+                                    GroupName="AppTheme"
+                                    IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}">
+                                    <RadioButton.CommandParameter>
+                                        <xaml:ElementTheme>Dark</xaml:ElementTheme>
+                                    </RadioButton.CommandParameter>
+                                </RadioButton>
+                                <RadioButton
+                                    x:Uid="Settings_Theme_Default"
+                                    Command="{x:Bind ViewModel.SwitchThemeCommand}"
+                                    GroupName="AppTheme"
+                                    IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Default, Mode=OneWay}">
+                                    <RadioButton.CommandParameter>
+                                        <xaml:ElementTheme>Default</xaml:ElementTheme>
+                                    </RadioButton.CommandParameter>
+                                </RadioButton>
+                            </StackPanel>
+                        </labs:SettingsCard>
+                    </labs:SettingsExpander.Items>
+                </labs:SettingsExpander>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -20,7 +20,7 @@
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:SettingViewModel">
                         <labs:SettingsCard Header="{x:Bind Header}" Description="{x:Bind Description}"
-                                       IsClickEnabled="True" Command="{x:Bind NavigateSettingsCommand}" Margin="0 0 0 5">
+                                       IsClickEnabled="True" Command="{x:Bind NavigateSettingsCommand}" Margin="{ThemeResource SettingsCardMargin}">
                             <labs:SettingsCard.HeaderIcon>
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="{x:Bind Glyph}"/>
                             </labs:SettingsCard.HeaderIcon>

--- a/src/Styles/TextBlock.xaml
+++ b/src/Styles/TextBlock.xaml
@@ -24,4 +24,12 @@
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
 
+    <!--  Style (inc. the correct spacing) of a section header  -->
+    <Style x:Key="SettingsSectionHeaderTextBlockStyle"
+               BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+               TargetType="TextBlock">
+        <Style.Setters>
+            <Setter Property="Margin" Value="1,28,0,4" />
+        </Style.Setters>
+    </Style>
 </ResourceDictionary>

--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -1,6 +1,4 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Thickness x:Key="LargeTopMargin">0,36,0,0</Thickness>
     <Thickness x:Key="LargeTopBottomMargin">0,36,0,36</Thickness>
@@ -38,4 +36,6 @@
     <Thickness x:Key="SettingsPageSubTitleMargin">0,0,0,16</Thickness>
     <Thickness x:Key="SettingsPageSubTitleArrowMargin">12,0,8,0</Thickness>
 
+    <Thickness x:Key="SettingsCardMargin">0,0,0,4</Thickness>
+    <x:Double x:Key="SettingsCardSpacing">4</x:Double>
 </ResourceDictionary>

--- a/src/Views/FeedbackPage.xaml
+++ b/src/Views/FeedbackPage.xaml
@@ -9,7 +9,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:DevHome.Common.Helpers"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
-    xmlns:xaml="using:Microsoft.UI.Xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     mc:Ignorable="d"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
@@ -94,7 +93,7 @@
                     <Run x:Uid="Feedback_OpenSource_LinkText"></Run>
                 </Hyperlink>
                 </TextBlock>
-                <StackPanel>
+                <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
                     <labs:SettingsCard x:Uid="Feedback_ReportBug">
                         <labs:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -21,11 +21,6 @@
 
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
-                <ResourceDictionary>
-                    <Style x:Key="MainPageCardStyle" TargetType="labs:SettingsCard">
-                        <Setter Property="CornerRadius" Value="7" />
-                    </Style>
-                </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
 
             <ResourceDictionary.ThemeDictionaries>
@@ -74,7 +69,7 @@
         <!-- Main content -->
         <controls:SetupShell Grid.Row="1" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel Spacing="30">
+                <StackPanel>
                     <commonviews:Banner
                         TextWidth="345"
                         HideButtonVisibility="True"
@@ -85,12 +80,11 @@
                         BackgroundSource="{ThemeResource Setup_Banner_Back}"
                         OverlaySource="{ThemeResource Setup_Banner_Front}" />
 
-                    <StackPanel Spacing="5">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_EnvironmentSetup" />
+                    <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+                        <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_EnvironmentSetup" />
                         <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
                         <Grid Background="Transparent">
                             <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
-                                               Style="{StaticResource MainPageCardStyle}"
                                                IsClickEnabled="True"
                                                Command="{x:Bind ViewModel.StartSetupCommand}"
                                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
@@ -111,7 +105,6 @@
                             </ToolTipService.ToolTip>
                         </Grid>
                         <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_ConfigurationFile"
-                                           Style="{StaticResource MainPageCardStyle}"
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
                                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
@@ -122,10 +115,9 @@
                         </labs:SettingsCard>
                     </StackPanel>
 
-                    <StackPanel Spacing="5">
-                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_QuickConfiguration" />
+                    <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+                        <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_QuickConfiguration" />
                         <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
-                                           Style="{StaticResource MainPageCardStyle}"
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartRepoConfigCommand}"
                                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
@@ -137,7 +129,6 @@
                         <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
                         <Grid Background="Transparent">
                             <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
-                                               Style="{StaticResource MainPageCardStyle}"
                                                IsClickEnabled="True"
                                                Command="{x:Bind ViewModel.StartAppManagementCommand}"
                                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
@@ -158,7 +149,6 @@
                             </ToolTipService.ToolTip>
                         </Grid>
                         <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
-                                           Style="{StaticResource MainPageCardStyle}"
                                            IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
                                            Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" >
                             <labs:SettingsCard.ActionIcon>


### PR DESCRIPTION
## Summary of the pull request
This PR adds some styling consistency to various pages where `SettingsCards` are used. These changes are inline with design specifications (Windows Visual Library in Figma) and other 1P apps (like PowerToys)

Machinge config (before vs. after)
![image](https://github.com/microsoft/devhome/assets/9866362/d7ca6051-606d-4722-8bf8-8c8799e89ede)

Feedback (before vs. after)
![image](https://github.com/microsoft/devhome/assets/9866362/6600fe24-ea2c-4d98-8059-6e00ee1c4bc8)

Settings (before vs. after)
![image](https://github.com/microsoft/devhome/assets/9866362/2d003508-0892-430d-8166-2cce1678ee33)

Preferences (before vs. after)
![image](https://github.com/microsoft/devhome/assets/9866362/7a4f25a7-345f-4254-8ba5-1d50f3d1dd65)

Accounts (before vs. after)
![image](https://github.com/microsoft/devhome/assets/9866362/dfb60c88-172a-4188-bad1-20e0c37844e2)

Extensions (before vs. after)
![image](https://github.com/microsoft/devhome/assets/9866362/5e03ce4c-1565-4546-ae8a-76a74856b4bc)




## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [X] Closes #664 #671 #560
- [ ] Tests added/passed
- [ ] Documentation updated
