### PR TITLE
Give Settings pages "sticky" headers

### DIFF
--- a/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
@@ -20,7 +20,7 @@ public partial class AboutViewModel : ObservableObject
 
     private static string GetVersionDescription()
     {
-        IAppInfoService appInfoService = Application.Current.GetService<IAppInfoService>();
+        var appInfoService = Application.Current.GetService<IAppInfoService>();
         var version = appInfoService.GetAppVersion();
 
         return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";

--- a/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
@@ -7,10 +7,10 @@ using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Logging;
 using DevHome.Settings.Models;
-using DevHome.Telemetry;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.Settings.ViewModels;
+
 public partial class AccountsProviderViewModel : ObservableObject
 {
     public IDeveloperIdProvider DeveloperIdProvider { get; }

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -9,17 +9,21 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <ScrollViewer
+    <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}"
-        VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="{StaticResource XSmallTopMargin}">
-            <BreadcrumbBar
-                x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-                ItemClicked="BreadcrumbBar_ItemClicked"
-                ItemsSource="{x:Bind Breadcrumbs}" />
+        Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
             <labs:SettingsExpander x:Uid="Settings_About_Card" IsExpanded="True">
                 <labs:SettingsExpander.HeaderIcon>
                     <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/DevHome.ico" />
@@ -40,6 +44,6 @@
                     </labs:SettingsCard>
                 </labs:SettingsExpander.Items>
             </labs:SettingsExpander>
-        </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:helpers="using:DevHome.Common.Helpers"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -32,12 +32,17 @@
         </DataTemplate>
     </Page.Resources>
 
-    <ScrollViewer MaxWidth="{ThemeResource MaxPageContentWidth}"
-                  Margin="{ThemeResource ContentPageMargin}"
-                  VerticalScrollBarVisibility="Auto">
+    <ScrollViewer
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{ThemeResource ContentPageMargin}"
+        VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="AccountsContentArea">
-            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
-
+            <BreadcrumbBar
+                x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+                ItemClicked="BreadcrumbBar_ItemClicked"
+                ItemsSource="{x:Bind Breadcrumbs}" />
+            
             <StackPanel x:Name="AddAccountMainStackPanel" Margin="{StaticResource XSmallTopMargin}">
                 <labs:SettingsCard x:Uid="Settings_Accounts_AddAccount">
                     <labs:SettingsCard.HeaderIcon>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -32,18 +32,22 @@
         </DataTemplate>
     </Page.Resources>
 
-    <ScrollViewer
+    <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}"
-        VerticalScrollBarVisibility="Auto">
-        <StackPanel x:Name="AccountsContentArea">
-            <BreadcrumbBar
-                x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-                ItemClicked="BreadcrumbBar_ItemClicked"
-                ItemsSource="{x:Bind Breadcrumbs}" />
-            
-            <StackPanel x:Name="AddAccountMainStackPanel" Margin="{StaticResource XSmallTopMargin}">
+        Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+            <StackPanel>
                 <labs:SettingsCard x:Uid="Settings_Accounts_AddAccount">
                     <labs:SettingsCard.HeaderIcon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8fa;"/>
@@ -66,14 +70,12 @@
                         </Button.Resources>
                     </Button>
                 </labs:SettingsCard>
-            </StackPanel>
                 
-            <StackPanel>
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.AccountsProviders}"
                                ItemTemplate="{StaticResource AccountsProviderViewTemplate}"
                                HorizontalAlignment="Stretch" VerticalAlignment="Center">
                 </ItemsRepeater>
             </StackPanel>
-        </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -32,7 +32,9 @@
         </DataTemplate>
     </Page.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <ScrollViewer MaxWidth="{ThemeResource MaxPageContentWidth}"
