### PR TITLE
Use SVG to render widget charts

### DIFF
--- a/CoreWidgetProvider/Helpers/CPUStats.cs
+++ b/CoreWidgetProvider/Helpers/CPUStats.cs
@@ -78,7 +78,7 @@ internal class CPUStats : IDisposable
 
     internal string CreateCPUImageUrl()
     {
-        return ChartHelper.CreateImageUrl(CpuChartValues, "cpu");
+        return ChartHelper.CreateImageUrl(CpuChartValues, ChartHelper.ChartType.CPU);
     }
 
     internal string GetCpuProcessText(int cpuProcessIndex)

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -1,138 +1,226 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Drawing;
-using System.Drawing.Drawing2D;
+using System.Text;
+using System.Xml.Linq;
 
 namespace CoreWidgetProvider.Helpers;
 
 internal class ChartHelper
 {
-    private static readonly Color DarkGrayColor = Color.FromArgb(0, 213, 224, 247);
+    public enum ChartType
+    {
+        CPU,
+        GPU,
+        Mem,
+        Net,
+    }
 
-    private static readonly Pen CPUChartPen = new (Color.FromArgb(255, 57, 184, 227));
-    private static readonly Pen GPUChartPen = new (Color.FromArgb(255, 222, 104, 242));
-    private static readonly Pen MemChartPen = new (Color.FromArgb(255, 92, 158, 250));
-    private static readonly Pen NetChartPen = new (Color.FromArgb(255, 245, 98, 142));
+    private static readonly string LightGrayBoxStyle = "fill:none;stroke:lightgrey;stroke-width:1";
 
-    private static readonly Brush CPUBrush100 = new LinearGradientBrush(new Point(150, 5), new Point(150, 95), Color.FromArgb(105, 57, 184, 227), Color.FromArgb(65, 0, 86, 110));
-    private static readonly Brush CPUBrush50 = new LinearGradientBrush(new Point(150, 50), new Point(150, 95), Color.FromArgb(105, 57, 184, 227), Color.FromArgb(65, 0, 86, 110));
-    private static readonly Brush CPUBrush20 = new LinearGradientBrush(new Point(150, 77), new Point(150, 95), Color.FromArgb(105, 57, 184, 227), Color.FromArgb(65, 0, 86, 110));
+    private static readonly string CPULineStyle = "fill:none;stroke:rgb(57,184,227);stroke-width:1";
+    private static readonly string GPULineStyle = "fill:none;stroke:rgb(222,104,242);stroke-width:1";
+    private static readonly string MemLineStyle = "fill:none;stroke:rgb(92,158,250);stroke-width:1";
+    private static readonly string NetLineStyle = "fill:none;stroke:rgb(245,98,142);stroke-width:1";
 
-    private static readonly Brush GPUBrush100 = new LinearGradientBrush(new Point(150, 5), new Point(150, 95), Color.FromArgb(105, 222, 104, 242), Color.FromArgb(65, 125, 0, 138));
-    private static readonly Brush GPUBrush50 = new LinearGradientBrush(new Point(150, 50), new Point(150, 95), Color.FromArgb(105, 222, 104, 242), Color.FromArgb(65, 125, 0, 138));
-    private static readonly Brush GPUBrush20 = new LinearGradientBrush(new Point(150, 77), new Point(150, 95), Color.FromArgb(105, 222, 104, 242), Color.FromArgb(65, 125, 0, 138));
+    private static readonly string FillStyle = "fill:url(#gradientId);stroke:transparent";
 
-    private static readonly Brush MemBrush100 = new LinearGradientBrush(new Point(150, 5), new Point(150, 95), Color.FromArgb(105, 92, 158, 250), Color.FromArgb(65, 0, 34, 92));
-    private static readonly Brush MemBrush50 = new LinearGradientBrush(new Point(150, 50), new Point(150, 95), Color.FromArgb(105, 92, 158, 250), Color.FromArgb(65, 0, 34, 92));
-    private static readonly Brush MemBrush20 = new LinearGradientBrush(new Point(150, 77), new Point(150, 95), Color.FromArgb(105, 92, 158, 250), Color.FromArgb(65, 0, 34, 92));
+    private static readonly string CPUBrushStop1Style = "stop-color:rgb(57,184,227);stop-opacity:0.4";
+    private static readonly string CPUBrushStop2Style = "stop-color:rgb(0,86,110);stop-opacity:0.25";
 
-    private static readonly Brush NetBrush100 = new LinearGradientBrush(new Point(150, 5), new Point(150, 95), Color.FromArgb(105, 245, 98, 142), Color.FromArgb(65, 130, 0, 47));
-    private static readonly Brush NetBrush50 = new LinearGradientBrush(new Point(150, 50), new Point(150, 95), Color.FromArgb(105, 245, 98, 142), Color.FromArgb(65, 130, 0, 47));
-    private static readonly Brush NetBrush20 = new LinearGradientBrush(new Point(150, 77), new Point(150, 95), Color.FromArgb(105, 245, 98, 142), Color.FromArgb(65, 130, 0, 47));
+    private static readonly string GPUBrushStop1Style = "stop-color:rgb(222,104,242);stop-opacity:0.4";
+    private static readonly string GPUBrushStop2Style = "stop-color:rgb(125,0,138);stop-opacity:0.25";
+
+    private static readonly string MemBrushStop1Style = "stop-color:rgb(92,158,250);stop-opacity:0.4";
+    private static readonly string MemBrushStop2Style = "stop-color:rgb(0,34,92);stop-opacity:0.25";
+
+    private static readonly string NetBrushStop1Style = "stop-color:rgb(245,98,142);stop-opacity:0.4";
+    private static readonly string NetBrushStop2Style = "stop-color:rgb(130,0,47);stop-opacity:0.25";
 
     private const int MaxChartValues = 30;
 
     private static readonly object _lock = new ();
 
-    public static string CreateImageUrl(List<float> chartValues, string type)
+    public static string CreateImageUrl(List<float> chartValues, ChartType type)
     {
-        var bytes = CreateChart(chartValues, type);
+        var chartStr = CreateChart(chartValues, type);
+        var bytes = Encoding.UTF8.GetBytes(chartStr);
         var b64String = Convert.ToBase64String(bytes);
-        return "data:image/png;base64," + b64String;
+        return "data:image/svg+xml;base64," + b64String;
     }
 
-    public static byte[] CreateChart(List<float> chartValues, string type)
+    public static string CreateChart(List<float> chartValues, ChartType type)
     {
-        var width = 268;
-        var height = 100;
-        var bitmap = new Bitmap(width, height);
-        var points = new List<PointF>();
-        var chartPen = CPUChartPen;
-        var brush20 = CPUBrush20;
-        var brush50 = CPUBrush50;
-        var brush100 = CPUBrush100;
-
-        using (var g = Graphics.FromImage(bitmap))
+        /* // Values to use for testing when a static image is desired.
+        chartValues.Clear();
+        chartValues = new List<float>
         {
-            float minHeight = 95;
-            var startChartX = 5 + ((30 - chartValues.Count) * 10);
+            10, 30, 20, 40, 30, 50, 40, 60, 50, 100,
+            10, 30, 20, 40, 30, 50, 40, 60, 50, 70,
+            0, 30, 20, 40, 30, 50, 40, 60, 50, 70,
+        }; */
 
-            for (var pointIndex = chartValues.Count - 1; pointIndex >= 0; pointIndex--)
-            {
-                points.Add(new PointF(startChartX + (10 * pointIndex), 95 - (chartValues[pointIndex] / 100 * 90)));
-                minHeight = Math.Min(minHeight, 95 - (chartValues[pointIndex] / 100 * 90));
-            }
+        var height = 102;
+        var width = 264;
 
-            lock (_lock)
-            {
-                g.SmoothingMode = SmoothingMode.AntiAlias;
+        var chartDoc = new XDocument();
 
-                using var darkGreyBrush = new SolidBrush(DarkGrayColor);
-                g.FillRectangle(darkGreyBrush, 0, 0, width - 1, height - 1);
-                g.DrawRectangle(Pens.LightGray, 0, 0, width - 1, height - 1);
+        lock (_lock)
+        {
+            // The SVG is made of three shapes:
+            // * a colored line, plotting the points on the graph
+            // * a transparent line, outlining the gradient under the graph
+            // * a grey box, outlining the entire image
+            // The SVG also contains a definition for the fill gradient.
+            var svgElement = CreateBlankSvg(height, width);
 
-                if (chartValues.Count >= 2)
-                {
-                    if (type == "gpu")
-                    {
-                        chartPen = GPUChartPen;
-                        brush20 = GPUBrush20;
-                        brush50 = GPUBrush50;
-                        brush100 = GPUBrush100;
-                    }
-                    else if (type == "mem")
-                    {
-                        chartPen = MemChartPen;
-                        brush20 = MemBrush20;
-                        brush50 = MemBrush50;
-                        brush100 = MemBrush100;
-                    }
-                    else if (type == "net")
-                    {
-                        chartPen = NetChartPen;
-                        brush20 = NetBrush20;
-                        brush50 = NetBrush50;
-                        brush100 = NetBrush100;
-                    }
+            // Create the line that will show the points on the graph.
+            var lineElement = new XElement("polyline");
+            var points = TransformPointsToLine(chartValues, out var startX, out var finalX);
+            lineElement.SetAttributeValue("points", points.ToString());
+            lineElement.SetAttributeValue("style", GetLineStyle(type));
 
-                    points.Add(new PointF(startChartX, 95));
-                    points.Add(new PointF(295, 95));
-                    points.Add(new PointF(295, 95 - (chartValues.Last() / 100 * 90)));
+            // Create the line that will contain the gradient fill.
+            TransformPointsToLoop(points, startX, finalX);
+            var fillElement = new XElement("polyline");
+            fillElement.SetAttributeValue("points", points.ToString());
+            fillElement.SetAttributeValue("style", FillStyle);
 
-                    if (minHeight >= 77)
-                    {
-                        g.FillPolygon(brush20, points.ToArray());
-                    }
-                    else if (minHeight >= 50)
-                    {
-                        g.FillPolygon(brush50, points.ToArray());
-                    }
-                    else
-                    {
-                        g.FillPolygon(brush100, points.ToArray());
-                    }
+            // Add the gradient definition and the three shapes to the svg.
+            svgElement.Add(CreateGradientDefinition(type));
+            svgElement.Add(fillElement);
+            svgElement.Add(lineElement);
+            svgElement.Add(CreateBorderBox(height, width));
 
-                    for (var pointIndex = 0; pointIndex < points.Count - 4; pointIndex++)
-                    {
-                        g.DrawLine(chartPen, points[pointIndex].X, points[pointIndex].Y, points[pointIndex + 1].X, points[pointIndex + 1].Y);
-                    }
-                }
-            }
+            chartDoc.Add(svgElement);
         }
 
-        var bytes = BitmapToByteArray(bitmap);
-        bitmap.Dispose();
-        points.Clear();
-        GC.Collect();
-        return bytes;
+        return chartDoc.ToString();
     }
 
-    public static byte[] BitmapToByteArray(Bitmap img)
+    private static XElement CreateBlankSvg(int height, int width)
     {
-        using var stream = new MemoryStream();
-        img.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-        return stream.ToArray();
+        var svgElement = new XElement("svg");
+        svgElement.SetAttributeValue("height", height);
+        svgElement.SetAttributeValue("width", width);
+        return svgElement;
+    }
+
+    private static XElement CreateGradientDefinition(ChartType type)
+    {
+        var defsElement = new XElement("defs");
+        var gradientElement = new XElement("linearGradient");
+
+        // Vertical gradients are created when x1 and x2 are equal and y1 and y2 differ.
+        gradientElement.SetAttributeValue("x1", "0%");
+        gradientElement.SetAttributeValue("x2", "0%");
+        gradientElement.SetAttributeValue("y1", "0%");
+        gradientElement.SetAttributeValue("y2", "100%");
+        gradientElement.SetAttributeValue("id", "gradientId");
+
+        string stop1Style;
+        string stop2Style;
+        switch (type)
+        {
+            case ChartType.GPU:
+                stop1Style = GPUBrushStop1Style;
+                stop2Style = GPUBrushStop2Style;
+                break;
+            case ChartType.Mem:
+                stop1Style = MemBrushStop1Style;
+                stop2Style = MemBrushStop2Style;
+                break;
+            case ChartType.Net:
+                stop1Style = NetBrushStop1Style;
+                stop2Style = NetBrushStop2Style;
+                break;
+            case ChartType.CPU:
+            default:
+                stop1Style = CPUBrushStop1Style;
+                stop2Style = CPUBrushStop2Style;
+                break;
+        }
+
+        var stop1 = new XElement("stop");
+        stop1.SetAttributeValue("offset", "0%");
+        stop1.SetAttributeValue("style", stop1Style);
+
+        var stop2 = new XElement("stop");
+        stop2.SetAttributeValue("offset", "95%");
+        stop2.SetAttributeValue("style", stop2Style);
+
+        gradientElement.Add(stop1);
+        gradientElement.Add(stop2);
+        defsElement.Add(gradientElement);
+
+        return defsElement;
+    }
+
+    private static XElement CreateBorderBox(int height, int width)
+    {
+        var boxElement = new XElement("rect");
+        boxElement.SetAttributeValue("height", height);
+        boxElement.SetAttributeValue("width", width);
+        boxElement.SetAttributeValue("style", LightGrayBoxStyle);
+        return boxElement;
+    }
+
+    private static string GetLineStyle(ChartType type)
+    {
+        var lineStyle = type switch
+        {
+            ChartType.CPU => CPULineStyle,
+            ChartType.GPU => GPULineStyle,
+            ChartType.Mem => MemLineStyle,
+            ChartType.Net => NetLineStyle,
+            _ => CPULineStyle,
+        };
+
+        return lineStyle;
+    }
+
+    private static StringBuilder TransformPointsToLine(List<float> chartValues, out int startX, out int finalX)
+    {
+        var points = new StringBuilder();
+
+        var pxBtwnPoints = 9;
+
+        // The X value where the graph starts must be adjusted so that the graph is right-aligned.
+        // The max available width of the widget is 268. Since there is a 1 px border around the chart, the width of the chart's line must be <=266.
+        // To create a chart of exactly the right size, we'll have 30 points with 9 pixels in between:
+        // index 0            1                      2 - 262                          263
+        // 1 px left border + 1 px for first point + 29 segments * 9 px per segment + 1 px right border = 264 pixels total in width.
+
+        // When the chart doesn't have all points yet, move the chart over to the right by increasing the starting X coordinate.
+        // For a chart with only 1 point, the svg will not render a polyline.
+        // For a chart with 2 points, starting X coordinate ==  1 + (30 -  2) * 9 == 1 + 28 * 9 == 1 + 252 == 253
+        // For a chart with 30 points, starting X coordinate == 1 + (30 - 30) * 9 == 1 +  0 * 9 == 1 +   0 ==   1
+        startX = 1 + ((MaxChartValues - chartValues.Count) * pxBtwnPoints);
+        finalX = startX;
+        foreach (var origY in chartValues)
+        {
+            points.Append(finalX + "," + (101 - origY) + " ");
+            finalX += pxBtwnPoints;
+        }
+
+        // Remove the trailing space.
+        if (points.Length > 0)
+        {
+            points.Remove(points.Length - 1, 1);
+            finalX -= pxBtwnPoints;
+        }
+
+        return points;
+    }
+
+    private static void TransformPointsToLoop(StringBuilder points, int startX, int finalX)
+    {
+        // Close the loop.
+        // Add a point at the most recent X value that corresponds with y = 0
+        points.Append(" " + finalX + ",101 ");
+
+        // Add a point at the start of the chart that corresponds with y = 0
+        points.Append(startX + ",101");
     }
 
     public static void AddNextChartValue(float value, List<float> chartValues)

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -71,26 +71,49 @@ internal class ChartHelper
         return "data:image/svg+xml;base64," + b64String;
     }
 
