### PR TITLE
Remove built-in marshalling from P/Invoke-s

### DIFF
--- a/common/Helpers/RuntimeHelper.cs
+++ b/common/Helpers/RuntimeHelper.cs
@@ -2,22 +2,24 @@
 // Licensed under the MIT license.
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace DevHome.Common.Helpers;
 
-public class RuntimeHelper
+public static class RuntimeHelper
 {
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern int GetCurrentPackageFullName(ref int packageFullNameLength, StringBuilder? packageFullName);
-
-    public static bool IsMSIX
+    public static unsafe bool IsMSIX
     {
         get
         {
-            var length = 0;
+            const int APPMODEL_ERROR_NO_PACKAGE = 15700;
 
-            return GetCurrentPackageFullName(ref length, null) != 15700L;
+            uint length;
+
+            return GetCurrentPackageFullName(&length, null) != APPMODEL_ERROR_NO_PACKAGE;
+
+            // See: https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-getcurrentpackagefullname
+            [DllImport("kernel32", ExactSpelling = true)]
+            static extern int GetCurrentPackageFullName(uint* packageFullNameLength, ushort* packageFullName);
         }
     }
 }

--- a/common/Helpers/RuntimeHelper.cs
+++ b/common/Helpers/RuntimeHelper.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace DevHome.Common.Helpers;
 
@@ -11,15 +12,9 @@ public static class RuntimeHelper
     {
         get
         {
-            const int APPMODEL_ERROR_NO_PACKAGE = 15700;
-
             uint length = 0;
 
-            return GetCurrentPackageFullName(ref length, null) != APPMODEL_ERROR_NO_PACKAGE;
-
-            // See: https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-getcurrentpackagefullname
-            [DllImport("kernel32", ExactSpelling = true, CharSet = CharSet.Unicode)]
-            static extern int GetCurrentPackageFullName(ref uint packageFullNameLength, char[]? packageFullName);
+            return PInvoke.GetCurrentPackageFullName(ref length, null) != WIN32_ERROR.APPMODEL_ERROR_NO_PACKAGE;
         }
     }
 }

--- a/common/Helpers/RuntimeHelper.cs
+++ b/common/Helpers/RuntimeHelper.cs
@@ -7,19 +7,19 @@ namespace DevHome.Common.Helpers;
 
 public static class RuntimeHelper
 {
-    public static unsafe bool IsMSIX
+    public static bool IsMSIX
     {
         get
         {
             const int APPMODEL_ERROR_NO_PACKAGE = 15700;
 
-            uint length;
+            uint length = 0;
 
-            return GetCurrentPackageFullName(&length, null) != APPMODEL_ERROR_NO_PACKAGE;
+            return GetCurrentPackageFullName(ref length, null) != APPMODEL_ERROR_NO_PACKAGE;
 
             // See: https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-getcurrentpackagefullname
-            [DllImport("kernel32", ExactSpelling = true)]
-            static extern int GetCurrentPackageFullName(uint* packageFullNameLength, ushort* packageFullName);
+            [DllImport("kernel32", ExactSpelling = true, CharSet = CharSet.Unicode)]
+            static extern int GetCurrentPackageFullName(ref uint packageFullNameLength, char[]? packageFullName);
         }
     }
 }

--- a/common/NativeMethods.txt
+++ b/common/NativeMethods.txt
@@ -2,3 +2,4 @@
 FileOpenDialog
 IFileOpenDialog
 SHCreateItemFromParsingName
+GetCurrentPackageFullName

--- a/src/NativeMethods.txt
+++ b/src/NativeMethods.txt
@@ -2,3 +2,4 @@
 GlobalMemoryStatusEx
 GetSystemInfo
 CoCreateInstance
