### PR TITLE
UX Changes to align AddAccountDialog with design 

### DIFF
--- a/settings/DevHome.Settings/Assets/DarkHostConfig.json
+++ b/settings/DevHome.Settings/Assets/DarkHostConfig.json
@@ -10,9 +10,9 @@
         "extraLarge": 26
       },
       "fontWeights": {
-        "lighter": 600,
-        "default": 800,
-        "bolder": 1000
+        "lighter": 200,
+        "default": 400,
+        "bolder": 600
       }
     },
     "monospace": {

--- a/settings/DevHome.Settings/Assets/DarkHostConfig.json
+++ b/settings/DevHome.Settings/Assets/DarkHostConfig.json
@@ -86,9 +86,9 @@
     }
   },
   "imageSizes": {
-    "small": 130,
-    "medium": 170,
-    "large": 210
+    "small": 80,
+    "medium": 130,
+    "large": 180
   },
   "actions": {
     "maxActions": 5,

--- a/settings/DevHome.Settings/Assets/LightHostConfig.json
+++ b/settings/DevHome.Settings/Assets/LightHostConfig.json
@@ -86,9 +86,9 @@
     }
   },
   "imageSizes": {
-    "small": 110,
-    "medium": 150,
-    "large": 210
+    "small": 80,
+    "medium": 130,
+    "large": 180
   },
   "actions": {
     "maxActions": 5,

--- a/settings/DevHome.Settings/Assets/LightHostConfig.json
+++ b/settings/DevHome.Settings/Assets/LightHostConfig.json
@@ -10,9 +10,9 @@
         "extraLarge": 26
       },
       "fontWeights": {
-        "lighter": 600,
-        "default": 800,
-        "bolder": 1000
+        "lighter": 200,
+        "default": 400,
+        "bolder": 600
       }
     },
     "monospace": {

--- a/settings/DevHome.Settings/Views/LoginUIDialog.xaml
+++ b/settings/DevHome.Settings/Views/LoginUIDialog.xaml
@@ -13,9 +13,9 @@
 
     <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
     <ContentDialog.Resources>
-        <x:Double x:Key="ContentDialogMinWidth">333</x:Double>
+        <x:Double x:Key="ContentDialogMinWidth">360</x:Double>
         <x:Double x:Key="ContentDialogMinHeight">408</x:Double>
-        <x:Double x:Key="ContentDialogMaxWidth">333</x:Double>
+        <x:Double x:Key="ContentDialogMaxWidth">360</x:Double>
         <x:Double x:Key="ContentDialogMaxHeight">408</x:Double>
         <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
         <Thickness x:Key="ContentDialogPadding">0,0,0,0</Thickness>

--- a/settings/DevHome.Settings/Views/LoginUIDialog.xaml
+++ b/settings/DevHome.Settings/Views/LoginUIDialog.xaml
@@ -13,6 +13,10 @@
 
     <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
     <ContentDialog.Resources>
+        <x:Double x:Key="ContentDialogMinWidth">333</x:Double>
+        <x:Double x:Key="ContentDialogMinHeight">408</x:Double>
+        <x:Double x:Key="ContentDialogMaxWidth">333</x:Double>
+        <x:Double x:Key="ContentDialogMaxHeight">408</x:Double>
         <Thickness x:Key="ContentDialogTitleMargin">0,0,0,0</Thickness>
         <Thickness x:Key="ContentDialogPadding">0,0,0,0</Thickness>
     </ContentDialog.Resources>


### PR DESCRIPTION
## Summary of the pull request
This PR makes changes to the Add Account UI. 

## References and relevant issues
To align with the figma design for AddAccountDialog, the below changes were made: 
- Modify size of content dialog
- Decrease github logo size 

This PR is in conjunction with https://github.com/microsoft/devhomegithubextension/pull/208

## Detailed description of the pull request / Additional comments
**Light Theme**
![image](https://github.com/microsoft/devhome/assets/128866445/7d2412f6-71fb-4fce-a63d-423e1734892b)


**Dark Theme**
![image](https://github.com/microsoft/devhome/assets/128866445/66619823-38a1-41ed-82ad-1d8e685ba2a3)



## Validation steps performed
Manual Testing 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
