### PR TITLE
Upgrade nuget package for WindowsPackageManager

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
@@ -45,7 +45,7 @@
     - Feed the $(TargetDir)\WINMD path to CsWinRT in order to generate the projected classes
     NOTE: Suppressing the warning only is not enough as this will cause CoreClrInitFailure (0x80008089) error.
     -->
-    <PackageReference Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.5.863-preview">
+    <PackageReference Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.5.1572">
       <NoWarn>NU1701</NoWarn>
       <GeneratePathProperty>true</GeneratePathProperty>
       <IncludeAssets>none</IncludeAssets>


### PR DESCRIPTION
## Summary of the pull request
- Use the latest winmd from a non-preview release of winget.
- This fixes the error happening when resolving `CatalogPackageMetadata` class, causing the publisher name and learn more button to not be available in Dev Home with winget version v1.5.1572 and higher

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
- v1.5.1572: All fields are available
- v1.6.1573-preview: All fields are available

![image](https://github.com/microsoft/devhome/assets/104940545/a94301f4-8646-486b-abad-674e0deb99f7)


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
