### PR TITLE
Improved about section

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -185,11 +185,11 @@
   <data name="LoginUIDialogTitle.Text" xml:space="preserve">
     <value>Connect your account</value>
   </data>
-  <data name="Settings_About_Specifications.Text" xml:space="preserve">
-    <value>Dev Home specifications</value>
+  <data name="Settings_About_Card.Header" xml:space="preserve">
+    <value>Dev Home</value>
   </data>
-  <data name="Settings_About_Version.Text" xml:space="preserve">
-    <value>Version</value>
+	<data name="Settings_About_Card.Description" xml:space="preserve">
+    <value>© 2023 Microsoft. All rights reserved.</value>
   </data>
   <data name="Settings_About_RelatedLinks.Text" xml:space="preserve">
     <value>Related links</value>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -189,7 +189,7 @@
     <value>Dev Home</value>
   </data>
 	<data name="Settings_About_Card.Description" xml:space="preserve">
-    <value>© 2023 Microsoft. All rights reserved.</value>
+    <value>Made with 💗 by Microsoft and the DevHome community</value>
   </data>
   <data name="Settings_About_RelatedLinks.Text" xml:space="preserve">
     <value>Related links</value>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -188,7 +188,7 @@
   <data name="Settings_About_Card.Header" xml:space="preserve">
     <value>Dev Home</value>
   </data>
-	<data name="Settings_About_Card.Description" xml:space="preserve">
+  <data name="Settings_About_Card.Description" xml:space="preserve">
     <value>Made with 💗 by Microsoft and the Dev Home community</value>
   </data>
   <data name="Settings_About_RelatedLinks.Text" xml:space="preserve">

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -189,7 +189,7 @@
     <value>Dev Home</value>
   </data>
 	<data name="Settings_About_Card.Description" xml:space="preserve">
-    <value>Made with 💗 by Microsoft and the DevHome community</value>
+    <value>Made with 💗 by Microsoft and the Dev Home community</value>
   </data>
   <data name="Settings_About_RelatedLinks.Text" xml:space="preserve">
     <value>Related links</value>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -106,12 +106,6 @@
   <data name="Settings_Theme_Default.Content" xml:space="preserve">
     <value>Default</value>
   </data>
-  <data name="Settings_About.Text" xml:space="preserve">
-    <value>About this application</value>
-  </data>
-  <data name="Settings_AboutDescription.Text" xml:space="preserve">
-    <value>TODO: Replace with your app description.</value>
-  </data>
   <data name="SettingsPage_SourceCodeLink.Content" xml:space="preserve">
     <value>Source code</value>
   </data>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -2,55 +2,45 @@
     x:Class="DevHome.Settings.Views.AboutPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:helpers="using:DevHome.Common.Helpers"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:DevHome.Common.Helpers"
+    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light">
-                    <Color x:Key="CardBackground">#B3FFFFFF</Color>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <Color x:Key="CardBackground">#0DFFFFFF</Color>
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <ScrollViewer
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{ThemeResource ContentPageMargin}"
+        VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="{StaticResource XSmallTopMargin}">
-            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
+            <BreadcrumbBar
+                x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+                ItemClicked="BreadcrumbBar_ItemClicked"
+                ItemsSource="{x:Bind Breadcrumbs}" />
 
-            <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
-                          IsExpanded="true" Background="{ThemeResource CardBackground}"
-                          MinHeight="64" CornerRadius="6,6,0,0" Padding="47,0,47,7" >
-                <Expander.Header>
-                    <StackPanel Orientation="Horizontal">
-                        <Image Source="/Assets/DevHome.ico" HorizontalAlignment="Left" Width="16" Height="16" />
-                        <TextBlock x:Uid="Settings_About_Specifications" Margin="20,0,0,0" />
-                    </StackPanel>
-                </Expander.Header>
-                <Expander.Content>
-                    <StackPanel Orientation="Vertical">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock x:Uid="Settings_About_Version" Width="100" />
-                            <TextBlock Text="{x:Bind ViewModel.VersionDescription, Mode=OneWay}" />
+            <labs:SettingsExpander x:Uid="Settings_About_Card" IsExpanded="True">
+                <labs:SettingsExpander.HeaderIcon>
+                    <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/DevHome.ico" />
+                </labs:SettingsExpander.HeaderIcon>
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    IsTextSelectionEnabled="True"
+                    Text="{x:Bind ViewModel.VersionDescription, Mode=OneWay}" />
+                <labs:SettingsExpander.Items>
+                    <labs:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock x:Uid="Settings_About_RelatedLinks" Margin="{StaticResource XSmallTopBottomMargin}" />
+                            <HyperlinkButton x:Uid="SettingsPage_SourceCodeLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
+                            <HyperlinkButton x:Uid="SettingsPage_DocumentationLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
+                            <HyperlinkButton x:Uid="SettingsPage_ReleaseNotesLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
+                            <HyperlinkButton x:Uid="SettingsPage_PrivacyPolicyLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
                         </StackPanel>
