### PR TITLE
Dev Drive Event in What is new page.

### DIFF
--- a/common/TelemetryEvents/DisksAndVolumesSettingsPageTriggeredEvent.cs
+++ b/common/TelemetryEvents/DisksAndVolumesSettingsPageTriggeredEvent.cs
@@ -7,10 +7,10 @@ using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;
 
-namespace DevHome.SetupFlow.Common.TelemetryEvents;
+namespace DevHome.Common.TelemetryEvents;
 
 [EventData]
-internal class DisksAndVolumesSettingsPageTriggeredEvent : EventBase
+public class DisksAndVolumesSettingsPageTriggeredEvent : EventBase
 {
     public DisksAndVolumesSettingsPageTriggeredEvent(string source)
     {

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -6,6 +6,7 @@ using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Models;
 using DevHome.Services;
@@ -86,6 +87,10 @@ public sealed partial class WhatsNewPage : Page
         {
             // Only launch the disks and volumes settings page when the Dev Drive feature is enabled.
             // Otherwise redirect the user to the Dev Drive support page to learn more about the feature.
+            TelemetryFactory.Get<ITelemetry>().Log(
+                "LaunchDisksAndVolumesSettingsPageTriggered",
+                LogLevel.Measure,
+                new DisksAndVolumesSettingsPageTriggeredEvent(source: "WhatsNewPageView"));
             await Launcher.LaunchUriAsync(DevDriveUtil.IsDevDriveFeatureEnabled ? _devDrivePageKeyUri : _devDriveLearnMoreLinkUri);
         }
         else

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -87,9 +87,10 @@ public sealed partial class WhatsNewPage : Page
         {
             // Only launch the disks and volumes settings page when the Dev Drive feature is enabled.
             // Otherwise redirect the user to the Dev Drive support page to learn more about the feature.
+            // Critical level approved by subhasan
             TelemetryFactory.Get<ITelemetry>().Log(
                 "LaunchDisksAndVolumesSettingsPageTriggered",
-                LogLevel.Measure,
+                LogLevel.Critical,
                 new DisksAndVolumesSettingsPageTriggeredEvent(source: "WhatsNewPageView"));
             await Launcher.LaunchUriAsync(DevDriveUtil.IsDevDriveFeatureEnabled ? _devDrivePageKeyUri : _devDriveLearnMoreLinkUri);
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
@@ -81,7 +81,8 @@ internal class CreateDevDriveTask : ISetupTask
 
             try
             {
-                TelemetryFactory.Get<ITelemetry>().LogMeasure("CreateDevDrive_CreatingDevDrive_Event");
+                // Critical level approved by subhasan
+                TelemetryFactory.Get<ITelemetry>().Log("CreateDevDrive_CreatingDevDrive_Event", LogLevel.Critical, new EmptyEvent());
                 var manager = _host.GetService<IDevDriveManager>();
                 var validation = manager.GetDevDriveValidationResults(DevDrive);
                 manager.RemoveAllDevDrives();
@@ -109,7 +110,8 @@ internal class CreateDevDriveTask : ISetupTask
             finally
             {
                 timer.Stop();
-                TelemetryFactory.Get<ITelemetry>().Log("CreateDevDriveTriggered", LogLevel.Measure, new DevDriveTriggeredEvent(DevDrive, timer.ElapsedTicks, result));
+                // Critical level approved by subhasan
+                TelemetryFactory.Get<ITelemetry>().Log("CreateDevDriveTriggered", LogLevel.Critical, new DevDriveTriggeredEvent(DevDrive, timer.ElapsedTicks, result));
             }
         }).AsAsyncOperation();
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
@@ -110,6 +110,7 @@ internal class CreateDevDriveTask : ISetupTask
             finally
             {
                 timer.Stop();
+
                 // Critical level approved by subhasan
                 TelemetryFactory.Get<ITelemetry>().Log("CreateDevDriveTriggered", LogLevel.Critical, new DevDriveTriggeredEvent(DevDrive, timer.ElapsedTicks, result));
             }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -318,9 +318,10 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     [RelayCommand]
     public async void LaunchDisksAndVolumesSettingsPage()
     {
+        // Critical level approved by subhasan
         TelemetryFactory.Get<ITelemetry>().Log(
             "LaunchDisksAndVolumesSettingsPageTriggered",
-            LogLevel.Measure,
+            LogLevel.Critical,
             new DisksAndVolumesSettingsPageTriggeredEvent(source: "DevDriveView"));
         await Launcher.LaunchUriAsync(new Uri("ms-settings:disksandvolumes"));
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents;
 using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Common.TelemetryEvents;
 using DevHome.SetupFlow.Models;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Common.TelemetryEvents;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -155,10 +155,11 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     [RelayCommand]
     private async void LaunchDisksAndVolumesSettingsPage()
     {
+        // Critical level approved by subhasan
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Launching settings on Disks and Volumes page");
         TelemetryFactory.Get<ITelemetry>().Log(
             "LaunchDisksAndVolumesSettingsPageTriggered",
-            LogLevel.Measure,
+            LogLevel.Critical,
             new DisksAndVolumesSettingsPageTriggeredEvent(source: "MainPageView"));
         await Launcher.LaunchUriAsync(new Uri("ms-settings:disksandvolumes"));
     }


### PR DESCRIPTION
## Summary of the pull request
The "Create Dev Drive" button in the "Introducing Dev Home" page now has a telemetry event.

## References and relevant issues
#1155 

## Detailed description of the pull request / Additional comments
To allow the `WhatsNewPage` to see the DisksAndVolumesSettingsPageTriggeredEvent I moved the telemetry event to DevHome.Common.

## Validation steps performed
Manually ran DevHome.

## PR checklist
- [X] Closes #1155 
- [ ] Tests added/passed
- [ ] Documentation updated
