### PR TITLE
Text trimmed if no more space available on small cards

### DIFF
--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -181,7 +181,7 @@
     <value>Dev Home is getting things ready for you...</value>
   </data>
   <data name="WhatsNewPage_Title.Text" xml:space="preserve">
-    <value>Setup your dev environment</value>
+    <value>Set up your dev environment</value>
   </data>
   <data name="Feedback_Title.Text" xml:space="preserve">
     <value>Feedback</value>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -291,7 +291,7 @@
                                         Margin="0 16 0 25"
                                         TextWrapping="Wrap"
                                         VerticalAlignment="Stretch"
-                                        TextTrimming="CharacterEllipsis"
+                                        TextTrimming="WordEllipsis"
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -274,10 +274,6 @@
                                     VerticalAlignment="Top"/>
 
                                 <Grid Grid.Row="1" Padding="15 10 15 0" >
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="*" />

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -261,10 +261,6 @@
                                     </ResourceDictionary>
                                 </Grid.Resources>
 
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="*" />

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -268,6 +268,7 @@
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="*" />
+                                    <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
 
                                 <Image
@@ -276,28 +277,43 @@
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Top"/>
 
-                                <StackPanel Grid.Row="1" Padding="15 10 15 0" >
+                                <Grid Grid.Row="1" Padding="15 10 15 0" >
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
                                     <TextBlock
+                                        Grid.Row="0"
                                         HorizontalAlignment="Left"
                                         Style="{ThemeResource BodyTextStyle}"
                                         Text="{x:Bind Title}" />
 
                                     <TextBlock
+                                        Grid.Row="1"
                                         Margin="0 16 0 25"
                                         TextWrapping="Wrap"
+                                        VerticalAlignment="Stretch"
+                                        TextTrimming="CharacterEllipsis"
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton
+                                        Grid.Row="2"
                                         Content="{x:Bind Link}"
                                         Foreground="{ThemeResource LearnMoreForeground}"
                                         NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
                                         Padding="0"
                                         Margin="0"
                                         Visibility="{x:Bind ShouldShowLink}"/>
-                                </StackPanel>
+                                </Grid>
 
                                 <Button 
-                                    Grid.Row="1"
+                                    Grid.Row="2"
                                     Margin="15 0 15 10"
                                     DataContext="{x:Bind PageKey}"
                                     Click="Button_ClickAsync"


### PR DESCRIPTION
## Summary of the pull request

If there are no available space to fit the text in the small cards, we want the text to be trimmed ending in "...".

<img width="274" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/6e6abb32-ade3-4076-96df-187460ccd111">

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
