### PR TITLE
Allow keyboard navigation in app install packages

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupFlowNavigation.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupFlowNavigation.xaml
@@ -16,11 +16,11 @@
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="auto"/>
         </Grid.ColumnDefinitions>
-        <ContentControl Content="{x:Bind ContentTemplate, Mode=OneWay}" />
+        <ContentControl IsTabStop="False" Content="{x:Bind ContentTemplate, Mode=OneWay}" />
         <StackPanel Grid.Column="1" Orientation="Horizontal" >
-            <ContentControl Visibility="{x:Bind CancelVisibility, Mode=OneWay}" Content="{x:Bind CancelTemplate, Mode=OneWay}" />
-            <ContentControl Visibility="{x:Bind PreviousVisibility, Mode=OneWay}" Content="{x:Bind PreviousTemplate, Mode=OneWay}" />
-            <ContentControl Visibility="{x:Bind NextVisibility, Mode=OneWay}" Content="{x:Bind NextTemplate, Mode=OneWay}" />
+            <ContentControl IsTabStop="False" Visibility="{x:Bind CancelVisibility, Mode=OneWay}" Content="{x:Bind CancelTemplate, Mode=OneWay}" />
+            <ContentControl IsTabStop="False" Visibility="{x:Bind PreviousVisibility, Mode=OneWay}" Content="{x:Bind PreviousTemplate, Mode=OneWay}" />
+            <ContentControl IsTabStop="False" Visibility="{x:Bind NextVisibility, Mode=OneWay}" Content="{x:Bind NextTemplate, Mode=OneWay}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
@@ -59,6 +59,7 @@
                 <!-- Main content -->
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                     <ContentControl
+                        IsTabStop="False"
                         Margin="0 0 10 0"
                         HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Stretch"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -40,6 +40,11 @@
             Background="Transparent"
             SelectionChanged="PackagesFlipView_SelectionChanged"
             ItemsSource="{x:Bind PackageGroups, Mode=OneWay}">
+            <FlipView.ItemContainerStyle>
+                <Style TargetType="FlipViewItem">
+                    <Setter Property="IsTabStop" Value="False" />
+                </Style>
+            </FlipView.ItemContainerStyle>
             <FlipView.ItemTemplate>
                 <DataTemplate>
                     <!-- Grid added here to help update the FlipView

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
@@ -31,7 +31,7 @@
     </UserControl.Resources>
 
     <!-- Package card -->
-    <ContentControl>
+    <ContentControl IsTabStop="False">
         <ContentControl.Template>
             <ControlTemplate>
                 <Grid Style="{ThemeResource CardGridSecondaryStyle}" Padding="12" RowSpacing="12">
@@ -93,6 +93,7 @@
                             BorderThickness="0"
                             Command="{Binding ToggleSelectionCommand}"
                             HorizontalAlignment="Right"
+                            Margin="0,0,2,0"
                             Padding="5">
                             <FontIcon
                                 Glyph="{Binding IsSelected, Converter={StaticResource SelectButtonGlyphConverter}}"
@@ -128,6 +129,7 @@
 
                         <!-- Package link / "Installed" -->
                         <ContentControl
+                            IsTabStop="False"
                             Grid.Row="2"
                             Content="{Binding IsInstalled, Converter={StaticResource LearnMoreInstalledConverter}}" />
                     </Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
@@ -86,6 +86,9 @@
                         <ImageIcon Name="Image" Width="24" VerticalAlignment="Center" Source="{Binding Icon}"/>
 
                         <!-- Select button -->
+                        <!-- Adding a margin prevents FlipView's (overlay) next
+                             button from shadowing this button, and enables keyboard
+                             navigation -->
                         <Button
                             Grid.Column="1"
                             IsEnabled="{Binding IsInstalled, Converter={StaticResource BoolNegationConverter}}"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -81,6 +81,7 @@
                                 </NavigationView.MenuItemTemplate>
                                 <Frame MinHeight="100" Padding="12" HorizontalAlignment="Stretch">
                                     <ContentControl Content="{x:Bind ViewModel.SelectedReviewTab, Mode=OneWay}"
+                                                    IsTabStop="False"
                                                     HorizontalContentAlignment="Stretch"
                                                     VerticalContentAlignment="Stretch" >
                                         <ContentControl.ContentTemplateSelector>


### PR DESCRIPTION
## Summary of the pull request
- Remove tab stop from `FlipViewItem` which was causing keyboard navigation to move entire `FlipView` pages at a time.
- Remove tab stop from ghost elements
- Added a small right margin to the select button to prevent the `FlipView`'s next button from shadowing it in the bottom-rightmost package. This allows keyboard navigation to detect the select button for the last item.

## References and relevant issues
- https://task.ms/45060934

## Detailed description of the pull request / Additional comments

## Validation steps performed
<img src="https://github.com/microsoft/devhome/assets/104940545/a16a5570-bc8d-40da-b570-d911b07d8fae" Width="700" />


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
