### PR TITLE
Fix Breadcrumb colors on theme change

### DIFF
--- a/src/Styles/BreadcrumbBar.xaml
+++ b/src/Styles/BreadcrumbBar.xaml
@@ -14,6 +14,6 @@
     <FontWeight x:Key="BreadcrumbBarItemFontWeight">SemiBold</FontWeight>
 
     <!-- Applies to all items but the last (current) item -->
-    <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+    <ThemeResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
 
 </ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request
When a user changes the theme settings in Dev Home, the "Settings" part of the Breadcrumb control does not update. This change uses `ThemeResource` rather than `StaticResource` for the font color so that it updates appropriately.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Locally validated.

## PR checklist
- [x] Closes #1407
- [ ] Tests added/passed
- [ ] Documentation updated
