### PR TITLE
Trim long widget names

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -26,24 +26,26 @@
     <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize), Mode=OneWay}" 
           CornerRadius="7" BorderBrush="{ThemeResource WidgetBorderColor}" BorderThickness="1">
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
+            <RowDefinition Height="36" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <!-- Widget header: icon, title, menu -->
         <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}">
-            <StackPanel Orientation="Horizontal" Margin="15,10,15,5">
-                <Rectangle Width="16" Height="16" Margin="0,0,8,0" x:Name="WidgetHeaderIcon" />
+            <StackPanel Orientation="Horizontal" Margin="15,10,0,0" Spacing="8">
+                <Rectangle Width="16" Height="16" x:Name="WidgetHeaderIcon" />
                 <TextBlock AutomationProperties.AutomationId="WidgetTitle"
                            Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}"
                            VerticalAlignment="Center"
+                           MaxWidth="212"
+                           TextTrimming="CharacterEllipsis"
                            FontSize="{ThemeResource CaptionTextBlockFontSize}" />
             </StackPanel>
             <Button Tag="{x:Bind}" Content="&#xE712;"
                     x:Uid="WidgetMoreOptionsButton"
                     AutomationProperties.AutomationId="WidgetMoreOptionsButton"
                     FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{ThemeResource CaptionTextBlockFontSize}"
-                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="15,10,15,5" BorderThickness="0" Padding="5"
+                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10,15,0" BorderThickness="0" Padding="5"
                     Background="Transparent"
                     Click="OpenWidgetMenu">
                 <Button.Flyout>


### PR DESCRIPTION
## Summary of the pull request

If the display name of a widget is too long, it can overlap the "more options" menu. Instead, trim the name with an ellipsis.

This change also simplifies some spacing in the header, and specifically sets the header at 36 px high. Widget design guidance dictates a 48 px attribution area, and the adaptive cards render with 12 px of spacing at the top. This ends up ensuring the correct size.

![image](https://github.com/microsoft/devhome/assets/47155823/f40d3d6f-ab46-45c0-99a4-97d90cb7ae92)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
