### PR TITLE
Switch settings to use packageFullName instead of classId

### DIFF
--- a/settings/DevHome.Settings/Models/Setting.cs
+++ b/settings/DevHome.Settings/Models/Setting.cs
@@ -15,7 +15,7 @@ public class Setting
 
     public string Path { get; }
 
-    public string ClassId { get; }
+    public string FullName { get; }
 
     public string Header { get; }
 
@@ -36,7 +36,7 @@ public class Setting
                 Task.Run(() =>
                 {
                     var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-                    return localSettingsService.SaveSettingAsync(ClassId + "-ExtensionDisabled", !value);
+                    return localSettingsService.SaveSettingAsync(FullName + "-ExtensionDisabled", !value);
                 }).Wait();
 
                 _isExtensionEnabled = value;
@@ -55,7 +55,7 @@ public class Setting
                 Task.Run(() =>
                 {
                     var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-                    return localSettingsService.SaveSettingAsync(ClassId + "-NotificationsDisabled", !value);
+                    return localSettingsService.SaveSettingAsync(FullName + "-NotificationsDisabled", !value);
                 }).Wait();
 
                 _isNotificationsEnabled = value;
@@ -63,10 +63,10 @@ public class Setting
         }
     }
 
-    public Setting(string path, string classId, string header, string description, string glyph, bool hasToggleSwitch)
+    public Setting(string path, string fullName, string header, string description, string glyph, bool hasToggleSwitch)
     {
         Path = path;
-        ClassId = classId;
+        FullName = fullName;
         Header = header;
         Description = description;
         Glyph = glyph;
@@ -81,7 +81,7 @@ public class Setting
         var isDisabled = Task.Run(() =>
         {
             var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-            return localSettingsService.ReadSettingAsync<bool>(ClassId + "-ExtensionDisabled");
+            return localSettingsService.ReadSettingAsync<bool>(FullName + "-ExtensionDisabled");
         }).Result;
         return !isDisabled;
     }
@@ -91,7 +91,7 @@ public class Setting
         var isDisabled = Task.Run(() =>
         {
             var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-            return localSettingsService.ReadSettingAsync<bool>(ClassId + "-NotificationsDisabled");
+            return localSettingsService.ReadSettingAsync<bool>(FullName + "-NotificationsDisabled");
         }).Result;
         return !isDisabled;
     }

--- a/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
@@ -84,7 +84,7 @@ public partial class ExtensionsViewModel : ObservableRecipient
                 continue;
             }
 
-            var setting = new Setting("Plugins/" + pluginWrapper.PluginClassId, pluginWrapper.PluginClassId, pluginWrapper.Name, string.Empty, string.Empty, true);
+            var setting = new Setting("Plugins/" + pluginWrapper.PackageFullName, pluginWrapper.PackageFullName, pluginWrapper.Name, string.Empty, string.Empty, true);
             SettingsList.Add(new ExtensionViewModel(setting, this));
         }
     }

--- a/src/Services/PluginService.cs
+++ b/src/Services/PluginService.cs
@@ -181,7 +181,7 @@ public class PluginService : IPluginService
                 }
 
                 var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-                var isPluginDisabled = await localSettingsService.ReadSettingAsync<bool>(classId + "-ExtensionDisabled");
+                var isPluginDisabled = await localSettingsService.ReadSettingAsync<bool>(extension.Package.Id.FullName + "-ExtensionDisabled");
 
                 _installedPlugins.Add(pluginWrapper);
                 if (!isPluginDisabled)


### PR DESCRIPTION
## Summary of the pull request
Switch settings to use packageFullName instead of classId.  This fixes enable/disable of extensions when running side-by-side.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
