### PR TITLE
Various fixes

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -67,6 +67,7 @@ if ($IsAzurePipelineBuild) {
 $ErrorActionPreference = "Stop"
 
 # Install NuGet Cred Provider
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-Expression "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
 
 if (-not([string]::IsNullOrWhiteSpace($SDKNugetSource))) {

--- a/pluginsdk/Build.ps1
+++ b/pluginsdk/Build.ps1
@@ -34,7 +34,6 @@ Options:
 $ErrorActionPreference = "Stop"
 
 $buildPlatforms = "x64","x86","arm64","AnyCPU"
-$env:Build_Configuration = $Configuration
 
 $msbuildPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
 if ($IsAzurePipelineBuild) {
@@ -48,12 +47,12 @@ New-Item -ItemType Directory -Force -Path "$PSScriptRoot\_build"
 
 Try {
   foreach ($platform in $buildPlatforms) {
-    foreach ($configuration in $env:Build_Configuration.Split(",")) {
+    foreach ($config in $Configuration.Split(",")) {
       $msbuildArgs = @(
         ("$PSScriptRoot\DevHomeSDK.sln"),
         ("/p:Platform="+$platform),
-        ("/p:Configuration="+$configuration),
-        ("/binaryLogger:DevHome.SDK.$platform.$configuration.binlog")
+        ("/p:Configuration="+$config),
+        ("/binaryLogger:DevHome.SDK.$platform.$config.binlog")
       )
 
       & $msbuildPath $msbuildArgs

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -14,8 +14,16 @@ using Windows.ApplicationModel.Store.Preview.InstallControl;
 namespace DevHome.ViewModels;
 public class InitializationViewModel : ObservableObject
 {
+#if CANARY_BUILD
+    private const string GitHubExtensionStorePackageId = "9N806ZKPW85R";
+    private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension.Canary_8wekyb3d8bbwe";
+#elif STABLE_BUILD
     private const string GitHubExtensionStorePackageId = "9NZCC27PR6N6";
     private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe";
+#else
+    private const string GitHubExtensionStorePackageId = "";
+    private const string GitHubExtensionPackageFamilyName = "";
+#endif
 
     private const int StoreInstallTimeout = 60_000;
 

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -40,7 +40,8 @@ public class InitializationViewModel : ObservableObject
     {
         try
         {
-            if (!(await _pluginService.GetInstalledAppExtensionsAsync())
+            if (!string.IsNullOrEmpty(GitHubExtensionStorePackageId) &&
+                !(await _pluginService.GetInstalledAppExtensionsAsync())
                 .Any(extension => extension.AppInfo.PackageFamilyName.Equals(GitHubExtensionPackageFamilyName, StringComparison.OrdinalIgnoreCase)))
             {
                 var appInstallTask = InstallStorePackageAsync(GitHubExtensionStorePackageId);


### PR DESCRIPTION
## Summary of the pull request
1) Dev Home (Canary) will now auto install GitHub Extension (Canary) instead of Preview.
2) Dev Home (Dev) will not install anything.
3) Building PluginSDK will no longer force Dev Home to build as release.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1239
- [ ] Closes #1240 
- [ ] Tests added/passed
- [ ] Documentation updated
