### PR TITLE
[CI] Fix slowness in finding vstest.console.exe

### DIFF
--- a/.github/workflows/DevHome-CI.yml
+++ b/.github/workflows/DevHome-CI.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Find vstest.console.exe
       if: ${{ matrix.platform != 'arm64' }}
       run: |
-        $VSDevTestCmd = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere" -latest -prerelease -products * -find **\TestPlatform\vstest.console.exe
+        $VSDevTestCmd = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere" -latest -prerelease -products * -find Common7\IDE\Extensions\TestPlatform\vstest.console.exe
         if (!$VSDevTestCmd) { exit 1 }
         echo "Using VSDevTestCmd: ${VSDevTestCmd}"
         Add-Content $env:GITHUB_ENV "VSDevTestCmd=$VSDevTestCmd"


### PR DESCRIPTION
## Summary of the pull request
Add relative path to vstest.console.exe instead of glob pattern to resolve slowness in task

## References and relevant issues
#1106 

## Detailed description of the pull request / Additional comments
Added the relative path to vstest.console.exe in relation to the Visual Studio installation path. I've tested this locally and can see a considerable improvement with the speed of returning the vstest.console.exe from the vswhere command.

## Validation steps performed

## PR checklist
- [X] Closes #1106
- [ ] Tests added/passed
- [ ] Documentation updated
