### PR TITLE
Refactor widget icons

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -5,7 +5,6 @@
     x:Class="DevHome.Dashboard.Controls.WidgetControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:views="using:DevHome.Dashboard.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:DevHome.Dashboard.Helpers"
@@ -35,7 +34,7 @@
         <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}">
             <StackPanel Orientation="Horizontal" Margin="15,10,15,5">
                 <Rectangle Width="16" Height="16" Margin="0,0,8,0" x:Name="WidgetHeaderIcon"
-                           Fill="{x:Bind views:DashboardView.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme),Mode=OneWay}"/>
+                           Fill="{x:Bind helpers:WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme),Mode=OneWay}"/>
                 <TextBlock Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}" VerticalAlignment="Center" FontSize="{ThemeResource CaptionTextBlockFontSize}" />
             </StackPanel>
             <Button Tag="{x:Bind}" Content="&#xE712;"

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -213,6 +213,6 @@ public sealed partial class WidgetControl : UserControl
 
     private void OnActualThemeChanged(FrameworkElement sender, object args)
     {
-        WidgetHeaderIcon.Fill = DashboardView.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
+        WidgetHeaderIcon.Fill = WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -113,6 +113,7 @@ internal class WidgetIconCache
         {
             ImageSource = image,
         };
+
         return brush;
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CommunityToolkit.WinUI;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.Windows.Widgets.Hosts;
+using Windows.Storage.Streams;
+
+namespace DevHome.Dashboard.Helpers;
+internal class WidgetIconCache
+{
+    private static DispatcherQueue _dispatcher;
+
+    private static Dictionary<string, BitmapImage> _widgetLightIconCache;
+    private static Dictionary<string, BitmapImage> _widgetDarkIconCache;
+
+    public WidgetIconCache(DispatcherQueue dispatcher)
+    {
+        _dispatcher = dispatcher;
+        _widgetLightIconCache = new Dictionary<string, BitmapImage>();
+        _widgetDarkIconCache = new Dictionary<string, BitmapImage>();
+    }
+
+    public async Task CacheAllWidgetIcons(WidgetCatalog widgetCatalog)
+    {
+        var widgetDefs = widgetCatalog.GetWidgetDefinitions();
+        foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
+        {
+            await AddIconsToCache(widgetDef);
+        }
+    }
+
+    public async Task AddIconsToCache(WidgetDefinition widgetDef)
+    {
+        // Only cache icons for providers that we're including.
+        if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
+        {
+            var widgetDefId = widgetDef.Id;
+            try
+            {
+                Log.Logger()?.ReportDebug("DashboardView", $"Cache widget icon for {widgetDefId}");
+                var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
+                var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
+
+                // There is a widget bug where Definition update events are being raised as added events.
+                // If we already have an icon for this key, just remove and add again.
+                if (_widgetLightIconCache.ContainsKey(widgetDefId))
+                {
+                    _widgetLightIconCache.Remove(widgetDefId);
+                }
+
+                if (_widgetDarkIconCache.ContainsKey(widgetDefId))
+                {
+                    _widgetDarkIconCache.Remove(widgetDefId);
+                }
+
+                _widgetLightIconCache.Add(widgetDefId, itemLightImage);
+                _widgetDarkIconCache.Add(widgetDefId, itemDarkImage);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportError("DashboardView", $"Exception in CacheWidgetIcons:", ex);
+                _widgetLightIconCache.Add(widgetDefId, null);
+                _widgetDarkIconCache.Add(widgetDefId, null);
+            }
+        }
+    }
+
+    public static BitmapImage GetWidgetIconForTheme(WidgetDefinition widgetDefinition, ElementTheme theme)
+    {
+        BitmapImage image;
+        if (theme == ElementTheme.Light)
+        {
+            _widgetLightIconCache.TryGetValue(widgetDefinition.Id, out image);
+        }
+        else
+        {
+            _widgetDarkIconCache.TryGetValue(widgetDefinition.Id, out image);
+        }
+
+        return image;
+    }
+
+    public static Brush GetBrushForWidgetIcon(WidgetDefinition widgetDefinition, ElementTheme theme)
+    {
+        var image = GetWidgetIconForTheme(widgetDefinition, theme);
+
+        var brush = new ImageBrush
+        {
+            ImageSource = image,
+        };
+        return brush;
+    }
+
+    public void RemoveIconsFromCache(string definitionId)
+    {
+        _widgetLightIconCache.Remove(definitionId);
+        _widgetDarkIconCache.Remove(definitionId);
+    }
+
+    private static async Task<BitmapImage> WidgetIconToBitmapImage(IRandomAccessStreamReference iconStreamRef)
+    {
+        var itemImage = await _dispatcher.EnqueueAsync(async () =>
+        {
+            using var bitmapStream = await iconStreamRef.OpenReadAsync();
+            var itemImage = new BitmapImage();
+            await itemImage.SetSourceAsync(bitmapStream);
+            return itemImage;
+        });
+
+        return itemImage;
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -119,7 +119,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private StackPanel BuildWidgetNavItem(WidgetDefinition widgetDefinition)
     {
-        var image = DashboardView.GetWidgetIconForTheme(widgetDefinition, ActualTheme);
+        var image = WidgetIconCache.GetWidgetIconForTheme(widgetDefinition, ActualTheme);
         return BuildNavItem(image, widgetDefinition.DisplayTitle);
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -9,7 +9,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
-using CommunityToolkit.WinUI;
 using DevHome.Common;
 using DevHome.Common.Renderers;
 using DevHome.Dashboard.Helpers;
@@ -17,12 +16,9 @@ using DevHome.Dashboard.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Windows.Storage;
-using Windows.Storage.Streams;
 using Windows.System;
 
 namespace DevHome.Dashboard.Views;
@@ -40,11 +36,9 @@ public partial class DashboardView : ToolPage
     private static Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
 
     private readonly WidgetServiceHelper _widgetServiceHelper;
+    private readonly WidgetIconCache _widgetIconCache;
 
     private static bool _widgetHostInitialized;
-
-    private static Dictionary<string, BitmapImage> _widgetLightIconCache;
-    private static Dictionary<string, BitmapImage> _widgetDarkIconCache;
 
     public DashboardView()
     {
@@ -60,11 +54,10 @@ public partial class DashboardView : ToolPage
         PinnedWidgets = new ObservableCollection<WidgetViewModel>();
         PinnedWidgets.CollectionChanged += OnPinnedWidgetsCollectionChanged;
 
-        _widgetLightIconCache = new Dictionary<string, BitmapImage>();
-        _widgetDarkIconCache = new Dictionary<string, BitmapImage>();
-
         _renderer = new AdaptiveCardRenderer();
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+
+        _widgetIconCache = new WidgetIconCache(_dispatcher);
 
         ActualThemeChanged += OnActualThemeChanged;
 
@@ -180,97 +173,13 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
 
         // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-        await CacheWidgetIcons();
+        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
 
         await ConfigureWidgetRenderer(_renderer);
 
         RestorePinnedWidgets();
 
         LoadingWidgetsProgressRing.Visibility = Visibility.Collapsed;
-    }
-
-    private async Task CacheWidgetIcons()
-    {
-        var widgetDefs = _widgetCatalog.GetWidgetDefinitions();
-        foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
-        {
-            await CacheWidgetIcon(widgetDef);
-        }
-    }
-
-    private async Task CacheWidgetIcon(WidgetDefinition widgetDef)
-    {
-        // Only cache icons for providers that we're including.
-        if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
-        {
-            var widgetDefId = widgetDef.Id;
-            try
-            {
-                Log.Logger()?.ReportDebug("DashboardView", $"Cache widget icon for {widgetDefId}");
-                var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
-                var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
-
-                // There is a widget bug where Definition update events are being raised as added events.
-                // If we already have an icon for this key, just remove and add again.
-                if (_widgetLightIconCache.ContainsKey(widgetDefId))
-                {
-                    _widgetLightIconCache.Remove(widgetDefId);
-                }
-
-                if (_widgetDarkIconCache.ContainsKey(widgetDefId))
-                {
-                    _widgetDarkIconCache.Remove(widgetDefId);
-                }
-
-                _widgetLightIconCache.Add(widgetDefId, itemLightImage);
-                _widgetDarkIconCache.Add(widgetDefId, itemDarkImage);
-            }
-            catch (Exception ex)
-            {
-                Log.Logger()?.ReportError("DashboardView", $"Exception in CacheWidgetIcons:", ex);
-                _widgetLightIconCache.Add(widgetDefId, null);
-                _widgetDarkIconCache.Add(widgetDefId, null);
-            }
-        }
-    }
-
-    public static BitmapImage GetWidgetIconForTheme(WidgetDefinition widgetDefinition, ElementTheme theme)
-    {
-        BitmapImage image;
-        if (theme == ElementTheme.Light)
-        {
-            _widgetLightIconCache.TryGetValue(widgetDefinition.Id, out image);
-        }
-        else
-        {
-            _widgetDarkIconCache.TryGetValue(widgetDefinition.Id, out image);
-        }
-
-        return image;
-    }
-
-    public static Brush GetBrushForWidgetIcon(WidgetDefinition widgetDefinition, ElementTheme theme)
-    {
-        var image = GetWidgetIconForTheme(widgetDefinition, theme);
-
-        var brush = new Microsoft.UI.Xaml.Media.ImageBrush
-        {
-            ImageSource = image,
-        };
-        return brush;
-    }
-
-    public static async Task<BitmapImage> WidgetIconToBitmapImage(IRandomAccessStreamReference iconStreamRef)
-    {
-        var itemImage = await _dispatcher.EnqueueAsync(async () =>
-        {
-            using var bitmapStream = await iconStreamRef.OpenReadAsync();
-            var itemImage = new BitmapImage();
-            await itemImage.SetSourceAsync(bitmapStream);
-            return itemImage;
-        });
-
-        return itemImage;
     }
 
     private async void RestorePinnedWidgets()
@@ -358,7 +267,7 @@ public partial class DashboardView : ToolPage
             if (_widgetServiceHelper.EnsureWebExperiencePack())
             {
                 _widgetHostInitialized = InitializeWidgetHost();
-                await CacheWidgetIcons();
+                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
                 await ConfigureWidgetRenderer(_renderer);
             }
             else
@@ -455,7 +364,7 @@ public partial class DashboardView : ToolPage
     private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-        await CacheWidgetIcon(args.Definition);
+        await _widgetIconCache.AddIconsToCache(args.Definition);
     }
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
@@ -526,8 +435,7 @@ public partial class DashboardView : ToolPage
             }
         });
 
