### PR TITLE
Fix IFileOpenDialog extension filters memory leak

### DIFF
--- a/common/Extensions/WindowExExtensions.cs
+++ b/common/Extensions/WindowExExtensions.cs
@@ -119,20 +119,34 @@ public static class WindowExExtensions
                     out var fsd);
                 Marshal.ThrowExceptionForHR(hr);
 
-                // Set filters (e.g. "*.yaml", "*.yml", etc...)
+                IShellItem ppsi;
                 var extensions = new List<COMDLG_FILTERSPEC>();
-                foreach (var filter in filters)
+
+                try
                 {
-                    COMDLG_FILTERSPEC extension;
-                    extension.pszName = (char*)Marshal.StringToHGlobalUni(filter.Name);
-                    extension.pszSpec = (char*)Marshal.StringToHGlobalUni(filter.Type);
-                    extensions.Add(extension);
+                    // Set filters (e.g. "*.yaml", "*.yml", etc...)
+                    foreach (var filter in filters)
+                    {
+                        COMDLG_FILTERSPEC extension;
+                        extension.pszName = (char*)Marshal.StringToHGlobalUni(filter.Name);
+                        extension.pszSpec = (char*)Marshal.StringToHGlobalUni(filter.Type);
+                        extensions.Add(extension);
+                    }
+
+                    fsd.SetFileTypes(CollectionsMarshal.AsSpan(extensions));
+
+                    fsd.Show(new HWND(hWnd));
+                    fsd.GetResult(out ppsi);
                 }
-
-                fsd.SetFileTypes(extensions.ToArray());
-
-                fsd.Show(new HWND(hWnd));
-                fsd.GetResult(out var ppsi);
+                finally
+                {
+                    // Free all filter names and specs
+                    foreach (var extension in extensions)
+                    {
+                        Marshal.FreeHGlobal((IntPtr)extension.pszName.Value);
+                        Marshal.FreeHGlobal((IntPtr)extension.pszSpec.Value);
+                    }
+                }
 
                 PWSTR pFileName;
                 ppsi.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, &pFileName);


### PR DESCRIPTION
## Summary of the pull request

This PR fixes a memory leak in the file picker code, this time related to the file extension filters.
These were being allocated in the global heap but then never freed.
The C++ sample in the docs isn't freeing just because it's passing string literals.

While I was at it, I also used `CollectionMarshal.AsSpan` to skip an unnecessary `ToArray()` allocation.
We can just pass the underlying span for the list, since nobody else is mutating it anyway (we own it).

## Validation steps performed

Tested the file picker code path opening a file, works as expected.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
