### PR TITLE
Prevent crash when pinning widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -33,8 +33,7 @@
         <!-- Widget header: icon, title, menu -->
         <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}">
             <StackPanel Orientation="Horizontal" Margin="15,10,15,5">
-                <Rectangle Width="16" Height="16" Margin="0,0,8,0" x:Name="WidgetHeaderIcon"
-                           Fill="{x:Bind helpers:WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme),Mode=OneWay}"/>
+                <Rectangle Width="16" Height="16" Margin="0,0,8,0" x:Name="WidgetHeaderIcon" />
                 <TextBlock AutomationProperties.AutomationId="WidgetTitle"
                            Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}"
                            VerticalAlignment="Center"

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -18,20 +18,27 @@ public sealed partial class WidgetControl : UserControl
 {
     private MenuFlyoutItem _currentSelectedSize;
 
+    public WidgetViewModel WidgetSource
+    {
+        get => (WidgetViewModel)GetValue(WidgetSourceProperty);
+        set
+        {
+            SetValue(WidgetSourceProperty, value);
+            if (WidgetSource != null)
+            {
+                UpdateWidgetHeaderIconFill();
+            }
+        }
+    }
+
+    public static readonly DependencyProperty WidgetSourceProperty = DependencyProperty.Register(
+        nameof(WidgetSource), typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
+
     public WidgetControl()
     {
         this.InitializeComponent();
         ActualThemeChanged += OnActualThemeChanged;
     }
-
-    public WidgetViewModel WidgetSource
-    {
-        get => (WidgetViewModel)GetValue(WidgetSourceProperty);
-        set => SetValue(WidgetSourceProperty, value);
-    }
-
-    public static readonly DependencyProperty WidgetSourceProperty = DependencyProperty.Register(
-        nameof(WidgetSource), typeof(WidgetViewModel), typeof(WidgetControl), new PropertyMetadata(null));
 
     private void OpenWidgetMenu(object sender, RoutedEventArgs e)
     {
@@ -213,8 +220,13 @@ public sealed partial class WidgetControl : UserControl
         }
     }
 
-    private void OnActualThemeChanged(FrameworkElement sender, object args)
+    private async void OnActualThemeChanged(FrameworkElement sender, object args)
     {
-        WidgetHeaderIcon.Fill = WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
+        WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
+    }
+
+    private async void UpdateWidgetHeaderIconFill()
+    {
+        WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -222,11 +222,11 @@ public sealed partial class WidgetControl : UserControl
 
     private async void OnActualThemeChanged(FrameworkElement sender, object args)
     {
-        WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
+        WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIconAsync(WidgetSource.WidgetDefinition, ActualTheme);
     }
 
     private async void UpdateWidgetHeaderIconFill()
     {
-        WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIcon(WidgetSource.WidgetDefinition, ActualTheme);
+        WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIconAsync(WidgetSource.WidgetDefinition, ActualTheme);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -26,6 +26,9 @@ public sealed partial class WidgetControl : UserControl
             SetValue(WidgetSourceProperty, value);
             if (WidgetSource != null)
             {
+                // When the WidgetViewModel is updated, the widget icon must also be also updated.
+                // Since the icon update must happen asynchronously on the UI thread, it must be
+                // called in code rather than binding.
                 UpdateWidgetHeaderIconFillAsync();
             }
         }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -26,7 +26,7 @@ public sealed partial class WidgetControl : UserControl
             SetValue(WidgetSourceProperty, value);
             if (WidgetSource != null)
             {
-                UpdateWidgetHeaderIconFill();
+                UpdateWidgetHeaderIconFillAsync();
             }
         }
     }
@@ -225,7 +225,7 @@ public sealed partial class WidgetControl : UserControl
         WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIconAsync(WidgetSource.WidgetDefinition, ActualTheme);
     }
 
-    private async void UpdateWidgetHeaderIconFill()
+    private async void UpdateWidgetHeaderIconFillAsync()
     {
         WidgetHeaderIcon.Fill = await WidgetIconCache.GetBrushForWidgetIconAsync(WidgetSource.WidgetDefinition, ActualTheme);
     }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -35,19 +35,19 @@ internal class WidgetIconCache
     /// <summary>
     /// Caches icons for all widgets in the WidgetCatalog that are included in Dev Home.
     /// </summary>
