### PR TITLE
Userchriwall v pack in pipeline

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -500,14 +500,14 @@ stages:
 
     - task: CmdLine@2
       inputs:
-        script: ren $(Build.ArtifactStagingDirectory)\vpack\appxBundle\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
+        script: ren vpack\appxBundle\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app
       env: 
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
-        sourceDirectory: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
+        sourceDirectory: vpack\appxBundle
         description: VPack for DevHome
         pushPkgName: DevHome.app
         version: $(MSIXVersion).0

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -498,9 +498,11 @@ stages:
         artifactName: MsixBundle_Release
         targetPath: $(appxPackageDir)\vpack
 
-    - task: CmdLine@2
+    - task: PowerShell@2
+      displayName: Rename the bundle
       inputs:
-        script: ren $(appxPackageDir)\vpack\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
+        targetType: 'inline'
+        script: Get-ChildItem $(appxPackageDir)\vpack\*.msixbundle | Rename-Item -NewName $(appxPackageDir)\vpack\DevHome_8wekyb3d8bbwe.msixbundle
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -516,7 +516,8 @@ stages:
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app
-      env: SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      env: 
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         sourceDirectory: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
         description: VPack for DevHome

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -501,7 +501,7 @@ stages:
 
     - task: CmdLine@2
       inputs:
-      script: ren $(appxPackageDir)\vpack\*.msixbundle DevHome_8wekyb3d8bbwe.msixbundle
+        script: ren $(appxPackageDir)\vpack\*.msixbundle DevHome_8wekyb3d8bbwe.msixbundle
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -492,11 +492,11 @@ stages:
             pathtoPublish: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
             artifactName: vpackManifest
     
-            - task: PublishPipelineArtifact@0
-              displayName: Publish MSIX Bundle Artifacts
-              inputs:
-                artifactName: MsixBundle_${{ configuration }}
-                targetPath: AppxBundles\${{ configuration }}
+        - task: PublishPipelineArtifact@0
+          displayName: Publish MSIX Bundle Artifacts
+          inputs:
+            artifactName: MsixBundle_${{ configuration }}
+            targetPath: AppxBundles\${{ configuration }}
 
 - stage: Store_Publish
   dependsOn:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -472,11 +472,31 @@ stages:
             MaxConcurrency: '50'
             MaxRetryAttempts: '5'
 
-        - task: PublishPipelineArtifact@0
-          displayName: Publish MSIX Bundle Artifacts
+      - task: PkgESVPack@12
+        condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))
+        displayName: Create and push vpack for app
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        inputs:
+          sourceDirectory: AppxBundles\${{ configuration }}
+          description: VPack for DevHome
+          pushPkgName: DevHome.app
+          version: $(MSIXVersion)
+          owner: chriwall
+          provData: true
+
+        - task: PublishBuildArtifacts@1
+          condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))
+          displayName: Publish vpack\app artifact with vpack manifest
           inputs:
-            artifactName: MsixBundle_${{ configuration }}
-            targetPath: AppxBundles\${{ configuration }}
+            pathtoPublish: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
+            artifactName: vpackManifest
+    
+            - task: PublishPipelineArtifact@0
+              displayName: Publish MSIX Bundle Artifacts
+              inputs:
+                artifactName: MsixBundle_${{ configuration }}
+                targetPath: AppxBundles\${{ configuration }}
 
 - stage: Store_Publish
   dependsOn:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -477,6 +477,7 @@ stages:
           inputs:
             artifactName: MsixBundle_${{ configuration }}
             targetPath: AppxBundles\${{ configuration }}
+            
 - stage: VPack
   dependsOn:
   - SourceAnalysis
@@ -492,27 +493,14 @@ stages:
   - job: ReleaseVPack
     steps:
     - task: DownloadBuildArtifacts@0
-      displayName: Download msixBundleSigned artifact
+      displayName: Download MsixBundle_Release artifact
       inputs:
         artifactName: MsixBundle_Release
-
-    - task: CopyFiles@2
-      displayName: Copy signed MsixBundle to vpack staging folder
-      inputs:
-        sourceFolder: $(Build.ArtifactStagingDirectory)\MsixBundle_Release
-        contents: DevHome*_8wekyb3d8bbwe.msixbundle
-        targetFolder: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
+        targetPath: vpack\appxBundle
 
     - task: CmdLine@2
       inputs:
         script: ren $(Build.ArtifactStagingDirectory)\vpack\appxBundle\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