+                  Margin="{ThemeResource ContentPageMargin}"
+                  VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="AccountsContentArea">
             <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
 

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -130,7 +130,7 @@ public sealed partial class AccountsPage : Page
 
     private async Task ConfigureLoginUIRenderer(AdaptiveCardRenderer renderer)
     {
-        Microsoft.UI.Dispatching.DispatcherQueue dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        var dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
         // Add custom Adaptive Card renderer for LoginUI as done for Widgets.
         renderer.ElementRenderers.Set(LabelGroup.CustomTypeString, new LabelGroupRenderer());

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -13,17 +13,21 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <ScrollViewer
+    <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}"
-        VerticalScrollBarVisibility="Auto">
-        <StackPanel x:Name="ContentArea">
-            <BreadcrumbBar
-                x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-                ItemClicked="BreadcrumbBar_ItemClicked"
-                ItemsSource="{x:Bind Breadcrumbs}" />
-            
+        Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:ExtensionViewModel">
@@ -36,6 +40,6 @@
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>
-        </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -13,7 +13,10 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <ScrollViewer
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{ThemeResource ContentPageMargin}"
+        VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="ContentArea">
             <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
 

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -18,8 +18,12 @@
         Margin="{ThemeResource ContentPageMargin}"
         VerticalScrollBarVisibility="Auto">
         <StackPanel x:Name="ContentArea">
-            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
-
+            <BreadcrumbBar
+                x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+                ItemClicked="BreadcrumbBar_ItemClicked"
+                ItemsSource="{x:Bind Breadcrumbs}" />
+            
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:ExtensionViewModel">

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -12,7 +12,10 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <ScrollViewer MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{StaticResource ContentPageMargin}">
+    <ScrollViewer
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{StaticResource ContentPageMargin}"
+        VerticalScrollBarVisibility="Auto">
         <Grid>
             <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
             <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -17,7 +17,12 @@
         Margin="{StaticResource ContentPageMargin}"
         VerticalScrollBarVisibility="Auto">
         <Grid>
-            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
+            <BreadcrumbBar
+                x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+                ItemClicked="BreadcrumbBar_ItemClicked"
+                ItemsSource="{x:Bind Breadcrumbs}" />
+            
             <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                 <Grid>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -12,81 +12,84 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <ScrollViewer
