### PR TITLE
Update /logs trigger to not remove Needs-Triage label

### DIFF
--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -99,8 +99,6 @@ configuration:
               If you use Feedback Hub, please paste the URL at the bottom of the report here so we 
               can easily find it. 
       - removeLabel:
-          label: Needs-Triage
-      - removeLabel:
           label: Needs-Team-Response
     #
     # /needinfo


### PR DESCRIPTION
## Summary of the pull request
Asking for logs doesn't necessarily mean we want to remove Needs-Triage.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
