### PR TITLE
Switch ObservableRecipient to ObservableObject

### DIFF
--- a/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml;
 
 namespace DevHome.Settings.ViewModels;
 
-public partial class AboutViewModel : ObservableRecipient
+public partial class AboutViewModel : ObservableObject
 {
     [ObservableProperty]
     private string _versionDescription;

--- a/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
@@ -11,7 +11,7 @@ using Microsoft.UI.Xaml;
 
 namespace DevHome.Settings.ViewModels;
 
-public class AccountsViewModel : ObservableRecipient
+public class AccountsViewModel : ObservableObject
 {
     public ObservableCollection<AccountsProviderViewModel> AccountsProviders { get; } = new ();
 

--- a/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
@@ -15,7 +15,7 @@ using Windows.ApplicationModel;
 
 namespace DevHome.Settings.ViewModels;
 
-public partial class ExtensionViewModel : ObservableRecipient
+public partial class ExtensionViewModel : ObservableObject
 {
     private readonly Setting _setting;
 
@@ -48,7 +48,7 @@ public partial class ExtensionViewModel : ObservableRecipient
     }
 }
 
-public partial class ExtensionsViewModel : ObservableRecipient
+public partial class ExtensionsViewModel : ObservableObject
 {
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
 

--- a/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml;
 
 namespace DevHome.Settings.ViewModels;
 
-public partial class PreferencesViewModel : ObservableRecipient
+public partial class PreferencesViewModel : ObservableObject
 {
     private readonly IThemeSelectorService _themeSelectorService;
 

--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -11,7 +11,7 @@ using Microsoft.UI.Xaml;
 
 namespace DevHome.Settings.ViewModels;
 
-public partial class SettingViewModel : ObservableRecipient
+public partial class SettingViewModel : ObservableObject
 {
     private readonly Setting _setting;
 
@@ -40,7 +40,7 @@ public partial class SettingViewModel : ObservableRecipient
     }
 }
 
-public partial class SettingsViewModel : ObservableRecipient
+public partial class SettingsViewModel : ObservableObject
 {
     [ObservableProperty]
     private ObservableCollection<SettingViewModel> _settingsList = new ();

--- a/src/ViewModels/FeedbackViewModel.cs
+++ b/src/ViewModels/FeedbackViewModel.cs
@@ -15,7 +15,7 @@ using Windows.ApplicationModel;
 
 namespace DevHome.ViewModels;
 
-public partial class FeedbackViewModel : ObservableRecipient
+public partial class FeedbackViewModel : ObservableObject
 {
     private readonly IThemeSelectorService _themeSelectorService;
 

--- a/src/ViewModels/InfoBarModel.cs
+++ b/src/ViewModels/InfoBarModel.cs
@@ -12,7 +12,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.ViewModels;
 
-public partial class InfoBarModel : ObservableRecipient
+public partial class InfoBarModel : ObservableObject
 {
     [ObservableProperty]
     private string? _title;

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -12,7 +12,7 @@ using Microsoft.UI.Xaml;
 using Windows.ApplicationModel.Store.Preview.InstallControl;
 
 namespace DevHome.ViewModels;
-public class InitializationViewModel : ObservableRecipient
+public class InitializationViewModel : ObservableObject
 {
     private const string GitHubExtensionStorePackageId = "9NZCC27PR6N6";
     private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe";

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -12,7 +12,7 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace DevHome.ViewModels;
 
-public partial class ShellViewModel : ObservableRecipient
+public partial class ShellViewModel : ObservableObject
 {
     private readonly ILocalSettingsService _localSettingsService;
 

--- a/src/ViewModels/WhatsNewViewModel.cs
+++ b/src/ViewModels/WhatsNewViewModel.cs
@@ -7,7 +7,7 @@ using DevHome.Models;
 
 namespace DevHome.ViewModels;
 
-public class WhatsNewViewModel : ObservableRecipient
+public class WhatsNewViewModel : ObservableObject
 {
     public ObservableCollection<WhatsNewCard> Source { get; } = new ObservableCollection<WhatsNewCard>();
 

--- a/tools/SampleTool/src/ViewModels/SampleToolViewModel.cs
+++ b/tools/SampleTool/src/ViewModels/SampleToolViewModel.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Tools.SampleTool.ViewModels;
 
-public class SampleToolViewModel : ObservableRecipient
+public class SampleToolViewModel : ObservableObject
 {
     public SampleToolViewModel()
     {


### PR DESCRIPTION
## Summary of the pull request

This PR switches the base type of some viewmodels from `ObservableRecipient` to `ObservableObject`.

## Validation steps performed

Build the solution to ensure no warnings/errors, run and played with the app for a bit.

## PR checklist
- [X] Contributes to #841
- [ ] Tests added/passed (no tests changes)
- [ ] Documentation updated
