### PR TITLE
Update page tab navigation focus in setup flow main page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -76,6 +76,7 @@
             <!-- Allow customizing the header (e.g. add buttons, etc... ) -->
             <ContentControl
                 Grid.Column="1"
+                IsTabStop="False"
                 HorizontalAlignment="Right"
                 Template="{x:Bind HeaderTemplate, Mode=OneWay}" />
         </Grid>
@@ -88,6 +89,7 @@
             Text="{x:Bind Description, Mode=OneWay}" />
         <!-- Content -->
         <ContentControl Grid.Row="3" Grid.ColumnSpan="2"
+                        IsTabStop="False"
                         HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Stretch"
                         Content="{x:Bind SetupShellContent, Mode=OneWay}" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -32,6 +32,7 @@
             Grid.Row="0"
             HorizontalContentAlignment="Stretch"
             VerticalContentAlignment="Stretch"
+            IsTabStop="False"
             Content="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel, Mode=OneWay}">
             <ContentControl.ContentTemplateSelector>
                 <selectors:SetupFlowViewSelector>


### PR DESCRIPTION
## Summary of the pull request
-  Exclude content controls from tab navigation to eliminate ghost control focus.

## References and relevant issues
- https://task.ms/45055781

## Detailed description of the pull request / Additional comments

## Validation steps performed
### Before
Three ghost keyboard tabs
<img src="https://github.com/microsoft/devhome/assets/104940545/94a18436-90b5-4d19-9bd8-5f9cd5bf1429" Width="500" />

### After
Tab navigation directly jumps from the navigation bar to the banner control
<img src="https://github.com/microsoft/devhome/assets/104940545/064f1c36-5115-4b54-9c17-82d181311cd3" Width="500" />

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
