### PR TITLE
Fix poor background contrast with MicaBackdrop API

### DIFF
--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -11,7 +11,7 @@
     PersistenceId="MainWindow"
     Closed="MainWindow_Closed"
     mc:Ignorable="d">
-    <windowex:WindowEx.Backdrop>
-        <windowex:MicaSystemBackdrop/>
-    </windowex:WindowEx.Backdrop>
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
 </windowex:WindowEx>


### PR DESCRIPTION
## Summary of the pull request
This changes the window to use the WinUI SystemBackdrop API, which was added in Windows App SDK 1.3. The WinUIEx MicaSystemBackdrop API that is currently used, is, at least by default, not using color values consistent with Windows, which can cause very poor contrast. The WinUI built-in MicaBackdrop behaves as expected and fixes contrast issues.

## References and relevant issues
Fixes #749 

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #749 
- [ ] Tests added/passed
- [ ] Documentation updated
