### PR TITLE
Logging style messages and critical telemetry events.

### DIFF
--- a/telemetry/DevHome.Telemetry/ITelemetry.cs
+++ b/telemetry/DevHome.Telemetry/ITelemetry.cs
@@ -43,7 +43,7 @@ public interface ITelemetry
     public void LogTimeTaken(string eventName, uint timeTakenMilliseconds, Guid? relatedActivityId = null);
 
     /// <summary>
-    /// Log an informal event with no additional data.
+    /// Log an event with no additional data.
     /// </summary>
     /// <param name="eventName">The name of the event to log</param>
     /// <param name="isError">Set to true if an error condition raised this event.</param>

--- a/telemetry/DevHome.Telemetry/ITelemetry.cs
+++ b/telemetry/DevHome.Telemetry/ITelemetry.cs
@@ -48,7 +48,7 @@ public interface ITelemetry
     /// <param name="eventName">The name of the event to log</param>
     /// <param name="isError">Set to true if an error condition raised this event.</param>
     /// <param name="relatedActivityId">Optional relatedActivityId which will allow to correlate this telemetry with other telemetry in the same action/activity or thread and correlate them</param>
-    public void LogMeasure(string eventName, bool isError = false, Guid? relatedActivityId = null);
+    public void LogCritical(string eventName, bool isError = false, Guid? relatedActivityId = null);
 
     /// <summary>
     /// Log an informational event. Typically used for just a single event that's only called one place in the code.

--- a/telemetry/DevHome.Telemetry/Telemetry.cs
+++ b/telemetry/DevHome.Telemetry/Telemetry.cs
@@ -184,9 +184,9 @@ internal class Telemetry : ITelemetry
     /// <param name="eventName">The name of the event to log</param>
     /// <param name="isError">Set to true if an error condition raised this event.</param>
     /// <param name="relatedActivityId">GUID to correlate activities.</param>
-    public void LogMeasure(string eventName, bool isError = false, Guid? relatedActivityId = null)
+    public void LogCritical(string eventName, bool isError = false, Guid? relatedActivityId = null)
     {
-        this.LogInternal(eventName, LogLevel.Measure, new EmptyEvent(), relatedActivityId, isError);
+        this.LogInternal(eventName, LogLevel.Critical, new EmptyEvent(), relatedActivityId, isError);
     }
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow.UnitTest/LoadingScreenTests.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.UnitTest/LoadingScreenTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using DevHome.SetupFlow.ViewModels;
+
+namespace DevHome.SetupFlow.UnitTest;
+
+[TestClass]
+public class LoadingScreenTests : BaseSetupFlowTest
+{
+    [TestMethod]
+    public void HideRetryBannerTest()
+    {
+        var loadingViewModel = new LoadingViewModel(StringResource.Object, null, TestHost);
+
+        loadingViewModel.HideMaxRetryBanner();
+
+        Assert.IsFalse(loadingViewModel.ShowOutOfRetriesBanner);
+    }
+}

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
@@ -174,14 +174,14 @@ public partial class CloneRepoTask : ObservableObject, ISetupTask
             try
             {
                 Log.Logger?.ReportInfo(Log.Component.RepoConfig, $"Cloning repository {RepositoryToClone.DisplayName}");
-                TelemetryFactory.Get<ITelemetry>().Log("CloneTask_CloneRepo_Event", LogLevel.Measure, new ReposCloneEvent(ProviderName, _developerId));
+                TelemetryFactory.Get<ITelemetry>().Log("CloneTask_CloneRepo_Event", LogLevel.Critical, new ReposCloneEvent(ProviderName, _developerId));
                 await RepositoryToClone.CloneRepositoryAsync(_cloneLocation.FullName, _developerId);
             }
             catch (Exception e)
             {
                 Log.Logger?.ReportError(Log.Component.RepoConfig, $"Could not clone {RepositoryToClone.DisplayName}", e);
                 _actionCenterErrorMessage.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.CloneRepoErrorForActionCenter, RepositoryToClone.DisplayName, e.HResult.ToString("X", CultureInfo.CurrentCulture));