-    public async Task CacheAllWidgetIcons(WidgetCatalog widgetCatalog)
+    public async Task CacheAllWidgetIconsAsync(WidgetCatalog widgetCatalog)
     {
         var widgetDefs = widgetCatalog.GetWidgetDefinitions();
         foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
         {
-            await AddIconsToCache(widgetDef);
+            await AddIconsToCacheAsync(widgetDef);
         }
     }
 
     /// <summary>
     /// Caches two icons for each widget, one for light theme and one for dark theme.
     /// </summary>
-    public async Task AddIconsToCache(WidgetDefinition widgetDef)
+    public async Task AddIconsToCacheAsync(WidgetDefinition widgetDef)
     {
         // Only cache icons for providers that we're including.
         if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
@@ -76,7 +76,7 @@ internal class WidgetIconCache
             }
             catch (Exception ex)
             {
-                Log.Logger()?.ReportError("WidgetIconCache", $"Exception in AddIconsToCache:", ex);
+                Log.Logger()?.ReportError("WidgetIconCache", $"Exception in AddIconsToCacheAsync:", ex);
                 _widgetLightIconCache.Add(widgetDefId, null);
                 _widgetDarkIconCache.Add(widgetDefId, null);
             }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -130,7 +130,7 @@ internal class WidgetIconCache
         return brush;
     }
 
