### PR TITLE
Persist the order of widgets in the Dashboard

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetCustomState.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetCustomState.cs
@@ -8,6 +8,9 @@ internal sealed class WidgetCustomState
 {
     [JsonPropertyName("host")]
     public string Host { get; set; }
+
+    [JsonPropertyName("position")]
+    public int Position { get; set; } = -1;
 }
 
 [JsonSerializable(typeof(WidgetCustomState))]

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 
@@ -73,13 +74,23 @@ internal class WidgetHelpers
         return include;
     }
 
-    public static string CreateWidgetCustomState()
+    public static string CreateWidgetCustomState(int ordinal)
     {
         var state = new WidgetCustomState
         {
             Host = DevHomeHostName,
+            Position = ordinal,
         };
 
         return JsonSerializer.Serialize(state, SourceGenerationContext.Default.WidgetCustomState);
+    }
+
+    public static async Task SetPositionOnWidget(Widget widget, int ordinal)
+    {
+        var stateStr = await widget.GetCustomStateAsync();
+        var stateObj = JsonSerializer.Deserialize<WidgetCustomState>(stateStr);
+        stateObj.Position = ordinal;
+        stateStr = JsonSerializer.Serialize<WidgetCustomState>(stateObj);
+        await widget.SetCustomStateAsync(stateStr);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -88,9 +88,9 @@ internal class WidgetHelpers
     public static async Task SetPositionOnWidget(Widget widget, int ordinal)
     {
         var stateStr = await widget.GetCustomStateAsync();
-        var stateObj = JsonSerializer.Deserialize<WidgetCustomState>(stateStr);
-        stateObj.Position = ordinal;
-        stateStr = JsonSerializer.Serialize<WidgetCustomState>(stateObj);
+        var state = JsonSerializer.Deserialize(stateStr, SourceGenerationContext.Default.WidgetCustomState);
+        state.Position = ordinal;
+        stateStr = JsonSerializer.Serialize(state, SourceGenerationContext.Default.WidgetCustomState);
         await widget.SetCustomStateAsync(stateStr);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -85,7 +85,7 @@ internal class WidgetHelpers
         return JsonSerializer.Serialize(state, SourceGenerationContext.Default.WidgetCustomState);
     }
 
-    public static async Task SetPositionCustomState(Widget widget, int ordinal)
+    public static async Task SetPositionCustomStateAsync(Widget widget, int ordinal)
     {
         var stateStr = await widget.GetCustomStateAsync();
         var state = JsonSerializer.Deserialize(stateStr, SourceGenerationContext.Default.WidgetCustomState);

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -85,7 +85,7 @@ internal class WidgetHelpers
         return JsonSerializer.Serialize(state, SourceGenerationContext.Default.WidgetCustomState);
     }
 
-    public static async Task SetPositionOnWidget(Widget widget, int ordinal)
+    public static async Task SetPositionCustomState(Widget widget, int ordinal)
     {
         var stateStr = await widget.GetCustomStateAsync();
         var state = JsonSerializer.Deserialize(stateStr, SourceGenerationContext.Default.WidgetCustomState);

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -360,13 +360,13 @@ public partial class DashboardView : ToolPage
                             {
                                 if (!restoredWidgetsWithPosition.ContainsKey(position))
                                 {
-                                    restoredWidgetsWithPosition.Add(numUnorderedWidgets++, widget);
+                                    restoredWidgetsWithPosition.Add(position, widget);
                                 }
                                 else
                                 {
                                     // If there was an error and a widget with this position is alredy there,
                                     // treat this widget as unordered and put it into the unordered map.
-                                    restoredWidgetsWithoutPosition.Add(position, widget);
+                                    restoredWidgetsWithoutPosition.Add(numUnorderedWidgets++, widget);
                                 }
                             }
                             else

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -390,7 +390,7 @@ public partial class DashboardView : ToolPage
                 var widget = orderedWidget.Value;
                 var size = await widget.GetSizeAsync();
                 await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-                await WidgetHelpers.SetPositionCustomState(widget, finalPlace);
+                await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
 
                 finalPlace++;
             }
@@ -400,7 +400,7 @@ public partial class DashboardView : ToolPage
                 var widget = orderedWidget.Value;
                 var size = await widget.GetSizeAsync();
                 await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-                await WidgetHelpers.SetPositionCustomState(widget, finalPlace);
+                await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
 
                 finalPlace++;
             }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -44,8 +44,8 @@ public partial class DashboardView : ToolPage
 
     private static bool _widgetHostInitialized;
 
