### PR TITLE
Align scan mode and non-scan mode navigation experience in the setup flow main page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -90,7 +90,7 @@
                                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                                IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
                                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                               AutomationProperties.AccessibilityView="Raw"
+                                               AutomationProperties.AccessibilityView="Control"
                                                ActionIcon="{x:Null}" >
                                 <labs:SettingsCard.HeaderIcon>
                                     <ImageIcon
@@ -112,7 +112,7 @@
                                            Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
                                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Raw"
+                                           AutomationProperties.AccessibilityView="Control"
                                            ActionIcon="{x:Null}" >
                             <labs:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_ConfigurationFile.png" />
@@ -128,7 +128,7 @@
                                            Command="{x:Bind ViewModel.StartRepoConfigCommand}"
                                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Raw"
+                                           AutomationProperties.AccessibilityView="Control"
                                            ActionIcon="{x:Null}" >
                             <labs:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
@@ -143,7 +143,7 @@
                                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                                IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
                                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                               AutomationProperties.AccessibilityView="Raw"
+                                               AutomationProperties.AccessibilityView="Control"
                                                ActionIcon="{x:Null}" >
                                 <labs:SettingsCard.HeaderIcon>
                                     <ImageIcon
@@ -163,7 +163,7 @@
                                            AutomationProperties.AutomationId="DevDriveButton"
                                            IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Raw"
+                                           AutomationProperties.AccessibilityView="Control"
                                            Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
                             <labs:SettingsCard.ActionIcon>
                                 <!-- The open new window icon -->

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -89,6 +89,8 @@
                                                Command="{x:Bind ViewModel.StartSetupCommand}"
                                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                                IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
+                                               ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                               AutomationProperties.AccessibilityView="Raw"
                                                ActionIcon="{x:Null}" >
                                 <labs:SettingsCard.HeaderIcon>
                                     <ImageIcon
@@ -109,6 +111,8 @@
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
                                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                           AutomationProperties.AccessibilityView="Raw"
                                            ActionIcon="{x:Null}" >
                             <labs:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_ConfigurationFile.png" />
@@ -123,6 +127,8 @@
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartRepoConfigCommand}"
                                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                           AutomationProperties.AccessibilityView="Raw"
                                            ActionIcon="{x:Null}" >
                             <labs:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
@@ -136,6 +142,8 @@
                                                Command="{x:Bind ViewModel.StartAppManagementCommand}"
                                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
                                                IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
+                                               ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                               AutomationProperties.AccessibilityView="Raw"
                                                ActionIcon="{x:Null}" >
                                 <labs:SettingsCard.HeaderIcon>
                                     <ImageIcon
@@ -154,6 +162,8 @@
                         <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
                                            AutomationProperties.AutomationId="DevDriveButton"
                                            IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
+                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                           AutomationProperties.AccessibilityView="Raw"
                                            Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
                             <labs:SettingsCard.ActionIcon>
                                 <!-- The open new window icon -->


### PR DESCRIPTION
## Summary of the pull request
- By default, in non-scan mode, the narrator would say "More button" when navigating the setup flow main page using the keyboard Tab key.
- 'More' is the default value for the ActionIcon tooltip: [SettingsCards.cs](https://github.com/CommunityToolkit/Windows/blob/3c888a3178774c8b046200e0bf9c5ac4f9a22e24/components/SettingsControls/src/SettingsCard/SettingsCard.Properties.cs#L52C17-L52C17)
- Updated the code so the narrator mentions the button's header name instead: e.g. 'Configuration file button'

## References and relevant issues
Item number: 45056939

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
