### PR TITLE
Update dev drive enablement query

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using CommunityToolkit.Common;
+using DevHome.SetupFlow.Common.Helpers;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Shell;
@@ -72,10 +73,10 @@ public static class DevDriveUtil
     }
 
     // Not available in CsWin32, so we need to add this ourselves.
-    [DllImport("api-ms-win-core-sysinfo-l1-2-7.dll")]
+    [DllImport("api-ms-win-core-sysinfo-l1-2-6.dll")]
     private static extern DEVELOPER_DRIVE_ENABLEMENT_STATE GetDeveloperDriveEnablementState();
 
-    private static readonly BOOL IsDevDriveFeaturePresent = PInvoke.IsApiSetImplemented("api-ms-win-core-sysinfo-l1-2-7");
+    private static readonly BOOL IsDevDriveFeaturePresent = PInvoke.IsApiSetImplemented("api-ms-win-core-sysinfo-l1-2-6");
 
     /// <summary>
     /// Gets a value indicating whether the system has the ability to create Dev Drives
@@ -88,12 +89,20 @@ public static class DevDriveUtil
     {
         get
         {
-            if (!IsDevDriveFeaturePresent)
+            try
             {
+                if (!IsDevDriveFeaturePresent)
+                {
+                    return false;
+                }
+
+                return GetDeveloperDriveEnablementState() == DEVELOPER_DRIVE_ENABLEMENT_STATE.DeveloperDriveEnabled;
+            }
+            catch (Exception ex)
+            {
+                Log.Logger?.ReportError($"Unable to query for Dev Drive enablement: {ex.Message}");
                 return false;
             }
-
-            return GetDeveloperDriveEnablementState() == DEVELOPER_DRIVE_ENABLEMENT_STATE.DeveloperDriveEnabled;
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
Currently the Dev Drive enablement api is present in the Dev Channel in the api set api-ms-win-core-sysinfo-l1-2-7. However due to the way apisets are updated (See bug [here ](https://microsoft.visualstudio.com/OS/_workitems/edit/46081237) for more info). We need this to be version 6 so it can be used in the beta branches and for release. Today in these other channels, we always return false (meaning we don't show the dev drive ui) due to that apiset not existing on them.

Changes:

1. Updated dll from api-ms-win-core-sysinfo-l1-2-**7** to api-ms-win-core-sysinfo-l1-2-**6**
2. Added a try/catch for instances where an EntryPointNotFoundException may occur.
3. I've confirmed that the change works in the beta channel, dev channel and the canary channel.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1430
- [ ] Tests added/passed
- [ ] Documentation updated
