### PR TITLE
Fix GPU Widget going to 0

### DIFF
--- a/CoreWidgetProvider/Helpers/GPUStats.cs
+++ b/CoreWidgetProvider/Helpers/GPUStats.cs
@@ -103,7 +103,7 @@ internal class GPUStats : IDisposable
             {
                 try
                 {
-                    var sum = counters?.Sum(x => x.NextValue());
+                    var sum = counters?.Sum(x => x.NextValue()) ?? 0;
                     gpu.Usage = sum.GetValueOrDefault(0) / 100;
                     ChartHelper.AddNextChartValue(sum.GetValueOrDefault(0), gpu.GpuChartValues);
                 }

--- a/CoreWidgetProvider/Helpers/GPUStats.cs
+++ b/CoreWidgetProvider/Helpers/GPUStats.cs
@@ -109,7 +109,7 @@ internal class GPUStats : IDisposable
                 }
                 catch (InvalidOperationException ex)
                 {
-                    Log.Logger()?.ReportWarn("GPUStats", "InvalidOperationException", ex);
+                    Log.Logger()?.ReportWarn("GPUStats", "Failed to get next value", ex);
                     Log.Logger()?.ReportInfo("GPUStats", "Calling GetGPUPerfCounters again");
                     GetGPUPerfCounters();
                 }

--- a/CoreWidgetProvider/Helpers/GPUStats.cs
+++ b/CoreWidgetProvider/Helpers/GPUStats.cs
@@ -29,11 +29,11 @@ internal class GPUStats : IDisposable
 
     public GPUStats()
     {
-        GetGPUs();
+        LoadGPUs();
         GetGPUPerfCounters();
     }
 
-    public void GetGPUs()
+    public void LoadGPUs()
     {
         stats.Clear();
 
@@ -103,9 +103,10 @@ internal class GPUStats : IDisposable
             {
                 try
                 {
+                    // NextValue() can throw an InvalidOperationException if the counter is no longer there.
                     var sum = counters?.Sum(x => x.NextValue()) ?? 0;
-                    gpu.Usage = sum.GetValueOrDefault(0) / 100;
-                    ChartHelper.AddNextChartValue(sum.GetValueOrDefault(0), gpu.GpuChartValues);
+                    gpu.Usage = sum / 100;
+                    ChartHelper.AddNextChartValue(sum, gpu.GpuChartValues);
                 }
                 catch (InvalidOperationException ex)
                 {


### PR DESCRIPTION
## Summary of the pull request
There is an issue in the GPU widget where if one of the GPU counters goes away, when we call NextValue() on it, we get an InvalidOperationException and return 0. Since we continue to call NextValue() on the same counters, we continually get the exception and continue to get bad data until the widget is reinitialized. To fix this, re-initialize the list of counters if we get bad data. For ~1 second we will have outdated data, but this seems preferable to going to 0 for that second.

## References and relevant issues
Possibly related to #745

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
