### PR TITLE
Update minimum required versions of Windows Web Experience Pack

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -47,6 +47,10 @@ public partial class DashboardView : ToolPage
     private static SortedDictionary<string, BitmapImage> _widgetLightIconCache;
     private static SortedDictionary<string, BitmapImage> _widgetDarkIconCache;
 
+    private readonly Version minSupportedVersion400 = new (423, 3800);
+    private readonly Version minSupportedVersion500 = new (523, 3300);
+    private readonly Version version500 = new (500, 0);
+
     public DashboardView()
     {
         ViewModel = new DashboardViewModel();
@@ -127,16 +131,12 @@ public partial class DashboardView : ToolPage
 
         // Ensure the application is installed, and the version is high enough.
         const string packageName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
-        const int stableVer = 423;
-        const int stableMin = 3800; // 423.3800.0.0
-        const int stageVer = 523;
-        const int stageMin = 3300; // 523.3300.0.0
 
         var packageManager = new PackageManager();
         var packages = packageManager.FindPackagesForUser(string.Empty, packageName);
         if (packages.Any())
         {
-            // A user cannot actually have more than one version installed.
+            // A user cannot actually have more than one version installed, so only need to look at the first result.
             var package = packages.First();
 
             var version = package.Id.Version;
@@ -145,10 +145,8 @@ public partial class DashboardView : ToolPage
 
             Log.Logger()?.ReportInfo("DashboardView", $"{package.Id.FullName} Version: {major}.{minor}");
 
-            // Min 400's version is 423.3800.0.0
-            // Min 500's version is 523.3300.0.0
-            if ((major < stableVer) || (major == stableVer && minor < stableMin) ||
-                (major >= 500 && major < stageVer) || (major == stageVer && minor < stageMin))
+            // Create System.Version type from PackageVersion to test. System.Version supports CompareTo() for easy comparisons.
+            if (!IsVersionSupported(new (major, minor)))
             {
                 return false;
             }
@@ -162,6 +160,18 @@ public partial class DashboardView : ToolPage
         _validatedWebExpPack = true;
         return _validatedWebExpPack;
     }
+
+    /// <summary>
+    /// Tests whether a version is equal to or above the min, but less than the max.
+    /// </summary>
+    private bool IsVersionBetween(Version target, Version min, Version max) => target.CompareTo(min) >= 0 && target.CompareTo(max) < 0;
+
+    /// <summary>
+    /// Tests whether a version is equal to or above the min.
+    /// </summary>
+    private bool IsVersionAtOrAbove(Version target, Version min) => target.CompareTo(min) >= 0;
+
+    private bool IsVersionSupported(Version target) => IsVersionBetween(target, minSupportedVersion400, version500) || IsVersionAtOrAbove(target, minSupportedVersion500);
 
     private async Task<AdaptiveCardRenderer> GetConfigurationRendererAsync()
     {

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -145,8 +145,10 @@ public partial class DashboardView : ToolPage
 
             Log.Logger()?.ReportInfo("DashboardView", $"{package.Id.FullName} Version: {major}.{minor}");
 
-            if ((major < stableVer) || (major == stableVer && minor < stableMin) || // Min 400's version is 423.3800.0.0
-                (major >= 500 && major < stageVer) || (major == stageVer && minor < stageMin)) // Min 500's version is 523.3300.0.0
+            // Min 400's version is 423.3800.0.0
+            // Min 500's version is 523.3300.0.0
+            if ((major < stableVer) || (major == stableVer && minor < stableMin) ||
+                (major >= 500 && major < stageVer) || (major == stageVer && minor < stageMin))
             {
                 return false;
             }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -145,7 +145,8 @@ public partial class DashboardView : ToolPage
 
             Log.Logger()?.ReportInfo("DashboardView", $"{package.Id.FullName} Version: {major}.{minor}");
 
-            if ((major < stableVer) || (major == stableVer && minor < stableMin) || (major == stageVer && minor < stageMin))
+            if ((major < stableVer) || (major == stableVer && minor < stableMin) || // Min 400's version is 423.3800.0.0
+                (major >= 500 && major < stageVer) || (major == stageVer && minor < stageMin)) // Min 500's version is 523.3300.0.0
             {
                 return false;
             }


### PR DESCRIPTION
## Summary of the pull request
There was a bug in the logic we use to check the installed version of the app -- version 521 was not popping up the dialog to update, but also would fail when trying to create a widget, so the AddWidgetDialog would not show up. 

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #866
- [ ] Tests added/passed
- [ ] Documentation updated
