### PR TITLE
SDK changes to add ShowLogonSession

### DIFF
--- a/pluginsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/pluginsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
   </ItemGroup>
     
   <ItemGroup>

--- a/pluginsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/pluginsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -102,6 +102,8 @@ namespace Microsoft.Windows.DevHome.SDK
 
         IPluginAdaptiveCardController GetAdaptiveCardController(String[] args);
 
+        Windows.Foundation.IAsyncOperation<IDeveloperId> ShowLogonSession(Microsoft.UI.WindowId windowHandle);
+
         // The below events (LoggedIn, LoggedOut and Updated) are legacy events.
         event Windows.Foundation.EventHandler<IDeveloperId> LoggedIn;
 
@@ -111,7 +113,7 @@ namespace Microsoft.Windows.DevHome.SDK
 
         event Windows.Foundation.TypedEventHandler<IDeveloperIdProvider, Object> Changed;
 
-        AuthenticationState developerIDState; 
+        AuthenticationState DeveloperIdState; 
     };
 
     [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]

--- a/pluginsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
+++ b/pluginsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -164,6 +166,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.targets')" />
+    <Import Project="..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -171,5 +175,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.1\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.WindowsAppSDK.1.3.230724000\build\native\Microsoft.WindowsAppSDK.targets'))" />
   </Target>
 </Project>

--- a/pluginsdk/Microsoft.Windows.DevHome.SDK/packages.config
+++ b/pluginsdk/Microsoft.Windows.DevHome.SDK/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.220531.1" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.1" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.3.230724000" targetFramework="native" />
 </packages>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -17,7 +17,9 @@ using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.ApplicationModel.Resources;
+using Microsoft.Windows.DevHome.SDK;
 using Windows.Storage;
+using WinUIEx;
 
 namespace DevHome.Settings.Views;
 
@@ -60,24 +62,7 @@ public sealed partial class AccountsPage : Page
         var numProviders = ViewModel.AccountsProviders.Count;
         if (numProviders == 1)
         {
-            if (ViewModel.AccountsProviders[0].DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
-            {
-                await ShowLoginUIAsync("Settings", this, ViewModel.AccountsProviders[0]);
-            }
-            else if (ViewModel.AccountsProviders[0].DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
-            {
-                IntPtr windowHandle = IntPtr.Zero;
-                foreach (Process activeProcess in Process.GetProcesses())
-                {
-                    if (activeProcess.MainWindowTitle.Contains("Dev Home"))
-                    {
-                        windowHandle = activeProcess.MainWindowHandle;
-                    }
-                }
-
-                WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
-                await ViewModel.AccountsProviders[0].DeveloperIdProvider.ShowLogonSession(windowPtr);
-            }
+            await InitiateAddAccountUserExperienceAsync(this, ViewModel.AccountsProviders[0]);
         }
         else if (numProviders > 1)
         {
@@ -103,24 +88,7 @@ public sealed partial class AccountsPage : Page
         {
             if (addAccountButton.Tag is AccountsProviderViewModel accountProvider)
             {
-                if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
-                {
-                    await ShowLoginUIAsync("Settings", this, accountProvider);
-                }
-                else if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
-                {
-                    IntPtr windowHandle = IntPtr.Zero;
-                    foreach (Process activeProcess in Process.GetProcesses())
-                    {
-                        if (activeProcess.MainWindowTitle.Contains("Dev Home"))
-                        {
-                            windowHandle = activeProcess.MainWindowHandle;
-                        }
-                    }
-
-                    WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
-                    await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
-                }
+                await InitiateAddAccountUserExperienceAsync(this, accountProvider);
             }
             else
             {
@@ -235,6 +203,20 @@ public sealed partial class AccountsPage : Page
                 RequestedTheme = ActualTheme,
             };
             _ = await afterLogoutContentDialog.ShowAsync();
+        }
+    }
+
+    private async Task InitiateAddAccountUserExperienceAsync(Page parentPage, AccountsProviderViewModel accountProvider)
+    {
+        if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
+        {
+            await ShowLoginUIAsync("Settings", parentPage, accountProvider);
+        }
+        else if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
+        {
+            IntPtr windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
+            WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
+            await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
         }
     }
 }

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common.Extensions;
@@ -12,6 +13,7 @@ using DevHome.Common.Views;
 using DevHome.Logging;
 using DevHome.Settings.Models;
 using DevHome.Settings.ViewModels;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.ApplicationModel.Resources;
@@ -58,7 +60,24 @@ public sealed partial class AccountsPage : Page
         var numProviders = ViewModel.AccountsProviders.Count;
         if (numProviders == 1)
         {
-            await ShowLoginUIAsync("Settings", this, ViewModel.AccountsProviders[0]);
+            if (ViewModel.AccountsProviders[0].DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
+            {
+                await ShowLoginUIAsync("Settings", this, ViewModel.AccountsProviders[0]);
+            }
+            else if (ViewModel.AccountsProviders[0].DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
+            {
+                IntPtr windowHandle = IntPtr.Zero;
+                foreach (Process activeProcess in Process.GetProcesses())
+                {
+                    if (activeProcess.MainWindowTitle.Contains("Dev Home"))
+                    {
+                        windowHandle = activeProcess.MainWindowHandle;
+                    }
+                }
+
+                WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
+                await ViewModel.AccountsProviders[0].DeveloperIdProvider.ShowLogonSession(windowPtr);
+            }
         }
         else if (numProviders > 1)
         {
@@ -84,7 +103,24 @@ public sealed partial class AccountsPage : Page
         {
             if (addAccountButton.Tag is AccountsProviderViewModel accountProvider)
             {
-                await ShowLoginUIAsync("Settings", this, accountProvider);
+                if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
+                {
+                    await ShowLoginUIAsync("Settings", this, accountProvider);
+                }
+                else if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
+                {
+                    IntPtr windowHandle = IntPtr.Zero;
+                    foreach (Process activeProcess in Process.GetProcesses())
+                    {
+                        if (activeProcess.MainWindowTitle.Contains("Dev Home"))
+                        {
+                            windowHandle = activeProcess.MainWindowHandle;
+                        }
+                    }
+
+                    WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
+                    await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary of the pull request
This pull request does the following: 
- introduces a new IDeveloperIdProvider interface named ShowLogonSession
- nit: formats developerIDState to DeveloperIdState according to recommended guidelines
- uses ShowLogonSession in the connect developer account user flow

## References and relevant issues

## Detailed description of the pull request / Additional comments
The purpose of the new interface is to provide plugins the flexibility of driving a custom user experience if desired. In conjunction with the AuthenticationExperienceKind enums defined, this method may be called instead of using the AdaptiveCard for user interaction. 


## Validation steps performed
Local Build
Manual testing with devhomegithubextension

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