-                TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_ClouldNotClone_Event", LogLevel.Measure, new ExceptionEvent(e.HResult));
+                TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_ClouldNotClone_Event", LogLevel.Critical, new ExceptionEvent(e.HResult));
                 return TaskFinishedState.Failure;
             }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -101,11 +101,11 @@ internal class RepositoryProvider
     {
         if (!_repositories.IsValueCreated)
         {
-            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAllRepos_Event", LogLevel.Measure, new GetReposEvent("CallingExtension", _repositoryProvider.DisplayName, developerId));
+            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAllRepos_Event", LogLevel.Critical, new GetReposEvent("CallingExtension", _repositoryProvider.DisplayName, developerId));
             _repositories = new Lazy<IEnumerable<IRepository>>(_repositoryProvider.GetRepositoriesAsync(developerId).AsTask().Result);
         }
 
-        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAllRepos_Event", LogLevel.Measure, new GetReposEvent("FoundRepos", _repositoryProvider.DisplayName, developerId));
+        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAllRepos_Event", LogLevel.Critical, new GetReposEvent("FoundRepos", _repositoryProvider.DisplayName, developerId));
 
         return _repositories.Value;
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/TaskInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/TaskInformation.cs
@@ -22,30 +22,8 @@ public partial class TaskInformation : ObservableObject
     /// <summary>
     /// The message to display in the loading screen.
     /// </summary>
-    [ObservableProperty]
-    private string _messageToShow;
-
-    /// <summary>
-    /// If the status icon, green, yellow, or red, should be shown.
-    /// </summary>
-    [ObservableProperty]
-    private bool _statusIconGridVisibility;
-
-    /// <summary>
-    /// If the progress ring should be shown.  Only show a progress ring when the task is running.
-    /// </summary>
-    [ObservableProperty]
-    private bool _shouldShowProgressRing;
-
-    /// <summary>
-    /// The icon to display in the loading screen after a task is finished.
-    /// </summary>
-    [ObservableProperty]
-    private BitmapImage _statusSymbolIcon;
-
-    /// <summary>
-    /// Primary when the task is running, otherwise secondary.
-    /// </summary>
-    [ObservableProperty]
-    private SolidColorBrush _messageForeground;
+    public string MessageToShow
+    {
+        get; set;
+    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -96,6 +96,6 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
             allAddedRepos.Add(new FinalRepoResult(providerName, addKind, cloneLocationKind));
         }
 
-        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_AllReposAdded_Event", LogLevel.Measure, new RepoToolFinalReposToAddEvent(allAddedRepos));
+        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_AllReposAdded_Event", LogLevel.Critical, new RepoToolFinalReposToAddEvent(allAddedRepos));
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -260,6 +260,7 @@ public partial class AddRepoViewModel : ObservableObject
         Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Getting installed plugins with Repository and DevId providers");
         var pluginService = Application.Current.GetService<IPluginService>();
         var pluginWrappers = pluginService.GetInstalledPluginsAsync().Result;
+
         var plugins = pluginWrappers.Where(
             plugin => plugin.HasProviderType(ProviderType.Repository) &&
             plugin.HasProviderType(ProviderType.DeveloperId));

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -271,7 +271,7 @@ public partial class AddRepoViewModel : ObservableObject
         _providers.StartAllPlugins();
 
         ProviderNames = new ObservableCollection<string>(_providers.GetAllProviderNames());
-        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_SearchForProviders_Event", LogLevel.Measure, new ProviderEvent(ProviderNames.Count));
+        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_SearchForProviders_Event", LogLevel.Critical, new ProviderEvent(ProviderNames.Count));
     }
 
     public void ChangeToUrlPage()