-
-    - task: PowerShell@2
-      displayName: GetfullVersion
-      inputs:
-        filePath: 'build\Scripts\CreateBuildInfo.ps1'
-        arguments: -Version $(MSIXVersion) -IsAzurePipelineBuild $true
-      name: FullVersion
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app
@@ -522,7 +510,7 @@ stages:
         sourceDirectory: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
         description: VPack for DevHome
         pushPkgName: DevHome.app
-        version: $(FullVersion)
+        version: $(MSIXVersion).0
         owner: chriwall
         provData: true
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -492,9 +492,11 @@ stages:
   jobs:
   - job: ReleaseVPack
     steps:
-    - task: DownloadBuildArtifacts@0
+      path: s
+    - task: DownloadBuildArtifacts@2
       displayName: Download MsixBundle_Release artifact
       inputs:
+        buildType: 'current'
         artifactName: MsixBundle_Release
         targetPath: $(appxPackageDir)\vpack
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -507,6 +507,13 @@ stages:
       inputs:
         script: ren $(Build.ArtifactStagingDirectory)\vpack\appxBundle\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
 
+    - task: PowerShell@2
+      displayName: GetfullVersion
+      inputs:
+        filePath: 'build\Scripts\CreateBuildInfo.ps1'
+        arguments: -Version $(MSIXVersion) -IsAzurePipelineBuild $true
+      name: FullVersion
+
     - task: PkgESVPack@12
       displayName: Create and push vpack for app
       env: SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -514,7 +521,7 @@ stages:
         sourceDirectory: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
         description: VPack for DevHome
         pushPkgName: DevHome.app
-        version: $(MSIXVersion)
+        version: $(FullVersion)
         owner: chriwall
         provData: true
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -492,8 +492,7 @@ stages:
   jobs:
   - job: ReleaseVPack
     steps:
-    - task: DownloadBuildArtifacts@2
-      displayName: Download MsixBundle_Release artifact
+    - task: DownloadPipelineArtifact@2
       inputs:
         buildType: 'current'
         artifactName: MsixBundle_Release

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -497,18 +497,18 @@ stages:
         buildType: 'current'
         artifactName: MsixBundle_Release
         itemPattern: '*.msixbundle'
-        targetPath: $(appxPackageDir)\vpack
+        targetPath: $(Build.ArtifactStagingDirectory)\$(appxPackageDir)\vpack
 
     - task: CmdLine@2
       inputs:
-        script: ren $(appxPackageDir)\vpack\*.msixbundle DevHome_8wekyb3d8bbwe.msixbundle
+        script: ren $(Build.ArtifactStagingDirectory)\$(appxPackageDir)\vpack\*.msixbundle DevHome_8wekyb3d8bbwe.msixbundle
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app
       env: 
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
-        sourceDirectory: $(appxPackageDir)\vpack
+        sourceDirectory: $(Build.ArtifactStagingDirectory)\$(appxPackageDir)\vpack
         description: VPack for DevHome
         pushPkgName: DevHome.app
         version: $(MSIXVersion).0

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -472,18 +472,18 @@ stages:
             MaxConcurrency: '50'
             MaxRetryAttempts: '5'
 
-      - task: PkgESVPack@12
-        condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))
-        displayName: Create and push vpack for app
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        inputs:
-          sourceDirectory: AppxBundles\${{ configuration }}
-          description: VPack for DevHome
-          pushPkgName: DevHome.app
-          version: $(MSIXVersion)
-          owner: chriwall
-          provData: true
+        - task: PkgESVPack@12
+          condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))
+          displayName: Create and push vpack for app
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            sourceDirectory: AppxBundles\${{ configuration }}
+            description: VPack for DevHome
+            pushPkgName: DevHome.app
+            version: $(MSIXVersion)
+            owner: chriwall
+            provData: true
 
         - task: PublishBuildArtifacts@1
           condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -496,18 +496,18 @@ stages:
       displayName: Download MsixBundle_Release artifact
       inputs:
         artifactName: MsixBundle_Release
-        targetPath: vpack\appxBundle
+        targetPath: $(appxPackageDir)\vpack
 
     - task: CmdLine@2
       inputs:
-        script: ren vpack\appxBundle\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
+        script: ren $(appxPackageDir)\vpack\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app
       env: 
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
-        sourceDirectory: vpack\appxBundle
+        sourceDirectory: $(appxPackageDir)\vpack
         description: VPack for DevHome
         pushPkgName: DevHome.app
         version: $(MSIXVersion).0

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -496,7 +496,7 @@ stages:
       inputs:
         buildType: 'current'
         artifactName: MsixBundle_Release
