### PR TITLE
Add skeleton of Extensions Library page

### DIFF
--- a/exclusion.dic
+++ b/exclusion.dic
@@ -16,3 +16,4 @@
 ﻿othersoftware
 ﻿supportinginfo
 ﻿enums
+﻿downloadsandupdates

--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -38,4 +38,6 @@
 
     <Thickness x:Key="SettingsCardMargin">0,0,0,4</Thickness>
     <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+
+    <Thickness x:Key="ExtensionLibrarySubTitleMargin">0,32,0,16</Thickness>
 </ResourceDictionary>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -62,4 +62,20 @@
     <value>Extensions</value>
     <comment>Navigation pane content</comment>
   </data>
+  <data name="ExtensionLibraryPage_Title.Text" xml:space="preserve">
+    <value>Extensions</value>
+    <comment>Header text for Extension Library page</comment>
+  </data>
+  <data name="OnYourPcTextBlock.Text" xml:space="preserve">
+    <value>On your PC</value>
+    <comment>Header for the list of packages currently installed on the user's computer</comment>
+  </data>
+  <data name="GetUpdatesButton.Content" xml:space="preserve">
+    <value>Get updates</value>
+    <comment>Button that allows the user to check if the store has updates for current packages</comment>
+  </data>
+  <data name="AvailableFromStoreTextBlock.Text" xml:space="preserve">
+    <value>Available from the Store</value>
+    <comment>Header for the list of packages available for download from the store</comment>
+  </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Windows.System;
 
 namespace DevHome.ExtensionLibrary.ViewModels;
 
@@ -9,5 +13,11 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 {
     public ExtensionLibraryViewModel()
     {
+    }
+
+    [RelayCommand]
+    public async Task GetUpdatesButton()
+    {
+        await Launcher.LaunchUriAsync(new ("ms-windows-store://downloadsandupdates"));
     }
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -16,7 +16,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     }
 
     [RelayCommand]
-    public async Task GetUpdatesButton()
+    public async Task GetUpdatesButtonAsync()
     {
         await Launcher.LaunchUriAsync(new ("ms-windows-store://downloadsandupdates"));
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -10,6 +10,24 @@
     xmlns:pg="using:DevHome.Common"
     mc:Ignorable="d">
 
-    <Grid>
+    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,22,0,0">
+            <StackPanel>
+
+                <!-- On your PC items -->
+                <Grid Margin="{StaticResource SettingsPageSubTitleMargin}">
+                    <TextBlock x:Uid="OnYourPcTextBlock" />
+                    <Button x:Uid="GetUpdatesButton"
+                            HorizontalAlignment="Right"
+                            Style="{ThemeResource AccentButtonStyle}" 
+                            Command="{x:Bind ViewModel.GetUpdatesButtonCommand}"/>
+                </Grid>
+
+                <!-- Available items -->
+                <TextBlock x:Uid="AvailableFromStoreTextBlock"
+                           Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />
+
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </pg:ToolPage>


### PR DESCRIPTION
## Summary of the pull request
In the interest of keeping PRs small, add headers and a button to the page. The "Get updates" button should probably be smarter, but this is a barebones possible solution.

![image](https://github.com/microsoft/devhome/assets/47155823/167e57cf-3e4a-43d3-a444-79eed382f4c8)
