### PR TITLE
Prevent concurrent launches of the Add Widget dialog

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -13,6 +13,8 @@
     xmlns:views="using:DevHome.Dashboard.Views"
     xmlns:controls="using:DevHome.Dashboard.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
@@ -41,7 +43,13 @@
         <Grid Grid.Row="0" Margin="0,0,0,22">
             <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource TitleTextBlockStyle}" HorizontalAlignment="Left"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right" Click="AddWidget_Click"/>
+                <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right">
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="Click">
+                            <ic:InvokeCommandAction Command="{x:Bind AddWidgetClickCommand}"/>
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                </Button>
             </StackPanel>
         </Grid>
 
@@ -89,7 +97,13 @@
                 <!-- Widget grid empty message -->
                 <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
                     <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
-                    <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" Click="AddWidget_Click" HorizontalAlignment="Center" />
+                    <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center">
+                        <i:Interaction.Behaviors>
+                            <ic:EventTriggerBehavior EventName="Click">
+                                <ic:InvokeCommandAction Command="{x:Bind AddWidgetClickCommand}"/>
+                            </ic:EventTriggerBehavior>
+                        </i:Interaction.Behaviors>
+                    </HyperlinkButton>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -263,11 +263,6 @@ public partial class DashboardView : ToolPage
     [RelayCommand]
     public async Task AddWidgetClickAsync()
     {
-        await AddWidgetAsync();
-    }
-
-    private async Task AddWidgetAsync()
-    {
         // If this is the first time we're initializing the Dashboard, or if initialization failed last time, initialize now.
         if (!_widgetHostInitialized)
         {

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
+using CommunityToolkit.Mvvm.Input;
 using DevHome.Common;
 using DevHome.Common.Renderers;
 using DevHome.Dashboard.Helpers;
@@ -259,7 +260,13 @@ public partial class DashboardView : ToolPage
         await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
     }
 
-    private async void AddWidget_Click(object sender, RoutedEventArgs e)
+    [RelayCommand]
+    public async Task AddWidgetClickAsync()
+    {
+        await AddWidgetAsync();
+    }
+
+    private async Task AddWidgetAsync()
     {
         // If this is the first time we're initializing the Dashboard, or if initialization failed last time, initialize now.
         if (!_widgetHostInitialized)


### PR DESCRIPTION
## Summary of the pull request
Clicking the "Add Widget" button could crash the app, since only one Content Dialog can be open at one time, and a second dialog would try to open before the first one disabled the button. Switching from the "Click" handler to the CommunityToolkit RelayCommand prevents this concurrency. As [stated in the docs](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/generators/relaycommand#:~:text=Whenever%20a%20command,as%20being%20disabled.):  "Whenever a command is asynchronous, it can be configured to decide whether to allow concurrent executions or not. When using the RelayCommand attribute, this can be set via the AllowConcurrentExecutions property. The default is false, meaning that until an execution is pending, the command will signal its state as being disabled."

## References and relevant issues
#1260
## Detailed description of the pull request / Additional comments

## Validation steps performed
Tested locally.

## PR checklist
- [x] Closes #1260
- [ ] Tests added/passed
- [ ] Documentation updated
