### PR TITLE
Round corners of What's New background

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -33,7 +33,7 @@
 
     <ScrollViewer HorizontalScrollMode="Disabled" VerticalScrollMode="Auto" MaxWidth="{ThemeResource MaxPageBackgroundWidth}">
         <RelativePanel>
-            <Grid>
+            <Grid CornerRadius="8">
                 <Image Source="{ThemeResource Background}" MinWidth="{ThemeResource MaxPageBackgroundWidth}" VerticalAlignment="Top" HorizontalAlignment="Center" Stretch="UniformToFill" />
             </Grid>
             <Grid x:Name="ContentArea" Padding="35 0 35 30" HorizontalAlignment="Center">


### PR DESCRIPTION
## Summary of the pull request
The background image of the What's New page relies on corner transparencies to look rounded, and is also set to Stretch="UniformToFill". This means that when the image compresses to its min width, the corner will be compressed and look square. By rounding the corners of the containing grid, we can avoid this square look.
Before:
![image](https://github.com/microsoft/devhome/assets/47155823/3a1010a0-d797-41ff-918d-813d34d958d6)

After:
![image](https://github.com/microsoft/devhome/assets/47155823/924087d2-6ee9-4645-a371-ddb1811f32a8)


## References and relevant issues
#1246

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #1246
- [ ] Tests added/passed
- [ ] Documentation updated
