### PR TITLE
Adjust widget dialog sizes with window size

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -9,12 +9,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
-    Style="{StaticResource DefaultContentDialogStyle}">
+    Style="{StaticResource DefaultContentDialogStyle}"
+    SizeChanged="ContentDialog_SizeChanged">
 
     <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
     <ContentDialog.Resources>
         <x:Double x:Key="ContentDialogMinWidth">652</x:Double>
-        <x:Double x:Key="ContentDialogMinHeight">684</x:Double>
         <x:Double x:Key="ContentDialogMaxWidth">652</x:Double>
         <x:Double x:Key="ContentDialogMaxHeight">684</x:Double>
         <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
@@ -25,7 +25,7 @@
 
     <StackPanel>
         <!-- Title and Close button -->
-        <Grid>
+        <Grid x:Name="AddWidgetTitleBar">
             <TextBlock x:Uid="AddWidgetsTitle" HorizontalAlignment="Left" Margin="16,10,0,0" />
             <Button HorizontalAlignment="Right" Click="CancelButton_Click"
                     BorderThickness="0" Background="Transparent" Padding="10">
@@ -45,6 +45,7 @@
                         IsPaneToggleButtonVisible="False"
                         IsTitleBarAutoPaddingEnabled="False"
                         OpenPaneLength="218"
+                        MaxHeight="650"
                         SelectionChanged="AddWidgetNavigationView_SelectionChanged">
             <NavigationView.MenuItems>
             </NavigationView.MenuItems>
@@ -57,15 +58,16 @@
                 </Grid.RowDefinitions>
 
                 <ScrollViewer Grid.Row="0"
+                              x:Name="ConfigurationContentViewer"
                               Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}"
-                              VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch"
-                              MinHeight="530" MaxHeight="530">
+                              VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
                     <Frame x:Name="ConfigurationContentFrame" Margin="45,45,45,0"
                            Content="{x:Bind ViewModel.WidgetFrameworkElement, Mode=OneWay}" />
                 </ScrollViewer>
 
                 <!-- Pin button -->
                 <Grid Grid.Row="1"
+                      x:Name="PinRow"
                       Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
                     <Button x:Name="PinButton"
                             VerticalAlignment="Bottom" HorizontalAlignment="Center"

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -341,14 +341,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
     {
         const int ContentDialogMaxHeight = 684;
 
-        if (this.ActualHeight < ContentDialogMaxHeight)
-        {
-            AddWidgetNavigationView.Height = this.ActualHeight - AddWidgetTitleBar.ActualHeight;
-        }
-        else
-        {
-            AddWidgetNavigationView.Height = ContentDialogMaxHeight - AddWidgetTitleBar.ActualHeight;
-        }
+        AddWidgetNavigationView.Height = Math.Min(this.ActualHeight, ContentDialogMaxHeight) - AddWidgetTitleBar.ActualHeight;
 
         // Subtract 45 for the margin around ConfigurationContentFrame.
         ConfigurationContentViewer.Height = AddWidgetNavigationView.Height - PinRow.ActualHeight - 45;

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -336,4 +336,21 @@ public sealed partial class AddWidgetDialog : ContentDialog
             }
         });
     }
+
+    private void ContentDialog_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        const int ContentDialogMaxHeight = 684;
+
+        if (this.ActualHeight < ContentDialogMaxHeight)
+        {
+            AddWidgetNavigationView.Height = this.ActualHeight - AddWidgetTitleBar.ActualHeight;
+        }
+        else
+        {
+            AddWidgetNavigationView.Height = ContentDialogMaxHeight - AddWidgetTitleBar.ActualHeight;
+        }
+
+        // Subtract 45 for the margin around ConfigurationContentFrame.
+        ConfigurationContentViewer.Height = AddWidgetNavigationView.Height - PinRow.ActualHeight - 45;
+    }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -9,12 +9,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
-    Style="{StaticResource DefaultContentDialogStyle}">
+    Style="{StaticResource DefaultContentDialogStyle}"
+    SizeChanged="ContentDialog_SizeChanged">
 
     <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
     <ContentDialog.Resources>
         <x:Double x:Key="ContentDialogMinWidth">434</x:Double>
