### PR TITLE
Use JSON generators for WidgetCustomState

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetCustomState.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetCustomState.cs
@@ -4,8 +4,13 @@
 using System.Text.Json.Serialization;
 
 namespace DevHome.Dashboard.Helpers;
-internal class WidgetCustomState
+internal sealed class WidgetCustomState
 {
     [JsonPropertyName("host")]
     public string Host { get; set; }
+}
+
+[JsonSerializable(typeof(WidgetCustomState))]
+internal sealed partial class SourceGenerationContext : JsonSerializerContext
+{
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -79,6 +79,7 @@ internal class WidgetHelpers
         {
             Host = DevHomeHostName,
         };
-        return JsonSerializer.Serialize(state);
+
+        return JsonSerializer.Serialize(state, SourceGenerationContext.Default.WidgetCustomState);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -345,7 +345,7 @@ public partial class DashboardView : ToolPage
                     Log.Logger()?.ReportInfo("DashboardView", $"GetWidgetCustomState: {stateStr}");
                     if (!string.IsNullOrEmpty(stateStr))
                     {
-                        var stateObj = System.Text.Json.JsonSerializer.Deserialize<WidgetCustomState>(stateStr);
+                        var stateObj = System.Text.Json.JsonSerializer.Deserialize(stateStr, SourceGenerationContext.Default.WidgetCustomState);
                         if (stateObj.Host == WidgetHelpers.DevHomeHostName)
                         {
                             var size = await widget.GetSizeAsync();


### PR DESCRIPTION
## Overview

This PR uses the JSON generators to make the serialization of `WidgetCustomState` trim/AOT-friendly.

## Validation steps performed

Ran the app and verified those code paths were hit and working as expected.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
