### PR TITLE
Add detailed repo clone error message (#1229)

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -889,7 +889,7 @@
     <comment>Message when a repository is cloning.  Param:Clone Path</comment>
   </data>
   <data name="CloneRepoError" xml:space="preserve">
-    <value>Couldn't clone {0}</value>
+    <value>Couldn't clone {0} because </value>
     <comment>Message when a repository encountered an error when cloning. Param: Repo Name</comment>
   </data>
   <data name="CloneRepoRestart" xml:space="preserve">


### PR DESCRIPTION
## Summary of the pull request

When there is an error, DevHome won't give any clue of the reason why error happens. The error code itself is not really explaining what happened. So, I made a little change to show you what error message supposed to be. It's expected to be as this:

![Fixed repo clone error message](https://github.com/microsoft/devhome/assets/30412448/8ed1a6ca-ca0c-4c2e-b8e5-b164361b69a4)

I admit that the message at the illustration is not really explaining much. Because I have to modify a lot of codes for each task, which potentially disturbs the code structure. At least it gives you a rough illustration of how telling the error reason.

## References and relevant issues

This issue #1229 still unreplied by the way.

## Detailed description of the pull request / Additional comments

I still struggling to understand how the i18n works in this project. Please let me know the better way to change the hard-coded string to be properly implemented string and it should be a string template that could be modified in runtime. I failed to figure out, please help me to help you...

## Validation steps performed

To try the changes, clone a same GitHub repository twice. It's recommended to use SSH protocol instead of HTTPS.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