-                    </StackPanel>
-                </Expander.Content>
-            </Expander>
-            <StackPanel Orientation="Horizontal" Background="{ThemeResource CardBackground}"
-                        CornerRadius="0,0,6,6" Padding="15,0,47,7" Margin="1,0,1,0">
-                <TextBlock x:Uid="Settings_About_RelatedLinks" VerticalAlignment="Center" />
-                <HyperlinkButton x:Uid="SettingsPage_SourceCodeLink" Margin="{StaticResource SettingsPageHyperlinkButtonMargin}" />
-                <HyperlinkButton x:Uid="SettingsPage_DocumentationLink" Margin="{StaticResource SettingsPageHyperlinkButtonMargin}" />
-                <HyperlinkButton x:Uid="SettingsPage_ReleaseNotesLink" Margin="{StaticResource SettingsPageHyperlinkButtonMargin}" />
-                <HyperlinkButton x:Uid="SettingsPage_PrivacyPolicyLink" Margin="{StaticResource SettingsPageHyperlinkButtonMargin}" />
-            </StackPanel>
+                    </labs:SettingsCard>
+                </labs:SettingsExpander.Items>
+            </labs:SettingsExpander>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -18,6 +18,7 @@
 
     <Thickness x:Key="XSmallLeftMargin">8,0,0,0</Thickness>
     <Thickness x:Key="XSmallTopMargin">0,8,0,0</Thickness>
+    <Thickness x:Key="XSmallTopBottomMargin">0,8,0,8</Thickness>
     <Thickness x:Key="XSmallLeftTopRightBottomMargin">8,8,8,8</Thickness>
 
     <Thickness x:Key="XXSmallTopMargin">0,4,0,0</Thickness>
@@ -33,7 +34,7 @@
 
     <Thickness x:Key="MenuBarContentMargin">36,24,36,0</Thickness>
 
-    <Thickness x:Key="SettingsPageHyperlinkButtonMargin">12,0,0,0</Thickness>
+    <Thickness x:Key="HyperlinkButtonNegativeMargin">-12,0,0,0</Thickness>
 
     <Thickness x:Key="SettingsPageSubTitleMargin">0,0,0,16</Thickness>
     <Thickness x:Key="SettingsPageSubTitleArrowMargin">12,0,8,0</Thickness>


### PR DESCRIPTION
## Summary of the pull request
- Using a `SettingsExpander` for the About section, with a design that is inline with design specs and other 1P apps (like Store, Clock, Photos)
- Version number is now selectable so it can be copied easier
- Added the "Made with ..", [similar to PowerToys](https://github.com/microsoft/PowerToys/blob/a0b9af039d7505f510e2496607e8b62bd6ecc6c6/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw#LL1192C1-L1192C54)

Before:
![image](https://github.com/microsoft/devhome/assets/9866362/0332c0cb-71b4-42d0-aa52-1a54a3317eab)

After:
![image](https://github.com/microsoft/devhome/assets/9866362/7fe8fa8c-703e-4cfc-a219-8a1694f96a50)

## References and relevant issues
Figma design spec:
![image](https://github.com/microsoft/devhome/assets/9866362/64129853-3987-4a51-a9a8-8d0070733750)

Photos
![image](https://github.com/microsoft/devhome/assets/9866362/195f598d-c084-4add-b785-569899799740)

Camera
![image](https://github.com/microsoft/devhome/assets/9866362/1866b98b-2a09-4f21-9c2e-e0f645943e14)

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #689
- [ ] Tests added/passed
- [ ] Documentation updated
