### PR TITLE
[ci]: Set up CI to automate WinGet submissions

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,0 +1,27 @@
+name: Submit Microsoft.DevHome package to Windows Package Manager Community Repository
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    steps:
+      - name: Submit package to Windows Package Manager Community Repository
+        run: |
+
+          $packageId = "Microsoft.DevHome"
+          $gitToken = "${{ secrets.WINGET_PAT }}"
+
+          # Fetching latest release from GitHub
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/microsoft/devhome/releases"
+          $targetRelease = $github | Where-Object -Property name -match 'Dev Home'| Select-Object -First 1
+          $installerUrl = $targetRelease | Select-Object -ExpandProperty assets -First 1 | Where-Object -Property name -match 'Windows.DevHome.*?msixbundle' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = $targetRelease.tag_name.Trim("v")
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update $packageId --version $packageVersion --urls "$installerUrl" --submit --token $gitToken


### PR DESCRIPTION
## Summary of the pull request
Add winget-submission.yml to automatically submit a newer version to winget-pkgs repository for a new release. Inspiration taken from https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml

## References and relevant issues
- #1217


## Detailed description of the pull request / Additional comments

For the CI to work, a maintainer needs to add a GitHub Personal-Access-Token (PAT) as a "Repository Secret" named `WINGET_PAT`. Instructions on creating a PAT can be found over at [winget-create's repo](https://github.com/microsoft/winget-create#github-personal-access-token-classic-permissions)


## Validation steps performed

Tested all the commands locally; The following command be used as a test on how a hypothetical update would work using winget-create (Don't hesitate on running the command as it won't generate and auto-submit a PR, I've omitted the `--submit` flag from it)

```powershell
wingetcreate update Microsoft.DevHome --version 2.0 --urls "https://github.com/microsoft/devhome/releases/download/v0.200.170.0/Windows.DevHome_0.200.170.0.msixbundle"
```

## PR checklist
- [x] Closes #1217
- [ ] Tests added/passed
- [ ] Documentation updated
