### PR TITLE
Update add repo dialog to make dev drive checkbox checked by default

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
@@ -73,7 +73,7 @@ public class DevDriveManager : IDevDriveManager
     public string DefaultDevDriveLocation => _defaultDevDriveLocation;
 
     /// <inheritdoc/>
-    public IList<IDevDrive> DevDrivesMarkedForCreation => _devDrives.ToList();
+    public IList<IDevDrive> DevDrivesMarkedForCreation => RepositoriesUsingDevDrive > 0 ? _devDrives.ToList() : new List<IDevDrive>();
 
     /// <summary>
     /// Gets a view model that will show information related to a Dev Drive we create

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/EditDevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/EditDevDriveViewModel.cs
@@ -56,7 +56,14 @@ public partial class EditDevDriveViewModel : ObservableObject
         get; set;
     }
 
-    private bool _canShowDevDriveUI;
+    /// <summary>
+    /// Gets a value indicating whether we should show the Dev Drive Checkbox in the UI.
+    /// The Dev Drive checkbox is only shown when a Dev Drive does not already exist on the system.
+    /// </summary>
+    public bool CanShowDevDriveUI
+    {
+        get; private set;
+    }
 
     /// <summary>
     /// Gets a value indicating whether the drive label, location, size or drive letter has changed when the Dev Drive window closes.
@@ -83,6 +90,12 @@ public partial class EditDevDriveViewModel : ObservableObject
     /// </summary>
     [ObservableProperty]
     private bool _isDevDriveCheckboxEnabled;
+
+    /// <summary>
+    /// Boolean to control whether the Dev Drive checkbox is checked or unchecked.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isDevDriveCheckboxChecked;
 
     [ObservableProperty]
     private bool _devDriveValidationError;
@@ -112,7 +125,7 @@ public partial class EditDevDriveViewModel : ObservableObject
 
     public void ShowDevDriveUIIfEnabled()
     {
-        if (_canShowDevDriveUI)
+        if (CanShowDevDriveUI)
         {
             ShowDevDriveInformation = Visibility.Visible;
         }
@@ -211,17 +224,17 @@ public partial class EditDevDriveViewModel : ObservableObject
             {
                 ShowDevDriveInformation = Visibility.Collapsed;
                 DevDrive = existingDevDrives.OrderByDescending(x => x.DriveSizeInBytes).First();
-                _canShowDevDriveUI = false;
+                CanShowDevDriveUI = false;
                 return;
             }
         }
         else
         {
-            _canShowDevDriveUI = false;
+            CanShowDevDriveUI = false;
             return;
         }
 
-        _canShowDevDriveUI = true;
+        CanShowDevDriveUI = true;
     }
 
     public bool IsDevDriveValid()

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Services;
@@ -11,6 +12,7 @@ using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
+using DevHome.SetupFlow.Utilities;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -26,7 +28,40 @@ public partial class RepoConfigViewModel : SetupPageViewModelBase
 
     private readonly IDevDriveManager _devDriveManager;
 
