### PR TITLE
Fix GitHub bot /logs rule

### DIFF
--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -78,7 +78,7 @@ configuration:
       if:
       - payloadType: Issue_Comment
       - commentContains:
-          pattern: '\/logs)'
+          pattern: '\/logs'
           isRegex: True
       - or:
         - activitySenderHasAssociation:
@@ -98,7 +98,6 @@ configuration:
               repo names). Alternatively, you can open a Feedback Hub issue and attach them there. 
               If you use Feedback Hub, please paste the URL at the bottom of the report here so we 
               can easily find it. 
-      - closeIssue
       - removeLabel:
           label: Needs-Triage
       - removeLabel:


### PR DESCRIPTION
## Summary of the pull request
Logs rule wasn't working because of an errant ')'. Also, don't close the issue when the /logs trigger is used.

## References and relevant issues
#1340