### PR TITLE
Clean up BoolToVisibilityConverters

### DIFF
--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -9,15 +9,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:settings="using:DevHome.Settings.ViewModels"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
-    <Page.Resources>
-        <ResourceDictionary>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
-        </ResourceDictionary>
-    </Page.Resources>
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <StackPanel x:Name="ContentArea">
@@ -29,7 +23,7 @@
                         <labs:SettingsCard Header="{x:Bind Header}"
                                            Margin="{ThemeResource SettingsCardMargin}"
                                            IsClickEnabled="False" Command="{x:Bind NavigateSettingsCommand}">
-                            <ToggleSwitch Visibility="{x:Bind HasToggleSwitch, Converter={StaticResource BoolToVisibilityConverter}}"
+                            <ToggleSwitch Visibility="{x:Bind HasToggleSwitch}"
                                           IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
                         </labs:SettingsCard>
                     </DataTemplate>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -8,17 +8,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
-    xmlns:settings="using:DevHome.Settings.ViewModels"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:behaviors="using:DevHome.Common.Behaviors" 
-    xmlns:helpers="using:DevHome.Common.Helpers"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
-    <Page.Resources>
-        <ResourceDictionary>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
-        </ResourceDictionary>
-    </Page.Resources>
 
     <ScrollViewer MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{StaticResource ContentPageMargin}">
         <Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -10,7 +10,7 @@
     <UserControl.Resources>
         <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
         <converters:BoolToObjectConverter x:Key="StepperBoolToGlyphBrushConverter" TrueValue="{ThemeResource AccentFillColorDisabledBrush}" FalseValue="{ThemeResource AccentFillColorDefaultBrush}" />
-        <converters:BoolToObjectConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
+        <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
         <!-- If no custom header template was provided, display a TextBlock -->
         <ControlTemplate x:Name="defaultHeaderTemplate">
             <ContentPresenter />

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -9,7 +9,6 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
-        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converters:BoolToObjectConverter x:Key="StepperBoolToGlyphBrushConverter" TrueValue="{ThemeResource AccentFillColorDisabledBrush}" FalseValue="{ThemeResource AccentFillColorDefaultBrush}" />
         <converters:BoolToObjectConverter x:Key="BoolToInverseVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
         <!-- If no custom header template was provided, display a TextBlock -->
@@ -29,7 +28,7 @@
             <TextBlock
                 Style="{ThemeResource TitleTextBlockStyle}"
                 TextWrapping="WrapWholeWords"
-                Visibility="{x:Bind UseOrchestratorTitle, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                Visibility="{x:Bind UseOrchestratorTitle, Mode=OneWay}"
                 Text="{x:Bind Orchestrator.FlowTitle}" />
             <TextBlock
                 Style="{ThemeResource TitleTextBlockStyle}"
@@ -43,7 +42,7 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <!-- Stepper showing the progress within the flow -->
-            <StackPanel Visibility="{x:Bind Orchestrator.CurrentPageViewModel.IsStepPage, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
+            <StackPanel Visibility="{x:Bind Orchestrator.CurrentPageViewModel.IsStepPage, Mode=OneWay}">
                 <ItemsRepeater ItemsSource="{x:Bind Orchestrator.SetupStepPages, Mode=OneWay}">
                     <ItemsRepeater.Layout>
                         <StackLayout Orientation="Horizontal" Spacing="5"/>
@@ -51,7 +50,7 @@
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewModels:SetupPageViewModelBase">
                             <StackPanel Spacing="8" Orientation="Horizontal"
-                                Visibility="{x:Bind IsStepPage, Converter={StaticResource BoolToVisibilityConverter}}">
+                                Visibility="{x:Bind IsStepPage}">
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
                                           FontSize="16"
                                           Glyph="&#xEA3B;"
@@ -59,13 +58,13 @@
                                 <TextBlock VerticalAlignment="Center" Text="{x:Bind PageTitle}" />
                                 <StackPanel VerticalAlignment="Center" Visibility="{x:Bind IsLastStepPage, Converter={StaticResource BoolToInverseVisibilityConverter}}">
                                     <ProgressBar Width="20" Value="100"
-                                                 Visibility="{x:Bind IsPastPage, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                 Visibility="{x:Bind IsPastPage}"
                                                  Background="{ThemeResource AccentFillColorDisabledBrush}" />
                                     <ProgressBar Width="20" Value="50"
-                                                 Visibility="{x:Bind IsCurrentPage, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                 Visibility="{x:Bind IsCurrentPage}"
                                                  Background="{ThemeResource AccentFillColorDisabledBrush}" />
                                     <ProgressBar Width="20" Value="0"
