### PR TITLE
Flip banner image for RTL languages

### DIFF
--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -13,7 +13,8 @@
         <!-- Set Min sizes so that image gets clipped as window narrows, rather than scaling down -->
         <Image Stretch="Uniform" Source="{x:Bind OverlaySource, Mode=OneWay}" 
                AutomationProperties.AccessibilityView="Raw"
-               Margin="0 0 0 0" MinHeight="214" MinWidth="{ThemeResource MaxPageContentWidth}"/>
+               Margin="0 0 0 0" MinHeight="214" MinWidth="{ThemeResource MaxPageContentWidth}"
+               FlowDirection="{x:Bind FlowDirection}" />
 
         <!-- Hide Banner Button -->
         <Button HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10"


### PR DESCRIPTION
## Summary of the pull request
The banner images are designed to fit around text. If the text moves over due to RTL, the banner image should flip as well.

LTR:
![image](https://github.com/microsoft/devhome/assets/47155823/f5f6bc2c-3c83-40a1-a6ef-3205b0d74dc5)

RTL:
![image](https://github.com/microsoft/devhome/assets/47155823/60cbb7f6-5ff9-43cb-ac32-9e6fbcf446b9)

## References and relevant issues
#1209

## Detailed description of the pull request / Additional comments

## Validation steps performed
Verified locally

## PR checklist
- [x] Closes #1209
- [ ] Tests added/passed
- [ ] Documentation updated
