### PR TITLE
Adding Pattern Matching Template

### DIFF
--- a/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -41,6 +41,9 @@
     <Content Include="Widgets\Templates\SSHWalletTemplate.json">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+	  <Content Include="Widgets\Templates\SSHWalletPatternMatching.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -66,4 +69,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
+  <ProjectExtensions><VisualStudio><UserProperties widgets_4templates_4sshwalletpatternmatching_1json__JsonSchema="https://codemagic.io/codemagic-schema.json" /></VisualStudio></ProjectExtensions>
 </Project>

--- a/CoreWidgetProvider/Widgets/Enums/WidgetAction.cs
+++ b/CoreWidgetProvider/Widgets/Enums/WidgetAction.cs
@@ -20,6 +20,11 @@ public enum WidgetAction
     Connect,
 
     /// <summary>
+    /// Action to connect to a host after user inputs pattern.
+    /// </summary>
+    PatternConnect,
+
+    /// <summary>
     /// Action to show previous widget item.
     /// </summary>
     PrevItem,

--- a/CoreWidgetProvider/Widgets/Enums/WidgetPageState.cs
+++ b/CoreWidgetProvider/Widgets/Enums/WidgetPageState.cs
@@ -8,4 +8,5 @@ public enum WidgetPageState
     Configure,
     Loading,
     Content,
+    Pattern,
 }

--- a/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -161,6 +161,10 @@ internal class SSHWalletWidget : CoreWidget
         cmd.StartInfo = info;
 
         cmd.Start();
+
+        // If we get here we have tried to connect so reset to the ssh host list
+        Page = WidgetPageState.Content;
+        UpdateWidget();
     }
 
     private void HandleCheckPath(WidgetActionInvokedArgs args)

--- a/CoreWidgetProvider/Widgets/Templates/SSHWalletPatternMatching.json
+++ b/CoreWidgetProvider/Widgets/Templates/SSHWalletPatternMatching.json
@@ -4,22 +4,54 @@
   "version": "1.5",
   "body": [
     {
-      "type": "TextBlock",
-      "text": "Your SSH key contains pattern matching. Fill out the pattern to connect.",
-      "wrap": true
-    },
-    {
-      "type": "Input.Text",
-      "placeholder": "Placeholder text"
-    },
-    {
-      "type": "ActionSet",
-      "actions": [
+      "type": "Container",
+      "items": [
         {
-          "type": "Action.Submit",
-          "title": "Connect"
+          "type": "TextBlock",
+          "text": "Your SSH key contains pattern matching. Fill out the pattern to connect.",
+          "wrap": true,
+          "horizontalAlignment": "Left",
+          "size": "Medium",
+          "weight": "Bolder"
+        },
+        {
+          "type": "ColumnSet",
+          "spacing": "large",
+          "columns": [
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "type": "Input.Text",
+                  "id": "PatternHost",
+                  "spacing": "large",
+                  "style": "Url",
+                  "value": "${patternHost}"
+                }
+              ],
+              "width": "stretch"
+            },
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "type": "ActionSet",
+                  "actions": [
+                    {
+                      "type": "Action.Execute",
+                      "title": "Connect",
+                      "tooltip": "%Widget_Template_Tooltip/Submit%",
+                      "verb": "PatternConnect"
+                    }
+                  ]
+                }
+              ],
+              "width": "auto"
+            }
+          ]
         }
       ]
     }
   ]
 }
+

--- a/CoreWidgetProvider/Widgets/Templates/SSHWalletPatternMatching.json
+++ b/CoreWidgetProvider/Widgets/Templates/SSHWalletPatternMatching.json
@@ -1,0 +1,25 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Your SSH key contains pattern matching. Fill out the pattern to connect.",
+      "wrap": true
+    },
+    {
+      "type": "Input.Text",
+      "placeholder": "Placeholder text"
+    },
+    {
+      "type": "ActionSet",
+      "actions": [
+        {
+          "type": "Action.Submit",
+          "title": "Connect"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
…a pattern to connect based on ssh config patterns## Summary of the pull request

## References and relevant issues
#893 

## Detailed description of the pull request / Additional comments
This PR allows for users to fill in hosts that have pattern matching(*,?) in the /.ssh/config file. 

<img width="251" alt="image" src="https://github.com/microsoft/devhome/assets/98557455/eeaae758-471e-4455-a122-2109bc892196">

<img width="253" alt="image" src="https://github.com/microsoft/devhome/assets/98557455/b23ff845-2715-48f1-a914-e262dccbd71a">

<img width="252" alt="image" src="https://github.com/microsoft/devhome/assets/98557455/9c87dc40-1c36-4008-941d-ad10acfe937b">


## Validation steps performed
Locally tested on a variety of hosts in config file that contain pattern matching.


## PR checklist
- [x] Closes #893 
- [ ] Tests added/passed
- [ ] Documentation updated
