### PR TITLE
Improve Summary screen by adding more details about applied resources

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Helpers/ElevatedConfigureUnitTaskResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Helpers/ElevatedConfigureUnitTaskResult.cs
@@ -10,6 +10,10 @@ public sealed class ElevatedConfigureUnitTaskResult
 {
     public string? UnitName { get; set; }
 
+    public string? Id { get; set; }
+
+    public string? Description { get; set; }
+
     public string? Intent { get; set; }
 
     public bool IsSkipped { get; set; }

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
@@ -36,8 +36,7 @@ public sealed class ElevatedConfigurationTask
                 taskResult.RebootRequired = result.RequiresReboot;
                 taskResult.UnitResults = result.Result.UnitResults.Select(unitResult =>
                 {
-                    object descriptionObj;
-                    unitResult.Unit.Directives.TryGetValue("description", out descriptionObj);
+                    unitResult.Unit.Directives.TryGetValue("description", out var descriptionObj);
                     return new ElevatedConfigureUnitTaskResult
                     {
                         UnitName = unitResult.Unit.UnitName,

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
@@ -34,12 +34,19 @@ public sealed class ElevatedConfigurationTask
                 taskResult.TaskAttempted = true;
                 taskResult.TaskSucceeded = result.Succeeded;
                 taskResult.RebootRequired = result.RequiresReboot;
-                taskResult.UnitResults = result.Result.UnitResults.Select(unitResult => new ElevatedConfigureUnitTaskResult
+                taskResult.UnitResults = result.Result.UnitResults.Select(unitResult =>
                 {
-                    UnitName = unitResult.Unit.UnitName,
-                    Intent = unitResult.Unit.Intent.ToString(),
-                    IsSkipped = unitResult.State == ConfigurationUnitState.Skipped,
-                    HResult = unitResult.ResultInformation?.ResultCode?.HResult ?? HRESULT.S_OK,
+                    object descriptionObj;
+                    unitResult.Unit.Directives.TryGetValue("description", out descriptionObj);
+                    return new ElevatedConfigureUnitTaskResult
+                    {
+                        UnitName = unitResult.Unit.UnitName,
+                        Id = unitResult.Unit.Identifier,
+                        Description = descriptionObj?.ToString() ?? string.Empty,
+                        Intent = unitResult.Unit.Intent.ToString(),
+                        IsSkipped = unitResult.State == ConfigurationUnitState.Skipped,
+                        HResult = unitResult.ResultInformation?.ResultCode?.HResult ?? HRESULT.S_OK,
+                    };
                 }).ToList();
 
                 if (result.ResultException != null)

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
@@ -14,8 +14,7 @@ public class ConfigurationUnitResult
     {
         UnitName = result.Unit.UnitName;
         Id = result.Unit.Identifier;
-        object descriptionObj;
-        result.Unit.Directives.TryGetValue("description", out descriptionObj);
+        result.Unit.Directives.TryGetValue("description", out var descriptionObj);
         Description = descriptionObj?.ToString() ?? string.Empty;
         Intent = result.Unit.Intent.ToString();
         IsSkipped = result.State == ConfigurationUnitState.Skipped;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
@@ -21,12 +21,18 @@ public class ConfigurationUnitResult
     public ConfigurationUnitResult(ElevatedConfigureUnitTaskResult result)
     {
         UnitName = result.UnitName;
+        Id = result.Id;
+        Description = result.Description;
         Intent = result.Intent;
         IsSkipped = result.IsSkipped;
         HResult = result.HResult;
     }
 
     public string UnitName { get; }
+
+    public string Id { get; }
+
+    public string Description { get; }
 
     public string Intent { get; }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
@@ -13,6 +13,10 @@ public class ConfigurationUnitResult
     public ConfigurationUnitResult(ApplyConfigurationUnitResult result)
     {
         UnitName = result.Unit.UnitName;
+        Id = result.Unit.Identifier;
+        object descriptionObj;
+        result.Unit.Directives.TryGetValue("description", out descriptionObj);
+        Description = descriptionObj?.ToString() ?? string.Empty;
         Intent = result.Unit.Intent.ToString();
         IsSkipped = result.State == ConfigurationUnitState.Skipped;
         HResult = result.ResultInformation?.ResultCode?.HResult ?? HRESULT.S_OK;

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -29,7 +29,10 @@ public static class StringResourceKey
     public static readonly string ConfigurationUnitFailed = nameof(ConfigurationUnitFailed);
     public static readonly string ConfigurationUnitSkipped = nameof(ConfigurationUnitSkipped);
     public static readonly string ConfigurationUnitSuccess = nameof(ConfigurationUnitSuccess);
-    public static readonly string ConfigurationUnitSummary = nameof(ConfigurationUnitSummary);
+    public static readonly string ConfigurationUnitSummaryFull = nameof(ConfigurationUnitSummaryFull);
+    public static readonly string ConfigurationUnitSummaryMinimal = nameof(ConfigurationUnitSummaryMinimal);
+    public static readonly string ConfigurationUnitSummaryNoDescription = nameof(ConfigurationUnitSummaryNoDescription);
+    public static readonly string ConfigurationUnitSummaryNoId = nameof(ConfigurationUnitSummaryNoId);
     public static readonly string ConfigurationUnitStats = nameof(ConfigurationUnitStats);
     public static readonly string ConfigurationViewTitle = nameof(ConfigurationViewTitle);
     public static readonly string DevDriveReviewTitle = nameof(DevDriveReviewTitle);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -221,9 +221,21 @@
     <value>Configuration successfully applied</value>
     <comment>Message displayed when applying a configuration unit succeeds.</comment>
   </data>
-  <data name="ConfigurationUnitSummary" xml:space="preserve">
+  <data name="ConfigurationUnitSummaryFull" xml:space="preserve">
+    <value>{0} : {3} [{1} {2}]</value>
+    <comment>{Locked="{0}","{1}","{2}","{3}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit id. {3} is replaced by the configuration unit description.</comment>
+  </data>
+  <data name="ConfigurationUnitSummaryMinimal" xml:space="preserve">
     <value>{0} : {1}</value>
     <comment>{Locked="{0}","{1}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name.</comment>
+  </data>
+  <data name="ConfigurationUnitSummaryNoDescription" xml:space="preserve">
+    <value>{0} : {1} [{2}]</value>
+    <comment>{Locked="{0}","{1}","{2}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit id.</comment>
+  </data>
+  <data name="ConfigurationUnitSummaryNoId" xml:space="preserve">
+    <value>{0} : {2} [{1}]</value>
+    <comment>{Locked="{0}","{1}","{2}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit description.</comment>
   </data>
   <data name="ConfigurationUnitStats" xml:space="preserve">
     <value>Succeeded: {0} | Failed: {1} | Skipped: {2}</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -223,19 +223,19 @@
   </data>
   <data name="ConfigurationUnitSummaryFull" xml:space="preserve">
     <value>{0} : {3} [{1} {2}]</value>
-    <comment>{Locked="{0}","{1}","{2}","{3}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit id. {3} is replaced by the configuration unit description.</comment>
+    <comment>{Locked="{0}","{1}","{2}","{3}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit id. {3} is replaced by the configuration unit description. A string with all values replaced could look like "Apply : Install VS [WinGetPackage vspackage]"</comment>
   </data>
   <data name="ConfigurationUnitSummaryMinimal" xml:space="preserve">
     <value>{0} : {1}</value>
-    <comment>{Locked="{0}","{1}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name.</comment>
+    <comment>{Locked="{0}","{1}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. A string with all values replaced could look like "Apply : WinGetPackage"</comment>
   </data>
   <data name="ConfigurationUnitSummaryNoDescription" xml:space="preserve">
     <value>{0} : {1} [{2}]</value>
-    <comment>{Locked="{0}","{1}","{2}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit id.</comment>
+    <comment>{Locked="{0}","{1}","{2}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit id. A string with all values replaced could look like "Apply : WinGetPackage [vspackage]"</comment>
   </data>
   <data name="ConfigurationUnitSummaryNoId" xml:space="preserve">
     <value>{0} : {2} [{1}]</value>
-    <comment>{Locked="{0}","{1}","{2}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit description.</comment>
+    <comment>{Locked="{0}","{1}","{2}"}Summary text for a configuration unit. {0} is replaced by the configuration unit intent (e.g. Assert, Inform, Apply). {1} is replaced by the configuration unit name. {2} is replaced by the configuration unit description. A string with all values replaced could look like "Apply : Install VS [WinGetPackage]"</comment>
   </data>
   <data name="ConfigurationUnitStats" xml:space="preserve">
     <value>Succeeded: {0} | Failed: {1} | Skipped: {2}</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationUnitResultViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationUnitResultViewModel.cs
@@ -29,7 +29,7 @@ public class ConfigurationUnitResultViewModel
         _unitResult = unitResult;
     }
 
-    public string Title => _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSummary, _unitResult.Intent, _unitResult.UnitName);
+    public string Title => BuildTitle();
 
     public string ApplyResult => GetApplyResult();
 
@@ -53,5 +53,25 @@ public class ConfigurationUnitResultViewModel
         }
 
         return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSuccess);
+    }
+
+    private string BuildTitle()
+    {
+        if (string.IsNullOrEmpty(_unitResult.Id) && string.IsNullOrEmpty(_unitResult.Description))
+        {
+            return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSummaryMinimal, _unitResult.Intent, _unitResult.UnitName);
+        }
+
+        if (string.IsNullOrEmpty(_unitResult.Id))
+        {
+            return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSummaryNoId, _unitResult.Intent, _unitResult.UnitName, _unitResult.Description);
+        }
+
+        if (string.IsNullOrEmpty(_unitResult.Description))
+        {
+            return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSummaryNoDescription, _unitResult.Intent, _unitResult.UnitName, _unitResult.Id);
+        }
+
+        return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSummaryFull, _unitResult.Intent, _unitResult.UnitName, _unitResult.Id, _unitResult.Description);
     }
 }


### PR DESCRIPTION
## Summary of the pull request

Add new variants for the applied resource summary.

## References and relevant issues

#873

## Detailed description of the pull request / Additional comments

The current applied resource summary only includes the _Intent_ and the _Unit Name_ and this PR adds three new variants for the applied resource summary, resulting in four available variants as shown below.

New variants will be choosen according to the presence of the unit _Identifier_ (`id`) and the _Description_ directive.

* **FULL**: Used when all the info is available

  Format: `{Intent} : {Description} [{UnitName} {Identifier}]`

  ![FULL](https://github.com/microsoft/devhome/assets/4399580/cda923db-e807-40a7-b4c0-a460e618fa7f)

* **MISSING ID**: Used when only the _Identifier_ is missing

  Format: `{Intent} : {Description} [{UnitName}]`

  ![NO ID](https://github.com/microsoft/devhome/assets/4399580/8b1be377-2d51-4299-94e5-191ff8f2a727)

* **MISSING DESCRIPTION**: Used when only the _Description_ is missing

  Format: `{Intent} : {UnitName} [{Identifier}]`

  ![NO DESCRIPTION](https://github.com/microsoft/devhome/assets/4399580/29676de3-5219-4c47-ac4e-8f24fb6a722b)

* **MINIMAL**: Used when both _Identifier_ and _Description_ are missing. This is the current format

  Format: `{Intent} : {UnitName}`

  ![MINIMAL](https://github.com/microsoft/devhome/assets/4399580/986d84ed-62df-445f-8a96-c135a4943037)



## Validation steps performed

## PR checklist
- [x] Closes #873
- [ ] Tests added/passed
- [ ] Documentation updated
