### PR TITLE
Fix page headers and margins

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -14,7 +14,7 @@
 
     <ScrollViewer MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{StaticResource ContentPageMargin}">
         <Grid>
-        <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
+            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
             <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                 <Grid>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -79,10 +79,10 @@
             <StackPanel Orientation="Vertical"
                     x:Name="ContentArea" Margin="{StaticResource MediumTopBottomMargin}">
                 <TextBlock Margin="{StaticResource MediumTopBottomMargin}">
-                <Run x:Uid="Settings_Feedback_OpenSource"/>
-                <Hyperlink x:Uid="Settings_Feedback_OpenSource_Link" TextDecorations="None">
-                    <Run x:Uid="Settings_Feedback_OpenSource_LinkText"></Run>
-                </Hyperlink>
+                    <Run x:Uid="Settings_Feedback_OpenSource"/>
+                    <Hyperlink x:Uid="Settings_Feedback_OpenSource_Link" TextDecorations="None">
+                        <Run x:Uid="Settings_Feedback_OpenSource_LinkText" />
+                    </Hyperlink>
                 </TextBlock>
                 <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
                     <labs:SettingsCard x:Uid="Settings_Feedback_ReportBug">

--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -25,10 +25,9 @@
     <Thickness x:Key="NavigationViewContentGridBorderThickness">1,1,0,0</Thickness>
     <CornerRadius x:Key="NavigationViewContentGridCornerRadius">8,0,0,0</CornerRadius>
     <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>
-    <Thickness x:Key="NavigationViewHeaderMargin">56,34,0,0</Thickness>
-    <Thickness x:Key="NavigationViewPageContentMargin">56,24,56,0</Thickness>
+    <Thickness x:Key="NavigationViewHeaderMargin">40,0,0,0</Thickness>
 
-    <Thickness x:Key="ContentPageMargin">40,48,40,0</Thickness>
+    <Thickness x:Key="ContentPageMargin">40,0,40,0</Thickness>
 
     <Thickness x:Key="MenuBarContentMargin">36,24,36,0</Thickness>
 

--- a/src/Views/ShellPage.xaml
+++ b/src/Views/ShellPage.xaml
@@ -76,7 +76,7 @@
                     <Grid>
                         <TextBlock
                             Text="{Binding}"
-                            Style="{ThemeResource TitleTextBlockStyle}" />
+                            Style="{ThemeResource SubtitleTextBlockStyle}" />
                     </Grid>
                 </DataTemplate>
             </NavigationView.HeaderTemplate>
@@ -88,7 +88,7 @@
                             <Grid>
                                 <TextBlock
                                     Text="{Binding}"
-                                    Style="{ThemeResource TitleTextBlockStyle}" />
+                                    Style="{ThemeResource SubtitleTextBlockStyle}" />
                             </Grid>
                         </DataTemplate>
                     </behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
@@ -110,9 +110,10 @@
                     Message="{x:Bind ViewModel.ShellInfoBarModel.Description, Mode=TwoWay}" 
                     IsOpen="{x:Bind ViewModel.ShellInfoBarModel.IsOpen, Mode=TwoWay}" 
                     MaxWidth="{ThemeResource MaxPageContentWidth}" />
-                <Grid Grid.Row="1">
-                    <Frame x:Name="NavigationFrame" />
-                </Grid>
+                <Frame
+                    Grid.Row="1"
+                    x:Name="NavigationFrame"
+                    CornerRadius="{ThemeResource OverlayCornerRadius}" />
             </Grid>
         </NavigationView>
     </Grid>

--- a/src/Views/ShellPage.xaml.cs
+++ b/src/Views/ShellPage.xaml.cs
@@ -77,7 +77,7 @@ public sealed partial class ShellPage : Page
         ShellInfoBar.Margin = new Thickness()
         {
             Left = ShellInfoBar.Margin.Left,
-            Top = sender.DisplayMode == NavigationViewDisplayMode.Minimal ? 50 : 5,
+            Top = sender.DisplayMode == NavigationViewDisplayMode.Minimal ? 50 : 0,
             Right = ShellInfoBar.Margin.Right,
             Bottom = ShellInfoBar.Margin.Bottom,
         };

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -33,7 +33,7 @@
 
     <ScrollViewer HorizontalScrollMode="Disabled" VerticalScrollMode="Auto" MaxWidth="{ThemeResource MaxPageBackgroundWidth}">
         <RelativePanel>
-            <Grid CornerRadius="8">
+            <Grid>
                 <Image Source="{ThemeResource Background}" MinWidth="{ThemeResource MaxPageBackgroundWidth}" VerticalAlignment="Top" HorizontalAlignment="Center" Stretch="UniformToFill" />
             </Grid>
             <Grid x:Name="ContentArea" Padding="35 0 35 30" HorizontalAlignment="Center">

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -41,7 +41,7 @@
 
         <!-- Header - Title and Add Widget button -->
         <Grid Grid.Row="0" Margin="0,0,0,22">
-            <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource TitleTextBlockStyle}" HorizontalAlignment="Left"/>
+            <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right">
                     <i:Interaction.Behaviors>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -26,12 +26,12 @@
         <!-- Title -->
         <StackPanel Grid.Row="0">
             <TextBlock
-                Style="{ThemeResource TitleTextBlockStyle}"
+                Style="{ThemeResource SubtitleTextBlockStyle}"
                 TextWrapping="WrapWholeWords"
                 Visibility="{x:Bind UseOrchestratorTitle, Mode=OneWay}"
                 Text="{x:Bind Orchestrator.FlowTitle}" />
             <TextBlock
-                Style="{ThemeResource TitleTextBlockStyle}"
+                Style="{ThemeResource SubtitleTextBlockStyle}"
                 TextWrapping="WrapWholeWords"
                 Visibility="{x:Bind Title, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}"
                 Text="{x:Bind Title, Mode=OneWay}" />


### PR DESCRIPTION
## Summary of the pull request
- Page titles should be 20 pt text (SubtitleTextBlockStyle) rather than 28 pt text (TitleTextBlockStyle)
   - #567
- **FeedbackPage.xaml**: Fix code indentation
- **Thickness.xaml**: 
  - Remove `NavigationViewPageContentMargin`. It was not used in Dev Home or WinUI 3 code.
  - Adjust `NavigationViewHeaderMargin` so that if a default header were used (we don't use any currently) it would be displayed in the same location our custom headers are displayed.
  - Adjust `ContentPageMargin` so the page content is higher up
    - In design specs / #869
- **ShellPage.xaml**: Remove unnecessary extra Grid. Round corner here, instead of in WhatsNewPage.xaml, as suggested in https://github.com/microsoft/devhome/pull/1258#discussion_r1253655793
- **ShellPage.xaml.cs**: Change ShellInfoBar to display with 0 height. It is not currently used anywhere, but the 5 px height was pushing down the content of every page. If the service is used in the future, this sizing can be tweaked.
- **WhatsNewPage.xaml**: Remove rounded corner in favor of above. Rest of change is whitespace, LF newlines got converted to CRLF (these should all be changed eventually)

Old look:
![image](https://github.com/microsoft/devhome/assets/47155823/4d00f912-cd4b-4411-8f32-1d227631851a)

New look:
![image](https://github.com/microsoft/devhome/assets/47155823/f8879ecf-6d43-4572-8880-29756a1d76e6)

## Validation steps performed
Tested locally.

## PR checklist
- [x] Closes #567
- [x] Closes #869
- [ ] Tests added/passed
- [ ] Documentation updated
