### PR TITLE
fix: changed label string Core into Dev Home

### DIFF
--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -211,15 +211,15 @@
     <value>Introducing Dev Home</value>
   </data>
   <data name="WidgetProviderDisplayNameDev" xml:space="preserve">
-    <value>Core (Dev)</value>
+    <value>Dev Home (Dev)</value>
     <comment>The display name for core widgets provider</comment>
   </data>
   <data name="WidgetProviderDisplayNameCanary" xml:space="preserve">
-    <value>Core (Canary)</value>
+    <value>Dev Home (Canary)</value>
     <comment>The display name for core widgets provider</comment>
   </data>
   <data name="WidgetProviderDisplayNameStable" xml:space="preserve">
-    <value>Core (Preview)</value>
+    <value>Dev Home (Preview)</value>
     <comment>The display name for core widgets provider</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Fixed a label that was already in `Core`; I changed it to '`Dev Home`'.
## References and relevant issues
#988
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #988
- [ ] Tests added/passed
- [ ] Documentation updated