-                                                 Visibility="{x:Bind IsUpcomingPage, Converter={StaticResource BoolToVisibilityConverter}}"
+                                                 Visibility="{x:Bind IsUpcomingPage}"
                                                  Background="{ThemeResource AccentFillColorDisabledBrush}" />
                                 </StackPanel>
                             </StackPanel>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -10,7 +10,7 @@
     <UserControl.Resources>
         <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
         <converters:BoolToObjectConverter x:Key="StepperBoolToGlyphBrushConverter" TrueValue="{ThemeResource AccentFillColorDisabledBrush}" FalseValue="{ThemeResource AccentFillColorDefaultBrush}" />
-        <converters:BoolToObjectConverter x:Key="BoolToInverseVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
+        <converters:BoolToObjectConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
         <!-- If no custom header template was provided, display a TextBlock -->
         <ControlTemplate x:Name="defaultHeaderTemplate">
             <ContentPresenter />
@@ -56,7 +56,7 @@
                                           Glyph="&#xEA3B;"
                                           Foreground="{x:Bind IsUpcomingPage, Converter={StaticResource StepperBoolToGlyphBrushConverter}}" />
                                 <TextBlock VerticalAlignment="Center" Text="{x:Bind PageTitle}" />
-                                <StackPanel VerticalAlignment="Center" Visibility="{x:Bind IsLastStepPage, Converter={StaticResource BoolToInverseVisibilityConverter}}">
+                                <StackPanel VerticalAlignment="Center" Visibility="{x:Bind IsLastStepPage, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
                                     <ProgressBar Width="20" Value="100"
                                                  Visibility="{x:Bind IsPastPage}"
                                                  Background="{ThemeResource AccentFillColorDisabledBrush}" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -7,12 +7,10 @@
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
-               xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-               xmlns:i="using:Microsoft.Xaml.Interactivity"
                xmlns:labs="using:CommunityToolkit.Labs.WinUI"
-               x:Uid="ms-resource:///DevHome.SetupFlow/Resources/CloneRepoDialog"
-               mc:Ignorable="d"
                xmlns:models="using:DevHome.SetupFlow.Models"
+               mc:Ignorable="d"
+               x:Uid="ms-resource:///DevHome.SetupFlow/Resources/CloneRepoDialog"
                x:Name="AddRepoContentDialog"
                PrimaryButtonClick="AddRepoContentDialog_PrimaryButtonClick"
                IsPrimaryButtonEnabled="{x:Bind AddRepoViewModel.ShouldPrimaryButtonBeEnabled, Mode=OneWay}"
@@ -25,7 +23,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml"/>
                 <ResourceDictionary>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
                     <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
                     <converters:BoolToObjectConverter x:Key="BoolToGlyphConverter" TrueValue="&#xF0BD;" FalseValue="&#xF03F;"/>
                 </ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
@@ -9,14 +9,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:util="using:DevHome.SetupFlow.Utilities"
-    xmlns:vm="using:DevHome.SetupFlow.ViewModels"
     xmlns:services="using:DevHome.Common.Services"
     mc:Ignorable="d"
     Background="{ThemeResource ContentDialogBackground}"
     Foreground="{ThemeResource ContentDialogForeground}">
     <Page.Resources>
         <ResourceDictionary>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
             <converters:EmptyObjectToObjectConverter x:Key="EmptyObjectToObjectConverter" NotEmptyValue="Visible" EmptyValue="Collapsed"/>
             <util:DevDriveEnumToLocalizedStringConverter x:Key="DevDriveEnumToLocalizedStringConverter"/>
         </ResourceDictionary>
@@ -55,159 +53,158 @@
                 HorizontalContentAlignment="Center"
                 VerticalContentAlignment="Center"
                 TabNavigation="Cycle">
-                    <StackPanel
-                        Margin="10 0 10 0">
-                        <Grid
+                <StackPanel
+                    Margin="10 0 10 0">
+                    <Grid
+                        Margin="0 0 0 12"
+                        RowDefinitions="*, Auto, *, *"
+                        ColumnDefinitions="*"
+                        HorizontalAlignment="Left">
+                        <TextBlock
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowTitle"
+                            Style="{ThemeResource SubtitleTextBlockStyle}"
+                            Margin="0 5 0 12"
+                            Grid.Row="0"
+                            TextWrapping="Wrap" />
+                        <TextBlock
                             Margin="0 0 0 12"