+    /// <summary>
+    /// Creates an SVG image for the chart.
+    /// </summary>
+    /// <param name="chartValues">The values to plot on the chart</param>
+    /// <param name="type">The type of chart. Each chart type uses different colors.</param>
+    /// <remarks>
+    /// The SVG is made of three shapes: <br/>
+    /// 1. A colored line, plotting the points on the graph <br/>
+    /// 2. A transparent line, outlining the gradient under the graph <br/>
+    /// 3. A grey box, outlining the entire image <br/>
+    /// The SVG also contains a definition for the fill gradient.
+    /// </remarks>
+    /// <returns>A string representing the chart as an SVG image.</returns>
     public static string CreateChart(List<float> chartValues, ChartType type)
     {
-        // Values to use for testing when a static image is desired.
+        // The SVG created by this method will look similar to this:
+        /*
+        <svg height="102" width="264">
+            <defs>
+                <linearGradient x1="0%" x2="0%" y1="0%" y2="100%" id="gradientId">
+                    <stop offset="0%" style="stop-color:rgb(222,104,242);stop-opacity:0.4" />
+                    <stop offset="95%" style="stop-color:rgb(125,0,138);stop-opacity:0.25" />
+                </linearGradient>
+            </defs>
+            <polyline points="1,91 10,71 253,51 262,31 262,101 1,101" style="fill:url(#gradientId);stroke:transparent" />
+            <polyline points="1,91 10,71 253,51 262,31" style="fill:none;stroke:rgb(222,104,242);stroke-width:1" />
+            <rect height="102" width="264" style="fill:none;stroke:lightgrey;stroke-width:1" />
+        </svg>
+        */
+
+        // The following code can be uncommented for testing when a static image is desired.
         /* chartValues.Clear();
         chartValues = new List<float>
         {
             10, 30, 20, 40, 30, 50, 40, 60, 50, 100,
             10, 30, 20, 40, 30, 50, 40, 60, 50, 70,
             0, 30, 20, 40, 30, 50, 40, 60, 50, 70,
-        }; */
+        };*/
 
         var chartDoc = new XDocument();
 
         lock (_lock)
         {
-            // The SVG is made of three shapes:
-            // 1. A colored line, plotting the points on the graph
-            // 2. A transparent line, outlining the gradient under the graph
-            // 3. A grey box, outlining the entire image
-            // The SVG also contains a definition for the fill gradient.
             var svgElement = CreateBlankSvg(ChartHeight, ChartWidth);
 
             // Create the line that will show the points on the graph.

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -73,8 +73,8 @@ internal class ChartHelper
 
     public static string CreateChart(List<float> chartValues, ChartType type)
     {
-        /* // Values to use for testing when a static image is desired.
-        chartValues.Clear();
+        // Values to use for testing when a static image is desired.
+        /* chartValues.Clear();
         chartValues = new List<float>
         {
             10, 30, 20, 40, 30, 50, 40, 60, 50, 100,
@@ -87,9 +87,9 @@ internal class ChartHelper
         lock (_lock)
         {
             // The SVG is made of three shapes:
-            // * a colored line, plotting the points on the graph
-            // * a transparent line, outlining the gradient under the graph
-            // * a grey box, outlining the entire image
+            // 1. A colored line, plotting the points on the graph
+            // 2. A transparent line, outlining the gradient under the graph
+            // 3. A grey box, outlining the entire image
             // The SVG also contains a definition for the fill gradient.
             var svgElement = CreateBlankSvg(ChartHeight, ChartWidth);
 
@@ -207,26 +207,26 @@ internal class ChartHelper
         // To create a chart of exactly the right size, we'll have 30 points with 9 pixels in between:
         // index 0            1                      2 - 262                          263
         // 1 px left border + 1 px for first point + 29 segments * 9 px per segment + 1 px right border = 264 pixels total in width.
-        var pxBtwnPoints = 9;
+        const int pxBetweenPoints = 9;
 
         // When the chart doesn't have all points yet, move the chart over to the right by increasing the starting X coordinate.
         // For a chart with only 1 point, the svg will not render a polyline.
         // For a chart with 2 points, starting X coordinate ==  1 + (30 -  2) * 9 == 1 + 28 * 9 == 1 + 252 == 253
         // For a chart with 30 points, starting X coordinate == 1 + (30 - 30) * 9 == 1 +  0 * 9 == 1 +   0 ==   1
-        startX = 1 + ((MaxChartValues - chartValues.Count) * pxBtwnPoints);
+        startX = 1 + ((MaxChartValues - chartValues.Count) * pxBetweenPoints);
         finalX = startX;
         foreach (var origY in chartValues)
         {
             var finalY = ChartHeight - 1 - origY;
             points.Append(CultureInfo.InvariantCulture, $"{finalX},{finalY} ");
-            finalX += pxBtwnPoints;
+            finalX += pxBetweenPoints;
         }
 
         // Remove the trailing space.
         if (points.Length > 0)
         {
             points.Remove(points.Length - 1, 1);
-            finalX -= pxBtwnPoints;
+            finalX -= pxBetweenPoints;
         }
 
         return points;

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Xml.Linq;
+using CoreWidgetProvider.Widgets;
 
 namespace CoreWidgetProvider.Helpers;
 
@@ -16,26 +17,47 @@ internal class ChartHelper
         Net,
     }
 
-    private static readonly string LightGrayBoxStyle = "fill:none;stroke:lightgrey;stroke-width:1";
+    public const int ChartHeight = 102;
+    public const int ChartWidth = 264;
 
-    private static readonly string CPULineStyle = "fill:none;stroke:rgb(57,184,227);stroke-width:1";
-    private static readonly string GPULineStyle = "fill:none;stroke:rgb(222,104,242);stroke-width:1";
-    private static readonly string MemLineStyle = "fill:none;stroke:rgb(92,158,250);stroke-width:1";
-    private static readonly string NetLineStyle = "fill:none;stroke:rgb(245,98,142);stroke-width:1";
+    private const string LightGrayBoxStyle = "fill:none;stroke:lightgrey;stroke-width:1";
 
-    private static readonly string FillStyle = "fill:url(#gradientId);stroke:transparent";
+    private const string CPULineStyle = "fill:none;stroke:rgb(57,184,227);stroke-width:1";
+    private const string GPULineStyle = "fill:none;stroke:rgb(222,104,242);stroke-width:1";
+    private const string MemLineStyle = "fill:none;stroke:rgb(92,158,250);stroke-width:1";
+    private const string NetLineStyle = "fill:none;stroke:rgb(245,98,142);stroke-width:1";
 
-    private static readonly string CPUBrushStop1Style = "stop-color:rgb(57,184,227);stop-opacity:0.4";
-    private static readonly string CPUBrushStop2Style = "stop-color:rgb(0,86,110);stop-opacity:0.25";
+    private const string FillStyle = "fill:url(#gradientId);stroke:transparent";
 
-    private static readonly string GPUBrushStop1Style = "stop-color:rgb(222,104,242);stop-opacity:0.4";
-    private static readonly string GPUBrushStop2Style = "stop-color:rgb(125,0,138);stop-opacity:0.25";
+    private const string CPUBrushStop1Style = "stop-color:rgb(57,184,227);stop-opacity:0.4";
+    private const string CPUBrushStop2Style = "stop-color:rgb(0,86,110);stop-opacity:0.25";
 
-    private static readonly string MemBrushStop1Style = "stop-color:rgb(92,158,250);stop-opacity:0.4";
-    private static readonly string MemBrushStop2Style = "stop-color:rgb(0,34,92);stop-opacity:0.25";
+    private const string GPUBrushStop1Style = "stop-color:rgb(222,104,242);stop-opacity:0.4";
+    private const string GPUBrushStop2Style = "stop-color:rgb(125,0,138);stop-opacity:0.25";
 
-    private static readonly string NetBrushStop1Style = "stop-color:rgb(245,98,142);stop-opacity:0.4";
-    private static readonly string NetBrushStop2Style = "stop-color:rgb(130,0,47);stop-opacity:0.25";
+    private const string MemBrushStop1Style = "stop-color:rgb(92,158,250);stop-opacity:0.4";
+    private const string MemBrushStop2Style = "stop-color:rgb(0,34,92);stop-opacity:0.25";
+
+    private const string NetBrushStop1Style = "stop-color:rgb(245,98,142);stop-opacity:0.4";
+    private const string NetBrushStop2Style = "stop-color:rgb(130,0,47);stop-opacity:0.25";
+
+    private const string SvgElement = "svg";
+    private const string RectElement = "rect";
+    private const string PolylineElement = "polyline";
+    private const string DefsElement = "defs";
+    private const string LinearGradientElement = "linearGradient";
+    private const string StopElement = "stop";
+
+    private const string HeightAttr = "height";
+    private const string WidthAttr = "width";
+    private const string StyleAttr = "style";
+    private const string PointsAttr = "points";
+    private const string OffsetAttr = "offset";
+    private const string X1Attr = "x1";
+    private const string X2Attr = "x2";
+    private const string Y1Attr = "y1";
+    private const string Y2Attr = "y2";
+    private const string IdAttr = "id";
 
     private const int MaxChartValues = 30;
 
@@ -60,9 +82,6 @@ internal class ChartHelper
             0, 30, 20, 40, 30, 50, 40, 60, 50, 70,
         }; */
 
-        var height = 102;
-        var width = 264;
-
         var chartDoc = new XDocument();
 
         lock (_lock)
@@ -72,25 +91,25 @@ internal class ChartHelper
             // * a transparent line, outlining the gradient under the graph
             // * a grey box, outlining the entire image
             // The SVG also contains a definition for the fill gradient.
-            var svgElement = CreateBlankSvg(height, width);
+            var svgElement = CreateBlankSvg(ChartHeight, ChartWidth);
 
             // Create the line that will show the points on the graph.
-            var lineElement = new XElement("polyline");
+            var lineElement = new XElement(PolylineElement);
             var points = TransformPointsToLine(chartValues, out var startX, out var finalX);
-            lineElement.SetAttributeValue("points", points.ToString());
-            lineElement.SetAttributeValue("style", GetLineStyle(type));
+            lineElement.SetAttributeValue(PointsAttr, points.ToString());
+            lineElement.SetAttributeValue(StyleAttr, GetLineStyle(type));
 
             // Create the line that will contain the gradient fill.
             TransformPointsToLoop(points, startX, finalX);
-            var fillElement = new XElement("polyline");
-            fillElement.SetAttributeValue("points", points.ToString());
-            fillElement.SetAttributeValue("style", FillStyle);
+            var fillElement = new XElement(PolylineElement);
+            fillElement.SetAttributeValue(PointsAttr, points.ToString());
+            fillElement.SetAttributeValue(StyleAttr, FillStyle);
 
             // Add the gradient definition and the three shapes to the svg.
             svgElement.Add(CreateGradientDefinition(type));
             svgElement.Add(fillElement);
             svgElement.Add(lineElement);
-            svgElement.Add(CreateBorderBox(height, width));
+            svgElement.Add(CreateBorderBox(ChartHeight, ChartWidth));
 
             chartDoc.Add(svgElement);
         }
@@ -100,23 +119,23 @@ internal class ChartHelper
 
     private static XElement CreateBlankSvg(int height, int width)
     {
-        var svgElement = new XElement("svg");
-        svgElement.SetAttributeValue("height", height);
-        svgElement.SetAttributeValue("width", width);
+        var svgElement = new XElement(SvgElement);
+        svgElement.SetAttributeValue(HeightAttr, height);
+        svgElement.SetAttributeValue(WidthAttr, width);
         return svgElement;
     }
 
     private static XElement CreateGradientDefinition(ChartType type)
     {
-        var defsElement = new XElement("defs");
-        var gradientElement = new XElement("linearGradient");
+        var defsElement = new XElement(DefsElement);
+        var gradientElement = new XElement(LinearGradientElement);
 
         // Vertical gradients are created when x1 and x2 are equal and y1 and y2 differ.
-        gradientElement.SetAttributeValue("x1", "0%");
-        gradientElement.SetAttributeValue("x2", "0%");
-        gradientElement.SetAttributeValue("y1", "0%");
-        gradientElement.SetAttributeValue("y2", "100%");
-        gradientElement.SetAttributeValue("id", "gradientId");
+        gradientElement.SetAttributeValue(X1Attr, "0%");
+        gradientElement.SetAttributeValue(X2Attr, "0%");
+        gradientElement.SetAttributeValue(Y1Attr, "0%");
+        gradientElement.SetAttributeValue(Y2Attr, "100%");
+        gradientElement.SetAttributeValue(IdAttr, "gradientId");
 
         string stop1Style;
         string stop2Style;
@@ -141,13 +160,13 @@ internal class ChartHelper
                 break;
         }
 
-        var stop1 = new XElement("stop");
-        stop1.SetAttributeValue("offset", "0%");
-        stop1.SetAttributeValue("style", stop1Style);
+        var stop1 = new XElement(StopElement);
+        stop1.SetAttributeValue(OffsetAttr, "0%");
+        stop1.SetAttributeValue(StyleAttr, stop1Style);
 
-        var stop2 = new XElement("stop");
-        stop2.SetAttributeValue("offset", "95%");
-        stop2.SetAttributeValue("style", stop2Style);
+        var stop2 = new XElement(StopElement);
+        stop2.SetAttributeValue(OffsetAttr, "95%");
+        stop2.SetAttributeValue(StyleAttr, stop2Style);
 
         gradientElement.Add(stop1);
         gradientElement.Add(stop2);
@@ -158,10 +177,10 @@ internal class ChartHelper
 
     private static XElement CreateBorderBox(int height, int width)
     {
-        var boxElement = new XElement("rect");
-        boxElement.SetAttributeValue("height", height);
-        boxElement.SetAttributeValue("width", width);
-        boxElement.SetAttributeValue("style", LightGrayBoxStyle);
+        var boxElement = new XElement(RectElement);
+        boxElement.SetAttributeValue(HeightAttr, height);
+        boxElement.SetAttributeValue(WidthAttr, width);
+        boxElement.SetAttributeValue(StyleAttr, LightGrayBoxStyle);
         return boxElement;
     }
 
@@ -183,13 +202,12 @@ internal class ChartHelper
     {
         var points = new StringBuilder();
 
-        var pxBtwnPoints = 9;
-
         // The X value where the graph starts must be adjusted so that the graph is right-aligned.
         // The max available width of the widget is 268. Since there is a 1 px border around the chart, the width of the chart's line must be <=266.
         // To create a chart of exactly the right size, we'll have 30 points with 9 pixels in between:
         // index 0            1                      2 - 262                          263
         // 1 px left border + 1 px for first point + 29 segments * 9 px per segment + 1 px right border = 264 pixels total in width.
+        var pxBtwnPoints = 9;
 
         // When the chart doesn't have all points yet, move the chart over to the right by increasing the starting X coordinate.
         // For a chart with only 1 point, the svg will not render a polyline.
@@ -199,7 +217,8 @@ internal class ChartHelper
         finalX = startX;
         foreach (var origY in chartValues)
         {
-            points.Append(finalX + "," + (101 - origY) + " ");
+            var finalY = ChartHeight - 1 - origY;
+            points.Append(finalX + "," + finalY + " ");
             finalX += pxBtwnPoints;
         }
 
@@ -217,10 +236,10 @@ internal class ChartHelper
     {
         // Close the loop.
         // Add a point at the most recent X value that corresponds with y = 0
-        points.Append(" " + finalX + ",101 ");
+        points.Append(" " + finalX + "," + (ChartHeight - 1));
 
         // Add a point at the start of the chart that corresponds with y = 0
-        points.Append(startX + ",101");
+        points.Append(" " + startX + "," + (ChartHeight - 1));
     }
 
     public static void AddNextChartValue(float value, List<float> chartValues)

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using System.Xml.Linq;
-using CoreWidgetProvider.Widgets;
 
 namespace CoreWidgetProvider.Helpers;
 

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Globalization;
 using System.Text;
 using System.Xml.Linq;
 
@@ -217,7 +218,7 @@ internal class ChartHelper
         foreach (var origY in chartValues)
         {
             var finalY = ChartHeight - 1 - origY;
-            points.Append(finalX + "," + finalY + " ");
+            points.Append(CultureInfo.InvariantCulture, $"{finalX},{finalY} ");
             finalX += pxBtwnPoints;
         }
 
@@ -235,10 +236,10 @@ internal class ChartHelper
     {
         // Close the loop.
         // Add a point at the most recent X value that corresponds with y = 0
-        points.Append(" " + finalX + "," + (ChartHeight - 1));
+        points.Append(CultureInfo.InvariantCulture, $" {finalX},{ChartHeight - 1}");
 
         // Add a point at the start of the chart that corresponds with y = 0
-        points.Append(" " + startX + "," + (ChartHeight - 1));
+        points.Append(CultureInfo.InvariantCulture, $" {startX},{ChartHeight - 1}");
     }
 
     public static void AddNextChartValue(float value, List<float> chartValues)

--- a/CoreWidgetProvider/Helpers/GPUStats.cs
+++ b/CoreWidgetProvider/Helpers/GPUStats.cs
@@ -118,7 +118,7 @@ internal class GPUStats : IDisposable
 
     internal string CreateGPUImageUrl(int gpuChartIndex)
     {
-        return ChartHelper.CreateImageUrl(stats.ElementAt(gpuChartIndex).GpuChartValues, "gpu");
+        return ChartHelper.CreateImageUrl(stats.ElementAt(gpuChartIndex).GpuChartValues, ChartHelper.ChartType.GPU);
     }
 
     internal string GetGPUName(int gpuActiveIndex)

--- a/CoreWidgetProvider/Helpers/MemoryStats.cs
+++ b/CoreWidgetProvider/Helpers/MemoryStats.cs
@@ -80,7 +80,7 @@ internal class MemoryStats : IDisposable
 
     public string CreateMemImageUrl()
     {
-        return ChartHelper.CreateImageUrl(MemChartValues, "mem");
+        return ChartHelper.CreateImageUrl(MemChartValues, ChartHelper.ChartType.Mem);
     }
 
     public void Dispose()

--- a/CoreWidgetProvider/Helpers/NetworkStats.cs
+++ b/CoreWidgetProvider/Helpers/NetworkStats.cs
@@ -90,7 +90,7 @@ internal class NetworkStats : IDisposable
 
     public string CreateNetImageUrl(int netChartIndex)
     {
-        return ChartHelper.CreateImageUrl(NetChartValues.ElementAt(netChartIndex).Value, "net");
+        return ChartHelper.CreateImageUrl(NetChartValues.ElementAt(netChartIndex).Value, ChartHelper.ChartType.Net);
     }
 
     public string GetNetworkName(int networkIndex)

--- a/CoreWidgetProvider/Widgets/SystemCPUUsageWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemCPUUsageWidget.cs
@@ -45,6 +45,8 @@ internal class SystemCPUUsageWidget : CoreWidget, IDisposable
             cpuData.Add("cpuUsage", FloatToPercentString(currentData.CpuUsage));
             cpuData.Add("cpuSpeed", SpeedToString(currentData.CpuSpeed));
             cpuData.Add("cpuGraphUrl", currentData.CreateCPUImageUrl());
+            cpuData.Add("chartHeight", ChartHelper.ChartHeight + "px");
+            cpuData.Add("chartWidth", ChartHelper.ChartWidth + "px");
 
             cpuData.Add("cpuProc1", currentData.GetCpuProcessText(0));
             cpuData.Add("cpuProc2", currentData.GetCpuProcessText(1));

--- a/CoreWidgetProvider/Widgets/SystemGPUUsageWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemGPUUsageWidget.cs
@@ -52,6 +52,8 @@ internal class SystemGPUUsageWidget : CoreWidget, IDisposable
             gpuData.Add("gpuName", gpuName);
             gpuData.Add("gpuTemp", stats.GetGPUTemperature(gpuActiveIndex));
             gpuData.Add("gpuGraphUrl", stats.CreateGPUImageUrl(gpuActiveIndex));
+            gpuData.Add("chartHeight", ChartHelper.ChartHeight + "px");
+            gpuData.Add("chartWidth", ChartHelper.ChartWidth + "px");
 
             DataState = WidgetDataState.Okay;
             ContentData = gpuData.ToJsonString();

--- a/CoreWidgetProvider/Widgets/SystemMemoryWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemMemoryWidget.cs
@@ -69,6 +69,8 @@ internal class SystemMemoryWidget : CoreWidget, IDisposable
             memoryData.Add("pagedPoolMem", MemUlongToString(currentData.MemPagedPool));
             memoryData.Add("nonPagedPoolMem", MemUlongToString(currentData.MemNonPagedPool));
             memoryData.Add("memGraphUrl", currentData.CreateMemImageUrl());
+            memoryData.Add("chartHeight", ChartHelper.ChartHeight + "px");
+            memoryData.Add("chartWidth", ChartHelper.ChartWidth + "px");
 
             DataState = WidgetDataState.Okay;
             ContentData = memoryData.ToJsonString();

--- a/CoreWidgetProvider/Widgets/SystemNetworkUsageWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemNetworkUsageWidget.cs
@@ -69,6 +69,8 @@ internal class SystemNetworkUsageWidget : CoreWidget, IDisposable
             networkData.Add("netReceived", BytesToBitsPerSecString(networkStats.Received));
             networkData.Add("networkName", netName);
             networkData.Add("netGraphUrl", currentData.CreateNetImageUrl(networkIndex));
+            networkData.Add("chartHeight", ChartHelper.ChartHeight + "px");
+            networkData.Add("chartWidth", ChartHelper.ChartWidth + "px");
 
             DataState = WidgetDataState.Okay;
             ContentData = networkData.ToJsonString();

--- a/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
@@ -4,8 +4,9 @@
     {
       "type": "Image",
       "url": "${cpuGraphUrl}",
-      "height": "100px",
-      "width": "268px"
+      "height": "102x",
+      "width": "264px",
+      "horizontalAlignment": "center"
     },
     {
       "type": "ColumnSet",

--- a/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
@@ -47,7 +47,7 @@
     },
     {
       "type": "TextBlock",
-      "subtle": "true",
+      "isSubtle": true,
       "text": "%CPUUsage_Widget_Template/Processes%",
       "wrap": true
     },
@@ -76,8 +76,7 @@
                 {
                   "type": "Action.Execute",
                   "title": "%CPUUsage_Widget_Template/End_Process%",
-                  "verb": "CpuKill1",
-                  "horizontalAlignment": "right"
+                  "verb": "CpuKill1"
                 }
               ]
             }

