### PR TITLE
Fix build to use published sdk

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -145,7 +145,7 @@ Try {
             ("DevHome.sln"),
             ("/p:Platform="+$platform),
             ("/p:Configuration="+$configuration),
-            ("/p:DevHomeSDKVersion="+$env:sdk_version),
+            # ("/p:DevHomeSDKVersion="+$env:sdk_version),
             ("/restore"),
             ("/binaryLogger:DevHome.$platform.$configuration.binlog"),
             ("/p:AppxPackageOutput=$appxPackageDir\DevHome-$platform.msix"),

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -237,7 +237,7 @@ stages:
           retryCountOnTaskFailure: 2
           inputs:
             filePath: 'Build.ps1'
-            arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion) -VersionOfSDK $(VersionOfSDK) -SDKNugetSource $(Pipeline.Workspace)\sdkArtifacts\ -BuildStep "msix" -AzureBuildingBranch "$(BuildingBranch)" -IsAzurePipelineBuild
+            arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion) -BuildStep "msix" -AzureBuildingBranch "$(BuildingBranch)" -IsAzurePipelineBuild
 
         - task: EsrpCodeSigning@2
           inputs:


### PR DESCRIPTION
## Summary of the pull request
Official builds first build the sdk and then build Dev Home from that sdk.  Normally this was fine, but we have a breaking change in the sdk right now and Dev Home hasn't been updated to account for that.  This is more the correct behavior anyway.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