-                            RowDefinitions="*, Auto, *, *"
-                            ColumnDefinitions="*"
-                            HorizontalAlignment="Left">
-                            <TextBlock
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowTitle"
-                                Style="{ThemeResource SubtitleTextBlockStyle}"
-                                Margin="0 5 0 12"
-                                Grid.Row="0"
-                                TextWrapping="Wrap" />
-                            <TextBlock
-                                Margin="0 0 0 12"
-                                Width="450"
-                                Grid.Row="1"
-                                TextWrapping="Wrap" >
-                                <!-- 
-                                    The comment tags and the spaces Before the Run tags are necessary so the clickable area
-                                    of the hyperlink does not extend to edge of the grid column, and instead stay only over the text.
-                                -->
-                                <Span
-                                    xml:space="preserve">
-                                    <Run x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowOnlyOneDevDriveAllowedHeader" /> <!--
-                                    --><Hyperlink
-                                            UnderlineStyle="None"
-                                            NavigateUri="https://go.microsoft.com/fwlink/?linkid=2226090"><!--
-                                        --> <Run x:Uid="ms-resource:///DevHome.SetupFlow/Resources/LearnMore" /> <!--
-                                        --></Hyperlink> <!--
-                                    --></Span>
-                            </TextBlock>
-                            <TextBlock
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowLaunchSettingsDisksAndVolumesHeader"
-                                Grid.Row="2"
-                                TextWrapping="Wrap" 
-                                Margin="0 0 0 1"/>
-                            <HyperlinkButton
-                                Grid.Row="4"
-                                Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}"
-                                Padding="0"
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowLaunchSettingsDisksAndVolumesHyperLink">
-                            </HyperlinkButton>
-                        </Grid>
-                        <Grid
-                            Margin="0 0 0 12"
-                            ColumnDefinitions="4*, *, Auto"
-                            RowDefinitions="*, *">
-                            <TextBox 
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowNameTextBox"
-                                x:Name="DriveLabelTextBox"
-                                Grid.Column="0"
-                                Grid.Row="0"
-                                Margin="0 0 18 0"
-                                HorizontalAlignment="Stretch"
-                                Text="{x:Bind ViewModel.DriveLabel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                MaxLength="{x:Bind util:DevDriveUtil.MaxDriveLabelSize}"
-                                IsSpellCheckEnabled="False">
-                            </TextBox>
-                            <NumberBox 
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Size"
-                                x:Name="DriveSizeNumberBox"
-                                Grid.Column="1"
-                                Grid.Row="0"
-                                Margin="0"
-                                HorizontalAlignment="Stretch"
-                                Value="{x:Bind ViewModel.Size, Mode=TwoWay}"
-                                Maximum="{x:Bind ViewModel.MaximumAllowedSize, Mode=OneWay}"
-                                Minimum="{x:Bind ViewModel.MinimumAllowedSize, Mode=OneWay}"
-                                AcceptsExpression="False"
-                                NumberFormatter="{x:Bind ViewModel.DevDriveDecimalFormatter, Mode=OneWay}"
-                                ValidationMode="InvalidInputOverwritten">
-                            </NumberBox> 
-                            <ComboBox 
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowByteUnitComboBox"
-                                x:Name="DriveByteUnitComboBox"
-                                Grid.Column="2"
-                                Grid.Row="0"
-                                Margin="13 26 0 0"
-                                Padding="5"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Bottom"
-                                ItemsSource="{x:Bind ViewModel.ByteUnitList, Mode=OneWay}"
-                                DisplayMemberPath="Value"
-                                SelectedIndex="{x:Bind ViewModel.ComboBoxByteUnit, Mode=TwoWay }">
-                            </ComboBox>
-                            <ItemsRepeater
-                                ItemsSource="{x:Bind ViewModel.FileNameAndSizeErrorList, Mode=OneWay}"
-                                Grid.Row="1"
-                                Grid.ColumnSpan="3"
-                                Margin="0, 5, 0, 0">
-                                <ItemsRepeater.ItemTemplate>
-                                    <DataTemplate x:DataType="services:DevDriveValidationResult">
-                                        <InfoBar
-                                            Margin="0, 3, 0, 3"
-                                            IsClosable="False"
-                                            Severity="Error"
-                                            IsOpen="True"
-                                            Message="{Binding Converter={StaticResource DevDriveEnumToLocalizedStringConverter}}" />
-                                    </DataTemplate>
-                                </ItemsRepeater.ItemTemplate>
+                            Width="450"
+                            Grid.Row="1"
+                            TextWrapping="Wrap" >
+                            <!-- 
+                                The comment tags and the spaces Before the Run tags are necessary so the clickable area
+                                of the hyperlink does not extend to edge of the grid column, and instead stay only over the text.
+                            -->
+                            <Span
+                                xml:space="preserve">
+                                <Run x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowOnlyOneDevDriveAllowedHeader" /> <!--
+                                --><Hyperlink
+                                        UnderlineStyle="None"
+                                        NavigateUri="https://go.microsoft.com/fwlink/?linkid=2226090"><!--
+                                    --> <Run x:Uid="ms-resource:///DevHome.SetupFlow/Resources/LearnMore" /> <!--
+                                    --></Hyperlink> <!--
+                                --></Span>
+                        </TextBlock>
+                        <TextBlock
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowLaunchSettingsDisksAndVolumesHeader"
+                            Grid.Row="2"
+                            TextWrapping="Wrap" 
+                            Margin="0 0 0 1"/>
+                        <HyperlinkButton
+                            Grid.Row="4"
+                            Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}"
+                            Padding="0"
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowLaunchSettingsDisksAndVolumesHyperLink">
+                        </HyperlinkButton>
+                    </Grid>
+                    <Grid
+                        Margin="0 0 0 12"
+                        ColumnDefinitions="4*, *, Auto"
+                        RowDefinitions="*, *">
+                        <TextBox 
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowNameTextBox"
+                            x:Name="DriveLabelTextBox"
+                            Grid.Column="0"
+                            Grid.Row="0"
+                            Margin="0 0 18 0"
+                            HorizontalAlignment="Stretch"
+                            Text="{x:Bind ViewModel.DriveLabel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            MaxLength="{x:Bind util:DevDriveUtil.MaxDriveLabelSize}"
+                            IsSpellCheckEnabled="False">
+                        </TextBox>
+                        <NumberBox 
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Size"
+                            x:Name="DriveSizeNumberBox"
+                            Grid.Column="1"
+                            Grid.Row="0"
+                            Margin="0"
+                            HorizontalAlignment="Stretch"
+                            Value="{x:Bind ViewModel.Size, Mode=TwoWay}"
+                            Maximum="{x:Bind ViewModel.MaximumAllowedSize, Mode=OneWay}"
+                            Minimum="{x:Bind ViewModel.MinimumAllowedSize, Mode=OneWay}"
+                            AcceptsExpression="False"
+                            NumberFormatter="{x:Bind ViewModel.DevDriveDecimalFormatter, Mode=OneWay}"
+                            ValidationMode="InvalidInputOverwritten">
+                        </NumberBox>
+                        <ComboBox 
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowByteUnitComboBox"
+                            x:Name="DriveByteUnitComboBox"
+                            Grid.Column="2"
+                            Grid.Row="0"
+                            Margin="13 26 0 0"
+                            Padding="5"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Bottom"
+                            ItemsSource="{x:Bind ViewModel.ByteUnitList, Mode=OneWay}"
+                            DisplayMemberPath="Value"
+                            SelectedIndex="{x:Bind ViewModel.ComboBoxByteUnit, Mode=TwoWay }">
+                        </ComboBox>
+                        <ItemsRepeater
+                            ItemsSource="{x:Bind ViewModel.FileNameAndSizeErrorList, Mode=OneWay}"
+                            Grid.Row="1"
+                            Grid.ColumnSpan="3"
+                            Margin="0, 5, 0, 0">
+                            <ItemsRepeater.ItemTemplate>
+                                <DataTemplate x:DataType="services:DevDriveValidationResult">
+                                    <InfoBar
+                                        Margin="0, 3, 0, 3"
+                                        IsClosable="False"
+                                        Severity="Error"
+                                        IsOpen="True"
+                                        Message="{Binding Converter={StaticResource DevDriveEnumToLocalizedStringConverter}}" />
+                                </DataTemplate>
+                            </ItemsRepeater.ItemTemplate>
                         </ItemsRepeater>
                     </Grid>
