### PR TITLE
Directly add NuGet.org to nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -7,6 +7,7 @@
   </config>
   <packageSources>
     <clear />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="DevHomeDependencies" value="https://pkgs.dev.azure.com/ms/DevHome/_packaging/DevHomeDependencies/nuget/v3/index.json" />
     <add key="SDKLocalSource" value=".\pluginsdk\_build" />
   </packageSources>


### PR DESCRIPTION
## Summary of the pull request
Add NuGet.org to nuget.config.  This enables other packages versions to be used without requiring credentials to add to DevHomeDependencies feed.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #734 
- [ ] Tests added/passed
- [ ] Documentation updated
