### PR TITLE
Update version scheme to account for stub app

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -196,7 +196,9 @@ Try {
     $xIdentity = [System.Xml.Linq.XName]::Get("{http://schemas.microsoft.com/appx/manifest/foundation/windows10}Identity");
     $appxmanifestPath = (Join-Path $env:Build_RootDirectory "DevHomeStub\DevHomeStubPackage\Package.appxmanifest")
     $appxmanifest = [System.Xml.Linq.XDocument]::Load($appxmanifestPath)
-    $appxmanifest.Root.Element($xIdentity).Attribute("Version").Value = (($env:msix_version).Substring(0, $env:msix_version.LastIndexOf('.')) + ".0")
+    $versionParts = ($env:msix_version).Split('.')
+    $versionParts[1] = [string]([int]($versionParts[1]) - 1)
+    $appxmanifest.Root.Element($xIdentity).Attribute("Version").Value = ($versionParts -join '.')
     $appxmanifest.Save($appxmanifestPath)
 
     & $msbuildPath  $msbuildArgs

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -23,7 +23,7 @@ parameters:
     - Release
 
 variables:
-  MSIXVersion: '0.300'
+  MSIXVersion: '0.301'
   VersionOfSDK: '0.100'
   solution: '**/DevHome.sln'
   appxPackageDir: 'AppxPackages'


### PR DESCRIPTION
## Summary of the pull request
DevHome version will now be a.b01.c.0.  The stub app will then be the 2nd part minus 1: a.b00.c.0.  If DevHome increments the 2nd part, it will need to be incremented by at least 2.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