-                        <Grid
-                            Margin="0 0 0 12"
-                            ColumnDefinitions="*, Auto"
-                            RowDefinitions="*, *">
-                            <TextBox 
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowLocationTextBox"
-                                x:Name="DriveLocationTextBox"
-                                Grid.Column="0"
-                                Grid.Row="0"
-                                Margin="0"
-                                Text="{x:Bind ViewModel.Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                MaxLength="{x:Bind util:DevDriveUtil.MaxDrivePathLength}"
-                                IsSpellCheckEnabled="False" 
-                                TextWrapping="Wrap">
-                            </TextBox>
-                            <Button 
-                                Grid.Column="1"
-                                Grid.Row="0"
-                                Margin="10 26 0 0"
-                                Padding="30 7 33 7"
-                                HorizontalContentAlignment="Center"
-                                VerticalAlignment="Bottom"
-                                Command="{x:Bind ViewModel.ChooseFolderLocationCommand, Mode=OneWay}">
+                    <Grid
+                        Margin="0 0 0 12"
+                        ColumnDefinitions="*, Auto"
+                        RowDefinitions="*, *">
+                        <TextBox 
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowLocationTextBox"
+                            x:Name="DriveLocationTextBox"
+                            Grid.Column="0"
+                            Grid.Row="0"
+                            Margin="0"
+                            Text="{x:Bind ViewModel.Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            MaxLength="{x:Bind util:DevDriveUtil.MaxDrivePathLength}"
+                            IsSpellCheckEnabled="False" 
+                            TextWrapping="Wrap">
+                        </TextBox>
+                        <Button 
+                            Grid.Column="1"
+                            Grid.Row="0"
+                            Margin="10 26 0 0"
+                            Padding="30 7 33 7"
+                            HorizontalContentAlignment="Center"
+                            VerticalAlignment="Bottom"
+                            Command="{x:Bind ViewModel.ChooseFolderLocationCommand, Mode=OneWay}">
                             <TextBlock 
