### PR TITLE
Add bot rule to add In-PR label

### DIFF
--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -39,5 +39,11 @@ configuration:
       - payloadType: Issue_Comment
       then:
       - cleanEmailReply
+    - description: Add In-PR when an issue has a linked PR that will close it
+      if:
+      - payloadType: Pull_Request
+      then:
+      - inPrLabel:
+          label: In-PR
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
## Summary of the pull request
It's hard to see when an issue has a fix in PR. We should have the bot auto-label issues with "In-PR" when pull requests get created that address issues.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
I wasn't able to test this, but I grabbed the code from the Terminal repo

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
