### PR TITLE
Show DevHome when a second instance is opened

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -9,7 +9,6 @@ using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
 using DevHome.Helpers;
-using DevHome.Logging;
 using DevHome.Services;
 using DevHome.Settings.Extensions;
 using DevHome.SetupFlow.Extensions;
@@ -107,6 +106,22 @@ public partial class App : Application, IApp
 
         UnhandledException += App_UnhandledException;
         AppInstance.GetCurrent().Activated += OnActivated;
+    }
+
+    public void ShowMainWindow()
+    {
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(MainWindow);
+            if (Windows.Win32.PInvoke.IsIconic(new Windows.Win32.Foundation.HWND(hWnd)))
+            {
+                MainWindow.Restore();
+            }
+            else
+            {
+                MainWindow.SetForegroundWindow();
+            }
+        });
     }
 
     private async void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/NativeMethods.txt
+++ b/src/NativeMethods.txt
@@ -3,3 +3,4 @@ GlobalMemoryStatusEx
 GetSystemInfo
 CoCreateInstance
 SetForegroundWindow
+IsIconic

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.UI.Dispatching;
 namespace DevHome;
 public static class Program
 {
+    private static App? _app;
+
     [STAThread]
     public static void Main(string[] args)
     {
@@ -20,7 +22,7 @@ public static class Program
                 var dispatcherQueue = DispatcherQueue.GetForCurrentThread();
                 var context = new DispatcherQueueSynchronizationContext(dispatcherQueue);
                 SynchronizationContext.SetSynchronizationContext(context);
-                var app = new App();
+                _app = new App();
             });
         }
     }
@@ -30,13 +32,23 @@ public static class Program
         var mainInstance = Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey("main");
         var activatedEventArgs = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
 
-        if (!mainInstance.IsCurrent)
+        var isRedirect = false;
+        if (mainInstance.IsCurrent)
+        {
+            mainInstance.Activated += OnActivated;
+        }
+        else
         {
             // Redirect the activation (and args) to the "main" instance, and exit.
             await mainInstance.RedirectActivationToAsync(activatedEventArgs);
-            return true;
+            isRedirect = true;
         }
 
-        return false;
+        return isRedirect;
+    }
+
+    private static void OnActivated(object? sender, Microsoft.Windows.AppLifecycle.AppActivationArguments e)
+    {
+        _app?.ShowMainWindow();
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Show DevHome when a second instance is opened

## References and relevant issues
https://github.com/microsoft/devhome/issues/759

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated that DevHome is showed when a second instance is opened across the following scenarios:
- DevHome not in foreground
- DevHome minimized
- DevHome maximized

## PR checklist
- [x] Closes #759
- [ ] Tests added/passed
- [ ] Documentation updated
