### PR TITLE
List store packages on Extensions page

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Assets/extensionResult.json
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Assets/extensionResult.json
@@ -1,0 +1,35 @@
+{
+  "ProductIds": ["9NZCC27PR6N6", "9N8MHTPHNGVV"],
+  "Products":
+  [
+    {
+      "LocalizedProperties":
+	  [
+        {
+          "PublisherName": "Microsoft Corporation",
+          "ProductTitle": "Dev Home GitHub Extension (Preview)"
+        }
+      ],
+      "ProductId": "9NZCC27PR6N6",
+      "Properties":
+	  {
+        "PackageFamilyName": "Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe"
+      }
+    },
+    {
+      "LocalizedProperties": 
+	  [
+        {
+          "PublisherName": "Microsoft Corporation",
+          "ProductTitle": "Dev Home (Preview)"
+		}
+      ],
+      "ProductId": "9N8MHTPHNGVV",
+      "Properties":
+	  {
+        "PackageFamilyName": "Microsoft.Windows.DevHome_8wekyb3d8bbwe"
+      }
+    }
+  ],
+  "TotalResultCount": 2
+}

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>DevHome.ExtensionLibrary</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
     <ProjectReference Include="..\..\..\logging\DevHome.Logging.csproj" />
+    <ProjectReference Include="..\..\..\settings\DevHome.Settings\DevHome.Settings.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Helpers/Log.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Helpers/Log.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using DevHome.Logging;
+
+#nullable enable
+
+namespace DevHome.Dashboard.Helpers;
+
+public class Log
+{
+    private static readonly ComponentLogger _logger = new ("ExtensionLibrary");
+
+    public static Logger? Logger() => _logger.Logger;
+}
+#nullable disable

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -83,11 +83,15 @@
     <comment>Text on button that allows user to get the package from the store</comment>
   </data>
   <data name="NoAvailableExtensions.Text" xml:space="preserve">
-    <value>You've already installed all available extensions!</value>
+    <value>No more extensions are available.</value>
     <comment>Message shown when there are no extensions left to install</comment>
   </data>
   <data name="StoreErrorMessage.Text" xml:space="preserve">
-    <value>Dev Home could not retrieve available extensions from the Microsoft Store.</value>
+    <value>Couldn't get extensions right now. Try again later.</value>
     <comment>Message shown when there was an issue getting information about extensions available in the Microsoft Store</comment>
+  </data>
+  <data name="SendFeedback.Content" xml:space="preserve">
+    <value>Send feedback</value>
+    <comment>A link to a page where the user can submit feedback about a bug</comment>
   </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -78,4 +78,16 @@
     <value>Available from the Store</value>
     <comment>Header for the list of packages available for download from the store</comment>
   </data>