@@ -385,7 +385,7 @@ public partial class AddRepoViewModel : ObservableObject
         var loggedInAccounts = await Task.Run(() => _providers.GetAllLoggedInAccounts(repositoryProviderName));
         if (!loggedInAccounts.Any())
         {
-            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAccount_Event", LogLevel.Measure, new RepoDialogGetAccountEvent(repositoryProviderName, alreadyLoggedIn: false));
+            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAccount_Event", LogLevel.Critical, new RepoDialogGetAccountEvent(repositoryProviderName, alreadyLoggedIn: false));
 
             // Throw away developerId because DevHome allows one account per provider. GetAllLoggedInAccounts is called
             // in anticipation of 1 Provider : N DeveloperIds
@@ -394,7 +394,7 @@ public partial class AddRepoViewModel : ObservableObject
         }
         else
         {
-            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAccount_Event", LogLevel.Measure, new RepoDialogGetAccountEvent(repositoryProviderName, alreadyLoggedIn: true));
+            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAccount_Event", LogLevel.Critical, new RepoDialogGetAccountEvent(repositoryProviderName, alreadyLoggedIn: true));
         }
 
         Accounts = new ObservableCollection<string>(loggedInAccounts.Select(x => x.LoginId()));
@@ -507,7 +507,7 @@ public partial class AddRepoViewModel : ObservableObject
             UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlValidationNotFound);
             ShouldShowUrlError = Visibility.Visible;
             Log.Logger?.ReportInfo(Log.Component.RepoConfig, e.ToString());
-            TelemetryFactory.Get<ITelemetry>().LogMeasure("RepoDialog_RepoNotFound_Event");
+            TelemetryFactory.Get<ITelemetry>().LogCritical("RepoDialog_RepoNotFound_Event");
             return;
         }
 
@@ -538,7 +538,7 @@ public partial class AddRepoViewModel : ObservableObject
             UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlValidationRepoAlreadyAdded);
             ShouldShowUrlError = Visibility.Visible;
             Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Repository has already been added.");
-            TelemetryFactory.Get<ITelemetry>().LogMeasure("RepoTool_RepoAlreadyAdded_Event");
+            TelemetryFactory.Get<ITelemetry>().LogCritical("RepoTool_RepoAlreadyAdded_Event");
             return;
         }
 
@@ -561,10 +561,10 @@ public partial class AddRepoViewModel : ObservableObject
         IsFetchingRepos = true;
         await Task.Run(() =>
         {
-            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetRepos_Event", LogLevel.Measure, new RepoToolEvent("GettingAllLoggedInAccounts"));
+            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetRepos_Event", LogLevel.Critical, new RepoToolEvent("GettingAllLoggedInAccounts"));
             var loggedInDeveloper = _providers.GetAllLoggedInAccounts(repositoryProvider).FirstOrDefault(x => x.LoginId() == loginId);
 
-            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetRepos_Event", LogLevel.Measure, new RepoToolEvent("GettingAllRepos"));
+            TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetRepos_Event", LogLevel.Critical, new RepoToolEvent("GettingAllRepos"));
             _repositoriesForAccount = _providers.GetAllRepositories(repositoryProvider, loggedInDeveloper);
         });
         IsFetchingRepos = false;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingMessageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingMessageViewModel.cs
@@ -24,7 +24,8 @@ public partial class LoadingMessageViewModel : ObservableObject
     private bool _shouldShowProgressRing;
 
     /// <summary>
-    /// The status symbol icon is the red, green, or yellow icon the is next to a task when it is completed.
+    /// The status symbol icon is the red, green, or yellow icon that is next to a task when it has been completed.
+
     /// </summary>
     [ObservableProperty]
     private bool _shouldShowStatusSymbolIcon;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingMessageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingMessageViewModel.cs
