### PR TITLE
Removing an unused member, PluginName

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.249" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.499.248.2228" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20230706-x2201" />

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.499.248.2228" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.249" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20230706-x2201" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -63,11 +63,6 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         get; set;
     }
 
-    public string PluginName
-    {
-        get; set;
-    }
-
     /// <summary>
     /// Gets or sets a value indicating whether the repository is to be cloned on a Dev Drive.
     /// </summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -438,7 +438,6 @@ public partial class AddRepoViewModel : ObservableObject
 
             var cloningInformation = new CloningInformation(repoToRemove);
             cloningInformation.ProviderName = _providers.DisplayName(providerName);
-            cloningInformation.PluginName = providerName;
             cloningInformation.OwningAccount = developerId;
 
             EverythingToClone.Remove(cloningInformation);
@@ -456,7 +455,6 @@ public partial class AddRepoViewModel : ObservableObject
             var cloningInformation = new CloningInformation(repoToAdd);
             cloningInformation.RepositoryProvider = _providers.GetProvider(providerName);
             cloningInformation.ProviderName = _providers.DisplayName(providerName);
-            cloningInformation.PluginName = providerName;
             cloningInformation.OwningAccount = developerId;
             cloningInformation.EditClonePathAutomationName = _stringResource.GetLocalized(StringResourceKey.RepoPageEditClonePathAutomationProperties, $"{providerName}/{repositoryToAdd}");
             cloningInformation.RemoveFromCloningAutomationName = _stringResource.GetLocalized(StringResourceKey.RepoPageRemoveRepoAutomationProperties, $"{providerName}/{repositoryToAdd}");
@@ -594,7 +592,7 @@ public partial class AddRepoViewModel : ObservableObject
         Repositories = new ObservableCollection<RepoViewListItem>(OrderRepos(_repositoriesForAccount));
 
         return _previouslySelectedRepos.Where(x => x.OwningAccount != null)
-            .Where(x => x.PluginName.Equals(repositoryProvider, StringComparison.OrdinalIgnoreCase)
+            .Where(x => x.RepositoryProvider.DisplayName.Equals(repositoryProvider, StringComparison.OrdinalIgnoreCase)
             && x.OwningAccount.LoginId.Equals(loginId, StringComparison.OrdinalIgnoreCase))
             .Select(x => new RepoViewListItem(x.RepositoryToClone));
     }


### PR DESCRIPTION
## Summary of the pull request
PluginName was from a bygone era before Providers had .DisplayName.  PluginName isn't needed anymore.  It is removed.

Additionally, PluginName caused a bug.  AddRepoViewModel.SetRepositories would fail if PluginName is null.  This can happen if repos were added via URL.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
