### PR TITLE
Correctly show message when there are no pinned widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -15,11 +15,13 @@
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
     <Page.Resources>
         <ResourceDictionary>
+            <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Visible" TrueValue="Collapsed" />
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <x:String x:Key="DashboardBannerFront">ms-appx:///DevHome.Dashboard/Assets/DashboardBannerFrontLight.png</x:String>
@@ -104,7 +106,8 @@
                               HorizontalAlignment="Center"/>
 
                 <!-- Widget grid empty message -->
-                <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0"
+                            Visibility="{x:Bind views:DashboardView.PinnedWidgets.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}">
                     <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
                     <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center">
                         <i:Interaction.Behaviors>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -82,8 +82,7 @@ public partial class DashboardView : ToolPage
         }
         else
         {
-            // If above initialization failed, there are no widgets, show the message.
-            NoWidgetsStackPanel.Visibility = Visibility.Visible;
+            Log.Logger()?.ReportWarn("DashboardView", $"Initialization failed");
         }
 
 #if DEBUG
@@ -253,7 +252,6 @@ public partial class DashboardView : ToolPage
         else
         {
             Log.Logger()?.ReportInfo("DashboardView", $"Found 0 widgets for this host");
-            NoWidgetsStackPanel.Visibility = Visibility.Visible;
         }
     }
 
@@ -463,8 +461,6 @@ public partial class DashboardView : ToolPage
                 item.PropertyChanged += PinnedWidgetsPropertyChanged;
             }
         }
-
-        NoWidgetsStackPanel.Visibility = (PinnedWidgets.Count > 0) ? Visibility.Collapsed : Visibility.Visible;
     }
 
     private async void PinnedWidgetsPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request
There are some bugs around when the "no widgets pinned" message shows up, and it's not visible every time it should be. This change uses a converter to prevent those bugs.
![image](https://github.com/microsoft/devhome/assets/47155823/3f8219bb-2d49-4f0e-b915-db735b735e35)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
