### PR TITLE
Fix App install page issues

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
@@ -71,23 +71,29 @@ public partial class PackageViewModel : ObservableObject
         _packageLightThemeIcon = new Lazy<BitmapImage>(() => GetIconByTheme(RestoreApplicationIconTheme.Light));
         _installPackageTask = new Lazy<InstallPackageTask>(CreateInstallTask);
         _packageDescription = new Lazy<string>(GetPackageDescription);
+
+        Version = _package.Version;
+        Name = _package.Name;
+        IsInstalled = _package.IsInstalled;
+        CatalogName = _package.CatalogName;
+        PublisherName = !string.IsNullOrEmpty(_package.PublisherName) ? _package.PublisherName : PublisherNameNotAvailable;
     }
 
     public PackageUniqueKey UniqueKey => _package.UniqueKey;
 
     public IWinGetPackage Package => _package;
 
-    public string Name => _package.Name;
-
     public BitmapImage Icon => _themeSelector.IsDarkTheme() ? _packageDarkThemeIcon.Value : _packageLightThemeIcon.Value;
 
-    public string Version => _package.Version;
+    public string Name { get; }
 
-    public bool IsInstalled => _package.IsInstalled;
+    public string Version { get; }
 
-    public string CatalogName => _package.CatalogName;
+    public bool IsInstalled { get; }
 
-    public string PublisherName => !string.IsNullOrEmpty(_package.PublisherName) ? _package.PublisherName : PublisherNameNotAvailable;
+    public string CatalogName { get; }
+
+    public string PublisherName { get; }
 
     public string PackageTitle => Name;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
@@ -67,16 +67,21 @@ public partial class PackageViewModel : ObservableObject
         _package = package;
         _themeSelector = themeSelector;
         _wingetFactory = wingetFactory;
-        _packageDarkThemeIcon = new Lazy<BitmapImage>(() => GetIconByTheme(RestoreApplicationIconTheme.Dark));
-        _packageLightThemeIcon = new Lazy<BitmapImage>(() => GetIconByTheme(RestoreApplicationIconTheme.Light));
-        _installPackageTask = new Lazy<InstallPackageTask>(CreateInstallTask);
-        _packageDescription = new Lazy<string>(GetPackageDescription);
 
+        // Initialize package view model properties in the constructor to
+        // accelerate fetching the data when bound in the view and to avoid
+        // frequently requesting the values from the proxy COM object
         Version = _package.Version;
         Name = _package.Name;
         IsInstalled = _package.IsInstalled;
         CatalogName = _package.CatalogName;
         PublisherName = !string.IsNullOrEmpty(_package.PublisherName) ? _package.PublisherName : PublisherNameNotAvailable;
+
+        // Lazy-initialize optional or expensive view model members
+        _packageDarkThemeIcon = new Lazy<BitmapImage>(() => GetIconByTheme(RestoreApplicationIconTheme.Dark));
+        _packageLightThemeIcon = new Lazy<BitmapImage>(() => GetIconByTheme(RestoreApplicationIconTheme.Light));
+        _installPackageTask = new Lazy<InstallPackageTask>(CreateInstallTask);
+        _packageDescription = new Lazy<string>(GetPackageDescription);
     }
 
     public PackageUniqueKey UniqueKey => _package.UniqueKey;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -17,6 +17,7 @@
     <StackPanel>
         <!-- Card header -->
         <controls:SettingsCard
+            SizeChanged="SettingsCard_SizeChanged"
             Background="Transparent"
             Header="{x:Bind Catalog.Name}"
             Description="{x:Bind Catalog.Description}">
@@ -43,7 +44,7 @@
         <FlipView
             x:Name="PackagesFlipView"
             Background="Transparent"
-            LayoutUpdated="OnLayoutUpdated"
+            SelectionChanged="PackagesFlipView_SelectionChanged"
             ItemsSource="{x:Bind PackageGroups, Mode=OneWay}">
             <FlipView.ItemTemplate>
                 <DataTemplate>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
@@ -116,11 +116,22 @@ public sealed partial class PackageCatalogView : UserControl
 
     private void SettingsCard_SizeChanged(object sender, SizeChangedEventArgs e)
     {
+        // Manually update the height of the FlipView since by default the
+        // control does not auto-resize to fit its current selected panel
+        // content. The FlipView content (grid of package cards) is by default
+        // responsive/adaptive to the screen size, hence the expected behavior
+        // is for the FlipView control to automatically adjust its height as
+        // the width of the panel changes. To avoid possible layout cycle
+        // exceptions, we use the SizeChanged event on an adjacent node and
+        // register a handler to perform the FlipView height update.
         UpdateFlipViewHeight();
     }
 
     private void PackagesFlipView_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        // Update the FlipView height when navigating to the next/previous
+        // panel of package cards (e.g. last panel might have less items, hence
+        // update the FlipView height accordingly)
         UpdateFlipViewHeight();
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
@@ -114,10 +114,15 @@ public sealed partial class PackageCatalogView : UserControl
         UpdateFlipViewHeight();
     }
 
-    /// <summary>
-    /// Handler for <see cref="FrameworkElement.LayoutUpdated"/>.
-    /// </summary>
-    private void OnLayoutUpdated(object sender, object e) => UpdateFlipViewHeight();
+    private void SettingsCard_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateFlipViewHeight();
+    }
+
+    private void PackagesFlipView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        UpdateFlipViewHeight();
+    }
 
     public static readonly DependencyProperty CatalogProperty = DependencyProperty.Register(nameof(Catalog), typeof(PackageCatalogViewModel), typeof(PackageCatalogView), new PropertyMetadata(null, (c, _) => ((PackageCatalogView)c).UpdateAll()));
     public static readonly DependencyProperty GroupSizeProperty = DependencyProperty.Register(nameof(GroupSize), typeof(int), typeof(PackageCatalogView), new PropertyMetadata(4, (c, _) => ((PackageCatalogView)c).UpdateAll()));


### PR DESCRIPTION
## Summary of the pull request
This PR addresses two issues in the App Install page:
1. Layout cycle that can occur when updating the `FlipView` height during the layout update event. Example of a cycle:
    - Initial `FlipView` layout update => Handler updating `FlipView` height => Causing another `FlipView` layout update (cycle)
    - PR fix: Instead of using `LayoutUpdated` event to update the `FlipView` height, use `SizeChanged` event on an adjacent node to prevent a cycle. Also update the height when the selected `FlipView` panel changes.
2. Exception thrown when calling the WinGet projected property `InstalledVersion` frequently from XAML bindings.
    - `InstalledVersion` is used to determine the visual state of a package in the App Install page
    - PR fix: Cache the values from the WinGet proxy COM object in the view model by initializing them in the constructor.

## References and relevant issues
#768

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated artifacts from this branch on a machine where the App install page originally crashed when selecting packages and attempting to navigate to next/previous apps page.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
