### PR TITLE
Update style of Settings BreadcrumbBar

### DIFF
--- a/src/Styles/BreadcrumbBar.xaml
+++ b/src/Styles/BreadcrumbBar.xaml
@@ -8,9 +8,12 @@
 
     <FontFamily x:Key="ContentControlThemeFontFamily">XamlAutoFontFamily</FontFamily>
 
-    <x:Double x:Key="BreadcrumbBarItemFontSize">28</x:Double>
+    <x:Double x:Key="BreadcrumbBarItemFontSize">20</x:Double>
     <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="BreadcrumbBarItemFontSize" />
 
-    <FontWeight x:Key="BreadcrumbBarItemFontWeight">SemiBold</FontWeight>
+    <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
+
+    <!-- Applies to all items but the last (current) item -->
+    <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
 
 </ResourceDictionary>

--- a/src/Styles/BreadcrumbBar.xaml
+++ b/src/Styles/BreadcrumbBar.xaml
@@ -11,7 +11,7 @@
     <x:Double x:Key="BreadcrumbBarItemFontSize">20</x:Double>
     <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="BreadcrumbBarItemFontSize" />
 
-    <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
+    <FontWeight x:Key="BreadcrumbBarItemFontWeight">SemiBold</FontWeight>
 
     <!-- Applies to all items but the last (current) item -->
     <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />


### PR DESCRIPTION
## Summary of the pull request
Take app from this:
![image](https://github.com/microsoft/devhome/assets/47155823/d81d7303-b91e-4327-ac86-d54885635df4)

To this:
![image](https://github.com/microsoft/devhome/assets/47155823/1f7e5b91-3e9c-4e96-bd2d-9de7e6504653)

- Change text size from 28 to 20, to align with spec
- Change page titles that aren't the current page titles to the secondary font color
- Chevron is not changed, but matches spec size and should look better next to new item text size.

All new values align with spec. 

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1143
- [ ] Tests added/passed
- [ ] Documentation updated