-        <x:Double x:Key="ContentDialogMinHeight">684</x:Double>
         <x:Double x:Key="ContentDialogMaxWidth">434</x:Double>
         <x:Double x:Key="ContentDialogMaxHeight">684</x:Double>
         <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
@@ -24,7 +24,7 @@
 
     <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
         <!-- Close button -->
-        <Grid>
+        <Grid x:Name="CustomizeWidgetTitleBar">
             <Button HorizontalAlignment="Right" Click="CancelButton_Click"
                     BorderThickness="0" Background="Transparent" Margin="5">
                 <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
@@ -40,19 +40,20 @@
                 <RowDefinition Height="auto" />
             </Grid.RowDefinitions>
 
-            <ScrollViewer VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch" Grid.Row="0"
-                            MinHeight="520" MaxHeight="520">
+            <ScrollViewer Grid.Row="0"
+                          x:Name="ConfigurationContentViewer"
+                          VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
                 <Frame x:Name="ConfigurationContentFrame" 
                         Content="{x:Bind ViewModel.WidgetFrameworkElement, Mode=OneWay}" />
             </ScrollViewer>
 
-            <Button x:Name="UpdateWidgetButton" x:Uid="UpdateWidgetButton"
+            <Button Grid.Row="1"
+                    x:Name="UpdateWidgetButton" x:Uid="UpdateWidgetButton"
                     VerticalAlignment="Bottom" HorizontalAlignment="Center"
                     Visibility="Visible"
                     IsEnabled="{x:Bind ViewModel.Configuring, Mode=OneWay, Converter={StaticResource BoolNegation}}"
                     Height="32" Width="118"
                     Click="UpdateWidgetButton_Click"
-                    Grid.Row="1"
                     Margin="0,40" />
         </Grid>
     </StackPanel>

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
@@ -102,4 +102,21 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
             });
         }
     }
+
+    private void ContentDialog_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        const int ContentDialogMaxHeight = 684;
+
+        if (this.ActualHeight < ContentDialogMaxHeight)
+        {
+            ConfigurationContentGrid.Height = this.ActualHeight - CustomizeWidgetTitleBar.ActualHeight;
+        }
+        else
+        {
+            ConfigurationContentGrid.Height = ContentDialogMaxHeight - CustomizeWidgetTitleBar.ActualHeight;
+        }
+
+        // Subtract 80 for the margin around the button.
+        ConfigurationContentViewer.Height = ConfigurationContentGrid.Height - UpdateWidgetButton.ActualHeight - 80;
+    }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
@@ -107,14 +107,7 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
     {
         const int ContentDialogMaxHeight = 684;
 
-        if (this.ActualHeight < ContentDialogMaxHeight)
-        {
-            ConfigurationContentGrid.Height = this.ActualHeight - CustomizeWidgetTitleBar.ActualHeight;
-        }
-        else
-        {
-            ConfigurationContentGrid.Height = ContentDialogMaxHeight - CustomizeWidgetTitleBar.ActualHeight;
-        }
+        ConfigurationContentGrid.Height = Math.Min(this.ActualHeight, ContentDialogMaxHeight) - CustomizeWidgetTitleBar.ActualHeight;
 
         // Subtract 80 for the margin around the button.
         ConfigurationContentViewer.Height = ConfigurationContentGrid.Height - UpdateWidgetButton.ActualHeight - 80;


### PR DESCRIPTION
## Summary of the pull request
This change fixes the sizing of various parts of the widget dialogs (add widget and customize widget). Instead of forcing one height all the time (via min and max ContentDialogHeights), we now let the dialog size itself to the containing window. When the window size changes, we adjust the size of the dialog accordingly, so that no part of the dialog is cut off outside the window's view. As an extra precaution, set the MaxHeight on the NavigationView, so that the NavigationView can never grow bigger than the dialog around it (thanks @ssccinng for this part). We also manually set the height of the add and configuration content (the widget part) since naturally the ScrollViewer will want to fit its entire contents, rather than resize to its parent.

## References and relevant issues
#574 and #584

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #574
- [ ] Closes #584
- [ ] Tests added/passed
- [ ] Documentation updated