+  <data name="GetButton.Content" xml:space="preserve">
+    <value>Get</value>
+    <comment>Text on button that allows user to get the package from the store</comment>
+  </data>
+  <data name="NoAvailableExtensions.Text" xml:space="preserve">
+    <value>You've already installed all available extensions!</value>
+    <comment>Message shown when there are no extensions left to install</comment>
+  </data>
+  <data name="StoreErrorMessage.Text" xml:space="preserve">
+    <value>Dev Home could not retrieve available extensions from the Microsoft Store.</value>
+    <comment>Message shown when there was an issue getting information about extensions available in the Microsoft Store</comment>
+  </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -2,22 +2,151 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.WinUI;
+using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using DevHome.Dashboard.Helpers;
+using Microsoft.UI.Xaml;
+using Windows.Data.Json;
+using Windows.Storage;
 using Windows.System;
 
 namespace DevHome.ExtensionLibrary.ViewModels;
 
 public partial class ExtensionLibraryViewModel : ObservableObject
 {
+    private readonly string devHomeProductId = "9N8MHTPHNGVV";
+
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
+
+    [ObservableProperty]
+    private ObservableCollection<StorePackageViewModel> _storePackagesList = new ();
+
+    [ObservableProperty]
+    private bool _shouldShowStoreError = false;
+
     public ExtensionLibraryViewModel()
     {
+        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+
+        var pluginService = Application.Current.GetService<IPluginService>();
+        pluginService.OnPluginsChanged -= OnPluginsChanged;
+        pluginService.OnPluginsChanged += OnPluginsChanged;
+
+        GetAvailablePackages();
     }
 
     [RelayCommand]
     public async Task GetUpdatesButtonAsync()
     {
         await Launcher.LaunchUriAsync(new ("ms-windows-store://downloadsandupdates"));
+    }
+
+    private async void OnPluginsChanged(object? sender, EventArgs e)
+    {
+        await _dispatcher.EnqueueAsync(() =>
+        {
+            ShouldShowStoreError = false;
+            GetAvailablePackages();
+        });
+    }
+
+    private async Task<string> GetStoreData()
+    {
+        var packagesFileContents = string.Empty;
+        var packagesFileName = "extensionResult.json";
+        try
+        {
+            Log.Logger()?.ReportInfo("ExtensionLibraryViewModel", $"Get packages file '{packagesFileName}'");
+            var uri = new Uri($"ms-appx:///DevHome.ExtensionLibrary/Assets/{packagesFileName}");
+            var file = await StorageFile.GetFileFromApplicationUriAsync(uri).AsTask().ConfigureAwait(false);
+            packagesFileContents = await FileIO.ReadTextAsync(file);
+        }
+        catch (Exception ex)
+        {
+            Log.Logger()?.ReportError("ExtensionLibraryViewModel", "Error retrieving packages", ex);
+            ShouldShowStoreError = true;
+        }
+
+        return packagesFileContents;
+    }
+
+    private async void GetAvailablePackages()
+    {
+        StorePackagesList.Clear();
+
+        var storeData = await GetStoreData();
+        if (string.IsNullOrEmpty(storeData))
+        {
+            Log.Logger()?.ReportError("ExtensionLibraryViewModel", "No package data found");
+            ShouldShowStoreError = true;
+            return;
+        }
+
+        var jsonObj = JsonObject.Parse(storeData);
+        if (jsonObj != null)
+        {
+            var products = jsonObj.GetNamedArray("Products");
+            foreach (var product in products)
+            {
+                var productObj = product.GetObject();
+                var productId = productObj.GetNamedString("ProductId");
+
+                // Don't show self as available.
+                if (productId == devHomeProductId)
+                {
+                    continue;
+                }
+
+                var title = string.Empty;
+                var publisher = string.Empty;
+
+                var localizedProperties = productObj.GetNamedArray("LocalizedProperties");
+                foreach (var localizedProperty in localizedProperties)
+                {
+                    var propertyObject = localizedProperty.GetObject();
+                    title = propertyObject.GetNamedValue("ProductTitle").GetString();
+                    publisher = propertyObject.GetNamedValue("PublisherName").GetString();
+                }
+
+                var properties = productObj.GetNamedObject("Properties");
+                var packageFamilyName = properties.GetNamedString("PackageFamilyName");
+
+                // Don't show packages of already installed extensions as available.
+                if (IsAlreadyInstalled(packageFamilyName))
+                {
+                    continue;
+                }
+
+                Log.Logger()?.ReportError("ExtensionLibraryViewModel", $"Found package: {productId}, {packageFamilyName}");
+                var storePackage = new StorePackageViewModel(productId, title, publisher, packageFamilyName);
+                StorePackagesList.Add(storePackage);
+            }
+        }
+    }
+
+    private bool IsAlreadyInstalled(string packageFamilyName)
+    {
+        // Coming  in next commit.
+        return false;
+    }
+
+    /// <summary>
+    /// Determine whether to show a message that there are no more packages with Dev Home extensions available to
+    /// install. This message is shown when there are no extensions in the list and there was no error retrieving the
+    /// list from the store data.
+    /// </summary>
+    public Visibility GetNoAvailablePackagesVisibility(int availablePackagesCount, bool shouldShowStoreError)
+    {
+        if (availablePackagesCount == 0 && !shouldShowStoreError)
+        {
+            return Visibility.Visible;
+        }
+
+        return Visibility.Collapsed;
     }
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -10,6 +10,7 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Dashboard.Helpers;
+using DevHome.Settings.ViewModels;
 using Microsoft.UI.Xaml;
 using Windows.Data.Json;
 using Windows.Storage;
@@ -148,5 +149,12 @@ public partial class ExtensionLibraryViewModel : ObservableObject
         }
 
         return Visibility.Collapsed;