-        itemPattern: *.msixbundle
+        itemPattern: '*.msixbundle'
         targetPath: $(appxPackageDir)\vpack
 
     - task: CmdLine@2

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -496,13 +496,12 @@ stages:
       inputs:
         buildType: 'current'
         artifactName: MsixBundle_Release
+        itemPattern: *.msixbundle
         targetPath: $(appxPackageDir)\vpack
 
-    - task: PowerShell@2
-      displayName: Rename the bundle
+    - task: CmdLine@2
       inputs:
-        targetType: 'inline'
-        script: Get-ChildItem $(appxPackageDir)\vpack\*.msixbundle | Rename-Item -NewName $(appxPackageDir)\vpack\DevHome_8wekyb3d8bbwe.msixbundle
+      script: ren $(appxPackageDir)\vpack\*.msixbundle DevHome_8wekyb3d8bbwe.msixbundle
 
     - task: PkgESVPack@12
       displayName: Create and push vpack for app

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -492,7 +492,6 @@ stages:
   jobs:
   - job: ReleaseVPack
     steps:
-      path: s
     - task: DownloadBuildArtifacts@2
       displayName: Download MsixBundle_Release artifact
       inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -471,32 +471,59 @@ stages:
             SessionTimeout: '60'
             MaxConcurrency: '50'
             MaxRetryAttempts: '5'
-
-        - task: PkgESVPack@12
-          condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))
-          displayName: Create and push vpack for app
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          inputs:
-            sourceDirectory: AppxBundles\${{ configuration }}
-            description: VPack for DevHome
-            pushPkgName: DevHome.app
-            version: $(MSIXVersion)
-            owner: chriwall
-            provData: true
-
-        - task: PublishBuildArtifacts@1
-          condition: and(eq(variables['BuildingBranch'], 'release'), eq('${{ configuration }}', 'Release'))
-          displayName: Publish vpack\app artifact with vpack manifest
-          inputs:
-            pathtoPublish: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
-            artifactName: vpackManifest
     
         - task: PublishPipelineArtifact@0
           displayName: Publish MSIX Bundle Artifacts
           inputs:
             artifactName: MsixBundle_${{ configuration }}
             targetPath: AppxBundles\${{ configuration }}
+- stage: VPack
+  dependsOn:
+  - SourceAnalysis
+  - Build_MsixBundle
+  condition: |
+    and
+    (
+      in(dependencies.Build_MsixBundle.result, 'Succeeded'),
+      in(dependencies.SourceAnalysis.result, 'Succeeded', 'SucceededWithIssues'),
+      eq(variables['BuildingBranch'], 'release')
+    )
+  jobs:
+  - job: ReleaseVPack
+    steps:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download msixBundleSigned artifact
+      inputs:
+        artifactName: MsixBundle_Release
+
+    - task: CopyFiles@2
+      displayName: Copy signed MsixBundle to vpack staging folder
+      inputs:
+        sourceFolder: $(Build.ArtifactStagingDirectory)\MsixBundle_Release
+        contents: DevHome*_8wekyb3d8bbwe.msixbundle
+        targetFolder: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
+
+    - task: CmdLine@2
+      inputs:
+        script: ren $(Build.ArtifactStagingDirectory)\vpack\appxBundle\*.msixBundle DevHome_8wekyb3d8bbwe.msixBundle
+
+    - task: PkgESVPack@12
+      displayName: Create and push vpack for app
+      env: SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      inputs:
+        sourceDirectory: $(Build.ArtifactStagingDirectory)\vpack\appxBundle
+        description: VPack for DevHome
+        pushPkgName: DevHome.app
+        version: $(MSIXVersion)
+        owner: chriwall
+        provData: true
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish vpack\app artifact with vpack manifest
+      inputs:
+        pathtoPublish: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
+        artifactName: vpackManifest
+      
 
 - stage: Store_Publish
   dependsOn:


### PR DESCRIPTION
## Summary of the pull request
AzurePipeline should create the VPack for bringing to other places.

## Detailed description of the pull request / Additional comments
Copies, renames, and prepares msixbundle for vpack, but only on the release branch

## Validation steps performed
Ran GitHub PR Validation, claiming to be release branch. Saw the Vpack created. Downloaded the VPack and made sure it was correct, with provenance.json and all.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