-                                    Text="{x:Bind ViewModel.LocalizedBrowseButtonText, Mode=OneWay}"/>
-                            </Button>
-                            <InfoBar
-                                Grid.Row="1"
-                                Grid.ColumnSpan="2"
-                                Margin="0 5 0 0"
-                                IsClosable="False"
-                                IsOpen="True"
-                                Severity="Error"
-                                Message="{x:Bind ViewModel.FolderLocationError, Mode=OneWay, Converter={StaticResource DevDriveEnumToLocalizedStringConverter}}"
-                                Visibility="{x:Bind ViewModel.FolderLocationError, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
-                                />
-                        </Grid>
-                        <Grid
-                            Margin="0 0 0 12"
-                            RowDefinitions="Auto, *">
-                            <ComboBox 
-                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowDriveLettersComboBox"
-                                x:Name="NoDriveLettersAvailableBox"
-                                Grid.Row="0"
-                                Padding="20 5 40 5"
-                                Margin="0 5 0 5"
-                                VerticalAlignment="Top"
-                                ItemsSource="{x:Bind ViewModel.DriveLetters, Mode=OneWay}"
-                                SelectedValue="{x:Bind ViewModel.ComboBoxDriveLetter, Mode=TwoWay}">
-                            </ComboBox>
+                                Text="{x:Bind ViewModel.LocalizedBrowseButtonText, Mode=OneWay}"/>
+                        </Button>
+                        <InfoBar
+                            Grid.Row="1"
+                            Grid.ColumnSpan="2"
+                            Margin="0 5 0 0"
+                            IsClosable="False"
+                            IsOpen="True"
+                            Severity="Error"
+                            Message="{x:Bind ViewModel.FolderLocationError, Mode=OneWay, Converter={StaticResource DevDriveEnumToLocalizedStringConverter}}"
+                            Visibility="{x:Bind ViewModel.FolderLocationError, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}" />
+                    </Grid>
+                    <Grid
+                        Margin="0 0 0 12"
+                        RowDefinitions="Auto, *">
+                        <ComboBox 
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DevDriveWindowDriveLettersComboBox"
+                            x:Name="NoDriveLettersAvailableBox"
+                            Grid.Row="0"
+                            Padding="20 5 40 5"
+                            Margin="0 5 0 5"
+                            VerticalAlignment="Top"
+                            ItemsSource="{x:Bind ViewModel.DriveLetters, Mode=OneWay}"
+                            SelectedValue="{x:Bind ViewModel.ComboBoxDriveLetter, Mode=TwoWay}">
+                        </ComboBox>
                         <InfoBar
                             Grid.Row="1"
                             Margin="0 5 0 0"
@@ -217,42 +214,41 @@
                             Message="{x:Bind ViewModel.DriveLetterError, Mode=OneWay, Converter={StaticResource DevDriveEnumToLocalizedStringConverter}}"
                             Visibility="{x:Bind ViewModel.DriveLetterError, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"/>
                     </Grid>
-                        <StackPanel 
-                            VerticalAlignment="Bottom">
-                            <Rectangle 
-                                Margin="0 10 0 15"
-                                HorizontalAlignment="Stretch" 
-                                Fill="{ThemeResource ControlStrokeColorSecondaryBrush}" 
-                                Height="1"/>
-                            <Grid
+                    <StackPanel 
+                        VerticalAlignment="Bottom">
+                        <Rectangle 
+                            Margin="0 10 0 15"
+                            HorizontalAlignment="Stretch" 
+                            Fill="{ThemeResource ControlStrokeColorSecondaryBrush}" 
+                            Height="1"/>
+                        <Grid
+                            VerticalAlignment="Bottom"
+                            ColumnDefinitions="Auto, Auto"
+                            HorizontalAlignment="Right">
+                            <Button 
+                                Grid.Column="0"
+                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Save"
+                                Style="{StaticResource AccentButtonStyle}"
+                                VerticalContentAlignment="Center"
+                                HorizontalContentAlignment="Center"
+                                HorizontalAlignment="Right"
                                 VerticalAlignment="Bottom"