@@ -6,6 +6,10 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace DevHome.SetupFlow.ViewModels;
+
+/// <summary>
+/// View Model to hold information for each message in the loading screen.
+/// </summary>
 public partial class LoadingMessageViewModel : ObservableObject
 {
     /// <summary>
@@ -19,6 +23,9 @@ public partial class LoadingMessageViewModel : ObservableObject
     [ObservableProperty]
     private bool _shouldShowProgressRing;
 
+    /// <summary>
+    /// The status symbol icon is the red, green, or yellow icon the is next to a task when it is completed.
+    /// </summary>
     [ObservableProperty]
     private bool _shouldShowStatusSymbolIcon;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingMessageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingMessageViewModel.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace DevHome.SetupFlow.ViewModels;
+public partial class LoadingMessageViewModel : ObservableObject
+{
+    /// <summary>
+    /// Gets the message to display in the loading screen.
+    /// </summary>
+    public string MessageToShow { get; }
+
+    /// <summary>
+    /// If the progress ring should be shown.  Only show a progress ring when the task is running.
+    /// </summary>
+    [ObservableProperty]
+    private bool _shouldShowProgressRing;
+
+    [ObservableProperty]
+    private bool _shouldShowStatusSymbolIcon;
+
+    /// <summary>
+    /// The icon to display in the loading screen after a task is finished.
+    /// </summary>
+    [ObservableProperty]
+    private BitmapImage _statusSymbolIcon;
+
+    /// <summary>
+    /// Primary when the task is running, otherwise secondary.
+    /// </summary>
+    [ObservableProperty]
+    private SolidColorBrush _messageForeground;
+
+    public LoadingMessageViewModel(string messageToShow)
+    {
+        MessageToShow = messageToShow;
+    }
+}

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -51,10 +51,10 @@ public partial class LoadingViewModel : SetupPageViewModelBase
     private int _retryCount;
 
     /// <summary>
-    /// A business rule for the loading screen is that all "executing" messages should always appear at the bottom
-    /// of the list of messages.  To enable this behavior all "finished" messages and "executing"-but-done messages
+    /// A business rule for the loading screen is  "executing" messages should appear at the bottom
+    /// of the list of messages.  To enable this behavior "finished" messages and "executing-but-done" messages
     /// need to be inserted at the index before the first executing message.
-    /// Keep track this is used to count backwards from Messages.count to get the index to add messages to.
+    /// To keep track of the index this is used to count backwards from Messages.count.
     /// </summary>
     private int _numberOfExecutingTasks;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -443,7 +443,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
                 loadingMessage.MessageForeground = (SolidColorBrush)Application.Current.Resources["TextFillColorPrimaryBrush"];
                 Messages.Add(loadingMessage);
 
-                // Keep incremenet inside TryEnqueue to enforce "locking"
+                // Keep increment inside TryEnqueue to enforce "locking"
                 _numberOfExecutingTasks++;
             });
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -83,7 +83,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     [RelayCommand]
     private void HideBanner()
     {
-        TelemetryFactory.Get<ITelemetry>().LogMeasure("MainPage_HideLearnMoreBanner_Event");
+        TelemetryFactory.Get<ITelemetry>().LogCritical("MainPage_HideLearnMoreBanner_Event");
         ShowBanner = false;
     }
 