-        _widgetLightIconCache.Remove(definitionId);
-        _widgetDarkIconCache.Remove(definitionId);
+        _widgetIconCache.RemoveIconsFromCache(definitionId);
     }
 
     // Listen for widgets being added or removed, so we can add or remove listeners on the WidgetViewModels' properties.

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -57,7 +57,7 @@ public partial class DashboardView : ToolPage
         _renderer = new AdaptiveCardRenderer();
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-        _widgetIconCache = new WidgetIconCache(_dispatcher);
+        _widgetIconCache = new WidgetIconCache();
 
         ActualThemeChanged += OnActualThemeChanged;
 
@@ -173,7 +173,7 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
 
         // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
+        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
 
         await ConfigureWidgetRenderer(_renderer);
 
@@ -267,7 +267,7 @@ public partial class DashboardView : ToolPage
             if (_widgetServiceHelper.EnsureWebExperiencePack())
             {
                 _widgetHostInitialized = InitializeWidgetHost();
-                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
+                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
                 await ConfigureWidgetRenderer(_renderer);
             }
             else
@@ -364,7 +364,7 @@ public partial class DashboardView : ToolPage
     private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-        await _widgetIconCache.AddIconsToCache(args.Definition);
+        await _widgetIconCache.AddIconsToCache(args.Definition, _dispatcher);
     }
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)


### PR DESCRIPTION
## Summary of the pull request
Part of modifying the Dashboard to use a better MVVM model. There should be no functionality changes with this PR.

## References and relevant issues
- #1221 

## Detailed description of the pull request / Additional comments
The WidgetIconCache is backed by two Dictionaries -- one for light theme icons, and one for dark. If a widget only specifies one icon (not themed) that icon goes into both caches.
- Move code related to caching widget icons into its own class
- Added method for removing icons for a given widget definition id from the cache (`RemoveIconsFromCache`)
- Changed a few method names for clarity
  - CacheWidgetIcons -> `CacheAllWidgetIcons`
  - CacheWidgetIcon -> `AddIconsToCache`

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
