### PR TITLE
Use accent color for widget Pin and Update buttons

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -73,6 +73,7 @@
                       x:Name="PinRow"
                       Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
                     <Button x:Name="PinButton"
+                            Style="{ThemeResource AccentButtonStyle}"
                             VerticalAlignment="Bottom" HorizontalAlignment="Center"
                             Visibility="Collapsed"
                             IsEnabled="{x:Bind ViewModel.Configuring, Mode=OneWay, Converter={StaticResource BoolNegation}}"

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -45,6 +45,7 @@
 
             <Button Grid.Row="1"
                     x:Name="UpdateWidgetButton" x:Uid="UpdateWidgetButton"
+                    Style="{ThemeResource AccentButtonStyle}"
                     VerticalAlignment="Bottom" HorizontalAlignment="Center"
                     Visibility="Visible"
                     IsEnabled="{x:Bind ViewModel.Configuring, Mode=OneWay, Converter={StaticResource BoolNegation}}"


### PR DESCRIPTION
## Summary of the pull request
Buttons should use the accent color for the current theme.

![image](https://github.com/microsoft/devhome/assets/47155823/5a9ec1aa-5b4a-430f-9761-a80bab4667e1)
![image](https://github.com/microsoft/devhome/assets/47155823/de7c06c3-95ce-4482-8b00-b03d2f5fa7d8)

## PR checklist
- [x] Closes #1474