### PR TITLE
Use antialiasing on Widget Charts

### DIFF
--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -66,6 +66,8 @@ internal class ChartHelper
 
             lock (_lock)
             {
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+
                 using var darkGreyBrush = new SolidBrush(DarkGrayColor);
                 g.FillRectangle(darkGreyBrush, 0, 0, width - 1, height - 1);
                 g.DrawRectangle(Pens.LightGray, 0, 0, width - 1, height - 1);


### PR DESCRIPTION
## Summary of the pull request
Related to #760. A true fix won't be so resource heavy, but in the meantime, we can at least use antialiasing to make it look better.

Before:
![image](https://github.com/microsoft/devhome/assets/47155823/2ed99bc9-91c0-423b-a4f9-3843c36550b7)

After:
![image](https://github.com/microsoft/devhome/assets/47155823/13ab51e8-a61b-4edf-9742-1ff90b88a7e6)


## References and relevant issues
- #760

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
