### PR TITLE
Make Close buttons consistent

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -10,6 +10,8 @@
     <DevHomeSDKVersion Condition="$(DevHomeSDKVersion) == ''">0.100.105</DevHomeSDKVersion>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Views\Banner.xaml" />
+    <None Remove="Views\CloseButton.xaml" />
     <None Remove="Views\HyperlinkTextBlock.xaml" />
   </ItemGroup>
 
@@ -41,6 +43,9 @@
 
   <ItemGroup>
     <Page Update="Views\Banner.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\CloseButton.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Update="Views\HyperlinkTextBlock.xaml">

--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -4,6 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:commonviews="using:DevHome.Common.Views"
     mc:Ignorable="d">
     <Grid Height="214">
         <Grid.Background>
@@ -17,15 +18,10 @@
                FlowDirection="{x:Bind FlowDirection}" />
 
         <!-- Hide Banner Button -->
-        <Button HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10"
-                BorderThickness="0" Background="Transparent" Padding="5"
-                x:Uid="BannerHideButton"
-                Command="{x:Bind HideButtonCommand}"
-                Visibility="{x:Bind HideButtonVisibility}">
-            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                       FontSize="{ThemeResource BodyTextBlockFontSize}"
-                       Text="&#xE711;" />
-        </Button>
+        <commonviews:CloseButton Margin="5"
+                                 x:Uid="BannerHideButton"
+                                 Command="{x:Bind HideButtonCommand}"
+                                 Visibility="{x:Bind HideButtonVisibility}" />
         <StackPanel VerticalAlignment="Center" Margin="38 0 0 0" Spacing="12">
             <TextBlock
                 MaxWidth="{x:Bind TextWidth}"

--- a/common/Views/CloseButton.xaml
+++ b/common/Views/CloseButton.xaml
@@ -11,14 +11,8 @@
     BorderThickness="0"
     Background="Transparent"
     Padding="10">
-    
-    <Button.Resources>
-        <Style TargetType="Button" />
-    </Button.Resources>
-    
-    <Grid>
-        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                   FontSize="{ThemeResource BodyTextBlockFontSize}" 
-                   Text="&#xE711;" />
-    </Grid>
+
+    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                FontSize="{ThemeResource BodyTextBlockFontSize}" 
+                Text="&#xE711;" />
 </Button>

--- a/common/Views/CloseButton.xaml
+++ b/common/Views/CloseButton.xaml
@@ -1,0 +1,24 @@
+<Button
+    x:Class="DevHome.Common.Views.CloseButton"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Style="{StaticResource DefaultButtonStyle}"
+    HorizontalAlignment="Right"
+    VerticalAlignment="Top"
+    BorderThickness="0"
+    Background="Transparent"
+    Padding="10">
+    
+    <Button.Resources>
+        <Style TargetType="Button" />
+    </Button.Resources>
+    
+    <Grid>
+        <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                   FontSize="{ThemeResource BodyTextBlockFontSize}" 
+                   Text="&#xE711;" />
+    </Grid>
+</Button>

--- a/common/Views/CloseButton.xaml.cs
+++ b/common/Views/CloseButton.xaml.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Common.Views;
+public sealed partial class CloseButton : Button
+{
+    public CloseButton()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/settings/DevHome.Settings/Views/LoginUIDialog.xaml
+++ b/settings/DevHome.Settings/Views/LoginUIDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:commonviews="using:DevHome.Common.Views"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}">
 
@@ -22,12 +23,7 @@
             <TextBlock x:Uid="LoginUIDialogTitle" HorizontalAlignment="Left"
                        Style="{ThemeResource SubtitleTextBlockStyle}" 
                        Margin="16,10,0,0"/>
-            <Button HorizontalAlignment="Right" Click="CloseButton_Click"
-                    BorderThickness="0" Background="Transparent" Padding="15">
-                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                           FontSize="{ThemeResource BodyTextBlockFontSize}"
-                           Text="&#xE711;" />
-            </Button>
+            <commonviews:CloseButton Click="CloseButton_Click" />
         </Grid>
 
         <Frame x:Name="LoginUIContent" />

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}"
@@ -27,12 +28,7 @@
         <!-- Title and Close button -->
         <Grid x:Name="AddWidgetTitleBar">
             <TextBlock x:Uid="AddWidgetsTitle" HorizontalAlignment="Left" Margin="16,10,0,0" />
-            <Button HorizontalAlignment="Right" Click="CancelButton_Click"
-                    BorderThickness="0" Background="Transparent" Padding="10">
-                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                           FontSize="{ThemeResource BodyTextBlockFontSize}" 
-                           Text="&#xE711;" />
-            </Button>
+            <commonviews:CloseButton Click="CancelButton_Click" />
         </Grid>
 
         <!-- Widgets available to pin-->

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}"
@@ -25,12 +26,7 @@
     <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
         <!-- Close button -->
         <Grid x:Name="CustomizeWidgetTitleBar">
-            <Button HorizontalAlignment="Right" Click="CancelButton_Click"
-                    BorderThickness="0" Background="Transparent" Margin="5">
-                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                           FontSize="{ThemeResource BodyTextBlockFontSize}" 
-                           Text="&#xE711;" />
-            </Button>
+            <commonviews:CloseButton Click="CancelButton_Click" />
         </Grid>
 
         <!-- Widget configuration UI -->

--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/SetupToolStyles.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/SetupToolStyles.xaml
@@ -21,8 +21,6 @@
     
     <!-- TODO Deprecated -->
     <x:String x:Key="SegoeFont">Segoe MDL2 Assets</x:String>
-    <x:String x:Key="FontIconSource">&#xE77B;</x:String>
-    <x:String x:Key="FontIconClose">&#xE711;</x:String>
 
     <!-- TODO Deprecated -->
     <Style x:Key="CheckBoxNoLabelStyle" TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -10,6 +10,7 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:models="using:DevHome.SetupFlow.Models"
+    xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
     setupFlowBehaviors:SetupFlowNavigationBehavior.PreviousVisibility="Collapsed"
     setupFlowBehaviors:SetupFlowNavigationBehavior.NextVisibility="Collapsed"
@@ -65,11 +66,7 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right" Spacing="5">
                     <Button x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequiredButton" Style="{ThemeResource DefaultButtonStyle}" Width="120"/>
-                    <Button Command="{x:Bind ViewModel.RemoveRestartGridCommand}" Style="{ThemeResource AlternateCloseButtonStyle}">
-                        <Button.Content>
-                            <SymbolIcon Symbol="Cancel"/>
-                        </Button.Content>
-                    </Button>
+                    <commonviews:CloseButton Command="{x:Bind ViewModel.RemoveRestartGridCommand}" />
                 </StackPanel>
             </Grid>
 


### PR DESCRIPTION
## Summary of the pull request
We use a Close button ("X" button") in a few places in Dev Home. This change creates a CloseButton control so that styling (Margin, Padding, Alignment, Text) will be consistent throughout. Also remove FontIconSource and FontIconClose from SetupToolStyles.xaml, which are not used anywhere.

## References and relevant issues
#916

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #916
- [ ] Tests added/passed
- [ ] Documentation updated
