### PR TITLE
Moving GetRepo logic to the non-UI thread

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -537,9 +537,12 @@ public partial class AddRepoViewModel : ObservableObject
     /// <summary>
     /// Gets all the repositories for the specified provider and account.
     /// </summary>
+    /// <remarks>
+    /// The side effect of this method is _repositoriesForAccount is populated with repositories.
+    /// </remarks>
     /// <param name="repositoryProvider">The provider.  This should match the display name of the plugin</param>
     /// <param name="loginId">The login Id to get the repositories for</param>
-    public async Task<IEnumerable<RepoViewListItem>> GetRepositories(string repositoryProvider, string loginId)
+    public async Task GetRepositoriesAsync(string repositoryProvider, string loginId)
     {
         _selectedAccount = loginId;
 
@@ -551,8 +554,17 @@ public partial class AddRepoViewModel : ObservableObject
             TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetRepos_Event", LogLevel.Measure, new RepoToolEvent("GettingAllRepos"));
             _repositoriesForAccount = _providers.GetAllRepositories(repositoryProvider, loggedInDeveloper);
         });
+    }
 
-        Application.Current.GetService<WindowEx>().DispatcherQueue.TryEnqueue(() => { Repositories = new ObservableCollection<RepoViewListItem>(OrderRepos(_repositoriesForAccount)); });
+    /// <summary>
+    /// Updates the UI with the repositories to display for the specific user and provider.
+    /// </summary>
+    /// <param name="repositoryProvider">The name of the provider</param>
+    /// <param name="loginId">The login ID</param>
+    /// <returns>All previously selected repos excluding any added via URL.</returns>
+    public IEnumerable<RepoViewListItem> SetRepositories(string repositoryProvider, string loginId)
+    {
+        Repositories = new ObservableCollection<RepoViewListItem>(OrderRepos(_repositoriesForAccount));
 
         return _previouslySelectedRepos.Where(x => x.OwningAccount != null)
             .Where(x => x.PluginName.Equals(repositoryProvider, StringComparison.OrdinalIgnoreCase)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -197,7 +197,7 @@ internal partial class AddRepoDialog
     /// <remarks>
     /// Fired when a user changes their account on a provider.
     /// </remarks>
-    private void AccountsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private async void AccountsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         // This gets fired when events are removed from the account combo box.
         // When the provider combo box is changed all accounts are removed from the account combo box
@@ -208,7 +208,8 @@ internal partial class AddRepoDialog
         {
             var loginId = (string)AccountsComboBox.SelectedValue;
             var providerName = (string)RepositoryProviderComboBox.SelectedValue;
-            SelectRepositories(AddRepoViewModel.GetRepositories(providerName, loginId));
+            var previouslySelectedRepositories = await AddRepoViewModel.GetRepositories(providerName, loginId);
+            SelectRepositories(previouslySelectedRepositories);
         }
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -208,8 +208,8 @@ internal partial class AddRepoDialog
         {
             var loginId = (string)AccountsComboBox.SelectedValue;
             var providerName = (string)RepositoryProviderComboBox.SelectedValue;
-            var previouslySelectedRepositories = await AddRepoViewModel.GetRepositories(providerName, loginId);
-            SelectRepositories(previouslySelectedRepositories);
+            await AddRepoViewModel.GetRepositoriesAsync(providerName, loginId);
+            SelectRepositories(AddRepoViewModel.SetRepositories(providerName, loginId));
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
The repo tool uses the UI thread to obtain all repositories for an account.

The long running code is moved to a background thread.

## References and relevant issues
#479 
## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually ran.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![GetReposOnADifferentThread](https://github.com/microsoft/devhome/assets/2517139/e11236c3-8770-4312-9859-4239b07fa302)