-    private static SortedDictionary<string, BitmapImage> _widgetLightIconCache;
-    private static SortedDictionary<string, BitmapImage> _widgetDarkIconCache;
+    private static Dictionary<string, BitmapImage> _widgetLightIconCache;
+    private static Dictionary<string, BitmapImage> _widgetDarkIconCache;
 
     private readonly Version minSupportedVersion400 = new (423, 3800);
     private readonly Version minSupportedVersion500 = new (523, 3300);
@@ -64,8 +64,8 @@ public partial class DashboardView : ToolPage
         PinnedWidgets = new ObservableCollection<WidgetViewModel>();
         PinnedWidgets.CollectionChanged += OnPinnedWidgetsCollectionChanged;
 
-        _widgetLightIconCache = new SortedDictionary<string, BitmapImage>();
-        _widgetDarkIconCache = new SortedDictionary<string, BitmapImage>();
+        _widgetLightIconCache = new Dictionary<string, BitmapImage>();
+        _widgetDarkIconCache = new Dictionary<string, BitmapImage>();
 
         _renderer = new AdaptiveCardRenderer();
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
@@ -240,7 +240,7 @@ public partial class DashboardView : ToolPage
 
         await ConfigureWidgetRenderer(_renderer);
 
-        RestorePinnedWidgets(null, null);
+        RestorePinnedWidgets();
 
         LoadingWidgetsProgressRing.Visibility = Visibility.Collapsed;
     }
@@ -329,14 +329,20 @@ public partial class DashboardView : ToolPage
         return itemImage;
     }
 
-    private async void RestorePinnedWidgets(object sender, RoutedEventArgs e)
+    private async void RestorePinnedWidgets()
     {
         Log.Logger()?.ReportInfo("DashboardView", "Get widgets for current host");
         var pinnedWidgets = _widgetHost.GetWidgets();
         if (pinnedWidgets != null)
         {
             Log.Logger()?.ReportInfo("DashboardView", $"Found {pinnedWidgets.Length} widgets for this host");
+            var restoredWidgetsWithPosition = new SortedDictionary<int, Widget>();
+            var restoredWidgetsWithoutPosition = new SortedDictionary<int, Widget>();
+            var numUnorderedWidgets = 0;
 
+            // Widgets do not come from the host in a deterministic order, so save their order in each widget's CustomState.
+            // Iterate through all the widgets and put them in order. If a widget does not have a position assigned to it,
+            // append it at the end. If a position is missing, just show the next widget in order.
             foreach (var widget in pinnedWidgets)
             {
                 try
@@ -346,10 +352,28 @@ public partial class DashboardView : ToolPage
                     if (!string.IsNullOrEmpty(stateStr))
                     {
                         var stateObj = System.Text.Json.JsonSerializer.Deserialize(stateStr, SourceGenerationContext.Default.WidgetCustomState);
+
                         if (stateObj.Host == WidgetHelpers.DevHomeHostName)
                         {
-                            var size = await widget.GetSizeAsync();
-                            AddWidgetToPinnedWidgetsAsync(widget, size);
+                            var position = stateObj.Position;
+                            if (position >= 0)
+                            {
+                                if (!restoredWidgetsWithPosition.ContainsKey(position))
+                                {
+                                    restoredWidgetsWithPosition.Add(numUnorderedWidgets++, widget);
+                                }
+                                else
+                                {
+                                    // If there was an error and a widget with this position is alredy there,
+                                    // treat this widget as unordered and put it into the unordered map.
+                                    restoredWidgetsWithoutPosition.Add(position, widget);
+                                }
+                            }
+                            else
+                            {
+                                // Widgets with no position will get the default of -1. Append these at the end.
+                                restoredWidgetsWithoutPosition.Add(numUnorderedWidgets++, widget);
+                            }
                         }
                     }
                 }
@@ -357,6 +381,28 @@ public partial class DashboardView : ToolPage
                 {
                     Log.Logger()?.ReportError("DashboardView", $"RestorePinnedWidgets(): ", ex);
                 }
+            }
+
+            // Now that we've ordered the widgets, put them in their final collection.
+            var finalPlace = 0;
+            foreach (var orderedWidget in restoredWidgetsWithPosition)
+            {
+                var widget = orderedWidget.Value;
+                var size = await widget.GetSizeAsync();
+                await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
+                await WidgetHelpers.SetPositionOnWidget(widget, finalPlace);
+
+                finalPlace++;
+            }
+
+            foreach (var orderedWidget in restoredWidgetsWithoutPosition)
+            {
+                var widget = orderedWidget.Value;
+                var size = await widget.GetSizeAsync();
+                await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
+                await WidgetHelpers.SetPositionOnWidget(widget, finalPlace);
+
+                finalPlace++;
             }
         }
         else
