### PR TITLE
Add Automation Names to list items in Add Widgets dialog

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -100,7 +100,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
                             IsEnabled = enable,
                         };
                         subItem.SetValue(AutomationProperties.AutomationIdProperty, $"NavViewItem_{widgetDef.Id}");
-                        subItem.SetValue(AutomationProperties.NameProperty, $"{widgetDef.DisplayTitle}");
+                        subItem.SetValue(AutomationProperties.NameProperty, widgetDef.DisplayTitle);
 
                         navItem.MenuItems.Add(subItem);
                     }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -100,6 +100,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
                             IsEnabled = enable,
                         };
                         subItem.SetValue(AutomationProperties.AutomationIdProperty, $"NavViewItem_{widgetDef.Id}");
+                        subItem.SetValue(AutomationProperties.NameProperty, $"{widgetDef.DisplayTitle}");
 
                         navItem.MenuItems.Add(subItem);
                     }


### PR DESCRIPTION
## Summary of the pull request
The available widgets in the Add Widget Dialog's NavigationView are built as custom nav items, so they need the AutomationProperties.NameProperty to be set to the Widget's display name in order to be read correctly

## References and relevant issues
#1323
## Detailed description of the pull request / Additional comments

## Validation steps performed
Tested manually with Narrator

## PR checklist
- [ ] Closes #1323
- [ ] Tests added/passed
- [ ] Documentation updated
