### PR TITLE
Fix IShellItem.GetDisplayName memory leak

### DIFF
--- a/common/Extensions/WindowExExtensions.cs
+++ b/common/Extensions/WindowExExtensions.cs
@@ -134,9 +134,14 @@ public static class WindowExExtensions
                 fsd.Show(new HWND(hWnd));
                 fsd.GetResult(out var ppsi);
 
+                // Get the display name and then manually free it after creating the string.
+                // See https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishellitem-getdisplayname:
+                // "It is the responsibility of the caller to free the string pointed to by ppszName
+                // when it is no longer needed. Call CoTaskMemFree on *ppszName to free the memory."
                 PWSTR pFileName;
                 ppsi.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, &pFileName);
                 fileName = new string(pFileName);
+                Marshal.FreeCoTaskMem((IntPtr)pFileName.Value);
             }
 
             return await StorageFile.GetFileFromPathAsync(fileName);


### PR DESCRIPTION
## Summary of the pull request

This PR fixes a memory leak in the file picker code. See MS Learn docs mentioned in the comment.

## Validation steps performed

Tested the file picker code path opening a file, works as expected.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