+    /// <summary>
+    /// The minimum available space the user should have on the drive that holds their OS, in gigabytes.
+    /// This value is not in bytes.
+    /// </summary>
+    private const double MinimumAvailableSpaceInGbForDevDriveAutoCheckbox = 200D;
+
+    /// <summary>
+    /// The minimum available space the user should have on the drive that holds their OS, in bytes.
+    /// </summary>
+    private readonly ulong _minimumAvailableSpaceInBytesForDevDriveAutoCheckbox = DevDriveUtil.ConvertToBytes(MinimumAvailableSpaceInGbForDevDriveAutoCheckbox, ByteUnit.GB);
+
+    private bool _shouldAutoCheckDevDriveCheckbox = true;
+
     public ISetupFlowStringResource LocalStringResource { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Dev Drive checkbox should be enabled when the user launches the add repository dialog.
+    /// If the user unchecks the checkbox then we respect their choice for that instance of the setup flow.
+    /// </summary>
+    public bool ShouldAutoCheckDevDriveCheckbox
+    {
+        get
+        {
+            var osDrive = new DriveInfo(Path.GetPathRoot(Environment.SystemDirectory));
+            if (!osDrive.IsReady || _minimumAvailableSpaceInBytesForDevDriveAutoCheckbox > (ulong)osDrive.AvailableFreeSpace)
+            {
+                _shouldAutoCheckDevDriveCheckbox = false;
+            }
+
+            return _shouldAutoCheckDevDriveCheckbox;
+        }
+
+        set => _shouldAutoCheckDevDriveCheckbox = value;
+    }
 
     /// <summary>
     /// All repositories the user wants to clone.

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
@@ -51,9 +51,17 @@ public partial class RepoConfigViewModel : SetupPageViewModelBase
     {
         get
         {
-            var osDrive = new DriveInfo(Path.GetPathRoot(Environment.SystemDirectory));
-            if (!osDrive.IsReady || _minimumAvailableSpaceInBytesForDevDriveAutoCheckbox > (ulong)osDrive.AvailableFreeSpace)
+            try
             {
+                var osDrive = new DriveInfo(Path.GetPathRoot(Environment.SystemDirectory));
+                if (!osDrive.IsReady || _minimumAvailableSpaceInBytesForDevDriveAutoCheckbox > (ulong)osDrive.AvailableFreeSpace)
+                {
+                    _shouldAutoCheckDevDriveCheckbox = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Logger?.ReportInfo(Log.Component.RepoConfig, $"Unable to check if Dev Drive checkbox should be auto checked: {ex.Message}");
                 _shouldAutoCheckDevDriveCheckbox = false;
             }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -155,6 +155,7 @@
                 <CheckBox
                         Click="MakeNewDevDriveCheckBox_Click" 
                         IsEnabled="{x:Bind EditDevDriveViewModel.IsDevDriveCheckboxEnabled}" 
+                        IsChecked="{x:Bind EditDevDriveViewModel.IsDevDriveCheckboxChecked, Mode=TwoWay}" 
                         Grid.Column="0" 
                         Grid.Row="0"
                         x:Uid="ms-resource:///DevHome.SetupFlow/Resources/NewDevDriveComboBox"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -182,7 +182,8 @@ internal partial class AddRepoDialog
                 location = (EditDevDriveViewModel.DevDrive != null) ? EditDevDriveViewModel.GetDriveDisplayName() : string.Empty;
             }
 
-            FolderPickerViewModel.CloneLocation = location;
+            // In cases where location is empty don't update the cloneLocation. Only update when there are actual values.
+            FolderPickerViewModel.CloneLocation = string.IsNullOrEmpty(location) ? FolderPickerViewModel.CloneLocation : location;
         }
 
         FolderPickerViewModel.ValidateCloneLocation();
@@ -314,12 +315,7 @@ internal partial class AddRepoDialog
         var isChecked = (sender as CheckBox).IsChecked;
         if (isChecked.Value)
         {
-            EditDevDriveViewModel.MakeDefaultDevDrive();
-            FolderPickerViewModel.DisableBrowseButton();
-            _oldCloneLocation = FolderPickerViewModel.CloneLocation;
-            FolderPickerViewModel.CloneLocation = EditDevDriveViewModel.GetDriveDisplayName();
-            FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
-            FolderPickerViewModel.InDevDriveScenario = true;
+            UpdateDevDriveInfo();
         }
         else
         {
@@ -404,5 +400,19 @@ internal partial class AddRepoDialog
             AddRepoViewModel.FilterRepositories(FilterTextBox.Text);
             SelectRepositories(AddRepoViewModel.EverythingToClone);
         }
+    }
+
+    /// <summary>
+    /// Update dialog to show Dev Drive information.
+    /// </summary>
+    public void UpdateDevDriveInfo()
+    {
+        EditDevDriveViewModel.MakeDefaultDevDrive();
+        FolderPickerViewModel.DisableBrowseButton();
+        _oldCloneLocation = FolderPickerViewModel.CloneLocation;
+        FolderPickerViewModel.CloneLocation = EditDevDriveViewModel.GetDriveDisplayName();
+        FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
+        FolderPickerViewModel.InDevDriveScenario = true;
+        EditDevDriveViewModel.IsDevDriveCheckboxChecked = true;
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -122,8 +122,6 @@
                                             Text="{x:Bind CloneLocationAlias, Mode=OneWay}" 
                                             IsEnabled="False"
                                             Visibility="{x:Bind CloneToDevDrive, Mode=OneWay}"
-                                            MinWidth="300"
-                                            MaxWidth="300"
                                             Margin="10, 5, 0, 5"/>
                                     <TextBox 
                                             Text="{x:Bind ClonePath}" 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Common.Extensions;
@@ -104,6 +105,11 @@ public sealed partial class RepoConfigView : UserControl
         // Start
         await getPluginsTask;
         await setupDevDrivesTask;
+        if (addRepoDialog.EditDevDriveViewModel.CanShowDevDriveUI && ViewModel.ShouldAutoCheckDevDriveCheckbox)
+        {
+            addRepoDialog.UpdateDevDriveInfo();
+        }
+
         var result = await addRepoDialog.ShowAsync(ContentDialogPlacement.InPlace);
 
         if (senderAsButton != null)
@@ -167,6 +173,13 @@ public sealed partial class RepoConfigView : UserControl
             // 1. Adding repos that haven't been selected, and
             // 2. Removing repos from the pre selected list.
             ViewModel.SaveSetupTaskInformation(everythingToClone);
+
+            // Check if user unchecked the Dev Drive checkbox before closing, to update the the behavior the next time the user launches the dialog. Note we only keep
+            // track of this for the current launch of the setup flow. If the user completes or cancels the setup flow and re enters, we do not keep the unchecked behavior.
+            if (!addRepoDialog.EditDevDriveViewModel.IsDevDriveCheckboxChecked)
+            {
+                ViewModel.ShouldAutoCheckDevDriveCheckbox = false;
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary of the pull request
This PR adds functionality to the Add repo dialog to auto check the Dev Drive checkbox when users launch the dialog. The Checkbox will only be auto checked in the following 4 cases:

1. The user has 200 GB or more of free available space
2. The Dev Drive feature is enabled
3. The user does not currently have a Dev Drive already on their system.
4. The user has not unchecked the checkbox previously when in the current instance of the setup flow
        **a**. Note: If a user cancels out of the setup flow or closes Dev Home and relaunches the setup flow, we will auto check the checkbox again assuming the first 3 requirements above have been met.

Changes:

1. Updated the `DevDrivesMarkedForCreation` property of the `DevDriveManager ` to only send its list of Dev Drives when there are repositories that will be cloned to them.
2. Updated the `EditDevDriveViewModel` class's field `_canShowDevDriveUI` to be a property called `CanShowDevDriveUI`. This will allow us to check the second and the third requirements above.
3.  Added an observable property to the `EditDevDriveViewModel `class that will bind two ways for the `IsChecked `attribute of the Dev Drive checkbox
4. Added a bool property `ShouldAutoCheckDevDriveCheckbox `to the `RepoConfigViewModel`, that will return true by default. False when requirement 1 and 4 above are not met. 
5. Moved the code logic that adds a Dev Drive in the `AddRepoDialog `class to its own method `UpdateDevDriveInfo`.
6. Updated the `CloneLocation_TextChanged `method of the `AddRepoDialog` class to only update the clone location when there is an actual value instead of an empty value.
7. Removed the `MinWidth `and `MaxWidth` in RepoConfigView.xaml for the `CloneLocationAlias `textbox, so it is consistent with the  `CloneLocation `textbox.

Video showing the auto checkbox functionality:

https://github.com/microsoft/devhome/assets/105318831/e6f966df-f93b-4344-bb36-c94d5aae1ee3


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Confirmed we can still clone repositories and create Dev Drives after this change.

## PR checklist
- [ ] Closes #1158
- [ ] Tests added/passed
- [ ] Documentation updated