@@ -105,7 +105,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
         Log.Logger?.ReportInfo($"Starting setup flow with ActivityId={Orchestrator.ActivityId}");
         TelemetryFactory.Get<ITelemetry>().Log(
             "MainPage_StartFlow_Event",
-            LogLevel.Measure,
+            LogLevel.Critical,
             new StartFlowEvent(flowNameForTelemetry),
             relatedActivityId: Orchestrator.ActivityId);
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SearchViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SearchViewModel.cs
@@ -93,7 +93,7 @@ public partial class SearchViewModel : ObservableObject
         {
             // Run the search on a separate (non-UI) thread to prevent lagging the UI.
             Log.Logger?.ReportInfo(Log.Component.AppManagement, $"Running package search for query [{text}]");
-            TelemetryFactory.Get<ITelemetry>().LogMeasure("Search_SerchingForApplication_Event");
+            TelemetryFactory.Get<ITelemetry>().LogCritical("Search_SerchingForApplication_Event");
             var matches = await Task.Run(async () => await _wpm.AllCatalogs.SearchAsync(text, SearchResultLimit), cancellationToken);
 
             // Don't update the UI if the operation was canceled

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -99,7 +99,7 @@ public partial class SetupFlowViewModel : ObservableObject
     {
         // Report this before touching the pages so the current Activity ID can be obtained.
         Log.Logger?.ReportInfo(Log.Component.Orchestrator, $"Terminating Setup flow by caller [{callerNameForTelemetry}]. ActivityId={Orchestrator.ActivityId}");
-        TelemetryFactory.Get<ITelemetry>().Log("SetupFlow_Termination", LogLevel.Measure, new EndFlowEvent(callerNameForTelemetry), relatedActivityId: Orchestrator.ActivityId);
+        TelemetryFactory.Get<ITelemetry>().Log("SetupFlow_Termination", LogLevel.Critical, new EndFlowEvent(callerNameForTelemetry), relatedActivityId: Orchestrator.ActivityId);
 
         Orchestrator.ReleaseRemoteFactory();
         _host.GetService<IDevDriveManager>().RemoveAllDevDrives();

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -115,21 +115,21 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     [RelayCommand]
     public async void LearnMore()
     {
-        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("LearnMoreAboutDevHome"));
+        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("LearnMoreAboutDevHome"));
         await Launcher.LaunchUriAsync(new Uri("https://learn.microsoft.com/windows/"));
     }
 
     [RelayCommand]
     public void GoToMainPage()
     {
-        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("MachineConfiguration"));
+        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("MachineConfiguration"));
         _setupFlowViewModel.TerminateCurrentFlow("Summary_GoToMainPage");
     }
 
     [RelayCommand]
     public void GoToDashboard()
     {
-        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("Dashboard"));
+        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("Dashboard"));
         _host.GetService<INavigationService>().NavigateTo(typeof(DashboardViewModel).FullName);
         _setupFlowViewModel.TerminateCurrentFlow("Summary_GoToDashboard");
     }
@@ -137,7 +137,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     [RelayCommand]
     public void GoToDevHomeSettings()
     {
-        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("DevHomeSettings"));
+        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("DevHomeSettings"));
         _host.GetService<INavigationService>().NavigateTo(typeof(SettingsViewModel).FullName);
         _setupFlowViewModel.TerminateCurrentFlow("Summary_GoToSettings");
     }
@@ -145,7 +145,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     [RelayCommand]
     public void GoToForDevelopersSettingsPage()
     {
-        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Measure, new NavigateFromSummaryEvent("WindowsDeveloperSettings"));
+        TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("WindowsDeveloperSettings"));
         Task.Run(() => Launcher.LaunchUriAsync(new Uri("ms-settings:developers"))).Wait();
     }
 