-    private static async Task<BitmapImage> WidgetIconToBitmapImageAsync(IRandomAccessStreamReference iconStreamRef)
+    private async Task<BitmapImage> WidgetIconToBitmapImageAsync(IRandomAccessStreamReference iconStreamRef)
     {
         // Return the bitmap image via TaskCompletionSource. Using WCT's EnqueueAsync does not suffice here, since if
         // we're already on the thread of the DispatcherQueue then it just directly calls the function, with no async involved.

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -56,8 +56,8 @@ internal class WidgetIconCache
             try
             {
                 Log.Logger()?.ReportDebug("WidgetIconCache", $"Cache widget icons for {widgetDefId}");
-                var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
-                var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
+                var itemLightImage = await WidgetIconToBitmapImageAsync(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
+                var itemDarkImage = await WidgetIconToBitmapImageAsync(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
 
                 // There is a widget bug where Definition update events are being raised as added events.
                 // If we already have an icon for this key, just remove and add again in case the icons changed.
@@ -124,7 +124,7 @@ internal class WidgetIconCache
         return brush;
     }
 
-    private static async Task<BitmapImage> WidgetIconToBitmapImage(IRandomAccessStreamReference iconStreamRef)
+    private static async Task<BitmapImage> WidgetIconToBitmapImageAsync(IRandomAccessStreamReference iconStreamRef)
     {
         var completionSource = new TaskCompletionSource<BitmapImage>();
         _dispatcher.TryEnqueue(async () =>

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -91,6 +91,8 @@ internal class WidgetIconCache
 
     public static async Task<BitmapImage> GetWidgetIconForThemeAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
+        // Return the WidgetDefinition Id via TaskCompletionSource. Using WCT's EnqueueAsync does not suffice here, since if
+        // we're already on the thread of the DispatcherQueue then it just directly calls the function, with no async involved.
         var completionSource = new TaskCompletionSource<string>();
         _dispatcher.TryEnqueue(() =>
         {
@@ -126,6 +128,8 @@ internal class WidgetIconCache
 
     private static async Task<BitmapImage> WidgetIconToBitmapImageAsync(IRandomAccessStreamReference iconStreamRef)
     {
+        // Return the bitmap image via TaskCompletionSource. Using WCT's EnqueueAsync does not suffice here, since if
+        // we're already on the thread of the DispatcherQueue then it just directly calls the function, with no async involved.
         var completionSource = new TaskCompletionSource<BitmapImage>();
         _dispatcher.TryEnqueue(async () =>
         {

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -112,7 +112,7 @@ internal class WidgetIconCache
         return image;
     }
 
-    public static async Task<Brush> GetBrushForWidgetIcon(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public static async Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
         var image = await GetWidgetIconForTheme(widgetDefinition, theme);
 

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -89,7 +89,7 @@ internal class WidgetIconCache
         _widgetDarkIconCache.Remove(definitionId);
     }
 
-    public static async Task<BitmapImage> GetWidgetIconForTheme(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public static async Task<BitmapImage> GetWidgetIconForThemeAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
         var completionSource = new TaskCompletionSource<string>();
         _dispatcher.TryEnqueue(() =>
@@ -114,7 +114,7 @@ internal class WidgetIconCache
 
     public static async Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
-        var image = await GetWidgetIconForTheme(widgetDefinition, theme);
+        var image = await GetWidgetIconForThemeAsync(widgetDefinition, theme);
 
         var brush = new ImageBrush
         {

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -37,11 +37,15 @@ internal class WidgetIconCache
     /// </summary>
     public async Task CacheAllWidgetIconsAsync(WidgetCatalog widgetCatalog)
     {
+        var cacheTasks = new List<Task>();
         var widgetDefs = widgetCatalog.GetWidgetDefinitions();
         foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
         {
-            await AddIconsToCacheAsync(widgetDef);
+            var task = AddIconsToCacheAsync(widgetDef);
+            cacheTasks.Add(task);
         }
+
+        await Task.WhenAll(cacheTasks);
     }
 
     /// <summary>

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using CommunityToolkit.WinUI;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -15,6 +14,8 @@ using Windows.Storage.Streams;
 namespace DevHome.Dashboard.Helpers;
 internal class WidgetIconCache
 {
+    private static DispatcherQueue _dispatcher;
+
     private static Dictionary<string, BitmapImage> _widgetLightIconCache;
     private static Dictionary<string, BitmapImage> _widgetDarkIconCache;
 
@@ -24,8 +25,9 @@ internal class WidgetIconCache
     /// <remarks>
     /// The WidgetIconCache is backed by two dictionaries, one for light themed icons and one for dark themed icons.
     /// </remarks>
-    public WidgetIconCache()
+    public WidgetIconCache(DispatcherQueue dispatcher)
     {
+        _dispatcher = dispatcher;
         _widgetLightIconCache = new Dictionary<string, BitmapImage>();
         _widgetDarkIconCache = new Dictionary<string, BitmapImage>();
     }
@@ -33,19 +35,19 @@ internal class WidgetIconCache
     /// <summary>
     /// Caches icons for all widgets in the WidgetCatalog that are included in Dev Home.
     /// </summary>
-    public async Task CacheAllWidgetIcons(WidgetCatalog widgetCatalog, DispatcherQueue dispatcher)
+    public async Task CacheAllWidgetIcons(WidgetCatalog widgetCatalog)
     {
         var widgetDefs = widgetCatalog.GetWidgetDefinitions();
         foreach (var widgetDef in widgetDefs ?? Array.Empty<WidgetDefinition>())
         {
-            await AddIconsToCache(widgetDef, dispatcher);
+            await AddIconsToCache(widgetDef);
         }
     }
 
     /// <summary>
     /// Caches two icons for each widget, one for light theme and one for dark theme.
     /// </summary>
-    public async Task AddIconsToCache(WidgetDefinition widgetDef, DispatcherQueue dispatcher)
+    public async Task AddIconsToCache(WidgetDefinition widgetDef)
     {
         // Only cache icons for providers that we're including.
         if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
@@ -54,8 +56,8 @@ internal class WidgetIconCache
             try
             {
                 Log.Logger()?.ReportDebug("WidgetIconCache", $"Cache widget icons for {widgetDefId}");
-                var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon, dispatcher);
-                var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon, dispatcher);
+                var itemLightImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Light).Icon);
+                var itemDarkImage = await WidgetIconToBitmapImage(widgetDef.GetThemeResource(WidgetTheme.Dark).Icon);
 
                 // There is a widget bug where Definition update events are being raised as added events.
                 // If we already have an icon for this key, just remove and add again in case the icons changed.
@@ -87,24 +89,32 @@ internal class WidgetIconCache
         _widgetDarkIconCache.Remove(definitionId);
     }
 
-    public static BitmapImage GetWidgetIconForTheme(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public static async Task<BitmapImage> GetWidgetIconForTheme(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
+        var completionSource = new TaskCompletionSource<string>();
+        _dispatcher.TryEnqueue(() =>
+        {
+            completionSource.TrySetResult(widgetDefinition.Id);
+        });
+
+        var widgetDefinitionId = await completionSource.Task;
+
         BitmapImage image;
         if (theme == ElementTheme.Light)
         {
-            _widgetLightIconCache.TryGetValue(widgetDefinition.Id, out image);
+            _widgetLightIconCache.TryGetValue(widgetDefinitionId, out image);
         }
         else
         {
-            _widgetDarkIconCache.TryGetValue(widgetDefinition.Id, out image);
+            _widgetDarkIconCache.TryGetValue(widgetDefinitionId, out image);
         }
 
         return image;
     }
 
-    public static Brush GetBrushForWidgetIcon(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public static async Task<Brush> GetBrushForWidgetIcon(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
-        var image = GetWidgetIconForTheme(widgetDefinition, theme);
+        var image = await GetWidgetIconForTheme(widgetDefinition, theme);
 
         var brush = new ImageBrush
         {
@@ -114,16 +124,19 @@ internal class WidgetIconCache
         return brush;
     }
 
-    private static async Task<BitmapImage> WidgetIconToBitmapImage(IRandomAccessStreamReference iconStreamRef, DispatcherQueue dispatcher)
+    private static async Task<BitmapImage> WidgetIconToBitmapImage(IRandomAccessStreamReference iconStreamRef)
     {
-        var itemImage = await dispatcher.EnqueueAsync(async () =>
+        var completionSource = new TaskCompletionSource<BitmapImage>();
+        _dispatcher.TryEnqueue(async () =>
         {
             using var bitmapStream = await iconStreamRef.OpenReadAsync();
             var itemImage = new BitmapImage();
             await itemImage.SetSourceAsync(bitmapStream);
-            return itemImage;
+            completionSource.TrySetResult(itemImage);
         });
 
-        return itemImage;
+        var bitmapImage = await completionSource.Task;
+
+        return bitmapImage;
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -9,9 +9,16 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}"
     SizeChanged="ContentDialog_SizeChanged">
+    <i:Interaction.Behaviors>
+        <ic:EventTriggerBehavior EventName="Loaded">
+            <ic:InvokeCommandAction Command="{x:Bind LoadedCommand}" />
+        </ic:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
 
     <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
     <ContentDialog.Resources>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -57,7 +57,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         SelectFirstWidgetByDefault();
     }
 
-    private void FillAvailableWidgets()
+    private async void FillAvailableWidgets()
     {
         AddWidgetNavigationView.MenuItems.Clear();
 
@@ -91,7 +91,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
                 {
                     if (widgetDef.ProviderDefinition.Id.Equals(providerDef.Id, StringComparison.Ordinal))
                     {
-                        var subItemContent = BuildWidgetNavItem(widgetDef);
+                        var subItemContent = await BuildWidgetNavItem(widgetDef);
                         var enable = !IsSingleInstanceAndAlreadyPinned(widgetDef);
                         var subItem = new NavigationViewItem
                         {
@@ -120,9 +120,9 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
     }
 
-    private StackPanel BuildWidgetNavItem(WidgetDefinition widgetDefinition)
+    private async Task<StackPanel> BuildWidgetNavItem(WidgetDefinition widgetDefinition)
     {
-        var image = WidgetIconCache.GetWidgetIconForTheme(widgetDefinition, ActualTheme);
+        var image = await WidgetIconCache.GetWidgetIconForTheme(widgetDefinition, ActualTheme);
         return BuildNavItem(image, widgetDefinition.DisplayTitle);
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
+using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.ViewModels;
@@ -52,12 +53,16 @@ public sealed partial class AddWidgetDialog : ContentDialog
         Application.Current.GetService<WindowEx>().Closed += OnMainWindowClosed;
 
         _widgetCatalog.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
+    }
 
-        FillAvailableWidgets();
+    [RelayCommand]
+    public async Task OnLoadedAsync()
+    {
+        await FillAvailableWidgetsAsync();
         SelectFirstWidgetByDefault();
     }
 
-    private async void FillAvailableWidgets()
+    private async Task FillAvailableWidgetsAsync()
     {
         AddWidgetNavigationView.MenuItems.Clear();
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -127,7 +127,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private async Task<StackPanel> BuildWidgetNavItem(WidgetDefinition widgetDefinition)
     {
-        var image = await WidgetIconCache.GetWidgetIconForTheme(widgetDefinition, ActualTheme);
+        var image = await WidgetIconCache.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
         return BuildNavItem(image, widgetDefinition.DisplayTitle);
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -74,7 +74,7 @@
                           DragItemsStarting="WidgetGridView_DragItemsStarting">
                     <GridView.ItemTemplate>
                         <DataTemplate x:DataType="vm:WidgetViewModel">
-                            <controls:WidgetControl WidgetSource="{x:Bind}" 
+                            <controls:WidgetControl WidgetSource="{x:Bind}"
                                                     AllowDrop="True" 
                                                     DragOver="WidgetControl_DragOver"
                                                     Drop="WidgetControl_Drop" />

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -178,7 +178,7 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
 
         // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
+        await _widgetIconCache.CacheAllWidgetIconsAsync(_widgetCatalog);
 
         await ConfigureWidgetRenderer(_renderer);
 
@@ -273,7 +273,7 @@ public partial class DashboardView : ToolPage
             if (_widgetServiceHelper.EnsureWebExperiencePack())
             {
                 _widgetHostInitialized = InitializeWidgetHost();
-                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
+                await _widgetIconCache.CacheAllWidgetIconsAsync(_widgetCatalog);
                 await ConfigureWidgetRenderer(_renderer);
             }
             else
@@ -370,7 +370,7 @@ public partial class DashboardView : ToolPage
     private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-        await _widgetIconCache.AddIconsToCache(args.Definition);
+        await _widgetIconCache.AddIconsToCacheAsync(args.Definition);
     }
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -62,7 +62,7 @@ public partial class DashboardView : ToolPage
         _renderer = new AdaptiveCardRenderer();
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-        _widgetIconCache = new WidgetIconCache();
+        _widgetIconCache = new WidgetIconCache(_dispatcher);
 
         ActualThemeChanged += OnActualThemeChanged;
 
@@ -178,7 +178,7 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
 
         // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
+        await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
 
         await ConfigureWidgetRenderer(_renderer);
 
@@ -273,7 +273,7 @@ public partial class DashboardView : ToolPage
             if (_widgetServiceHelper.EnsureWebExperiencePack())
             {
                 _widgetHostInitialized = InitializeWidgetHost();
-                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog, _dispatcher);
+                await _widgetIconCache.CacheAllWidgetIcons(_widgetCatalog);
                 await ConfigureWidgetRenderer(_renderer);
             }
             else
@@ -370,7 +370,7 @@ public partial class DashboardView : ToolPage
     private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
     {
         Log.Logger()?.ReportInfo("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-        await _widgetIconCache.AddIconsToCache(args.Definition, _dispatcher);
+        await _widgetIconCache.AddIconsToCache(args.Definition);
     }
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)


### PR DESCRIPTION
## Summary of the pull request
Sometimes pinning widgets causes Dev Home to crash (and this same issue may be responsible for some crashes when Dev Home opens). The crash happens because the call to `WidgetDefinition.Id` causes XAML re-entrancy. To avoid this, move those calls to the UI thread to prevent this reentrancy.

Since we're moving the call in `GetWidgetIconForTheme` to a `TryEnqueue` call, I changed `WidgetIconToBitmapImage` to use that too for consistency (and to not need the WCT).

Most functions in the WidgetIconCache need the DispatcherQueue from the View, so we pass it into the constructor now. That also means we don't have to do something complicated in the WidgetControl to be able to pass a dispatcher queue into `GetBrushForWidgetIcon`.

Move that `GetBrushForWidgetIcon` call from markup to code behind, since it's async now.

## References and relevant issues
#745

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #745
- [ ] Tests added/passed
- [ ] Documentation updated
