### PR TITLE
Replace deprecated icon glyphs

### DIFF
--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -22,7 +22,7 @@
                 Visibility="{x:Bind HideButtonVisibility}">
             <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
                        FontSize="{ThemeResource BodyTextBlockFontSize}"
-                       Text="&#xE10A;" />
+                       Text="&#xE711;" />
         </Button>
         <StackPanel VerticalAlignment="Center" Margin="38 0 0 0" Spacing="12">
             <TextBlock

--- a/settings/DevHome.Settings/Views/LoginUIDialog.xaml
+++ b/settings/DevHome.Settings/Views/LoginUIDialog.xaml
@@ -26,7 +26,7 @@
                     BorderThickness="0" Background="Transparent" Padding="15">
                 <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
                            FontSize="{ThemeResource BodyTextBlockFontSize}"
-                           Text="&#xE10A;" />
+                           Text="&#xE711;" />
             </Button>
         </Grid>
 

--- a/src/Views/FeedbackPage.xaml
+++ b/src/Views/FeedbackPage.xaml
@@ -112,7 +112,7 @@
                     <labs:SettingsCard x:Uid="Feedback_LocalizationIssue">
                         <labs:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
-                                  Glyph="&#xE128;"/>
+                                  Glyph="&#xE909;"/>
                         </labs:SettingsCard.HeaderIcon>
                         <Button x:Uid="Feedback_LocalizationIssue_Button" Click="DisplayLocalizationIssueDialog"/>
                     </labs:SettingsCard>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -31,7 +31,7 @@
                     BorderThickness="0" Background="Transparent" Padding="10">
                 <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
                            FontSize="{ThemeResource BodyTextBlockFontSize}" 
-                           Text="&#xE10A;" />
+                           Text="&#xE711;" />
             </Button>
         </Grid>
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -29,7 +29,7 @@
                     BorderThickness="0" Background="Transparent" Margin="5">
                 <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
                            FontSize="{ThemeResource BodyTextBlockFontSize}" 
-                           Text="&#xE10A;" />
+                           Text="&#xE711;" />
             </Button>
         </Grid>
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/SetupToolStyles.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/SetupToolStyles.xaml
@@ -21,8 +21,8 @@
     
     <!-- TODO Deprecated -->
     <x:String x:Key="SegoeFont">Segoe MDL2 Assets</x:String>
-    <x:String x:Key="FontIconSource">&#xE13D;</x:String>
-    <x:String x:Key="FontIconClose">&#xE10A;</x:String>
+    <x:String x:Key="FontIconSource">&#xE77B;</x:String>
+    <x:String x:Key="FontIconClose">&#xE711;</x:String>
 
     <!-- TODO Deprecated -->
     <Style x:Key="CheckBoxNoLabelStyle" TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
@@ -159,10 +159,10 @@
                                 <ImageIcon Source="{x:Bind Icon, Mode=OneWay}"/>
                             </ctControls:SettingsCard.HeaderIcon>
                             <ctControls:SettingsCard.ActionIcon>
-                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE10A;"/>
+                                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE711;"/>
                             </ctControls:SettingsCard.ActionIcon>
                             <Button Command="{x:Bind ToggleSelectionCommand, Mode=OneWay}" Padding="10" Background="Transparent" BorderThickness="0">
-                                <FontIcon FontSize="{ThemeResource CaptionTextBlockFontSize}" FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE106;"/>
+                                <FontIcon FontSize="{ThemeResource CaptionTextBlockFontSize}" FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
                             </Button>
                         </ctControls:SettingsCard>
                     </DataTemplate>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -29,7 +29,7 @@
                 <x:Double x:Key="SettingsCardWrapNoIconThreshold">0</x:Double>
             </controls:SettingsCard.Resources>
             <controls:SettingsCard.ActionIcon>
-                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE10A;"/>
+                <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE711;"/>
             </controls:SettingsCard.ActionIcon>
             <HyperlinkButton
                 Grid.Column="1"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
@@ -12,7 +12,7 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Show `RevToggleKey` icon if a package is selected (TrueValue), otherwise (FalseValue) show 'Add' icon -->
-            <converters:BoolToObjectConverter x:Key="SelectButtonGlyphConverter" TrueValue="&#xE845;" FalseValue="&#xE109;" />
+            <converters:BoolToObjectConverter x:Key="SelectButtonGlyphConverter" TrueValue="&#xE845;" FalseValue="&#xE710;" />
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
             <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
@@ -11,7 +11,7 @@
         <converters:CollectionVisibilityConverter x:Name="CollectionVisibilityConverter" EmptyValue="Visible" NotEmptyValue="Collapsed" />
         <converters:StringFormatConverter x:Name="StringFormatConverter" />
         <!-- Show `RevToggleKey` icon if a package is selected (TrueValue), otherwise (FalseValue) show 'Add' icon -->
-        <converters:BoolToObjectConverter x:Name="SelectButtonGlyphConverter" TrueValue="&#xE845;" FalseValue="&#xE109;" />
+        <converters:BoolToObjectConverter x:Name="SelectButtonGlyphConverter" TrueValue="&#xE845;" FalseValue="&#xE710;" />
         <converters:BoolNegationConverter x:Name="BoolNegationConverter" />
         <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
     </UserControl.Resources>


### PR DESCRIPTION
## Summary of the pull request
There were icon glyphs being used starting with E1 - [which are deprecated](https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font#icon-list)

These glyphs are now replaced with glyphs that are supported - they are exactly the same, so no visual changes.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #665
- [ ] Tests added/passed
- [ ] Documentation updated
