### PR TITLE
Skipping github extension installation and adding card to what's new page

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -162,13 +162,13 @@
     <value>Sign out</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_Content" xml:space="preserve">
-    <value>Please install an extension that provides account integration into Dev Home to add an account.</value>
+    <value>Install a Dev Home extension that uses your developer account, then sign in to add the account.</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_Title" xml:space="preserve">
-    <value>No Dev Home extensions found.</value>
+    <value>No extensions found</value>
   </data>
   <data name="Settings_Header" xml:space="preserve">
     <value>Settings</value>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -162,13 +162,13 @@
     <value>Sign out</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_Content" xml:space="preserve">
-    <value>Please install a Dev Home extension and restart Dev Home to add an account.</value>
+    <value>Please install an extension that provides account integration into Dev Home to add an account.</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_Title" xml:space="preserve">
-    <value>No Dev Home extensions found!</value>
+    <value>No Dev Home extensions found.</value>
   </data>
   <data name="Settings_Header" xml:space="preserve">
     <value>Settings</value>
@@ -185,10 +185,10 @@
   <data name="Settings_About_RelatedLinks.Text" xml:space="preserve">
     <value>Related links</value>
   </data>
-    <data name="Settings_Feedback_Header" xml:space="preserve">
+  <data name="Settings_Feedback_Header" xml:space="preserve">
     <value>Feedback</value>
   </data>
-    <data name="Settings_Feedback_Description" xml:space="preserve">
+  <data name="Settings_Feedback_Description" xml:space="preserve">
     <value>Report problems, suggest a feature, report translation problems</value>
   </data>
   <data name="Settings_Feedback_OpenSource.Text" xml:space="preserve">

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -130,7 +130,7 @@
     <comment>Text for a dropdown option in a file picker dialog to show all files in a directory</comment>
   </data>
   <data name="WhatsNewPage_DevIdCard.Description" xml:space="preserve">
-    <value>Sign in to your developer account to clone repositories and get notifications for them.</value>
+    <value>After you install an extension that connects one of your developer accounts to Dev Home, sign in to that account.</value>
   </data>
   <data name="WhatsNew.Content" xml:space="preserve">
     <value>Introducing Dev Home</value>
@@ -151,7 +151,7 @@
     <value>Monitor projects in your dashboard</value>
   </data>
   <data name="WhatsNewPage_DevIdCard.Title" xml:space="preserve">
-    <value>Connect to GitHub</value>
+    <value>Connect your developer account</value>
   </data>
   <data name="WhatsNewPage_NotifCard.Description" xml:space="preserve">
     <value>Keep up with pull requests, checks, merges, and more.</value>
@@ -235,11 +235,11 @@
     <comment>Name of app when run as administrator</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Button" xml:space="preserve">
-    <value>Explore extensions</value>
+    <value>Do more with Dev Home extensions</value>
     <comment>Button on extensions card on "whats new" page</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Description" xml:space="preserve">
-    <value>Extensions provide integration into the existing features of Dev Home. These features include the ability to recommend repositories to add when using the Machine Configuration tool and the ability to add additional Dev Home widgets to the dashboard.</value>
+    <value>Extensions help you get more out of Dev Home. For example, get recommendations for other repositories to add when setting up your machine in Dev Home and add other widgets to your dashboard.</value>
     <comment>Description of extensions card on "whats new" page</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Title" xml:space="preserve">

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -236,11 +236,14 @@
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Button" xml:space="preserve">
     <value>Explore extensions</value>
+    <comment>Button on extensions card on "whats new" page</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Description" xml:space="preserve">
     <value>Extensions provide integration into the existing features of Dev Home. These features include the ability to recommend repositories to add when using the Machine Configuration tool and the ability to add additional Dev Home widgets to the dashboard.</value>
+    <comment>Description of extensions card on "whats new" page</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Title" xml:space="preserve">
     <value>Explore Dev Home extensions</value>
+    <comment>Title of extensions card on "whats new" page</comment>
   </data>
 </root>

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -234,4 +234,13 @@
     <value>Administrator: Dev Home (Preview)</value>
     <comment>Name of app when run as administrator</comment>
   </data>
