### PR TITLE
Add account redirecting to extensions marketplace page

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -165,7 +165,7 @@
     <value>Install a Dev Home extension that uses your developer account, then sign in to add the account.</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText" xml:space="preserve">
-    <value>OK</value>
+    <value>Find Extensions</value>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_Title" xml:space="preserve">
     <value>No extensions found</value>
@@ -382,5 +382,8 @@
   <data name="Settings_Feedback_OpenSource_Link.NavigateUri" xml:space="preserve">
     <value>https://go.microsoft.com/fwlink/?linkid=2236981</value>
     <comment>This is the microsoft code of conduct link.</comment>
+  </data>
+  <data name="Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
   </data>
 </root>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -75,6 +75,7 @@ public sealed partial class AccountsPage : Page
                 Content = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_Content"),
                 PrimaryButtonText = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText"),
                 PrimaryButtonCommand = FindExtensionsCommand,
+                PrimaryButtonStyle = (Style)Application.Current.Resources["AccentButtonStyle"],
                 SecondaryButtonText = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText"),
                 XamlRoot = XamlRoot,
             };

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using AdaptiveCards.Rendering.WinUI3;
+using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Common.Renderers;
 using DevHome.Common.Services;
@@ -72,10 +74,19 @@ public sealed partial class AccountsPage : Page
                 Title = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_Title"),
                 Content = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_Content"),
                 PrimaryButtonText = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText"),
+                PrimaryButtonCommand = FindExtensionsCommand,
+                SecondaryButtonText = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText"),
                 XamlRoot = XamlRoot,
             };
             await noProvidersContentDialog.ShowAsync();
         }
+    }
+
+    [RelayCommand]
+    private void FindExtensions()
+    {
+        var navigationService = Application.Current.GetService<INavigationService>();
+        navigationService.NavigateTo("DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel");
     }
 
     private async void AddDeveloperId_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request

The new flow designed for when the user tries to add an account without having a provider installed that uses it, is to show a message and a button that redirects to the extensions marketplace page.

<img width="412" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/a4505725-e31e-4888-9a9b-dbd59e951d66">

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
