### PR TITLE
Only show terms checkbox if apps are selected

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
@@ -3,18 +3,14 @@
 
 extern alias Projection;
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
-using DevHome.SetupFlow.Common.Elevation;
-using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
 using Microsoft.Extensions.Hosting;
-using Projection::DevHome.SetupFlow.ElevatedComponent;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -32,6 +28,8 @@ public partial class ReviewViewModel : SetupPageViewModelBase
     private bool _readAndAgree;
 
     public bool HasApplicationsToInstall => Orchestrator.GetTaskGroup<AppManagementTaskGroup>()?.SetupTasks.Any() == true;
+
+    public bool RequiresTermsAgreement => HasApplicationsToInstall;
 
     public bool HasMSStoreApplicationsToInstall
     {
@@ -81,7 +79,16 @@ public partial class ReviewViewModel : SetupPageViewModelBase
 
     public void UpdateCanGoToNextPage()
     {
-        CanGoToNextPage = HasTasksToSetUp && ReadAndAgree;
+        CanGoToNextPage = HasTasksToSetUp && IsValidTermsAgreement();
         Orchestrator.NotifyNavigationCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Validate if the terms agreement is required and checked
+    /// </summary>
+    /// <returns>True if terms agreement is valid, false otherwise.</returns>
+    private bool IsValidTermsAgreement()
+    {
+        return !RequiresTermsAgreement || ReadAndAgree;
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -37,6 +37,7 @@
     <setupFlowBehaviors:SetupFlowNavigationBehavior.ContentTemplate>
         <CheckBox
             x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_ReadAndAgree"
+            Visibility="{x:Bind ViewModel.RequiresTermsAgreement, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
             IsChecked="{x:Bind ViewModel.ReadAndAgree, Mode=TwoWay}"/>
     </setupFlowBehaviors:SetupFlowNavigationBehavior.ContentTemplate>
 
@@ -110,7 +111,7 @@
                 </Expander>
 
                 <StackPanel Style="{StaticResource ReviewStackPanelStyle}"
-                            Visibility="{x:Bind ViewModel.HasApplicationsToInstall, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                            Visibility="{x:Bind ViewModel.RequiresTermsAgreement, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                     <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_TermsTitle" />
                     <TextBlock Style="{ThemeResource BodyTextBlockStyle}"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -37,7 +37,7 @@
     <setupFlowBehaviors:SetupFlowNavigationBehavior.ContentTemplate>
         <CheckBox
             x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_ReadAndAgree"
-            Visibility="{x:Bind ViewModel.RequiresTermsAgreement, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+            Visibility="{x:Bind ViewModel.RequiresTermsAgreement, Mode=OneWay}"
             IsChecked="{x:Bind ViewModel.ReadAndAgree, Mode=TwoWay}"/>
     </setupFlowBehaviors:SetupFlowNavigationBehavior.ContentTemplate>
 
@@ -111,7 +111,7 @@
                 </Expander>
 
                 <StackPanel Style="{StaticResource ReviewStackPanelStyle}"
-                            Visibility="{x:Bind ViewModel.RequiresTermsAgreement, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                            Visibility="{x:Bind ViewModel.RequiresTermsAgreement, Mode=OneWay}">
                     <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_TermsTitle" />
                     <TextBlock Style="{ThemeResource BodyTextBlockStyle}"


### PR DESCRIPTION
## Summary of the pull request
- Hide  "I agree and want to continue" if no apps are selected to install.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
### No apps to install
Hide terms checkbox
<img src="https://github.com/microsoft/devhome/assets/104940545/65582a34-381b-46db-b673-3dcb5ee45ec6" width="400" />

### At least one app selected
Sow terms checkbox
<img src="https://github.com/microsoft/devhome/assets/104940545/a17d64ef-c1b0-4991-a0e6-65a03eb9702c" width="400" />

### Clone repo
Hide terms checkbox
<img src="https://github.com/microsoft/devhome/assets/104940545/46ac28c4-e045-4104-b0dd-e71524bc1d38" width="400" />


## PR checklist
- [ ] Closes #772
- [ ] Tests added/passed
- [ ] Documentation updated
