### PR TITLE
Adjust widget styles and fix corners

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
@@ -5,7 +5,7 @@
     "medium": 20,
     "large": 30,
     "extraLarge": 40,
-    "padding": 10
+    "padding": 8
   },
   "separator": {
     "lineThickness": 0,

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
@@ -19,7 +19,7 @@
         "small": 12,
         "default": 12,
         "medium": 14,
-        "large": 18,
+        "large": 20,
         "extraLarge": 26
       },
       "fontWeights": {

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
@@ -1,6 +1,6 @@
 ﻿{
   "spacing": {
-    "small": 3,
+    "small": 4,
     "default": 8,
     "medium": 20,
     "large": 30,

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
@@ -5,7 +5,7 @@
     "medium": 20,
     "large": 30,
     "extraLarge": 40,
-    "padding": 10
+    "padding": 8
   },
   "separator": {
     "lineThickness": 0,

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
@@ -19,7 +19,7 @@
         "small": 12,
         "default": 12,
         "medium": 14,
-        "large": 18,
+        "large": 20,
         "extraLarge": 26
       },
       "fontWeights": {

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
@@ -1,6 +1,6 @@
 ﻿{
   "spacing": {
-    "small": 3,
+    "small": 4,
     "default": 8,
     "medium": 20,
     "large": 30,

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -31,7 +31,7 @@
         </Grid.RowDefinitions>
 
         <!-- Widget header: icon, title, menu -->
-        <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}">
+        <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" CornerRadius="7">
             <StackPanel Orientation="Horizontal" Margin="15,10,0,0" Spacing="8">
                 <Rectangle Width="16" Height="16" x:Name="WidgetHeaderIcon" />
                 <TextBlock AutomationProperties.AutomationId="WidgetTitle"

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -32,7 +32,7 @@
 
         <!-- Widget header: icon, title, menu -->
         <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" CornerRadius="7">
-            <StackPanel Orientation="Horizontal" Margin="15,10,0,0" Spacing="8">
+            <StackPanel Orientation="Horizontal" Margin="16,10,0,0" Spacing="8">
                 <Rectangle Width="16" Height="16" x:Name="WidgetHeaderIcon" />
                 <TextBlock AutomationProperties.AutomationId="WidgetTitle"
                            Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}"
@@ -45,7 +45,7 @@
                     x:Uid="WidgetMoreOptionsButton"
                     AutomationProperties.AutomationId="WidgetMoreOptionsButton"
                     FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{ThemeResource CaptionTextBlockFontSize}"
-                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10,15,0" BorderThickness="0" Padding="5"
+                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10,16,0" BorderThickness="0" Padding="5"
                     Background="Transparent"
                     Click="OpenWidgetMenu">
                 <Button.Flyout>
@@ -55,12 +55,12 @@
         </Grid>
 
         <!-- Widget content -->
-        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridLeft" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="5"
+        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridLeft" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="7"
                       HorizontalAlignment="Left" />
-        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridRight" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="5"
+        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridRight" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="7"
                       HorizontalAlignment="Right" />
         <ScrollViewer Grid.Row="1" x:Name="WidgetScrollViewer" Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}"
-                      VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" Padding="5,0" />
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" Padding="7,0" />
 
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary of the pull request
Adjust widget styles to better match design specs:
- small spacing should be 4
- padding should be 8
- large font should be 20
- since padding is smaller, adjust widget margins to be slightly bigger
- give inner widget corner a radius to fix the square corner
- give widget header the correct margin of 16

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1460
- [ ] Tests added/passed
- [ ] Documentation updated
