### PR TITLE
Launch Dev Home on windows startup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 -->
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -192,4 +192,8 @@
   <data name="Settings_About_RelatedLinks.Text" xml:space="preserve">
     <value>Related links</value>
   </data>
+  <data name="Settings_Preferences_StartupAppCard.Header" xml:space="preserve">
+    <value>Launch Dev Home when Windows starts</value>
+    <comment>Header for a card that contains settings for whether Dev Home should start on windows startup</comment>
+  </data>
 </root>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -193,7 +193,7 @@
     <value>Related links</value>
   </data>
   <data name="Settings_Preferences_StartupAppCard.Header" xml:space="preserve">
-    <value>Launch Dev Home when Windows starts</value>
+    <value>Start Dev Home when I sign in to Windows</value>
     <comment>Header for a card that contains settings for whether Dev Home should start on windows startup</comment>
   </data>
 </root>

--- a/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
@@ -1,25 +1,64 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Contracts.Services;
 using Microsoft.UI.Xaml;
+using Windows.ApplicationModel;
 
 namespace DevHome.Settings.ViewModels;
 
 public partial class PreferencesViewModel : ObservableObject
 {
+    private const string StartupTaskId = "DevHomeDefaultStartup";
+
     private readonly IThemeSelectorService _themeSelectorService;
 
     [ObservableProperty]
     private ElementTheme _elementTheme;
 
+    [ObservableProperty]
+    private bool _launchAtStartup;
+
+    [ObservableProperty]
+    private bool _launchAtStartupButtonEnabled;
+
     public PreferencesViewModel(IThemeSelectorService themeSelectorService)
     {
         _themeSelectorService = themeSelectorService;
         _elementTheme = _themeSelectorService.Theme;
+    }
+
+    public async Task OnPageLaunched()
+    {
+        var startupTask = await StartupTask.GetAsync(StartupTaskId);
+        if (startupTask != null)
+        {
+            switch (startupTask.State)
+            {
+                case StartupTaskState.DisabledByUser:
+                    LaunchAtStartupButtonEnabled = false;
+                    LaunchAtStartup = false;
+                    break;
+
+                case StartupTaskState.DisabledByPolicy:
+                    LaunchAtStartupButtonEnabled = false;
+                    LaunchAtStartup = false;
+                    break;
+
+                case StartupTaskState.Disabled:
+                    LaunchAtStartupButtonEnabled = true;
+                    break;
+
+                case StartupTaskState.Enabled:
+                    LaunchAtStartupButtonEnabled = false;
+                    LaunchAtStartup = true;
+                    break;
+            }
+        }
     }
 
     [RelayCommand]
@@ -30,6 +69,21 @@ public partial class PreferencesViewModel : ObservableObject
             ElementTheme = theme;
 
             await _themeSelectorService.SetThemeAsync(theme);
+        }
+    }
+
+    partial void OnLaunchAtStartupChanged(bool value)
+    {
+        var startup = StartupTask.GetAsync(StartupTaskId).GetAwaiter().GetResult();
+        if (value && startup.State != StartupTaskState.Enabled)
+        {
+            LaunchAtStartupButtonEnabled = false;
+
+            var newState = startup.RequestEnableAsync().GetAwaiter().GetResult();
+            if (newState != StartupTaskState.Enabled)
+            {
+                LaunchAtStartup = false;
+            }
         }
     }
 }

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -9,6 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:xaml="using:Microsoft.UI.Xaml"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    Loaded="Page_Loaded"
     mc:Ignorable="d">
     <Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
@@ -64,6 +65,25 @@
                         </labs:SettingsCard>
                     </labs:SettingsExpander.Items>
                 </labs:SettingsExpander>
+                <labs:SettingsCard
+                    x:Uid="Settings_Preferences_StartupAppCard"
+                    Margin="{ThemeResource SettingsCardMargin}"
+                    IsClickEnabled="False">
+                    <StackPanel Orientation="Horizontal">
+                        <ToggleSwitch
+                            Visibility="Visible"
+                            IsEnabled="{x:Bind ViewModel.LaunchAtStartupButtonEnabled, Mode=TwoWay}"
+                            IsOn="{x:Bind ViewModel.LaunchAtStartup, Mode=TwoWay}"
+                            Margin="0 0 15 0"/>
+                        <Button Click="StartupAppsExternalButton_Click" Padding="3">
+                            <FontIcon Glyph="&#xE8A7;"/>
+                        </Button>
+                    </StackPanel>
+                    <labs:SettingsCard.ActionIcon>
+                        <!-- The open new window icon -->
+                        <FontIcon Glyph="&#xE8A7;" />
+                    </labs:SettingsCard.ActionIcon>
+                </labs:SettingsCard>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -69,6 +69,9 @@
                     x:Uid="Settings_Preferences_StartupAppCard"
                     Margin="{ThemeResource SettingsCardMargin}"
                     IsClickEnabled="False">
+                    <labs:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE7B5;" />
+                    </labs:SettingsCard.HeaderIcon>
                     <StackPanel Orientation="Horizontal">
                         <ToggleSwitch
                             Visibility="Visible"

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.ObjectModel;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
@@ -43,5 +44,15 @@ public sealed partial class PreferencesPage : Page
             var crumb = (Breadcrumb)args.Item;
             crumb.NavigateTo();
         }
+    }
+
+    private async void Page_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.OnPageLaunched();
+    }
+
+    private async void StartupAppsExternalButton_Click(object sender, RoutedEventArgs e)
+    {
+        await Windows.System.Launcher.LaunchUriAsync(new Uri("ms-settings:startupapps"));
     }
 }

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" IgnorableNamespaces="uap uap3 rescap genTemplate desktop6">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" IgnorableNamespaces="uap uap3 rescap genTemplate desktop6">
   <Identity Name="Microsoft.Windows.DevHome.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
     <DisplayName>Dev Home (Dev)</DisplayName>
@@ -27,6 +27,9 @@
         <uap:SplashScreen Image="Assets\Preview\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
+		<uap5:Extension Category="windows.startupTask" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+		  <uap5:StartupTask TaskId="DevHomeDefaultStartup" Enabled="false" />
+		</uap5:Extension>
         <uap3:Extension Category="windows.appExtensionHost">
           <uap3:AppExtensionHost>
             <uap3:Name>com.microsoft.devhome</uap3:Name>


### PR DESCRIPTION
## Summary of the pull request
This PR adds a "Launch on windows startup" button in Settings > Preferences
The toggle when enabled allows Dev Home to start on windows startup

![image](https://github.com/microsoft/devhome/assets/66971578/8dce1979-1f86-43c8-842c-83ef71df7a01)


## References and relevant issues
Fixes #1042 
Fixes #624 

## Detailed description of the pull request / Additional comments
The windows StartupTask API currently only allows us to request the "launch on startup" to be enabled. It does not allow the feature to be disabled. Thus there is a open in settings app button added that allows opening the settings app at Apps > Startup Apps where the setting can be toggled

## Validation steps performed

## PR checklist
- [x] Closes #1042, #1142
- [ ] Tests added/passed
- [ ] Documentation updated