-                                ColumnDefinitions="Auto, Auto"
-                                HorizontalAlignment="Right">
-                                <Button 
-                                    Grid.Column="0"
-                                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Save"
-                                    Style="{StaticResource AccentButtonStyle}"
-                                    VerticalContentAlignment="Center"
-                                    HorizontalContentAlignment="Center"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Bottom"
-                                    Padding="50 10 50 10"
-                                    Margin="0 0 5 0"
-                                    Command="{x:Bind ViewModel.SaveButtonCommand, Mode=OneWay}"
-                                    />
-                                <Button 
-                                    Grid.Column="1"
-                                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Cancel"
-                                    VerticalContentAlignment="Center"
-                                    HorizontalContentAlignment="Center"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Bottom"
-                                    Padding="50 10 50 10"
-                                    Margin="5 0 0 0"
-                                    Command="{x:Bind ViewModel.CancelButtonCommand, Mode=OneWay}"/>
-                            </Grid>
-                        </StackPanel>
+                                Padding="50 10 50 10"
+                                Margin="0 0 5 0"
+                                Command="{x:Bind ViewModel.SaveButtonCommand, Mode=OneWay}" />
+                            <Button 
+                                Grid.Column="1"
+                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Cancel"
+                                VerticalContentAlignment="Center"
+                                HorizontalContentAlignment="Center"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Bottom"
+                                Padding="50 10 50 10"
+                                Margin="5 0 0 0"
+                                Command="{x:Bind ViewModel.CancelButtonCommand, Mode=OneWay}"/>
+                        </Grid>
                     </StackPanel>
+                </StackPanel>
             </ScrollViewer>
         </Grid>
     </UserControl>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/EditClonePathDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/EditClonePathDialog.xaml
@@ -20,7 +20,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupToolStyles.xaml" />
                 <ResourceDictionary>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
                     <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
@@ -28,7 +27,7 @@
     </ContentDialog.Resources>
     <StackPanel MinWidth="420">
         <StackPanel
-            Visibility="{x:Bind EditClonePathViewModel.ShouldShowAreYouSureMessage, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+            Visibility="{x:Bind EditClonePathViewModel.ShouldShowAreYouSureMessage, Mode=OneWay}"
             Width="400"
             Margin="0 20 0 20">
             <TextBlock

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -19,7 +19,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityInvertedConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+                    <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
                     <converters:BoolNegationConverter x:Key="BoolNegation"/>
                 </ResourceDictionary>
                 <ResourceDictionary>
@@ -94,7 +94,7 @@
                                 <!-- If the status icon is visible it means the task has stopped.  Don't show progress ring.-->
                                 <ProgressRing
                                     IsActive="{x:Bind StatusIconGridVisibility, Mode=OneWay, Converter={StaticResource BoolNegation}}"
-                                    Visibility="{x:Bind StatusIconGridVisibility, Mode=OneWay, Converter={StaticResource BoolToVisibilityInvertedConverter}}"
+                                    Visibility="{x:Bind StatusIconGridVisibility, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                                     Width="20" Height="20"/>
                                 <TextBlock Text="{x:Bind MessageToShow, Mode=OneWay}" Style="{StaticResource BodyStrongTextBlockStyle}" VerticalAlignment="Center"/>
                             </StackPanel>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -19,9 +19,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
                     <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityInvertedConverter" TrueValue="Collapsed" FalseValue="Visible"/>
-
                     <converters:BoolNegationConverter x:Key="BoolNegation"/>
                 </ResourceDictionary>
                 <ResourceDictionary>
@@ -38,7 +36,7 @@
     </UserControl.Resources>
 
     <StackPanel x:Name="LoadingPageStackPanel" Orientation="Vertical" Spacing="20">
-        <Grid Visibility="{x:Bind ViewModel.ShowOutOfRetriesBanner, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"  Background="{ThemeResource ComboBoxItemBackgroundPressed}" CornerRadius="5" Height="55" Padding="10">
+        <Grid Visibility="{x:Bind ViewModel.ShowOutOfRetriesBanner, Mode=OneWay}" Background="{ThemeResource ComboBoxItemBackgroundPressed}" CornerRadius="5" Height="55" Padding="10">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition MinWidth="100" />
@@ -90,7 +88,7 @@
                                 <ImageIcon
                                     Width="18"
                                     Height="18"
