### PR TITLE
Switch the MVVM Toolkit to 8.2.1

### DIFF
--- a/settings/DevHome.Settings/DevHome.Settings.csproj
+++ b/settings/DevHome.Settings/DevHome.Settings.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta">

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
   </ItemGroup>

--- a/tools/SampleTool/src/SampleTool.csproj
+++ b/tools/SampleTool/src/SampleTool.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
       <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
   </ItemGroup>
 

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Shimmer" Version="0.0.1" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -238,7 +238,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     /// Opens folder picker and adds folder to the drive location, if the user does not cancel the dialog.
     /// </summary>
     [RelayCommand]
-    public async Task ChooseFolderLocation()
+    public async Task ChooseFolderLocationAsync()
     {
         Log.Logger?.ReportInfo(Log.Component.DevDrive, "Opening file picker to select dev drive location");
         var folderPicker = new FolderPicker();
@@ -312,7 +312,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     /// Opens the Windows settings app and redirects the user to the disks and volumes page.
     /// </summary>
     [RelayCommand]
-    public async Task LaunchDisksAndVolumesSettingsPage()
+    public async Task LaunchDisksAndVolumesSettingsPageAsync()
     {
         // Critical level approved by subhasan
         TelemetryFactory.Get<ITelemetry>().Log(

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +14,6 @@ using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents;
 using DevHome.SetupFlow.Common.Helpers;
-using DevHome.SetupFlow.Common.TelemetryEvents;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
@@ -23,7 +21,6 @@ using DevHome.SetupFlow.Utilities;
 using DevHome.SetupFlow.Windows;
 using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Windows.Globalization.NumberFormatting;
 using Windows.Storage.Pickers;
 using Windows.System;
@@ -241,7 +238,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     /// Opens folder picker and adds folder to the drive location, if the user does not cancel the dialog.
     /// </summary>
     [RelayCommand]
-    public async void ChooseFolderLocation()
+    public async Task ChooseFolderLocation()
     {
         Log.Logger?.ReportInfo(Log.Component.DevDrive, "Opening file picker to select dev drive location");
         var folderPicker = new FolderPicker();
@@ -253,7 +250,6 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
         {
             Log.Logger?.ReportInfo(Log.Component.DevDrive, $"Selected Dev Drive location: {location.Path}");
             Location = location.Path;
-            OnPropertyChanged(nameof(Location));
         }
         else
         {
@@ -316,7 +312,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     /// Opens the Windows settings app and redirects the user to the disks and volumes page.
     /// </summary>
     [RelayCommand]
-    public async void LaunchDisksAndVolumesSettingsPage()
+    public async Task LaunchDisksAndVolumesSettingsPage()
     {
         // Critical level approved by subhasan
         TelemetryFactory.Get<ITelemetry>().Log(
@@ -336,7 +332,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     {
         Log.Logger?.ReportInfo(Log.Component.DevDrive, "Saving changes to Dev Drive");
         ByteUnit driveUnitOfMeasure = (ByteUnit)ComboBoxByteUnit;
-        var tempDrive = new Models.DevDrive()
+        var tempDrive = new DevDrive()
         {
             DriveLetter = ComboBoxDriveLetter.Value,
             DriveSizeInBytes = DevDriveUtil.ConvertToBytes(Size, driveUnitOfMeasure),

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -134,7 +134,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
     /// Command to re-run all tasks by moving them from _failedTasks to TasksToRun
     /// </summary>
     [RelayCommand]
-    public async void RestartFailedTasks()
+    public async Task RestartFailedTasks()
     {
         TelemetryFactory.Get<ITelemetry>().LogMeasure("Loading_RestartFailedTasks_Event");
         Log.Logger?.ReportInfo(Log.Component.Loading, "Restarting all failed tasks");

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -134,7 +134,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
     /// Command to re-run all tasks by moving them from _failedTasks to TasksToRun
     /// </summary>
     [RelayCommand]
-    public async Task RestartFailedTasks()
+    public async Task RestartFailedTasksAsync()
     {
         TelemetryFactory.Get<ITelemetry>().LogMeasure("Loading_RestartFailedTasks_Event");
         Log.Logger?.ReportInfo(Log.Component.Loading, "Restarting all failed tasks");

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -10,7 +10,6 @@ using DevHome.Common.Extensions;
 using DevHome.Common.TelemetryEvents;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.SetupFlow.Common.Helpers;
-using DevHome.SetupFlow.Common.TelemetryEvents;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
@@ -153,7 +152,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     /// Opens the Windows settings app and redirects the user to the disks and volumes page.
     /// </summary>
     [RelayCommand]
-    private async void LaunchDisksAndVolumesSettingsPage()
+    private async Task LaunchDisksAndVolumesSettingsPage()
     {
         // Critical level approved by subhasan
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Launching settings on Disks and Volumes page");
@@ -161,6 +160,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
             "LaunchDisksAndVolumesSettingsPageTriggered",
             LogLevel.Critical,
             new DisksAndVolumesSettingsPageTriggeredEvent(source: "MainPageView"));
+
         await Launcher.LaunchUriAsync(new Uri("ms-settings:disksandvolumes"));
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -152,7 +152,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     /// Opens the Windows settings app and redirects the user to the disks and volumes page.
     /// </summary>
     [RelayCommand]
-    private async Task LaunchDisksAndVolumesSettingsPage()
+    private async Task LaunchDisksAndVolumesSettingsPageAsync()
     {
         // Critical level approved by subhasan
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Launching settings on Disks and Volumes page");

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -113,7 +113,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     /// Method here for telemetry
     /// </summary>
     [RelayCommand]
-    public async Task LearnMore()
+    public async Task LearnMoreAsync()
     {
         TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("LearnMoreAboutDevHome"));
         await Launcher.LaunchUriAsync(new Uri("https://learn.microsoft.com/windows/"));

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -113,7 +113,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     /// Method here for telemetry
     /// </summary>
     [RelayCommand]
-    public async void LearnMore()
+    public async Task LearnMore()
     {
         TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("LearnMoreAboutDevHome"));
         await Launcher.LaunchUriAsync(new Uri("https://learn.microsoft.com/windows/"));


### PR DESCRIPTION
## Summary of the pull request

This PR bumps the MVVM Toolkit to 8.2.1 and applies the necessary fixes for the new analyzers.
You can learn more in the [blog post](https://devblogs.microsoft.com/dotnet/announcing-the-dotnet-community-toolkit-821/) and in the [release notes](https://github.com/CommunityToolkit/dotnet/releases/tag/v8.2.1).

## Validation steps performed

Build the solution to ensure no warnings/errors, run and played with the app for a bit.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