@@ -176,7 +176,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
 
     protected async override Task OnFirstNavigateToAsync()
     {
-        TelemetryFactory.Get<ITelemetry>().LogMeasure("Summary_NavigatedTo_Event");
+        TelemetryFactory.Get<ITelemetry>().LogCritical("Summary_NavigatedTo_Event");
         _orchestrator.ReleaseRemoteFactory();
         await ReloadCatalogsAsync();
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -20,7 +20,6 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
                     <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
-                    <converters:BoolNegationConverter x:Key="BoolNegation"/>
                     <converters:BoolToObjectConverter x:Key="BoolToTextBrush" TrueValue="{ThemeResource PrimaryTextStyle}" FalseValue="{ThemeResource SecondaryTextStyle}"/>
                 </ResourceDictionary>
                 <ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="using:DevHome.SetupFlow.Models"
+    xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     xmlns:commonModels="using:DevHome.SetupFlow.Models"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
@@ -89,15 +89,15 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="50"/>
-                <RowDefinition Height="500"/>
+                <RowDefinition Height="490"/>
             </Grid.RowDefinitions>
             <Border Grid.Column="0" Grid.Row="0" Style="{StaticResource DevHomeBorderStyle}" BorderThickness="0, 0, 0, 1">
                 <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Loading_ExecutingTasks" Style="{StaticResource SemiBoldTextStyle}"/>
             </Border>
             <ScrollViewer Grid.Column="0" Grid.Row="1" x:Name="AllRunningTasksScrollViewer" VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" Margin="0, 10, 0, 0">
-                <ListView ItemsSource="{x:Bind ViewModel.TasksToRun, Mode=OneWay}" SelectionMode="None">
+                <ListView ItemsSource="{x:Bind ViewModel.Messages, Mode=OneWay}" SelectionMode="None">
                     <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="models:TaskInformation">
+                        <DataTemplate x:DataType="viewmodels:LoadingMessageViewModel">
                             <StackPanel Orientation="Horizontal" Spacing="5">
                                 <StackPanel.Resources>
                                     <ResourceDictionary>
@@ -120,13 +120,11 @@
                                 <ImageIcon
                                     Width="18"
                                     Height="18"
-                                    Visibility="{x:Bind StatusIconGridVisibility, Mode=OneWay}"
+                                    Visibility="{x:Bind ShouldShowStatusSymbolIcon, Mode=OneWay}"
                                     Source="{x:Bind StatusSymbolIcon, Mode=OneWay}"/>
-
-                                <!-- If the status icon is visible it means the task has stopped.  Don't show progress ring.-->
                                 <ProgressRing
-                                    IsActive="{x:Bind StatusIconGridVisibility, Mode=OneWay, Converter={StaticResource BoolNegation}}"
-                                    Visibility="{x:Bind StatusIconGridVisibility, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
+                                    IsActive="{x:Bind ShouldShowProgressRing, Mode=OneWay}"
+                                    Visibility="{x:Bind ShouldShowProgressRing, Mode=OneWay}"
                                     Width="20" Height="20"/>
                                 <TextBlock Text="{x:Bind MessageToShow, Mode=OneWay}" VerticalAlignment="Center" Style="{x:Bind ShouldShowProgressRing, Mode=OneWay, Converter={StaticResource BoolToTextBrush}}"/>
                             </StackPanel>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -19,7 +19,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
-                    <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
                     <converters:BoolToObjectConverter x:Key="BoolToTextBrush" TrueValue="{ThemeResource PrimaryTextStyle}" FalseValue="{ThemeResource SecondaryTextStyle}"/>
                 </ResourceDictionary>
                 <ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -89,7 +89,7 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="50"/>
-                <RowDefinition Height="490"/>
+                <RowDefinition Height="400"/>
             </Grid.RowDefinitions>
             <Border Grid.Column="0" Grid.Row="0" Style="{StaticResource DevHomeBorderStyle}" BorderThickness="0, 0, 0, 1">
                 <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Loading_ExecutingTasks" Style="{StaticResource SemiBoldTextStyle}"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -149,13 +149,13 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-            <Grid x:Name="NoRepositoryStackPanel" Visibility="{x:Bind ViewModel.RepoReviewItems, Mode=OneWay, Converter={StaticResource CollectionShowWhenEmpty}}" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Grid x:Name="NoRepositoryGrid" Visibility="{x:Bind ViewModel.RepoReviewItems, Mode=OneWay, Converter={StaticResource CollectionShowWhenEmpty}}" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <Grid.RowDefinitions>
                     <RowDefinition/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelected"/>
-                <HyperlinkButton Grid.Row="1" Click="AddRepoButton_Click" HorizontalAlignment="Center" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelectedLink" />
+                <HyperlinkButton x:Name="AddRepoHyperLinkButton" Grid.Row="1" Click="AddRepoButton_Click" HorizontalAlignment="Center" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelectedLink" />
             </Grid>
         </Grid>
     </setupControls:SetupShell>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -85,7 +85,7 @@ public sealed partial class RepoConfigView : UserControl
         var dialogName = "RepoDialog";
         var telemetryLogger = TelemetryFactory.Get<ITelemetry>();
 
-        telemetryLogger.Log(EventName, LogLevel.Measure, new DialogEvent("Open", dialogName), relatedActivityId);
+        telemetryLogger.Log(EventName, LogLevel.Critical, new DialogEvent("Open", dialogName), relatedActivityId);
 
         // Both the hyperlink button and button call this.
         // disable the button to prevent users from double clicking it.
@@ -190,7 +190,7 @@ public sealed partial class RepoConfigView : UserControl
         {
             TelemetryFactory.Get<ITelemetry>().Log(
                 "RepoDialog_RepoAdded_Event",
-                LogLevel.Measure,
+                LogLevel.Critical,
                 RepoDialogAddRepoEvent.AddWithDevDrive(
                 addKind,
                 addRepoDialog.AddRepoViewModel.EverythingToClone.Count,
@@ -203,7 +203,7 @@ public sealed partial class RepoConfigView : UserControl
         {
             TelemetryFactory.Get<ITelemetry>().Log(
                 "RepoDialog_RepoAdded_Event",
-                LogLevel.Measure,
+                LogLevel.Critical,
                 RepoDialogAddRepoEvent.AddWithLocalPath(
                 addKind,
                 addRepoDialog.AddRepoViewModel.EverythingToClone.Count,
@@ -211,7 +211,7 @@ public sealed partial class RepoConfigView : UserControl
                 relatedActivityId);
         }
 
-        telemetryLogger.Log(EventName, LogLevel.Measure, new DialogEvent("Close", dialogName, result), relatedActivityId);
+        telemetryLogger.Log(EventName, LogLevel.Critical, new DialogEvent("Close", dialogName, result), relatedActivityId);
     }
 
     /// <summary>
@@ -225,7 +225,7 @@ public sealed partial class RepoConfigView : UserControl
         var relatedActivityId = Guid.NewGuid();
         var telemetryLogger = TelemetryFactory.Get<ITelemetry>();
 
-        telemetryLogger.Log(EventName, LogLevel.Measure, new DialogEvent("Open", dialogName), relatedActivityId);
+        telemetryLogger.Log(EventName, LogLevel.Critical, new DialogEvent("Open", dialogName), relatedActivityId);
 
         var cloningInformation = (sender as Button).DataContext as CloningInformation;
         var oldLocation = cloningInformation.CloningLocation;
@@ -248,7 +248,7 @@ public sealed partial class RepoConfigView : UserControl
             // so decrease the Dev Managers count.
             if (wasCloningToDevDrive && !cloningInformation.CloneToDevDrive)
             {
-                telemetryLogger.Log(EventName, LogLevel.Measure, new SwitchedCloningLocationEvent(CloneLocationKind.LocalPath, devDrive?.State == DevDriveState.New, devDrive?.State == DevDriveState.ExistsOnSystem), relatedActivityId);
+                telemetryLogger.Log(EventName, LogLevel.Critical, new SwitchedCloningLocationEvent(CloneLocationKind.LocalPath, devDrive?.State == DevDriveState.New, devDrive?.State == DevDriveState.ExistsOnSystem), relatedActivityId);
                 ViewModel.DevDriveManager.DecreaseRepositoriesCount();
                 ViewModel.DevDriveManager.CancelChangesToDevDrive();
             }
@@ -260,7 +260,7 @@ public sealed partial class RepoConfigView : UserControl
                 // User switched from local path to Dev Drive
                 if (!wasCloningToDevDrive)
                 {
-                    telemetryLogger.Log(EventName, LogLevel.Measure, new SwitchedCloningLocationEvent(CloneLocationKind.DevDrive), relatedActivityId);
+                    telemetryLogger.Log(EventName, LogLevel.Critical, new SwitchedCloningLocationEvent(CloneLocationKind.DevDrive), relatedActivityId);
                     ViewModel.DevDriveManager.IncreaseRepositoriesCount(1);
                 }
 
@@ -287,7 +287,7 @@ public sealed partial class RepoConfigView : UserControl
             ViewModel.DevDriveManager.RequestToCloseDevDriveWindow(editClonePathDialog.EditDevDriveViewModel.DevDrive);
         }
 
-        telemetryLogger.Log(EventName, LogLevel.Measure, new DialogEvent("Close", dialogName, result), relatedActivityId);
+        telemetryLogger.Log(EventName, LogLevel.Critical, new DialogEvent("Close", dialogName, result), relatedActivityId);
     }
 
     /// <summary>
@@ -303,6 +303,6 @@ public sealed partial class RepoConfigView : UserControl
             ViewModel.DevDriveManager.DecreaseRepositoriesCount();
         }
 
-        TelemetryFactory.Get<ITelemetry>().LogMeasure("RepoTool_RemoveRepo_Event");
+        TelemetryFactory.Get<ITelemetry>().LogCritical("RepoTool_RemoveRepo_Event");
     }
 }