+  <data name="WhatsNewPage_ExtensionsCard.Button" xml:space="preserve">
+    <value>Explore extensions</value>
+  </data>
+  <data name="WhatsNewPage_ExtensionsCard.Description" xml:space="preserve">
+    <value>Extensions provide integration into the existing features of Dev Home. These features include the ability to recommend repositories to add when using the Machine Configuration tool and the ability to add additional Dev Home widgets to the dashboard.</value>
+  </data>
+  <data name="WhatsNewPage_ExtensionsCard.Title" xml:space="preserve">
+    <value>Explore Dev Home extensions</value>
+  </data>
 </root>

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -36,6 +36,13 @@ public class InitializationViewModel : ObservableObject
         _pluginService = pluginService;
     }
 
+    public void OnPageLoaded()
+    {
+        App.MainWindow.Content = Application.Current.GetService<ShellPage>();
+
+        _themeSelector.SetRequestedTheme();
+    }
+
     public async Task OnPageLoadedAsync()
     {
         try

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -1,32 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System.Management.Automation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
-using DevHome.Logging;
 using DevHome.Views;
 using Microsoft.UI.Xaml;
-using Windows.ApplicationModel.Store.Preview.InstallControl;
 
 namespace DevHome.ViewModels;
 public class InitializationViewModel : ObservableObject
 {
-#if CANARY_BUILD
-    private const string GitHubExtensionStorePackageId = "9N806ZKPW85R";
-    private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension.Canary_8wekyb3d8bbwe";
-#elif STABLE_BUILD
-    private const string GitHubExtensionStorePackageId = "9NZCC27PR6N6";
-    private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe";
-#else
-    private const string GitHubExtensionStorePackageId = "";
-    private const string GitHubExtensionPackageFamilyName = "";
-#endif
-
-    private const int StoreInstallTimeout = 60_000;
-
     private readonly IThemeSelectorService _themeSelector;
     private readonly IPluginService _pluginService;
 
@@ -41,81 +25,5 @@ public class InitializationViewModel : ObservableObject
         App.MainWindow.Content = Application.Current.GetService<ShellPage>();
 
         _themeSelector.SetRequestedTheme();
-    }
-
-    public async Task OnPageLoadedAsync()
-    {
-        try
-        {
-            if (!string.IsNullOrEmpty(GitHubExtensionStorePackageId) &&
-                !(await _pluginService.GetInstalledAppExtensionsAsync())
-                .Any(extension => extension.AppInfo.PackageFamilyName.Equals(GitHubExtensionPackageFamilyName, StringComparison.OrdinalIgnoreCase)))
-            {
-                var appInstallTask = InstallStorePackageAsync(GitHubExtensionStorePackageId);
-
-                // wait for a maximum of StoreInstallTimeout milliseconds
-                var completedTask = await Task.WhenAny(appInstallTask, Task.Delay(StoreInstallTimeout));
-
-                if (completedTask.Exception is not null)
-                {
-                    throw completedTask.Exception;
-                }
-
-                if (completedTask != appInstallTask)
-                {
-                    throw new TimeoutException("Store Install task did not finish in time.");
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            GlobalLog.Logger?.ReportError("GitHubExtension Hydration Failed", ex);
-        }
-
-        App.MainWindow.Content = Application.Current.GetService<ShellPage>();
-
-        _themeSelector.SetRequestedTheme();
-    }
-
-    private async Task InstallStorePackageAsync(string packageId)
-    {
-        await Task.Run(() =>
-        {
-            var tcs = new TaskCompletionSource<bool>();
-
-            AppInstallItem installItem;
-
-            try
-            {
-                GlobalLog.Logger?.ReportInfo("Initialization Page: Starting extension app install");
-                installItem = new AppInstallManager().StartAppInstallAsync(packageId, null, true, false).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                GlobalLog.Logger?.ReportInfo("Initialization Page: Extension app install success");
-                tcs.SetException(ex);
-                return tcs.Task;
-            }
-
-            installItem.Completed += (sender, args) =>
-            {
-                tcs.SetResult(true);
-            };
-
-            installItem.StatusChanged += (sender, args) =>
-            {
-                if (installItem.GetCurrentStatus().InstallState == AppInstallState.Canceled
-                    || installItem.GetCurrentStatus().InstallState == AppInstallState.Error)
-                {
-                    tcs.TrySetException(new JobFailedException(installItem.GetCurrentStatus().ErrorCode.ToString()));
-                }
-                else if (installItem.GetCurrentStatus().InstallState == AppInstallState.Completed)
-                {
-                    tcs.SetResult(true);
-                }
-            };
-
-            return tcs.Task;
-        });
     }
 }

--- a/src/ViewModels/WhatsNewViewModel.cs
+++ b/src/ViewModels/WhatsNewViewModel.cs
@@ -11,14 +11,22 @@ public class WhatsNewViewModel : ObservableObject
 {
     public ObservableCollection<WhatsNewCard> Source { get; } = new ObservableCollection<WhatsNewCard>();
 
+    public ObservableCollection<WhatsNewCard> BigSource { get; } = new ObservableCollection<WhatsNewCard>();
+
     public void AddCard(WhatsNewCard card)
     {
         Source.Add(card);
     }
 
+    public void AddBigCard(WhatsNewCard card)
+    {
+        BigSource.Add(card);
+    }
+
     public void OnNavigatedTo(object parameter)
     {
         Source.Clear();
+        BigSource.Clear();
     }
 
     public void OnNavigatedFrom()

--- a/src/Views/InitializationPage.xaml.cs
+++ b/src/Views/InitializationPage.xaml.cs
@@ -23,8 +23,8 @@ public sealed partial class InitializationPage : Page
         ViewModel = initializationViewModel;
     }
 
-    private async void Page_Loaded(object sender, RoutedEventArgs e)
+    private void Page_Loaded(object sender, RoutedEventArgs e)
     {
-        await ViewModel.OnPageLoadedAsync();
+        ViewModel.OnPageLoaded();
     }
 }

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -38,7 +38,8 @@
             </Grid>
             <Grid x:Name="ContentArea" Padding="35 0 35 30" HorizontalAlignment="Center">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="330" />
+                    <RowDefinition Height="265" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
@@ -81,10 +82,118 @@
                     </StackPanel>
                 </Grid>
 
+
+                <muxc:ItemsRepeater
+                    Name="BigFeaturesContainer"
+                    Grid.Row="1"
+                    Margin="35, 5, 45, 45"
+                    animations:Connected.ListItemElementName="itemThumbnail"
+                    animations:Connected.ListItemKey="animationKeyContentGrid"
+                    ItemsSource="{x:Bind ViewModel.BigSource,Mode=OneWay}">
+
+                    <muxc:ItemsRepeater.Resources>
+                        <models:WhatsNewCard 
+                            x:Uid="WhatsNewPage_DevDashCard"
+                            x:Key="WhatsNewPage_DevDashCard"
+                            DarkThemeImage="ms-appx:///Assets/WhatsNewPage/DarkTheme/DashboardHero.png"
+                            LightThemeImage="ms-appx:///Assets/WhatsNewPage/LightTheme/DashboardHero.png"
+                            PageKey="DevHome.Dashboard.ViewModels.DashboardViewModel"
+                            Priority="0" />
+                    </muxc:ItemsRepeater.Resources>
+
+                    <muxc:ItemsRepeater.Layout>
+                        <muxc:UniformGridLayout 
+                            x:Name="BigCardGrid"
+                            Orientation="Horizontal" 
+                            MinItemWidth="600"
+                            MinItemHeight="188"
+                            MinRowSpacing="12" 
+                            MinColumnSpacing="12"
+                            ItemsStretch="Fill"
+                            MaximumRowsOrColumns="3"
+                            ItemsJustification="Center" />
+                    </muxc:ItemsRepeater.Layout>
+
+                    <muxc:ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="models:WhatsNewCard">
+                            <Grid
+                                HorizontalAlignment="Stretch"
+                                Padding="15 15"
+                                CornerRadius="{ThemeResource ControlCornerRadius}"
+                                Margin="0"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="{ThemeResource ExpanderBorderThickness}">
+                                <Grid.Resources>
+                                    <ResourceDictionary>
+                                        <ResourceDictionary.ThemeDictionaries>
+                                            <ResourceDictionary x:Key="Light">
+                                                <BitmapImage x:Key="ItemImage" UriSource="{x:Bind LightThemeImage}" />
+                                            </ResourceDictionary>
+                                            <ResourceDictionary x:Key="Dark">
+                                                <BitmapImage x:Key="ItemImage" UriSource="{x:Bind DarkThemeImage}" />
+                                            </ResourceDictionary>
+                                        </ResourceDictionary.ThemeDictionaries>
+                                    </ResourceDictionary>
+                                </Grid.Resources>
+
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <Image
+                                    Grid.Row="0"
+                                    Grid.Column="0"
+                                    Source="{ThemeResource ItemImage}"
+                                    MaxHeight="188"
+                                    MaxWidth="376"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Center"/>
+
+                                <StackPanel Grid.Column="1" Padding="15 10 15 0" >
+                                    <TextBlock
+                                        HorizontalAlignment="Left"
+                                        Style="{ThemeResource BodyTextStyle}"
+                                        Text="{x:Bind Title}" />
+
+                                    <TextBlock
+                                        Margin="0 16 0 25"
+                                        TextWrapping="Wrap"
+                                        Text="{x:Bind Description}"/>
+
+                                    <HyperlinkButton
+                                        Content="{x:Bind Link}"
+                                        Foreground="{ThemeResource LearnMoreForeground}"
+                                        NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
+                                        Padding="0"
+                                        Margin="0"
+                                        Visibility="{x:Bind ShouldShowLink}"/>
+
+                                    <Button 
+                                        Grid.Row="1"
+                                        Margin="0 0 0 10"
+                                        Padding="50 5 50 5"
+                                        DataContext="{x:Bind PageKey}"
+                                        Click="Button_ClickAsync"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Bottom"
+                                        Content="{x:Bind Button}" />
+
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </muxc:ItemsRepeater.ItemTemplate>
+                </muxc:ItemsRepeater>
+
                 <muxc:ItemsRepeater
                     Name="FeaturesContainer"
-                    Grid.Row="1"
-                    Margin="35, 45, 45, 45"
+                    Grid.Row="2"
+                    Margin="35, 5, 45, 45"
                     animations:Connected.ListItemElementName="itemThumbnail"
                     animations:Connected.ListItemKey="animationKeyContentGrid"
                     ItemsSource="{x:Bind ViewModel.Source,Mode=OneWay}">

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -111,16 +111,11 @@
                     </muxc:ItemsRepeater.Resources>
 
                     <muxc:ItemsRepeater.Layout>
-                        <muxc:UniformGridLayout 
+                        <muxc:StackLayout 
                             x:Name="BigCardGrid"
-                            Orientation="Horizontal" 
-                            MinItemWidth="600"
-                            MinItemHeight="188"
-                            MinRowSpacing="12" 
-                            MinColumnSpacing="12"
-                            ItemsStretch="Fill"
-                            MaximumRowsOrColumns="1"
-                            ItemsJustification="Center" />
+                            Spacing="12"
+                            Orientation="Vertical" >
+                        </muxc:StackLayout>
                     </muxc:ItemsRepeater.Layout>
 
                     <muxc:ItemsRepeater.ItemTemplate>
@@ -163,29 +158,19 @@
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Top"/>
 
-                                <Grid Grid.Column="1" Padding="65 10 15 0">
-
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    
+                                <StackPanel Grid.Column="1" Padding="65 10 15 0">
                                     <TextBlock
-                                        Grid.Row="0"
                                         HorizontalAlignment="Left"
                                         Style="{ThemeResource BodyTextStyle}"
                                         Text="{x:Bind Title}" />
 
                                     <TextBlock
-                                        Grid.Row="1"
                                         Margin="0 8 0 10"
                                         TextWrapping="Wrap"
                                         FontSize="12"
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton
-                                        Grid.Row="2"
                                         Content="{x:Bind Link}"
                                         Foreground="{ThemeResource LearnMoreForeground}"
                                         NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
@@ -194,7 +179,6 @@
                                         Visibility="{x:Bind ShouldShowLink}"/>
 
                                     <Button 
-                                        Grid.Row="3"
                                         Margin="0 0 0 10"
                                         Padding="50 5 50 5"
                                         DataContext="{x:Bind PageKey}"
@@ -204,7 +188,7 @@
                                         VerticalAlignment="Bottom"
                                         Content="{x:Bind Button}" />
 
-                                </Grid>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
                     </muxc:ItemsRepeater.ItemTemplate>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -86,19 +86,28 @@
                 <muxc:ItemsRepeater
                     Name="BigFeaturesContainer"
                     Grid.Row="1"
-                    Margin="35, 5, 45, 45"
+                    Margin="35, 5, 45, 10"
                     animations:Connected.ListItemElementName="itemThumbnail"
                     animations:Connected.ListItemKey="animationKeyContentGrid"
                     ItemsSource="{x:Bind ViewModel.BigSource,Mode=OneWay}">
 
                     <muxc:ItemsRepeater.Resources>
                         <models:WhatsNewCard 
-                            x:Uid="WhatsNewPage_DevDashCard"
-                            x:Key="WhatsNewPage_DevDashCard"
+                            x:Uid="WhatsNewPage_ExtensionsCard"
+                            x:Key="WhatsNewPage_ExtensionsCard"
                             DarkThemeImage="ms-appx:///Assets/WhatsNewPage/DarkTheme/DashboardHero.png"
                             LightThemeImage="ms-appx:///Assets/WhatsNewPage/LightTheme/DashboardHero.png"
-                            PageKey="DevHome.Dashboard.ViewModels.DashboardViewModel"
+                            PageKey="DevHome.Dashboard.ViewModels.ExtensionsViewModel"
                             Priority="0" />
+
+                        <models:WhatsNewCard 
+                            x:Uid="WhatsNewPage_DevIdCard"
+                            x:Key="WhatsNewPage_DevIdCard"
+                            DarkThemeImage="ms-appx:///Assets/WhatsNewPage/DarkTheme/DevIdHero.png"
+                            LightThemeImage="ms-appx:///Assets/WhatsNewPage/LightTheme/DevIdHero.png"
+                            PageKey="DevHome.Settings.ViewModels.AccountsViewModel"
+                            Priority="1" />
+
                     </muxc:ItemsRepeater.Resources>
 
                     <muxc:ItemsRepeater.Layout>
@@ -110,7 +119,7 @@
                             MinRowSpacing="12" 
                             MinColumnSpacing="12"
                             ItemsStretch="Fill"
-                            MaximumRowsOrColumns="3"
+                            MaximumRowsOrColumns="1"
                             ItemsJustification="Center" />
                     </muxc:ItemsRepeater.Layout>
 
@@ -120,7 +129,6 @@
                                 HorizontalAlignment="Stretch"
                                 Padding="15 15"
                                 CornerRadius="{ThemeResource ControlCornerRadius}"
-                                Margin="0"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                 BorderThickness="{ThemeResource ExpanderBorderThickness}">
@@ -138,12 +146,12 @@
                                 </Grid.Resources>
 
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="4*" />
+                                    <ColumnDefinition Width="6*" />
                                 </Grid.ColumnDefinitions>
 
                                 <Grid.RowDefinitions>
-                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
 
                                 <Image
@@ -153,20 +161,31 @@
                                     MaxHeight="188"
                                     MaxWidth="376"
                                     HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Center"/>
+                                    VerticalAlignment="Top"/>
 
-                                <StackPanel Grid.Column="1" Padding="15 10 15 0" >
+                                <Grid Grid.Column="1" Padding="65 10 15 0">
+
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    
                                     <TextBlock
+                                        Grid.Row="0"
                                         HorizontalAlignment="Left"
                                         Style="{ThemeResource BodyTextStyle}"
                                         Text="{x:Bind Title}" />
 
                                     <TextBlock
-                                        Margin="0 16 0 25"
+                                        Grid.Row="1"
+                                        Margin="0 8 0 10"
                                         TextWrapping="Wrap"
+                                        FontSize="12"
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton
+                                        Grid.Row="2"
                                         Content="{x:Bind Link}"
                                         Foreground="{ThemeResource LearnMoreForeground}"
                                         NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
@@ -175,16 +194,17 @@
                                         Visibility="{x:Bind ShouldShowLink}"/>
 
                                     <Button 
-                                        Grid.Row="1"
+                                        Grid.Row="3"
                                         Margin="0 0 0 10"
                                         Padding="50 5 50 5"
                                         DataContext="{x:Bind PageKey}"
+                                        FontSize="12"
                                         Click="Button_ClickAsync"
-                                        HorizontalAlignment="Stretch"
+                                        HorizontalAlignment="Left"
                                         VerticalAlignment="Bottom"
                                         Content="{x:Bind Button}" />
 
-                                </StackPanel>
+                                </Grid>
                             </Grid>
                         </DataTemplate>
                     </muxc:ItemsRepeater.ItemTemplate>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -97,17 +97,8 @@
                             x:Key="WhatsNewPage_ExtensionsCard"
                             DarkThemeImage="ms-appx:///Assets/WhatsNewPage/DarkTheme/DashboardHero.png"
                             LightThemeImage="ms-appx:///Assets/WhatsNewPage/LightTheme/DashboardHero.png"
-                            PageKey="DevHome.Dashboard.ViewModels.ExtensionsViewModel"
+                            PageKey="DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel"
                             Priority="0" />
-
-                        <models:WhatsNewCard 
-                            x:Uid="WhatsNewPage_DevIdCard"
-                            x:Key="WhatsNewPage_DevIdCard"
-                            DarkThemeImage="ms-appx:///Assets/WhatsNewPage/DarkTheme/DevIdHero.png"
-                            LightThemeImage="ms-appx:///Assets/WhatsNewPage/LightTheme/DevIdHero.png"
-                            PageKey="DevHome.Settings.ViewModels.AccountsViewModel"
-                            Priority="1" />
-
                     </muxc:ItemsRepeater.Resources>
 
                     <muxc:ItemsRepeater.Layout>

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -35,7 +35,7 @@ public sealed partial class WhatsNewPage : Page
 
     private async void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        await Application.Current.GetService<ILocalSettingsService>().SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstRun, false);