+    <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{StaticResource ContentPageMargin}"
-        VerticalScrollBarVisibility="Auto">
-        <Grid>
-            <BreadcrumbBar
-                x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-                ItemClicked="BreadcrumbBar_ItemClicked"
-                ItemsSource="{x:Bind Breadcrumbs}" />
-            
-            <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
-                <Grid>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
-                            <TextBox x:Name="ReportBugIssueTitle" x:Uid="Settings_Feedback_ReportBug_IssueTitle" AcceptsReturn="True"/>
-                            <TextBox x:Name="ReportBugReproSteps" x:Uid="Settings_Feedback_ReportBug_ReproSteps" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
-                            <TextBox x:Name="ReportBugExpectedBehavior" x:Uid="Settings_Feedback_ReportBug_ExpectedBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
-                            <TextBox x:Name="ReportBugActualBehavior" x:Uid="Settings_Feedback_ReportBug_ActualBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
-                            <Expander x:Name="ReportBugSysInfoExpander" Expanding="ShowSysInfoExpander_Expanding" Margin="{StaticResource SmallTopMargin}" Width="{StaticResource FeedbackExpanderWidth}">
-                                <Expander.Header>
-                                    <CheckBox x:Name="ReportBugIncludeSystemInfo" x:Uid="Settings_Feedback_ReportBug_IncludeSystemInfo" IsChecked="True"/>
-                                </Expander.Header>
-                                <Expander.Content>
-                                    <StackPanel>
-                                        <TextBlock x:Name="CpuID"/>
-                                        <TextBlock x:Name="PhysicalMemory"/>
-                                        <TextBlock x:Name="ProcessorArchitecture"/>
-                                    </StackPanel>
-                                </Expander.Content>
-                            </Expander>
-                            <Expander x:Name="ReportBugPluginsExpander" Expanding="ShowPluginsInfoExpander_Expanding" Width="{StaticResource FeedbackExpanderWidth}">
-                                <Expander.Header>
-                                    <CheckBox x:Name="ReportBugIncludePlugins" x:Uid="Settings_Feedback_ReportBug_IncludePlugins" IsChecked="True"/>
-                                </Expander.Header>
-                                <Expander.Content>
-                                    <StackPanel>
-                                        <TextBlock x:Name="ReportBugIncludePluginsList" />
-                                    </StackPanel>
-                                </Expander.Content>
-                            </Expander>
-                            <Expander x:Name="ReportBugExperimentInfoExpander" Width="{StaticResource FeedbackExpanderWidth}">
-                                <Expander.Header>
-                                    <CheckBox x:Name="ReportBugIncludeExperimentInfo" x:Uid="Settings_Feedback_ReportBug_IncludeExperimentInfo" IsChecked="True"/>
-                                </Expander.Header>
-                            </Expander>
-                        </StackPanel>
-                    </ScrollViewer>
-                </Grid>
-            </ContentDialog>
-            <ContentDialog x:Name="LocalizationIssueDialog" x:Uid="Settings_Feedback_LocalizationIssue_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
-                <Grid>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
-                        <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
-                            <TextBox x:Name="LocalizationIssueTitle" x:Uid="Settings_Feedback_LocalizationIssue_IssueTitle" AcceptsReturn="True"/>
-                            <TextBox x:Name="LocalizationIssueLanguageAffected" x:Uid="Settings_Feedback_LocalizationIssue_LanguageAffected" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
-                        </StackPanel>
-                    </ScrollViewer>
-                </Grid>
-            </ContentDialog>
-            <ContentDialog x:Name="suggestFeatureDialog" x:Uid="Settings_Feedback_SuggestFeature_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
-                <Grid>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
-                        <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
-                            <TextBox x:Name="SuggestFeatureTitle" x:Uid="Settings_Feedback_SuggestFeature_IssueTitle" AcceptsReturn="True"/>
-                            <TextBox x:Name="SuggestFeatureDescription" x:Uid="Settings_Feedback_SuggestFeature_Description" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
-                            <TextBox x:Name="SuggestFeatureScenario" x:Uid="Settings_Feedback_SuggestFeature_Scenario" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
-                            <TextBox x:Name="SuggestFeatureSupportingInfo" x:Uid="Settings_Feedback_SuggestFeature_SupportingInfo" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
-                        </StackPanel>
-                    </ScrollViewer>
-                </Grid>
-            </ContentDialog>
-            <StackPanel Orientation="Vertical"
-                    x:Name="ContentArea" Margin="{StaticResource MediumTopBottomMargin}">
-                <TextBlock Margin="{StaticResource MediumTopBottomMargin}">
+        Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+            <StackPanel>
+                <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
+                    <Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
+                                <TextBox x:Name="ReportBugIssueTitle" x:Uid="Settings_Feedback_ReportBug_IssueTitle" AcceptsReturn="True"/>
+                                <TextBox x:Name="ReportBugReproSteps" x:Uid="Settings_Feedback_ReportBug_ReproSteps" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
+                                <TextBox x:Name="ReportBugExpectedBehavior" x:Uid="Settings_Feedback_ReportBug_ExpectedBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
+                                <TextBox x:Name="ReportBugActualBehavior" x:Uid="Settings_Feedback_ReportBug_ActualBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
+                                <Expander x:Name="ReportBugSysInfoExpander" Expanding="ShowSysInfoExpander_Expanding" Margin="{StaticResource SmallTopMargin}" Width="{StaticResource FeedbackExpanderWidth}">
+                                    <Expander.Header>
+                                        <CheckBox x:Name="ReportBugIncludeSystemInfo" x:Uid="Settings_Feedback_ReportBug_IncludeSystemInfo" IsChecked="True"/>
+                                    </Expander.Header>
+                                    <Expander.Content>
+                                        <StackPanel>
+                                            <TextBlock x:Name="CpuID"/>
+                                            <TextBlock x:Name="PhysicalMemory"/>
+                                            <TextBlock x:Name="ProcessorArchitecture"/>
+                                        </StackPanel>
+                                    </Expander.Content>
+                                </Expander>
+                                <Expander x:Name="ReportBugPluginsExpander" Expanding="ShowPluginsInfoExpander_Expanding" Width="{StaticResource FeedbackExpanderWidth}">
+                                    <Expander.Header>
+                                        <CheckBox x:Name="ReportBugIncludePlugins" x:Uid="Settings_Feedback_ReportBug_IncludePlugins" IsChecked="True"/>
+                                    </Expander.Header>
+                                    <Expander.Content>
+                                        <StackPanel>
+                                            <TextBlock x:Name="ReportBugIncludePluginsList" />
+                                        </StackPanel>
+                                    </Expander.Content>
+                                </Expander>
+                                <Expander x:Name="ReportBugExperimentInfoExpander" Width="{StaticResource FeedbackExpanderWidth}">
+                                    <Expander.Header>
+                                        <CheckBox x:Name="ReportBugIncludeExperimentInfo" x:Uid="Settings_Feedback_ReportBug_IncludeExperimentInfo" IsChecked="True"/>
+                                    </Expander.Header>
+                                </Expander>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </ContentDialog>
+                <ContentDialog x:Name="LocalizationIssueDialog" x:Uid="Settings_Feedback_LocalizationIssue_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
+                    <Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
+                            <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
+                                <TextBox x:Name="LocalizationIssueTitle" x:Uid="Settings_Feedback_LocalizationIssue_IssueTitle" AcceptsReturn="True"/>
+                                <TextBox x:Name="LocalizationIssueLanguageAffected" x:Uid="Settings_Feedback_LocalizationIssue_LanguageAffected" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </ContentDialog>
+                <ContentDialog x:Name="suggestFeatureDialog" x:Uid="Settings_Feedback_SuggestFeature_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
+                    <Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
+                            <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
+                                <TextBox x:Name="SuggestFeatureTitle" x:Uid="Settings_Feedback_SuggestFeature_IssueTitle" AcceptsReturn="True"/>
+                                <TextBox x:Name="SuggestFeatureDescription" x:Uid="Settings_Feedback_SuggestFeature_Description" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
+                                <TextBox x:Name="SuggestFeatureScenario" x:Uid="Settings_Feedback_SuggestFeature_Scenario" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
+                                <TextBox x:Name="SuggestFeatureSupportingInfo" x:Uid="Settings_Feedback_SuggestFeature_SupportingInfo" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </ContentDialog>
+                <TextBlock Margin="{StaticResource MediumBottomMargin}">
                     <Run x:Uid="Settings_Feedback_OpenSource"/>
                     <Hyperlink x:Uid="Settings_Feedback_OpenSource_Link" TextDecorations="None">
                         <Run x:Uid="Settings_Feedback_OpenSource_LinkText" />