-                                    Visibility="{x:Bind StatusIconGridVisibility, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                    Visibility="{x:Bind StatusIconGridVisibility, Mode=OneWay}"
                                     Source="{x:Bind StatusSymbolIcon, Mode=OneWay}"/>
 
                                 <!-- If the status icon is visible it means the task has stopped.  Don't show progress ring.-->

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -14,7 +14,6 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
             <converters:BoolToObjectConverter x:Key="BoolToOpacityConverter" TrueValue="1" FalseValue="0.4" />
             <x:Double x:Key="SettingsCardHeaderIconMaxSize">32</x:Double>
@@ -46,7 +45,7 @@
         <!-- App installer update notification -->
         <InfoBar
             x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_AppInstallerUpdateInfoBar"
-            Visibility="{x:Bind ViewModel.ShowAppInstallerUpdateNotification, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+            Visibility="{x:Bind ViewModel.ShowAppInstallerUpdateNotification, Mode=OneWay}"
             Severity="Warning"
             IsOpen="True"
             Margin="0,0,0,9"
@@ -74,7 +73,7 @@
                         TextWidth="345"
                         HideButtonVisibility="True"
                         HideButtonCommand="{x:Bind ViewModel.HideBannerCommand}"
-                        Visibility="{x:Bind ViewModel.ShowBanner, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                        Visibility="{x:Bind ViewModel.ShowBanner, Mode=OneWay}"
                         ButtonCommand="{x:Bind ViewModel.BannerButtonCommand, Mode=OneWay}"
                         x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DefaultBanner"
                         BackgroundSource="{ThemeResource Setup_Banner_Back}"
@@ -150,7 +149,7 @@
                         </Grid>
                         <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
                                            IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
-                                           Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" >
+                                           Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
                             <labs:SettingsCard.ActionIcon>
                                 <!-- The open new window icon -->
                                 <FontIcon Glyph="&#xE8A7;" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -5,15 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.Labs.WinUI"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     xmlns:views="using:DevHome.SetupFlow.Views"
     mc:Ignorable="d">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
-        </ResourceDictionary>
-    </UserControl.Resources>
     <StackPanel>
         <!-- Card header -->
         <controls:SettingsCard
@@ -34,7 +28,7 @@
             </controls:SettingsCard.ActionIcon>
             <HyperlinkButton
                 Grid.Column="1"
-                Visibility="{x:Bind Catalog.CanAddAllPackages, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                Visibility="{x:Bind Catalog.CanAddAllPackages, Mode=OneWay}"
                 Command="{x:Bind Catalog.AddAllPackagesCommand}">
                 <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/AddAll" />
             </HyperlinkButton>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -6,8 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:primitives="using:CommunityToolkit.WinUI.UI.Controls.Primitives"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:setupControls="using:DevHome.SetupFlow.Controls"
     xmlns:models="using:DevHome.SetupFlow.Models"
@@ -17,7 +15,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
                     <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
                     <converters:BoolToObjectConverter x:Key="BoolToGlyphConverter" TrueValue="&#xF0BD;" FalseValue="&#xF03F;"/>
                     <converters:CollectionVisibilityConverter x:Key="CollectionShowWhenEmpty" EmptyValue="Visible" NotEmptyValue="Collapsed"/>
@@ -99,7 +96,7 @@
                                     <TextBox 
                                             Text="{x:Bind CloneLocationAlias, Mode=OneWay}" 
                                             IsEnabled="False"
-                                            Visibility="{x:Bind CloneToDevDrive, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                            Visibility="{x:Bind CloneToDevDrive, Mode=OneWay}"
                                             MinWidth="300"
                                             MaxWidth="300"
                                             Margin="10, 5, 0, 5"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -28,7 +28,6 @@
                     </Style>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <converters:EmptyCollectionToObjectConverter x:Key="EmptyCollectionToVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible" />
             <converters:EmptyCollectionToObjectConverter x:Key="EmptyCollectionToInverseVisibilityConverter" EmptyValue="Visible" NotEmptyValue="Collapsed" />
         </ResourceDictionary>
@@ -110,13 +109,13 @@
                 </Expander>
 
                 <StackPanel Style="{StaticResource ReviewStackPanelStyle}"
-                            Visibility="{x:Bind ViewModel.HasApplicationsToInstall, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                            Visibility="{x:Bind ViewModel.HasApplicationsToInstall, Mode=OneWay}">
                     <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}"
                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_TermsTitle" />
                     <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_Terms" />
                     <commonviews:HyperlinkTextBlock
-                        Visibility="{x:Bind ViewModel.HasMSStoreApplicationsToInstall, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                        Visibility="{x:Bind ViewModel.HasMSStoreApplicationsToInstall, Mode=OneWay}"
                         x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Review_MSStoreTerms" />
                 </StackPanel>
             </StackPanel>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -18,7 +18,7 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