@@ -414,7 +460,8 @@ public partial class DashboardView : ToolPage
         if (newWidget != null)
         {
             // Set custom state on new widget.
-            var newCustomState = WidgetHelpers.CreateWidgetCustomState();
+            var position = PinnedWidgets.Count;
+            var newCustomState = WidgetHelpers.CreateWidgetCustomState(position);
             Log.Logger()?.ReportDebug("DashboardView", $"SetCustomState: {newCustomState}");
             await newWidget.SetCustomStateAsync(newCustomState);
 
@@ -424,15 +471,9 @@ public partial class DashboardView : ToolPage
             {
                 var size = WidgetHelpers.GetDefaultWidgetSize(widgetDef.GetWidgetCapabilities());
                 await newWidget.SetSizeAsync(size);
-                AddWidgetToPinnedWidgetsAsync(newWidget, size);
+                await InsertWidgetInPinnedWidgetsAsync(newWidget, size, position);
             }
         }
-    }
-
-    private async void AddWidgetToPinnedWidgetsAsync(Widget widget, WidgetSize size)
-    {
-        Log.Logger()?.ReportDebug("DashboardView", $"Add widget to pinned widgets, id = {widget.Id}");
-        await InsertWidgetInPinnedWidgetsAsync(widget, size, PinnedWidgets.Count);
     }
 
     private async Task InsertWidgetInPinnedWidgetsAsync(Widget widget, WidgetSize size, int index)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -387,22 +387,12 @@ public partial class DashboardView : ToolPage
             var finalPlace = 0;
             foreach (var orderedWidget in restoredWidgetsWithPosition)
             {
-                var widget = orderedWidget.Value;
-                var size = await widget.GetSizeAsync();
-                await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-                await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
-
-                finalPlace++;
+                await PlaceWidget(orderedWidget, finalPlace++);
             }
 
             foreach (var orderedWidget in restoredWidgetsWithoutPosition)
             {
-                var widget = orderedWidget.Value;
-                var size = await widget.GetSizeAsync();
-                await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-                await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
-
-                finalPlace++;
+                await PlaceWidget(orderedWidget, finalPlace++);
             }
         }
         else
@@ -410,6 +400,14 @@ public partial class DashboardView : ToolPage
             Log.Logger()?.ReportInfo("DashboardView", $"Found 0 widgets for this host");
             NoWidgetsStackPanel.Visibility = Visibility.Visible;
         }
+    }
+
+    private async Task PlaceWidget(KeyValuePair<int, Widget> orderedWidget, int finalPlace)
+    {
+        var widget = orderedWidget.Value;
+        var size = await widget.GetSizeAsync();
+        await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
+        await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
     }
 
     private async void AddWidget_Click(object sender, RoutedEventArgs e)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -358,11 +358,7 @@ public partial class DashboardView : ToolPage
                             var position = stateObj.Position;
                             if (position >= 0)
                             {
-                                if (!restoredWidgetsWithPosition.ContainsKey(position))
-                                {
-                                    restoredWidgetsWithPosition.Add(position, widget);
-                                }
-                                else
+                                if (!restoredWidgetsWithPosition.TryAdd(position, widget))
                                 {
                                     // If there was an error and a widget with this position is alredy there,
                                     // treat this widget as unordered and put it into the unordered map.

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -390,7 +390,7 @@ public partial class DashboardView : ToolPage
                 var widget = orderedWidget.Value;
                 var size = await widget.GetSizeAsync();
                 await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-                await WidgetHelpers.SetPositionOnWidget(widget, finalPlace);
+                await WidgetHelpers.SetPositionCustomState(widget, finalPlace);
 
                 finalPlace++;
             }
@@ -400,7 +400,7 @@ public partial class DashboardView : ToolPage
                 var widget = orderedWidget.Value;
                 var size = await widget.GetSizeAsync();
                 await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-                await WidgetHelpers.SetPositionOnWidget(widget, finalPlace);
+                await WidgetHelpers.SetPositionCustomState(widget, finalPlace);
 
                 finalPlace++;
             }


### PR DESCRIPTION
## Summary of the pull request
Each time the Dashboard is opened, the widgets may present in a different order. This change saves their order so they will always be displayed in the same order.

## References and relevant issues
#463

## Detailed description of the pull request / Additional comments
When we get widgets from the host, they don't always come back in the same order. To keep order, this change adds an "position" field to the json that we keep in the widget's CustomState. When we add a new widget, the position will be the next available position. If a widget is edited, it will keep the position it had. If a widget somehow loses its saved position, it will get appended to the end of the list.

Migrating to a version with this change won't be an issue, any existing widgets will be assigned the order they show up in, as if they had "lost" their order as described above.

## Validation steps performed
Tested locally.

## PR checklist
- [x] Closes #463
- [ ] Tests added/passed
- [ ] Documentation updated