--- a/uitest/Pages/MachineConfigurationPage.cs
+++ b/uitest/Pages/MachineConfigurationPage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Diagnostics;
 using OpenQA.Selenium.Appium.Windows;
 
 namespace DevHome.UITest.Pages;
@@ -23,5 +24,12 @@ public class MachineConfigurationPage : ApplicationPage
     public MachineConfigurationPage(WindowsDriver<WindowsElement> driver)
         : base(driver)
     {
+    }
+
+    public RepoConfigPage GoToRepoPage()
+    {
+        Trace.WriteLine("Going to repo page");
+        CloneRepoButton.Click();
+        return new RepoConfigPage(Driver);
     }
 }

--- a/uitest/Pages/RepoConfigPage.cs
+++ b/uitest/Pages/RepoConfigPage.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using OpenQA.Selenium.Appium.Windows;
+
+namespace DevHome.UITest.Pages;
+public class RepoConfigPage : ApplicationPage
+{
+    private WindowsElement AddRepoButton => Driver.FindElementByName("AddRepositoriesButton");
+
+    public WindowsElement AddRepoHyperLinkButton => Driver.FindElementByAccessibilityId("AddRepoHyperLinkButton");
+
+    public RepoConfigPage(WindowsDriver<WindowsElement> driver)
+        : base(driver)
+    {
+    }
+}