-        <converters:BoolToVisibilityConverter x:Key="NegateBoolToVisibility" TrueValue="Collapsed" FalseValue="Visible" />
+        <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
     </Page.Resources>
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
@@ -85,7 +85,7 @@
                                 Command="{x:Bind ViewModel.CancelCommand, Mode=OneWay}"
                                 MinWidth="120" Margin="4,0"
                                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Cancel"
-                                Visibility="{x:Bind ViewModel.Orchestrator.ShouldShowDoneButton, Mode=OneWay, Converter={StaticResource NegateBoolToVisibility}}"/>
+                                Visibility="{x:Bind ViewModel.Orchestrator.ShouldShowDoneButton, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"/>
                             <Button
                                 Command="{x:Bind ViewModel.CancelCommand, Mode=OneWay}"
                                 MinWidth="120" Margin="4,0"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -18,7 +18,6 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
-        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converters:BoolToVisibilityConverter x:Key="NegateBoolToVisibility" TrueValue="Collapsed" FalseValue="Visible" />
     </Page.Resources>
 
@@ -77,7 +76,7 @@
 
         <controls:SetupFlowNavigation
             Grid.Row="1"
-            Visibility="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.IsNavigationBarVisible, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
+            Visibility="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.IsNavigationBarVisible, Mode=OneWay}">
             <i:Interaction.Behaviors>
                 <setupFlowBehaviors:SetupFlowNavigationBehavior>
                     <setupFlowBehaviors:SetupFlowNavigationBehavior.DefaultCancelTemplate>
@@ -98,7 +97,7 @@
                         <Button
                             Command="{x:Bind ViewModel.Orchestrator.GoToPreviousPageCommand, Mode=OneWay}"
                             MinWidth="120" Margin="4,0"
-                            Visibility="{x:Bind ViewModel.Orchestrator.HasPreviousPage, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                            Visibility="{x:Bind ViewModel.Orchestrator.HasPreviousPage, Mode=OneWay}"
                             x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Previous" />
                     </setupFlowBehaviors:SetupFlowNavigationBehavior.DefaultPreviousTemplate>
                     <!-- Workaround to show a tooltip on a disabled button

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -20,7 +20,6 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml"/>
                 <ResourceDictionary>
                     <converters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
                     <converters:BoolToVisibilityConverter x:Key="BoolToInverseVisibilityConverter"  TrueValue="Collapsed" FalseValue="Visible" />
                     <converters:BoolToObjectConverter x:Key="BoolToGlyphConverter" TrueValue="&#xF0BD;" FalseValue="&#xF03F;"/>
                     <ControlTemplate x:Key="LinksTemplate">
@@ -86,11 +85,11 @@
                     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Header"/>
                 <TextBlock
                     Style="{ThemeResource SubtitleTextBlockStyle}"
-                    Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                    Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay}"
                     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_HeaderWithErrors"/>
             </Grid>
 
-            <Grid Grid.Row="2" ColumnSpacing="25" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Grid Grid.Row="2" ColumnSpacing="25" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.77*" />
                     <ColumnDefinition Width="*" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -20,7 +20,7 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml"/>
                 <ResourceDictionary>
                     <converters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
-                    <converters:BoolToVisibilityConverter x:Key="BoolToInverseVisibilityConverter"  TrueValue="Collapsed" FalseValue="Visible" />
+                    <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter"  TrueValue="Collapsed" FalseValue="Visible" />
                     <converters:BoolToObjectConverter x:Key="BoolToGlyphConverter" TrueValue="&#xF0BD;" FalseValue="&#xF03F;"/>
                     <ControlTemplate x:Key="LinksTemplate">
                         <StackPanel Orientation="Vertical" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
@@ -81,7 +81,7 @@
                 <!-- Introduction to the summary page -->
                 <TextBlock
                     Style="{ThemeResource SubtitleTextBlockStyle}"
-                    Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay, Converter={StaticResource BoolToInverseVisibilityConverter}}"
+                    Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Header"/>
                 <TextBlock
                     Style="{ThemeResource SubtitleTextBlockStyle}"
@@ -153,7 +153,7 @@
             <!-- Grid with information on tasks completed-->
             <Grid
                 Grid.Row="2"
-                Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource BoolToInverseVisibilityConverter}}"
+                Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                 ColumnSpacing="50">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="auto"/>


### PR DESCRIPTION
## Summary of the pull request
We have a lot of unnecessary BoolToVisibilityConverters. They're built into XAML, so no need to redefine them, or call them explitly in Xaml. This change also consolidates on one name for NegatedBoolToVisibilityConverter, since three were being used. NegatedBoolToVisibilityConverter had the most instances, so I went with that one. Also fixes an instance where a BoolToVisibilityConverter was labeled as a BoolToObjectConverter.

It may be easiest to review this PR going commit by commit.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
