### PR TITLE
Accessibility Improvements on Widgets Dashboard

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -9,6 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:DevHome.Dashboard.Helpers"
     mc:Ignorable="d"
+    AutomationProperties.ItemStatus="Teste Felipe"
     AutomationProperties.Name="{x:Bind WidgetSource.WidgetDisplayTitle}">
 
     <UserControl.Resources>

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -8,7 +8,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:DevHome.Dashboard.Helpers"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    AutomationProperties.Name="{x:Bind WidgetSource.WidgetDisplayTitle}">
 
     <UserControl.Resources>
         <ResourceDictionary>

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -9,7 +9,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:DevHome.Dashboard.Helpers"
     mc:Ignorable="d"
-    AutomationProperties.ItemStatus="Teste Felipe"
     AutomationProperties.Name="{x:Bind WidgetSource.WidgetDisplayTitle}">
 
     <UserControl.Resources>

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -159,7 +159,7 @@ public sealed partial class WidgetControl : UserControl
                 break;
         }
 
-        MarkSize(_currentSelectedSize);
+        MarkSize(_currentSelectedSize, resourceLoader);
     }
 
     private async void OnMenuItemSizeClick(object sender, RoutedEventArgs e)
@@ -172,6 +172,7 @@ public sealed partial class WidgetControl : UserControl
                 if (_currentSelectedSize is not null)
                 {
                     _currentSelectedSize.Icon = null;
+                    _currentSelectedSize.ClearValue(AutomationProperties.ItemStatusProperty);
                 }
 
                 // Resize widget.
@@ -181,18 +182,20 @@ public sealed partial class WidgetControl : UserControl
 
                 // Set mark on new size.
                 _currentSelectedSize = menuSizeItem;
-                MarkSize(_currentSelectedSize);
+                var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
+                MarkSize(_currentSelectedSize, resourceLoader);
             }
         }
     }
 
-    private void MarkSize(MenuFlyoutItem menuSizeItem)
+    private void MarkSize(MenuFlyoutItem menuSizeItem, ResourceLoader resourceLoader)
     {
         var fontIcon = new FontIcon
         {
             Glyph = "\xE915",
         };
         menuSizeItem.Icon = fontIcon;
+        menuSizeItem.SetValue(AutomationProperties.ItemStatusProperty, resourceLoader.GetString("WidgetSizeSelected"));
     }
 
     private void AddCustomizeToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -159,7 +159,7 @@ public sealed partial class WidgetControl : UserControl
                 break;
         }
 
-        MarkSize(_currentSelectedSize, resourceLoader);
+        MarkSize(_currentSelectedSize);
     }
 
     private async void OnMenuItemSizeClick(object sender, RoutedEventArgs e)
@@ -182,14 +182,14 @@ public sealed partial class WidgetControl : UserControl
 
                 // Set mark on new size.
                 _currentSelectedSize = menuSizeItem;
-                var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
-                MarkSize(_currentSelectedSize, resourceLoader);
+                MarkSize(_currentSelectedSize);
             }
         }
     }
 
-    private void MarkSize(MenuFlyoutItem menuSizeItem, ResourceLoader resourceLoader)
+    private void MarkSize(MenuFlyoutItem menuSizeItem)
     {
+        var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
         var fontIcon = new FontIcon
         {
             Glyph = "\xE915",

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -158,4 +158,7 @@
     <value>Dashboard Banner</value>
     <comment>Name of the dashboard banner for automation</comment>
   </data>
+  <data name="CustomizeWidgetTitle.Text" xml:space="preserve">
+    <value>Customize widget</value>
+  </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -160,5 +160,10 @@
   </data>
   <data name="CustomizeWidgetTitle.Text" xml:space="preserve">
     <value>Customize widget</value>
+    <comment>Title for "Customize" dialog</comment>
+  </data>
+  <data name="WidgetSizeSelected" xml:space="preserve">
+    <value>Selected</value>
+    <comment>State of selected size for automatiom purposes</comment>
   </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -26,6 +26,7 @@
     <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
         <!-- Close button -->
         <Grid x:Name="CustomizeWidgetTitleBar">
+            <TextBlock x:Uid="CustomizeWidgetTitle" HorizontalAlignment="Left" Margin="16,5,0,0" />
             <commonviews:CloseButton Click="CancelButton_Click" />
         </Grid>
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -26,7 +26,7 @@
     <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
         <!-- Close button -->
         <Grid x:Name="CustomizeWidgetTitleBar">
-            <TextBlock x:Uid="CustomizeWidgetTitle" HorizontalAlignment="Left" Margin="16,5,0,0" />
+            <TextBlock x:Uid="CustomizeWidgetTitle" HorizontalAlignment="Left" Margin="16,10,0,0" />
             <commonviews:CloseButton Click="CancelButton_Click" />
         </Grid>
 


### PR DESCRIPTION
## Summary of the pull request
This PR adds a group of changes to address accessibility bugs in the widgets dashboard.
## References and relevant issues

## Detailed description of the pull request / Additional comments
- Added a title text to the customize widget dialog screen, similar to the add widget dialog. Then, the narrator can focus on it when the dialog opens and tell the user what is on the screen.
<img width="332" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/b04fe50e-2f46-40f0-b9be-e5885e25467a">

- Added a AutomationProperties.Name property to the widget control so the narrator can tell its title while interacting with it via keyboard.

- Added the AutomationProperties.ItemStatus to the widgets menu flyout. There is no built-in item selected in the flyout, as the selection is done by adding/removing the icon from the item. With this change, we also add/remove the automation property telling the status of the item is "Selected" for the current selected size. Still need to test it more in the narrator, I checked with Windows Accessibility Insights that all the Automation Properties were correct, but the narrator doesn't narrate it in the standard verbosity level.

## Validation steps performed
Tested locally.
## PR checklist
- [x] Closes #1290 #1291 #1292
- [ ] Tests added/passed
- [ ] Documentation updated
