### PR TITLE
Widgets: fix SSHWallet config path, remove CPU "End process" buttons, text size/weight

### DIFF
--- a/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -235,10 +235,11 @@ internal class SSHWalletWidget : CoreWidget
     {
         var configurationData = new JsonObject();
 
+        var defaultOrCurrentConfigFile = string.IsNullOrEmpty(configFile) ? DefaultConfigFile : configFile;
         var sshConfigData = new JsonObject
             {
                 { "configFile", configFile },
-                { "defaultConfigFile", DefaultConfigFile },
+                { "defaultOrCurrentConfigFile", defaultOrCurrentConfigFile },
                 { "numOfEntries", numOfEntries.ToString(CultureInfo.InvariantCulture) },
             };
 

--- a/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -235,11 +235,11 @@ internal class SSHWalletWidget : CoreWidget
     {
         var configurationData = new JsonObject();
 
-        var defaultOrCurrentConfigFile = string.IsNullOrEmpty(configFile) ? DefaultConfigFile : configFile;
+        var currentOrDefaultConfigFile = string.IsNullOrEmpty(configFile) ? DefaultConfigFile : configFile;
         var sshConfigData = new JsonObject
             {
                 { "configFile", configFile },
-                { "defaultOrCurrentConfigFile", defaultOrCurrentConfigFile },
+                { "currentOrDefaultConfigFile", currentOrDefaultConfigFile },
                 { "numOfEntries", numOfEntries.ToString(CultureInfo.InvariantCulture) },
             };
 

--- a/CoreWidgetProvider/Widgets/Templates/LoadingTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/LoadingTemplate.json
@@ -10,13 +10,11 @@
           "type": "TextBlock",
           "text": "%Widget_Template/Loading%",
           "wrap": true,
-          "horizontalAlignment": "Center"
+          "horizontalAlignment": "center"
         }
       ],
-      "horizontalAlignment": "Center",
-      "verticalContentAlignment": "Center",
-      "spacing": "ExtraLarge",
-      "separator": true
+      "verticalContentAlignment": "center",
+      "height": "stretch"
     }
   ]
 }

--- a/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
@@ -38,8 +38,8 @@
       },
       "spacing": "Medium",
       "style": "Url",
-      "placeholder": "${$root.configuration.defaultOrCurrentConfigFile}",
-      "value": "${$root.configuration.defaultOrCurrentConfigFile}"
+      "placeholder": "${$root.configuration.currentOrDefaultConfigFile}",
+      "value": "${$root.configuration.currentOrDefaultConfigFile}"
     },
     {
       "type": "Container",

--- a/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
@@ -38,8 +38,8 @@
       },
       "spacing": "Medium",
       "style": "Url",
-      "placeholder": "${$root.configuration.defaultConfigFile}",
-      "value": "${$root.configuration.defaultConfigFile}"
+      "placeholder": "${$root.configuration.defaultOrCurrentConfigFile}",
+      "value": "${$root.configuration.defaultOrCurrentConfigFile}"
     },
     {
       "type": "Container",
@@ -53,7 +53,6 @@
       ],
       "$when": "${errorMessage != null}",
       "separator": true,
-      "horizontalAlignment": "Center",
       "verticalContentAlignment": "Center",
       "style": "warning"
     },
@@ -65,13 +64,14 @@
           "text": "%SSH_Widget_Template/ConfigFilePath%",
           "wrap": true,
           "spacing": "Medium",
-          "size": "Small"
+          "size": "Small",
+          "isSubtle": true
         },
         {
           "type": "TextBlock",
           "text": "${configFile}",
           "wrap": true,
-          "weight": "Bolder",
+          "size": "medium",
           "spacing": "None"
         },
         {
@@ -79,20 +79,20 @@
           "text": "%SSH_Widget_Template/NumOfHosts%",
           "wrap": true,
           "spacing": "Medium",
-          "size": "Small"
+          "size": "Small",
+          "isSubtle": true
         },
         {
           "type": "TextBlock",
           "text": "${numOfEntries}",
           "wrap": true,
-          "weight": "Bolder",
+          "size": "medium",
           "spacing": "None"
         }
       ],
       "spacing": "Medium",
       "$data": "${$root.configuration}",
       "$when": "${$root.hasConfiguration}",
-      "horizontalAlignment": "Left",
       "bleed": true
     }
   ]

--- a/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
@@ -22,8 +22,8 @@
             {
               "type": "TextBlock",
               "size": "large",
+              "weight": "bolder",
               "text": "${cpuUsage}"
-              
             }
           ]
         },
