### PR TITLE
Setting XY Focus Navigation parameters in Widget Dashboard

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -77,12 +77,15 @@
                             <controls:WidgetControl WidgetSource="{x:Bind}"
                                                     AllowDrop="True" 
                                                     DragOver="WidgetControl_DragOver"
+                                                    XYFocusKeyboardNavigation="Disabled"
                                                     Drop="WidgetControl_Drop" />
                         </DataTemplate>
                     </GridView.ItemTemplate>
                     <GridView.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <controls:WidgetBoard />
+                            <controls:WidgetBoard XYFocusKeyboardNavigation="Enabled"
+                                                  XYFocusRightNavigationStrategy="RectilinearDistance"
+                                                  XYFocusLeftNavigationStrategy="RectilinearDistance"/>
                         </ItemsPanelTemplate>
                     </GridView.ItemsPanel>
                     <GridView.ItemContainerStyle>


### PR DESCRIPTION
## Summary of the pull request
This change adds parameters for XY focus navigation in the dashboard between widgets. With this, the user will be able to navigate between widgets using arrow keys and into the widget using tab.
## References and relevant issues
#1367 
## Detailed description of the pull request / Additional comments
This changes set the `XYFocusKeyboardNavigation` as enabled in the WidgetBoard control, setting the strategy for Left and Arrow navigation strategy to `RectiliniearDistante` to get a more consistent result. WidgetControl has its `XYFocusKeyboardNavigation` disabled to not let the arrow key navigation go into the widget while using it to go from one widget to another.
## Validation steps performed

## PR checklist
- [x] Closes #1367
- [ ] Tests added/passed
- [ ] Documentation updated
