### PR TITLE
Disallowing SSH Connection strings

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -84,6 +84,7 @@ public static class StringResourceKey
     public static readonly string SummaryPageOneRepositoryCloned = nameof(SummaryPageOneRepositoryCloned);
     public static readonly string SummaryPageAppsDownloadedCount = nameof(SummaryPageAppsDownloadedCount);
     public static readonly string SummaryPageReposClonedCount = nameof(SummaryPageReposClonedCount);
+    public static readonly string SSHConnectionStringNotAllowed = nameof(SSHConnectionStringNotAllowed);
 
     // Repository loading screen messages
     public static readonly string CloneRepoCreating = nameof(CloneRepoCreating);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1183,4 +1183,8 @@
     <value>Repository type</value>
     <comment>Header for the repo  grid</comment>
   </data>
+  <data name="SSHConnectionStringNotAllowed" xml:space="preserve">
+    <value>SSH connection strings are not allowed</value>
+    <comment>Error string when a user enters in an SSH connection string</comment>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -339,7 +339,8 @@ public partial class AddRepoViewModel : ObservableObject
                 return false;
             }
 
-            var sshMatch = Regex.Match(Url, "^.*@.*:.*\\/.*[.].*");
+            var sshMatch = Regex.Match(Url, "^.*@.*:.*\\/.*");
+
             if (sshMatch.Success)
             {
                 UrlParsingError = _stringResource.GetLocalized(StringResourceKey.SSHConnectionStringNotAllowed);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -334,6 +335,14 @@ public partial class AddRepoViewModel : ObservableObject
             if (!Uri.TryCreate(Url, UriKind.RelativeOrAbsolute, out _))
             {
                 UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlValidationBadUrl);
+                ShouldShowUrlError = Visibility.Visible;
+                return false;
+            }
+
+            var sshMatch = Regex.Match(Url, "^.*@.*:.*\\/.*[.].*");
+            if (sshMatch.Success)
+            {
+                UrlParsingError = _stringResource.GetLocalized(StringResourceKey.SSHConnectionStringNotAllowed);
                 ShouldShowUrlError = Visibility.Visible;
                 return false;
             }


### PR DESCRIPTION
## Summary of the pull request
DevHome does not allow SSH connection strings.  If a user put in an SSH connection string in the Repo tool, Dev Home would crash.

This fix prevents a user from using an SSH connection strings in the repo tool.

## References and relevant issues
#839 

## Detailed description of the pull request / Additional comments

## Validation steps performed
Tested with an SSH connection string and a github URL.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![DisallowSSHConnectionStrings](https://github.com/microsoft/devhome/assets/2517139/3c718392-ac83-4d30-a5e6-62dab721c3ca)
