### PR TITLE
Remove extra circle from stepper control in setup flow

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -167,12 +167,11 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         _wpm = wpm;
         _packageProvider = packageProvider;
         _catalogDataSourceLoacder = catalogDataSourceLoader;
+        _configurationUnitResults = new (GetConfigurationUnitResults);
+        _showRestartNeeded = Visibility.Collapsed;
 
         IsNavigationBarVisible = true;
         IsStepPage = false;
-
-        _configurationUnitResults = new (GetConfigurationUnitResults);
-        _showRestartNeeded = Visibility.Collapsed;
     }
 
     protected async override Task OnFirstNavigateToAsync()

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -167,7 +167,10 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         _wpm = wpm;
         _packageProvider = packageProvider;
         _catalogDataSourceLoacder = catalogDataSourceLoader;
+
         IsNavigationBarVisible = true;
+        IsStepPage = false;
+
         _configurationUnitResults = new (GetConfigurationUnitResults);
         _showRestartNeeded = Visibility.Collapsed;
     }


### PR DESCRIPTION
## Summary of the pull request

Removes an extra circle at the end of the stepper control in setup flow. The cause of this was that the Summary page was also marked as a step page, so there was an extra step to show in the control.

## Detailed description of the pull request / Additional comments

![image](https://github.com/microsoft/devhome/assets/14323496/23115a83-df10-4aef-9a0f-33f1cf78c1ee)

![image](https://github.com/microsoft/devhome/assets/14323496/35ae34f9-34ae-4056-830d-e1d5f00cb074)

## Validation steps performed

Manual validation; see screenshots.
The stepper is the only place the changed properties are used in, so there should be no other effects.