### PR TITLE
Truncate repo names in repo dialog.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepoViewListItem.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepoViewListItem.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.SetupFlow.Models;
@@ -23,6 +24,15 @@ public partial class RepoViewListItem : ObservableObject
     /// Gets the name of the repository
     /// </summary>
     public string RepoName { get; }
+
+    [ObservableProperty]
+    private bool _isRepoNameTrimmed;
+
+    [RelayCommand]
+    public void TextTrimmed()
+    {
+        IsRepoNameTrimmed = true;
+    }
 
     /// <summary>
     /// Gets the name of the organization that owns this repo.

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -79,10 +79,14 @@
                     </ListView.Header>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:RepoViewListItem">
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <FontIcon FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
-                                <TextBlock Text="{x:Bind RepoDisplayName}"/>
-                            </StackPanel>
+                            <Grid ColumnSpacing="5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="20"/>
+                                    <ColumnDefinition/>
+                                </Grid.ColumnDefinitions>
+                                <FontIcon Grid.Column="0" FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
+                                <TextBlock Grid.Column="1" Text="{x:Bind RepoDisplayName}" TextTrimming="CharacterEllipsis"/>
+                            </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -17,7 +17,9 @@
                DefaultButton="Primary"
                Style="{StaticResource DefaultContentDialogStyle}"
                PrimaryButtonText="{x:Bind AddRepoViewModel.PrimaryButtonText, Mode=OneWay}"
-               CornerRadius="8">
+               CornerRadius="8"
+               xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
+               xmlns:i="using:Microsoft.Xaml.Interactivity">
     <ContentDialog.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -80,12 +82,21 @@
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:RepoViewListItem">
                             <Grid ColumnSpacing="5">
+                                <ToolTipService.ToolTip>
+                                    <ToolTip IsEnabled="{x:Bind IsRepoNameTrimmed, Mode=OneWay}" Content="{x:Bind RepoDisplayName}"/>
+                                </ToolTipService.ToolTip>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="20"/>
                                     <ColumnDefinition/>
                                 </Grid.ColumnDefinitions>
                                 <FontIcon Grid.Column="0" FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
-                                <TextBlock Grid.Column="1" Text="{x:Bind RepoDisplayName}" TextTrimming="CharacterEllipsis"/>
+                                <TextBlock Grid.Column="1" Text="{x:Bind RepoDisplayName}" TextTrimming="CharacterEllipsis">
+                                    <i:Interaction.Behaviors>
+                                        <ic:EventTriggerBehavior EventName="IsTextTrimmedChanged">
+                                            <ic:InvokeCommandAction Command="{x:Bind TextTrimmedCommand}"/>
+                                        </ic:EventTriggerBehavior>
+                                     </i:Interaction.Behaviors>
+                                </TextBlock>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>


### PR DESCRIPTION
## Summary of the pull request
Originally, if a repo name was too long it would trail off the list view.
If the name is truncated the tooltip with the full name is visible.
Now the name is truncated.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually tested

## PR checklist
- [X] Closes #1210 
- [ ] Tests added/passed
- [ ] Documentation updated

Proof!
![ToolTipOnLongRepoNames](https://github.com/microsoft/devhome/assets/2517139/7a304743-5b17-4b94-893e-e29410eb5814)