@@ -130,6 +133,6 @@
                     </labs:SettingsCard>
                 </StackPanel>
             </StackPanel>
-        </Grid>
-    </ScrollViewer>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -203,7 +203,7 @@ public sealed partial class FeedbackPage : Page
     private string GetAppVersion()
     {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-        IAppInfoService appInfoService = Application.Current.GetService<IAppInfoService>();
+        var appInfoService = Application.Current.GetService<IAppInfoService>();
         var version = appInfoService.GetAppVersion();
 
         return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
@@ -247,9 +247,9 @@ public sealed partial class FeedbackPage : Page
 
     private string GetPhysicalMemory()
     {
-        CultureInfo cultures = new CultureInfo("en-US");
+        var cultures = new CultureInfo("en-US");
 
-        MEMORYSTATUSEX memStatus = default(MEMORYSTATUSEX);
+        MEMORYSTATUSEX memStatus = default;
         memStatus.dwLength = (uint)Marshal.SizeOf(typeof(MEMORYSTATUSEX));
         PInvoke.GlobalMemoryStatusEx(out memStatus);
 

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -13,35 +13,37 @@
     mc:Ignorable="d"
     Loaded="Page_Loaded">
 
-    <ScrollViewer
+    <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}"
-        VerticalScrollBarVisibility="Auto">
-        <StackPanel x:Name="ContentArea">
-            <BreadcrumbBar
-                x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-                ItemClicked="BreadcrumbBar_ItemClicked"
-                ItemsSource="{x:Bind Breadcrumbs}" />
+        Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-            <StackPanel Margin="{StaticResource SmallTopBottomMargin}">
-                <labs:SettingsCard x:Uid="Settings_Theme">
-                    <labs:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE790;" />
-                    </labs:SettingsCard.HeaderIcon>
-                    <ComboBox x:Name="ThemeSelectionComboBox">
-                        <ComboBoxItem x:Uid="Settings_Theme_Default" Tag="{x:Bind xaml:ElementTheme.Default}" />
-                        <ComboBoxItem x:Uid="Settings_Theme_Light" Tag="{x:Bind xaml:ElementTheme.Light}" />
-                        <ComboBoxItem x:Uid="Settings_Theme_Dark" Tag="{x:Bind xaml:ElementTheme.Dark}" />
-                        <i:Interaction.Behaviors>
-                            <ic:EventTriggerBehavior EventName="SelectionChanged">
-                                <ic:InvokeCommandAction Command="{x:Bind ViewModel.SwitchThemeCommand}" 
-                                                        CommandParameter="{x:Bind ((ComboBoxItem)ThemeSelectionComboBox.SelectedItem).Tag, Mode=OneWay}" />
-                            </ic:EventTriggerBehavior>
-                        </i:Interaction.Behaviors>
-                    </ComboBox>
-                </labs:SettingsCard>
-            </StackPanel>
-        </StackPanel>
-    </ScrollViewer>
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+            <labs:SettingsCard x:Uid="Settings_Theme">
+                <labs:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE790;" />
+                </labs:SettingsCard.HeaderIcon>
+                <ComboBox x:Name="ThemeSelectionComboBox">
+                    <ComboBoxItem x:Uid="Settings_Theme_Default" Tag="{x:Bind xaml:ElementTheme.Default}" />
+                    <ComboBoxItem x:Uid="Settings_Theme_Light" Tag="{x:Bind xaml:ElementTheme.Light}" />
+                    <ComboBoxItem x:Uid="Settings_Theme_Dark" Tag="{x:Bind xaml:ElementTheme.Dark}" />
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="SelectionChanged">
+                            <ic:InvokeCommandAction Command="{x:Bind ViewModel.SwitchThemeCommand}" 
+                                                    CommandParameter="{x:Bind ((ComboBoxItem)ThemeSelectionComboBox.SelectedItem).Tag, Mode=OneWay}" />
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                </ComboBox>
+            </labs:SettingsCard>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -12,7 +12,11 @@
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}" HorizontalAlignment="Center">
+    
+    <ScrollViewer
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{ThemeResource ContentPageMargin}"
+        VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
 

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -18,8 +18,12 @@
         Margin="{ThemeResource ContentPageMargin}"
         VerticalScrollBarVisibility="Auto">
         <StackPanel>
