### PR TITLE
Update Dev Drive card in whats new page based on Dev Drive feature availability

### DIFF
--- a/src/Models/WhatsNewCard.cs
+++ b/src/Models/WhatsNewCard.cs
@@ -45,4 +45,9 @@ public class WhatsNewCard
     {
         get; set;
     }
+
+    public bool? ShouldShowLink
+    {
+        get; set;
+    }
 }

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -7,6 +7,7 @@
     xmlns:animations="using:CommunityToolkit.WinUI.UI.Animations"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls" 
     xmlns:models="using:DevHome.Models"
+    xmlns:setupUtils="using:DevHome.SetupFlow.Utilities"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     Loaded="OnLoaded"
@@ -184,7 +185,8 @@
                                         Foreground="{ThemeResource LearnMoreForeground}"
                                         NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
                                         Padding="0"
-                                        Margin="0"/>
+                                        Margin="0"
+                                        Visibility="{x:Bind ShouldShowLink}"/>
                                 </StackPanel>
 
                                 <Button 

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -7,7 +7,6 @@
     xmlns:animations="using:CommunityToolkit.WinUI.UI.Animations"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls" 
     xmlns:models="using:DevHome.Models"
-    xmlns:setupUtils="using:DevHome.SetupFlow.Utilities"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     Loaded="OnLoaded"

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -22,11 +22,9 @@ namespace DevHome.Views;
 
 public sealed partial class WhatsNewPage : Page
 {
-    public Uri DevDrivePageKeyUri { get; private set; } = new ("ms-settings:disksandvolumes");
-
-    public Uri DevDriveLearnMoreLinkUri { get; private set; } = new ("https://go.microsoft.com/fwlink/?linkid=2236041");
-
-    public string DevDriveLinkResourceKey { get; private set; } = "WhatsNewPage_DevDriveCard/Link";
+    private readonly Uri _devDrivePageKeyUri = new ("ms-settings:disksandvolumes");
+    private readonly Uri _devDriveLearnMoreLinkUri = new ("https://go.microsoft.com/fwlink/?linkid=2236041");
+    private const string _devDriveLinkResourceKey = "WhatsNewPage_DevDriveCard/Link";
 
     public WhatsNewViewModel ViewModel
     {
@@ -56,11 +54,11 @@ public sealed partial class WhatsNewPage : Page
             }
 
             // When the Dev Drive feature is not enabled don't show the learn more uri link, but instead move the learn more text into the button content.
-            if (card!.PageKey!.Equals(DevDrivePageKeyUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(card.PageKey, _devDrivePageKeyUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
             {
                 if (!DevDriveUtil.IsDevDriveFeatureEnabled)
                 {
-                    card.Button = Application.Current.GetService<IStringResource>().GetLocalized(DevDriveLinkResourceKey);
+                    card.Button = Application.Current.GetService<IStringResource>().GetLocalized(_devDriveLinkResourceKey);
                     card.ShouldShowLink = false;
                 }
             }
@@ -84,11 +82,11 @@ public sealed partial class WhatsNewPage : Page
             return;
         }
 
-        if (pageKey.Equals(DevDrivePageKeyUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
+        if (pageKey.Equals(_devDrivePageKeyUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
         {
             // Only launch the disks and volumes settings page when the Dev Drive feature is enabled.
             // Otherwise redirect the user to the Dev Drive support page to learn more about the feature.
-            await Launcher.LaunchUriAsync(DevDriveUtil.IsDevDriveFeatureEnabled ? DevDrivePageKeyUri : DevDriveLearnMoreLinkUri);
+            await Launcher.LaunchUriAsync(DevDriveUtil.IsDevDriveFeatureEnabled ? _devDrivePageKeyUri : _devDriveLearnMoreLinkUri);
         }
         else
         {

--- a/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
@@ -69,7 +69,7 @@ public static class DevDriveUtil
     // numbers start at 22000.
     private const ushort DevDriveMajorVersion = 10;
     private const ushort DevDriveMinorVersion = 0;
-    private const ushort DevDriveMinBuildForDevChannel = 23451;
+    private const ushort DevDriveMinBuildForDevChannel = 23466;
     private const ushort DevDriveMaxBuildForDevChannel = 23999;
     private const ushort DevDriveMinBuildForCanaryChannel = 25846;
 


### PR DESCRIPTION
## Summary of the pull request
- Dev Drive has now been released in the Dev Channel - See : https://blogs.windows.com/windows-insider/2023/05/24/announcing-windows-11-insider-preview-build-23466/
- Updated the min build number for the Dev Channel to be 23466 in the Dev Drive util
- Updated the Dev Drive Card to only show the link when the feature is enabled
- Updated the Dev Drive Card's button text to show the "Learn more" text when the Dev Drive feature is not available.
- Updated button click behavior based on  Dev Drive feature availability
   - When disabled -> we launch the Dev Drive support page
   - When enabled -> we launch the disks and volumes settings page.  

**When feature is disabled:**

https://github.com/microsoft/devhome/assets/105318831/f462c5ea-77d4-457b-a1ba-9b95e7db1b05

**When feature is enabled.**

https://github.com/microsoft/devhome/assets/105318831/f6b9ead4-b561-4491-add0-09ae0773ded3



## References and relevant issues

## Detailed description of the pull request / Additional comments
**Note:** I'll need to also submit another PR over at learn.microsoft.com for the Dev Drive support page: with info on which builds we expect Dev Drive to be available on: https://learn.microsoft.com/en-us/windows/dev-drive/

## Validation steps performed
Tested locally on machine.

## PR checklist
- [X] Closes #725
- [X] Closes #792
- [ ] Tests added/passed
- [ ] Documentation updated
