### PR TITLE
Update Dashboard logging

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -101,8 +101,6 @@ public partial class WidgetViewModel : ObservableObject
 
     private async void RenderWidgetFrameworkElement()
     {
-        Log.Logger()?.ReportDebug("WidgetViewModel", "RenderWidgetFrameworkElement");
-
         var cardTemplate = await Widget.GetCardTemplateAsync();
         var cardData = await Widget.GetCardDataAsync();
 
@@ -291,7 +289,7 @@ public partial class WidgetViewModel : ObservableObject
 
     private void HandleWidgetUpdated(Widget sender, WidgetUpdatedEventArgs args)
     {
-        Log.Logger()?.ReportInfo("WidgetViewModel", $"HandleWidgetUpdated for widget {sender.Id}");
+        Log.Logger()?.ReportDebug("WidgetViewModel", $"HandleWidgetUpdated for widget {sender.Id}");
         RenderWidgetFrameworkElement();
     }
 }


### PR DESCRIPTION
## Summary of the pull request
With system widgets (GPU, CPU, etc) getting updated every second, logging every HandleWidgetUpdated() makes the output to difficult to read. Only log that method on the debug level, and don't log RenderWidgetFrameworkElement() at all.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
