### PR TITLE
On theme change, update title bar and widgets with ActualTheme

### DIFF
--- a/common/Extensions/WindowExExtensions.cs
+++ b/common/Extensions/WindowExExtensions.cs
@@ -75,7 +75,7 @@ public static class WindowExExtensions
         if (window.Content is FrameworkElement rootElement)
         {
             rootElement.RequestedTheme = theme;
-            TitleBarHelper.UpdateTitleBar(window, theme);
+            TitleBarHelper.UpdateTitleBar(window, rootElement.ActualTheme);
         }
     }
 

--- a/src/Services/ThemeSelectorService.cs
+++ b/src/Services/ThemeSelectorService.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license.
 
 using DevHome.Common.Contracts;
-using DevHome.Common.Helpers;
 using DevHome.Contracts.Services;
-using DevHome.Helpers;
 using Microsoft.UI.Xaml;
 
 namespace DevHome.Services;

--- a/src/Views/ShellPage.xaml.cs
+++ b/src/Views/ShellPage.xaml.cs
@@ -1,29 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Collections.ObjectModel;
-using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
-using DevHome.Contracts.Services;
-using DevHome.Dashboard.ViewModels;
-using DevHome.Helpers;
-using DevHome.Services;
 using DevHome.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Windows.System;
 
 namespace DevHome.Views;
 
-// TODO: Update NavigationViewItem titles and icons in ShellPage.xaml.
-// https://github.com/microsoft/devhome/issues/614
 public sealed partial class ShellPage : Page
 {
     public ShellViewModel ViewModel
@@ -46,16 +36,24 @@ public sealed partial class ShellPage : Page
         App.MainWindow.SetTitleBar(AppTitleBar);
         App.MainWindow.Activated += MainWindow_Activated;
         AppTitleBarText.Text = Application.Current.GetService<IAppInfoService>().GetAppNameLocalized();
+
+        ActualThemeChanged += OnActualThemeChanged;
     }
 
     private async void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        TitleBarHelper.UpdateTitleBar(App.MainWindow, RequestedTheme);
+        TitleBarHelper.UpdateTitleBar(App.MainWindow, ActualTheme);
 
         KeyboardAccelerators.Add(BuildKeyboardAccelerator(VirtualKey.Left, VirtualKeyModifiers.Menu));
         KeyboardAccelerators.Add(BuildKeyboardAccelerator(VirtualKey.GoBack));
 
         await ViewModel.OnLoaded();
+    }
+
+    private void OnActualThemeChanged(FrameworkElement sender, object args)
+    {
+        // Update the title bar if the system theme changes.
+        TitleBarHelper.UpdateTitleBar(App.MainWindow, ActualTheme);
     }
 
     private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -99,7 +99,7 @@ public partial class WidgetViewModel : ObservableObject
         WidgetDefinition = widgetDefintion;
     }
 
-    public void Refresh()
+    public void Render()
     {
         RenderWidgetFrameworkElement();
     }

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -99,6 +99,11 @@ public partial class WidgetViewModel : ObservableObject
         WidgetDefinition = widgetDefintion;
     }
 
+    public void Refresh()
+    {
+        RenderWidgetFrameworkElement();
+    }
+
     private async void RenderWidgetFrameworkElement()
     {
         Log.Logger()?.ReportDebug("WidgetViewModel", "RenderWidgetFrameworkElement");

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -174,6 +174,12 @@ public partial class DashboardView : ToolPage
     {
         // The app uses a different host config to render widgets (adaptive cards) in light and dark themes.
         await ConfigureWidgetRenderer(_renderer);
+
+        // Re-render the widgets with the new theme and renderer.
+        foreach (var widget in PinnedWidgets)
+        {
+            widget.Refresh();
+        }
     }
 
     private async Task ConfigureWidgetRenderer(AdaptiveCardRenderer renderer)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -178,7 +178,7 @@ public partial class DashboardView : ToolPage
         // Re-render the widgets with the new theme and renderer.
         foreach (var widget in PinnedWidgets)
         {
-            widget.Refresh();
+            widget.Render();
         }
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml
@@ -34,7 +34,7 @@
         <!-- Widget header: icon, title, menu -->
         <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}">
             <StackPanel Orientation="Horizontal" Margin="15,10,15,5">
-                <Rectangle Width="16" Height="16" Margin="0,0,8,0"
+                <Rectangle Width="16" Height="16" Margin="0,0,8,0" x:Name="WidgetHeaderIcon"
                            Fill="{x:Bind views:DashboardView.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme),Mode=OneWay}"/>
                 <TextBlock Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}" VerticalAlignment="Center" FontSize="{ThemeResource CaptionTextBlockFontSize}" />
             </StackPanel>

--- a/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/WidgetControl.xaml.cs
@@ -7,7 +7,6 @@ using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
@@ -20,6 +19,7 @@ public sealed partial class WidgetControl : UserControl
     public WidgetControl()
     {
         this.InitializeComponent();
+        ActualThemeChanged += OnActualThemeChanged;
     }
 
     public WidgetViewModel WidgetSource
@@ -208,5 +208,10 @@ public sealed partial class WidgetControl : UserControl
                 widgetViewModel.IsInEditMode = true;
             }
         }
+    }
+
+    private void OnActualThemeChanged(FrameworkElement sender, object args)
+    {
+        WidgetHeaderIcon.Fill = DashboardView.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Updates for both app and system theme changes.

On app theme change: when changing theme to Default, the title bar text does not change appropriately. This is because we're not updating the title bar when `TitleBarHelper.UpdateTitleBar()` is given Default. Instead, we should give it the actual theme so it can choose the correct resources.

On system theme change: ShellPage needs to listen to ActualThemeChanged events and update the title bar appropriately. Additionally, we weren't re-rendering the widgets if the system theme changed while the Dashboard was showing, so re-render them in that case.

## References and relevant issues
Fixes #511

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #511
- [ ] Tests added/passed
- [ ] Documentation updated
