### PR TITLE
Add icon to external links in Feedback settings

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -275,7 +275,7 @@
     <value>Create an extension</value>
     <comment>Creating a new extension</comment>
   </data>
-  <data name="Settings_Feedback_BuildExtension_Button.Content" xml:space="preserve">
+  <data name="Settings_Feedback_BuildExtension_Button.Text" xml:space="preserve">
     <value>Learn more</value>
     <comment>Description or instruction on building an extension</comment>
   </data>
@@ -315,7 +315,7 @@
     <value>Report a security vulnerability</value>
     <comment>Tell us about potential security concerns</comment>
   </data>
-  <data name="Settings_Feedback_ReportSecurity_Button.Content" xml:space="preserve">
+  <data name="Settings_Feedback_ReportSecurity_Button.Text" xml:space="preserve">
     <value>Learn more</value>
     <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -101,35 +101,45 @@
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xebe8;"/>
                         </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_ReportBug_Button" Click="DisplayReportBugDialog"/>
+                        <Button x:Uid="Settings_Feedback_ReportBug_Button" Click="DisplayReportBugDialog" MinWidth="150" />
                     </labs:SettingsCard>
                     <labs:SettingsCard x:Uid="Settings_Feedback_FeatureImprovement">
                         <labs:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xea80;"/>
                         </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_FeatureImprovement_Button" Click="DisplaySuggestFeature"/>
+                        <Button x:Uid="Settings_Feedback_FeatureImprovement_Button" Click="DisplaySuggestFeature"  MinWidth="150" />
                     </labs:SettingsCard>
                     <labs:SettingsCard x:Uid="Settings_Feedback_LocalizationIssue">
                         <labs:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xE909;"/>
                         </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_LocalizationIssue_Button" Click="DisplayLocalizationIssueDialog"/>
+                        <Button x:Uid="Settings_Feedback_LocalizationIssue_Button" Click="DisplayLocalizationIssueDialog"  MinWidth="150" />
                     </labs:SettingsCard>
                     <labs:SettingsCard x:Uid="Settings_Feedback_BuildExtension">
                         <labs:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xea86;"/>
                         </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_BuildExtension_Button" Click="BuildExtensionButtonClicked"/>
+                        <Button Click="BuildExtensionButtonClicked" MinWidth="150">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock x:Uid="Settings_Feedback_BuildExtension_Button" />
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" FontSize="12" />
+                            </StackPanel>
+                        </Button>
                     </labs:SettingsCard>
                     <labs:SettingsCard x:Uid="Settings_Feedback_ReportSecurity">
                         <labs:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xf552;"/>
                         </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_ReportSecurity_Button" Click="ReportSecurityButtonClicked"/>
+                        <Button Click="ReportSecurityButtonClicked" MinWidth="150">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock x:Uid="Settings_Feedback_ReportSecurity_Button" />
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" FontSize="12" />
+                            </StackPanel>
+                        </Button>
                     </labs:SettingsCard>
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
## Summary of the pull request

Make all the buttons equal width (at least with current English text) and add an icon to let the user know that the button links externally.

![image](https://github.com/microsoft/devhome/assets/47155823/65c4e6e3-092f-4ba4-bcce-a124217ddb8e)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