--- a/uitest/RepoConfigPageUiTests.cs
+++ b/uitest/RepoConfigPageUiTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using DevHome.UITest.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DevHome.UITest;
+
+[TestClass]
+public class RepoConfigPageUiTests : DevHomeTestBase
+{
+    [TestMethod]
+    public void TestNewRepoConfigPage()
+    {
+        var machineConfigurationPage = Application.NavigateToMachineConfigurationPage();
+        var repoConfigPage = machineConfigurationPage.GoToRepoPage();
+
+        // This button will be displayed when no repos are selected.
+        Assert.IsTrue(repoConfigPage.AddRepoHyperLinkButton.Displayed);
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
All secondary style messages are inserted into the list instead of being changed in-place.

Changed all events to Critical.  I did get permission for this.

## References and relevant issues

## Detailed description of the pull request / Additional comments
New ViewModel to handle loading screen messages.

Added code to facilitate inserting secondary messages at the index before any primary messages.

## Validation steps performed

## PR checklist
- [x] Closes #1308 
- [x] Closes #632
- [x] Tests added/passed Yes and yes.
- [ ] Documentation updated N/A

Movie!
![LoggingStyleMessagesButBetter](https://github.com/microsoft/devhome/assets/2517139/d53ef0bd-60d6-4b08-8ac8-d817dd52a9c2)
