### PR TITLE
Used AccentButtonStyle instead of manual background for what's new page

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -74,8 +74,7 @@
                         <Button
                             Margin="0 16"
                             MinWidth="258"
-                            Background="{ThemeResource ButtonAccentBackground}"
-                            Foreground="{ThemeResource ButtonAccentForeground}"
+                            Style="{ThemeResource AccentButtonStyle}"
                             Click="MachineConfigButton_Click"
                             x:Uid="WhatsNewPage_GetStartedButton" />
                         


### PR DESCRIPTION
## Summary of the pull request

Used the appropriate style for accent buttons for the what's new page button.

On rest:
![image](https://github.com/microsoft/devhome/assets/81253203/83d07572-d570-46b3-a33e-3b3a387ac4fd)

On hover:
![image](https://github.com/microsoft/devhome/assets/81253203/19dafcf7-a4ed-40ad-a0f3-9821a0dab077)

On hover before:
![image](https://github.com/microsoft/devhome/assets/81253203/3799e4e4-8871-445e-a31e-12ae91838f64)

## References and relevant issues

Issue #1009.

## PR checklist
- [x] Closes #1009
- [ ] Tests added/passed
- [ ] Documentation updated