+        await Application.Current.GetService<ILocalSettingsService>().SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstRun, true);
 
         var whatsNewCards = FeaturesContainer.Resources
             .Where((item) => item.Value.GetType() == typeof(WhatsNewCard))

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -35,7 +35,7 @@ public sealed partial class WhatsNewPage : Page
 
     private async void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        await Application.Current.GetService<ILocalSettingsService>().SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstRun, true);
+        await Application.Current.GetService<ILocalSettingsService>().SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstRun, false);
 
         var whatsNewCards = FeaturesContainer.Resources
             .Where((item) => item.Value.GetType() == typeof(WhatsNewCard))
@@ -60,6 +60,21 @@ public sealed partial class WhatsNewPage : Page
             }
 
             ViewModel.AddCard(card);
+        }
+
+        var whatsNewBigCards = BigFeaturesContainer.Resources
+            .Where((item) => item.Value.GetType() == typeof(WhatsNewCard))
+            .Select(card => card.Value as WhatsNewCard)
+            .OrderBy(card => card?.Priority ?? 0);
+
+        foreach (var card in whatsNewBigCards)
+        {
+            if (card is null)
+            {
+                continue;
+            }
+
+            ViewModel.AddBigCard(card);
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request

Adding the first iteration of the "What's new" page card that should redirect to the extension marketplace page. And also skipping the auto installation of the github extension.

<img width="638" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/b861e0e6-861e-4c14-b0c9-c4466ed2499f">

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