+    }
+
+    [RelayCommand]
+    public void SendFeedbackClick()
+    {
+        var navigationService = Application.Current.GetService<INavigationService>();
+        _ = navigationService.NavigateTo(typeof(FeedbackViewModel).FullName!);
     }
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/StorePackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/StorePackageViewModel.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Windows.System;
+
+namespace DevHome.ExtensionLibrary.ViewModels;
+public partial class StorePackageViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _productId;
+
+    [ObservableProperty]
+    private string _title;
+
+    [ObservableProperty]
+    private string _publisher;
+
+    [ObservableProperty]
+    private string _packageFamilyName;
+
+    public StorePackageViewModel(string productId, string title, string publisher, string packageFamilyName)
+    {
+        _productId = productId;
+        _title = title;
+        _publisher = publisher;
+        _packageFamilyName = packageFamilyName;
+    }
+
+    [RelayCommand]
+    public async Task LaunchStoreButton(string packageId)
+    {
+        var linkString = $"ms-windows-store://pdp/?ProductId={packageId}&mode=mini";
+        await Launcher.LaunchUriAsync(new (linkString));
+    }
+}

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -53,12 +53,16 @@
                            Visibility="{x:Bind ViewModel.GetNoAvailablePackagesVisibility(ViewModel.StorePackagesList.Count, ViewModel.ShouldShowStoreError), Mode=OneWay}"
                            Margin="0,50,0,0"
                            HorizontalAlignment="Center" />
-                <TextBlock x:Uid="StoreErrorMessage"
-                           Foreground="{ThemeResource SystemFillColorCautionBrush}"
-                           Visibility="{x:Bind ViewModel.ShouldShowStoreError, Mode=OneWay}"
-                           Margin="0,50,0,0"
-                           HorizontalAlignment="Center" />
-
+                <StackPanel Visibility="{x:Bind ViewModel.ShouldShowStoreError, Mode=OneWay}" HorizontalAlignment="Center">
+                    <TextBlock x:Uid="StoreErrorMessage"
+                               Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                               Margin="0,50,0,0"
+                               HorizontalAlignment="Center" />
+                    <HyperlinkButton x:Uid="SendFeedback"
+                                     HorizontalAlignment="Center"
+                                     Command="{x:Bind ViewModel.SendFeedbackClickCommand}">
+                    </HyperlinkButton>
+                </StackPanel>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -8,6 +8,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
+    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:viewmodels="using:DevHome.ExtensionLibrary.ViewModels"
     mc:Ignorable="d">
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
@@ -26,6 +28,36 @@
                 <!-- Available items -->
                 <TextBlock x:Uid="AvailableFromStoreTextBlock"
                            Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />
+                <ItemsRepeater ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
+                    <ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="viewmodels:StorePackageViewModel">
+                            <labs:SettingsCard Header="{x:Bind Title}"
+                                               Description="{x:Bind Publisher}"
+                                               Margin="{ThemeResource SettingsCardMargin}"
+                                               CornerRadius="3"
+                                               IsClickEnabled="False">
+                                <labs:SettingsCard.HeaderIcon>
+                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
+                                </labs:SettingsCard.HeaderIcon>
+                                <Button x:Uid="GetButton"
+                                        Padding="25 4 25 6"
+                                        MinWidth="118"
+                                        Command="{x:Bind LaunchStoreButtonCommand}"
+                                        CommandParameter="{x:Bind ProductId}" />
+                            </labs:SettingsCard>
+                        </DataTemplate>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
+                <!-- No available items messages -->
+                <TextBlock x:Uid="NoAvailableExtensions"
+                           Visibility="{x:Bind ViewModel.GetNoAvailablePackagesVisibility(ViewModel.StorePackagesList.Count, ViewModel.ShouldShowStoreError), Mode=OneWay}"
+                           Margin="0,50,0,0"
+                           HorizontalAlignment="Center" />
+                <TextBlock x:Uid="StoreErrorMessage"
+                           Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                           Visibility="{x:Bind ViewModel.ShouldShowStoreError, Mode=OneWay}"
+                           Margin="0,50,0,0"
+                           HorizontalAlignment="Center" />
 
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
## Summary of the pull request
Add the list of packages from the store to the Dev Home UI. This change does not include installed extensions.

![image](https://github.com/microsoft/devhome/assets/47155823/14799cf6-2990-4204-91a4-41366c833ac5)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
