### PR TITLE
Adding Automation Properties to the banner in dashboard

### DIFF
--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -58,6 +58,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BannerBackgroundImage.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Background Image</value>
+    <comment>Name of the background image of the banner</comment>
+  </data>
   <data name="BannerHideButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close</value>
     <comment>Name of the button that hides the banner</comment>

--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -58,10 +58,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="BannerBackgroundImage.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Background Image</value>
-    <comment>Name of the background image of the banner</comment>
-  </data>
   <data name="BannerHideButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close</value>
     <comment>Name of the button that hides the banner</comment>

--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -12,6 +12,7 @@
 
         <!-- Set Min sizes so that image gets clipped as window narrows, rather than scaling down -->
         <Image Stretch="Uniform" Source="{x:Bind OverlaySource, Mode=OneWay}" 
+               x:Uid="BannerBackgroundImage"
                Margin="0 0 0 0" MinHeight="214" MinWidth="{ThemeResource MaxPageContentWidth}"/>
 
         <!-- Hide Banner Button -->

--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -12,7 +12,7 @@
 
         <!-- Set Min sizes so that image gets clipped as window narrows, rather than scaling down -->
         <Image Stretch="Uniform" Source="{x:Bind OverlaySource, Mode=OneWay}" 
-               x:Uid="BannerBackgroundImage"
+               AutomationProperties.AccessibilityView="Raw"
                Margin="0 0 0 0" MinHeight="214" MinWidth="{ThemeResource MaxPageContentWidth}"/>
 
         <!-- Hide Banner Button -->

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -154,4 +154,8 @@
     <value>Get in Store app</value>
     <comment>Button text to go to store listing</comment>
   </data>
+  <data name="DashboardBanner.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Dashboard Banner</value>
+    <comment>Name of the dashboard banner for automation</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Adding automation properties to the banner  so the narrator can tell the user more context about the navigation and removing the background image from the treeview as it does not add useful information for accessibility.

## References and relevant issues

## Detailed description of the pull request / Additional comments

Changed the accessibility view of the background image to "Raw" so it is not accessible by the narrator as it not provide useful accessibility information.

Added AutomationProperties.Name field to the dashboard banner in the respective resource file, so when the narrator navigates to its contents, it tells the user that it is inside the dashboard banner.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
