### PR TITLE
Register DashboardViewModel as a service

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -101,6 +101,9 @@ public partial class App : Application, IApp
 
             // Setup flow
             services.AddSetupFlow(context);
+
+            // Dashboard
+            services.AddDashboard(context);
         }).
         Build();
 

--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using DevHome.Dashboard.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DevHome.Settings.Extensions;
+public static class ServiceExtensions
+{
+    public static IServiceCollection AddDashboard(this IServiceCollection services, HostBuilderContext context)
+    {
+        // View-models
+        services.AddSingleton<DashboardViewModel>();
+
+        return services;
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -47,4 +47,16 @@ public partial class DashboardViewModel : ObservableObject
 
         return show;
     }
+
+#if DEBUG
+    public void ResetDashboardBanner()
+    {
+        ShowDashboardBanner = true;
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        if (roamingProperties.ContainsKey(_hideDashboardBannerKey))
+        {
+            roamingProperties.Remove(_hideDashboardBannerKey);
+        }
+    }
+#endif
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -628,7 +628,7 @@ public partial class DashboardView : ToolPage
             roamingProperties.Remove("HideDashboardBanner");
         }
 
-        ViewModel.ShowDashboardBanner = true;
+        ViewModel.ResetDashboardBanner();
     }
 #endif
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common;
+using DevHome.Common.Extensions;
 using DevHome.Common.Renderers;
 using DevHome.Dashboard.Controls;
 using DevHome.Dashboard.Helpers;
@@ -47,7 +48,7 @@ public partial class DashboardView : ToolPage
 
     public DashboardView()
     {
-        ViewModel = new DashboardViewModel();
+        ViewModel = Application.Current.GetService<DashboardViewModel>();
         _widgetServiceHelper = new WidgetServiceHelper();
         this.InitializeComponent();
 


### PR DESCRIPTION
## Summary of the pull request
Rather than new-ing up a new DashboardViewModel each time we navigate to the Dashboard, register it as a singleton service so that the same instance is used each time, and we follow proper dependency injection principles.

It might be better to change this to transient in the future, but for now while Dashboard already has lifetime issues, let's keep it at one singleton.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