--- a/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
@@ -4,8 +4,8 @@
     {
       "type": "Image",
       "url": "${cpuGraphUrl}",
-      "height": "102x",
-      "width": "264px",
+      "height": "${chartHeight}",
+      "width": "${chartWidth}",
       "horizontalAlignment": "center"
     },
     {

--- a/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -4,8 +4,9 @@
     {
       "type": "Image",
       "url": "${gpuGraphUrl}",
-      "height": "100px",
-      "width": "268px"
+      "height": "102x",
+      "width": "264px",
+      "horizontalAlignment": "center"
     },
     {
       "type": "ColumnSet",

--- a/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -4,8 +4,8 @@
     {
       "type": "Image",
       "url": "${gpuGraphUrl}",
-      "height": "102x",
-      "width": "264px",
+      "height": "${chartHeight}",
+      "width": "${chartWidth}",
       "horizontalAlignment": "center"
     },
     {

--- a/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
@@ -4,8 +4,8 @@
     {
       "type": "Image",
       "url": "${memGraphUrl}",
-      "height": "102x",
-      "width": "264px",
+      "height": "${chartHeight}",
+      "width": "${chartWidth}",
       "horizontalAlignment": "center"
     },
     {

--- a/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
@@ -4,8 +4,9 @@
     {
       "type": "Image",
       "url": "${memGraphUrl}",
-      "height": "100px",
-      "width": "268px"
+      "height": "102x",
+      "width": "264px",
+      "horizontalAlignment": "center"
     },
     {
       "type": "ColumnSet",

--- a/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -4,8 +4,9 @@
     {
       "type": "Image",
       "url": "${netGraphUrl}",
-      "height": "100px",
-      "width": "268px"
+      "height": "102x",
+      "width": "264px",
+      "horizontalAlignment": "center"
     },
     {
       "type": "ColumnSet",

--- a/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -4,8 +4,8 @@
     {
       "type": "Image",
       "url": "${netGraphUrl}",
-      "height": "102x",
-      "width": "264px",
+      "height": "${chartHeight}",
+      "width": "${chartWidth}",
       "horizontalAlignment": "center"
     },
     {

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="WinUIEx" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="1.0.0" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="1.0.1" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="1.0.2" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of the pull request
Use SVG to render the charts instead of GDI+ to improve performance.
The charts should look the same (or slightly better), with the same colors. Sizing is tweaked a little, so there is not a gap at the left size of the chart anymore.
Update AdaptiveCards.Rendering.WinUI3 to version 1.0.2, which includes a fix for rendering SVGs.

I'll try to get some performance comparison numbers.

![image](https://github.com/microsoft/devhome/assets/47155823/95b05225-ff06-46a0-8987-530656d48813)

## References and relevant issues
#760

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #760
- [ ] Tests added/passed
- [ ] Documentation updated