@@ -53,103 +53,19 @@
       "wrap": true
     },
     {
-      "type": "ColumnSet",
-      "columns": [
-        {
-          "type": "Column",
-          "verticalContentAlignment": "center",
-          "items": [
-            {
-              "text": "${cpuProc1}",
-              "weight": "bolder",
-              "type": "TextBlock"
-            }
-          ]
-        },
-        {
-          "type": "Column",
-          "verticalContentAlignment": "center",
-          "width": "stretch",
-          "items": [
-            {
-              "type": "ActionSet",
-              "actions": [
-                {
-                  "type": "Action.Execute",
-                  "title": "%CPUUsage_Widget_Template/End_Process%",
-                  "verb": "CpuKill1"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "TextBlock",
+      "size": "medium",
+      "text": "${cpuProc1}"
     },
     {
-      "type": "ColumnSet",
-      "columns": [
-        {
-          "type": "Column",
-          "verticalContentAlignment": "center",
-          "items": [
-            {
-              "text": "${cpuProc2}",
-              "weight": "bolder",
-              "type": "TextBlock"
-            }
-          ]
-        },
-        {
-          "type": "Column",
-          "verticalContentAlignment": "center",
-          "width": "stretch",
-          "items": [
-            {
-              "type": "ActionSet",
-              "actions": [
-                {
-                  "type": "Action.Execute",
-                  "title": "%CPUUsage_Widget_Template/End_Process%",
-                  "verb": "CpuKill2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "TextBlock",
+      "size": "medium",
+      "text": "${cpuProc2}"
     },
     {
-      "type": "ColumnSet",
-      "columns": [
-        {
-          "type": "Column",
-          "verticalContentAlignment": "center",
-          "items": [
-            {
-              "text": "${cpuProc3}",
-              "weight": "bolder",
-              "type": "TextBlock"
-            }
-          ]
-        },
-        {
-          "type": "Column",
-          "verticalContentAlignment": "center",
-          "width": "stretch",
-          "items": [
-            {
-              "type": "ActionSet",
-              "actions": [
-                {
-                  "type": "Action.Execute",
-                  "title": "%CPUUsage_Widget_Template/End_Process%",
-                  "verb": "CpuKill3"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "TextBlock",
+      "size": "medium",
+      "text": "${cpuProc3}"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -23,7 +23,8 @@
             {
               "text": "${gpuUsage}",
               "type": "TextBlock",
-              "size": "large"
+              "size": "large",
+              "weight": "bolder"
             }
           ]
         },
@@ -41,6 +42,7 @@
               "text": "${gpuTemp}",
               "type": "TextBlock",
               "size": "large",
+              "weight": "bolder",
               "horizontalAlignment": "right"
             }
           ]
@@ -55,7 +57,8 @@
     },
     {
       "text": "${gpuName}",
-      "type": "TextBlock"
+      "type": "TextBlock",
+      "size": "medium"
     }
   ],
   "actions": [

--- a/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
@@ -23,7 +23,8 @@
             {
               "text": "${usedMem}",
               "type": "TextBlock",
-              "size": "large"
+              "size": "large",
+              "weight": "bolder"
             }
           ]
         },
@@ -41,6 +42,7 @@
               "text": "${allMem}",
               "type": "TextBlock",
               "size": "large",
+              "weight": "bolder",
               "horizontalAlignment": "right"
             }
           ]
@@ -100,7 +102,8 @@
             },
             {
               "text": "${pagedPoolMem}",
-              "type": "TextBlock"
+              "type": "TextBlock",
+              "size": "medium"
             }
           ]
         },
@@ -117,6 +120,7 @@
             {
               "text": "${nonPagedPoolMem}",
               "type": "TextBlock",
+              "size": "medium",
               "horizontalAlignment": "right"
             }
           ]

--- a/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -24,7 +24,8 @@
             {
               "text": "${netSent}",
               "type": "TextBlock",
-              "size": "large"
+              "size": "large",
+              "weight": "bolder"
             }
           ]
         },
@@ -32,10 +33,10 @@
           "type": "Column",
           "items": [
             {
-              "type": "TextBlock",
               "text": "%NetworkUsage_Widget_Template/Received%",
-              "size": "small",
+              "type": "TextBlock",
               "spacing": "none",
+              "size": "small",
               "isSubtle": true,
               "horizontalAlignment": "right"
             },
@@ -43,6 +44,7 @@
               "text": "${netReceived}",
               "type": "TextBlock",
               "size": "large",
+              "weight": "bolder",
               "horizontalAlignment": "right"
             }
           ]
@@ -52,11 +54,13 @@
     {
       "text": "%NetworkUsage_Widget_Template/Network_Name%",
       "type": "TextBlock",
+      "size": "small",
       "isSubtle": true
     },
     {
       "text": "${networkName}",
-      "type": "TextBlock"
+      "type": "TextBlock",
+      "size": "medium"
     }
   ],
   "actions": [


### PR DESCRIPTION
## Summary of the pull request

Fix various widget issues:
- All widgets: text sizes and weights
- CPU Widget: remove "end process" buttons. They moved around too often to be useful, and the user can open task manager instead.
- SSH Wallet Widget: 
  - Style loading screen to properly center text
  - Fix issue where when a configuration file was submitted, the summary page would put the default location back into the TextBox rather than the current file. Instead fill with default path, or user specified path if available.

![image](https://github.com/microsoft/devhome/assets/47155823/810e1651-88e5-40a0-90a7-21be47de68da)

![image](https://github.com/microsoft/devhome/assets/47155823/8585bb33-ed72-48a1-bbaf-0c69499ad7c1)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1460
- [ ] Tests added/passed
- [ ] Documentation updated
