### PR TITLE
App name is updated when run as administrator

### DIFF
--- a/src/Services/AppInfoService.cs
+++ b/src/Services/AppInfoService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Reflection;
+using System.Security.Principal;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
 using DevHome.Helpers;
@@ -10,14 +11,24 @@ using Windows.ApplicationModel;
 namespace DevHome.Services;
 public class AppInfoService : IAppInfoService
 {
+    private static bool RunningAsAdmin
+    {
+        get
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+    }
+
     public string GetAppNameLocalized()
     {
 #if CANARY_BUILD
-        return "AppDisplayNameCanary".GetLocalized();
+        return RunningAsAdmin ? "AppDisplayNameCanaryAdministrator".GetLocalized() : "AppDisplayNameCanary".GetLocalized();
 #elif STABLE_BUILD
-        return "AppDisplayNameStable".GetLocalized();
+        return RunningAsAdmin ? "AppDisplayNameStableAdministrator".GetLocalized() :  "AppDisplayNameStable".GetLocalized();
 #else
-        return "AppDisplayNameDev".GetLocalized();
+        return RunningAsAdmin ? "AppDisplayNameDevAdministrator".GetLocalized() : "AppDisplayNameDev".GetLocalized();
 #endif
     }
 

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -222,4 +222,16 @@
     <value>Core (Preview)</value>
     <comment>The display name for core widgets provider</comment>
   </data>
+  <data name="AppDisplayNameDevAdministrator" xml:space="preserve">
+    <value>Administrator: Dev Home (Dev)</value>
+    <comment>Name of app when run as administrator</comment>
+  </data>
+  <data name="AppDisplayNameCanaryAdministrator" xml:space="preserve">
+    <value>Administrator: Dev Home (Canary)</value>
+    <comment>Name of app when run as administrator</comment>
+  </data>
+  <data name="AppDisplayNameStableAdministrator" xml:space="preserve">
+    <value>Administrator: Dev Home (Preview)</value>
+    <comment>Name of app when run as administrator</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
When run as administrator, app name will now show "Administrator: Dev Home (<Preview/Canary/Dev>)"

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