-            <BreadcrumbBar x:Name="BreadcrumbBar" ItemsSource="{x:Bind Breadcrumbs}" ItemClicked="BreadcrumbBar_ItemClicked" Margin="0,0,0,16" />
-
+            <BreadcrumbBar
+                x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+                ItemClicked="BreadcrumbBar_ItemClicked"
+                ItemsSource="{x:Bind Breadcrumbs}" />
+            
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:SettingViewModel">

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -12,18 +12,22 @@
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
-    
-    <ScrollViewer
+
+    <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}"
-        VerticalScrollBarVisibility="Auto">
-        <StackPanel>
-            <BreadcrumbBar
-                x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-                ItemClicked="BreadcrumbBar_ItemClicked"
-                ItemsSource="{x:Bind Breadcrumbs}" />
-            
+        Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:SettingViewModel">
@@ -36,6 +40,6 @@
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>
-        </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
+    </Grid>
 </Page>


### PR DESCRIPTION
## Summary of the pull request
Settings pages should behave like the tools pages -- the headers should stay at the top as the page scrolls. This change standardizes the Settings pages to all have the same layout: a grid with two rows. The first row contains the header (BreadcrumbBar) and the second row contains a ScrollViewer that contains the rest of the content.

The pages also had inconsistent margins on their headers and content, which this change standardizes.

In the future, it would be ideal to have a Settings page template to enforce this consistency (similar to the PowerToys [SettingsPageControl](https://github.com/microsoft/PowerToys/blob/main/src/settings-ui/Settings.UI/SettingsXAML/Controls/SettingsPageControl/SettingsPageControl.xaml)).

Some files have large amounts of whitespace change, this is due to mixed line endings in those files.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #1439
- [ ] Tests added/passed
- [ ] Documentation updated