+SetForegroundWindow

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -16,7 +16,8 @@ namespace DevHome.Services;
 public class AccountsService : IAccountsService
 {
     [DllImport("user32", ExactSpelling = true)]
-    private static extern int SetForegroundWindow(IntPtr hWnd);
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
 
     public AccountsService()
     {

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -15,9 +15,8 @@ namespace DevHome.Services;
 
 public class AccountsService : IAccountsService
 {
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32", ExactSpelling = true)]
+    private static extern int SetForegroundWindow(IntPtr hWnd);
 
     public AccountsService()
     {
@@ -74,7 +73,7 @@ public class AccountsService : IAccountsService
         }
 
         // Bring focus back to DevHome after login
-        SetForegroundWindow(Process.GetCurrentProcess().MainWindowHandle);
+        _ = SetForegroundWindow(Process.GetCurrentProcess().MainWindowHandle);
     }
 
     public void LoggedOutEventHandler(object? sender, IDeveloperId developerId)

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using DevHome.Common.Contracts.Services;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
@@ -10,15 +9,13 @@ using DevHome.Common.TelemetryEvents;
 using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace DevHome.Services;
 
 public class AccountsService : IAccountsService
 {
-    [DllImport("user32", ExactSpelling = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
-
     public AccountsService()
     {
     }
@@ -74,7 +71,7 @@ public class AccountsService : IAccountsService
         }
 
         // Bring focus back to DevHome after login
-        _ = SetForegroundWindow(Process.GetCurrentProcess().MainWindowHandle);
+        _ = PInvoke.SetForegroundWindow((HWND)Process.GetCurrentProcess().MainWindowHandle);
     }
 
     public void LoggedOutEventHandler(object? sender, IDeveloperId developerId)

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/WindowsPackageManager/WindowsPackageManagerManualActivationFactory.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/WindowsPackageManager/WindowsPackageManagerManualActivationFactory.cs
@@ -36,7 +36,7 @@ public class WindowsPackageManagerManualActivationFactory : WindowsPackageManage
 
         try
         {
-            var hr = WinGetServerManualActivation_CreateInstance(&clsid, &iid, 0, &pUnknown);
+            var hr = WinGetServerManualActivation_CreateInstance(in clsid, in iid, 0, out pUnknown);
             Marshal.ThrowExceptionForHR(hr);
             return MarshalInterface<T>.FromAbi((IntPtr)pUnknown);
         }
@@ -53,8 +53,8 @@ public class WindowsPackageManagerManualActivationFactory : WindowsPackageManage
 
     [DllImport("winrtact.dll", ExactSpelling = true)]
     private static unsafe extern int WinGetServerManualActivation_CreateInstance(
-        Guid* clsid,
-        Guid* iid,
+        in Guid clsid,
+        in Guid iid,
         uint flags,
-        void** instance);
+        out void* instance);
 }

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/WindowsPackageManager/WindowsPackageManagerManualActivationFactory.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/WindowsPackageManager/WindowsPackageManagerManualActivationFactory.cs
@@ -30,31 +30,31 @@ public class WindowsPackageManagerManualActivationFactory : WindowsPackageManage
     {
     }
 
-    protected override T CreateInstance<T>(Guid clsid, Guid iid)
+    protected override unsafe T CreateInstance<T>(Guid clsid, Guid iid)
     {
-        var pUnknown = IntPtr.Zero;
+        void* pUnknown = null;
+
         try
         {
-            var hr = WinGetServerManualActivation_CreateInstance(clsid, iid, 0, out var instance);
+            var hr = WinGetServerManualActivation_CreateInstance(&clsid, &iid, 0, &pUnknown);
             Marshal.ThrowExceptionForHR(hr);
-            pUnknown = Marshal.GetIUnknownForObject(instance);
-            return MarshalInterface<T>.FromAbi(pUnknown);
+            return MarshalInterface<T>.FromAbi((IntPtr)pUnknown);
         }
         finally
         {
             // CoCreateInstance and FromAbi both AddRef on the native object.
             // Release once to prevent memory leak.
-            if (pUnknown != IntPtr.Zero)
+            if (pUnknown is not null)
             {
-                Marshal.Release(pUnknown);
+                Marshal.Release((IntPtr)pUnknown);
             }
         }
     }
 
-    [DllImport("winrtact.dll", EntryPoint = "WinGetServerManualActivation_CreateInstance", ExactSpelling = true, PreserveSig = true)]
-    private static extern int WinGetServerManualActivation_CreateInstance(
-        [In, MarshalAs(UnmanagedType.LPStruct)] Guid clsid,
-        [In, MarshalAs(UnmanagedType.LPStruct)] Guid iid,
+    [DllImport("winrtact.dll", ExactSpelling = true)]
+    private static unsafe extern int WinGetServerManualActivation_CreateInstance(
+        Guid* clsid,
+        Guid* iid,
         uint flags,
-        [Out, MarshalAs(UnmanagedType.IUnknown)] out object instance);
+        void** instance);
 }


### PR DESCRIPTION
## Summary of the pull request

This PR makes the manual P/Invoke-s in the codebase blittable and removes built-in marshalling.
Not touching those generated by CsWin32 for now (though would be nice to fix those too).

Benefits include:
- Stop relying on built-in COM interop (and avoid a useless double marshalling)
- Stop marshalling `StringBuilder`, which is not recommended (and not supported with `[LibraryImport]`)
- Marginally better performance
- Makes the code more AOT-friendly

cc. @jkoritzinsky for help reviewing this. I'm thinking we could only address these for now, and then once .NET 8 is out and the codebase moves to it we can also tackle the `[ComImport]` interface and class that's currently used by Dev Home. 

## Validation steps performed

Opening as draft, I have only tested the MSIX check code path for now.

## PR checklist
- [ ] ~Closes #xxx~
- [ ] Tests added/passed
- [ ] Documentation updated
