### PR TITLE
List installed packages on Extensions page

### DIFF
--- a/common/Services/IPluginWrapper.cs
+++ b/common/Services/IPluginWrapper.cs
@@ -66,6 +66,14 @@ public interface IPluginWrapper
     }
 
     /// <summary>
+    /// Gets the Unique Id for the extension
+    /// </summary>
+    public string ExtensionUniqueId
+    {
+        get;
+    }
+
+    /// <summary>
     /// Checks whether we have a reference to the plugin process and we are able to call methods on the interface.
     /// </summary>
     /// <returns>Whether we have a reference to the plugin process and we are able to call methods on the interface.</returns>

--- a/common/Services/IPluginWrapper.cs
+++ b/common/Services/IPluginWrapper.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Windows.DevHome.SDK;
+using Windows.ApplicationModel;
 
 namespace DevHome.Common.Services;
 public interface IPluginWrapper
@@ -24,9 +26,41 @@ public interface IPluginWrapper
     }
 
     /// <summary>
+    /// Gets PackageFamilyName of the extension
+    /// </summary>
+    string PackageFamilyName
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets Publisher of the extension
+    /// </summary>
+    string Publisher
+    {
+        get;
+    }
+
+    /// <summary>
     /// Gets class id (GUID) of the plugin class (which implements IPlugin) as mentioned in the manifest
     /// </summary>
     string PluginClassId
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the date on which the application package was installed or last updated.
+    /// </summary>
+    DateTimeOffset InstalledDate
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the PackageVersion of the extension
+    /// </summary>
+    PackageVersion Version
     {
         get;
     }

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -17,3 +17,4 @@
 ﻿supportinginfo
 ﻿enums
 ﻿downloadsandupdates
+﻿appsfeatures

--- a/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
@@ -84,7 +84,7 @@ public partial class ExtensionsViewModel : ObservableObject
                 continue;
             }
 
-            var setting = new Setting("Plugins/" + pluginWrapper.PackageFullName, pluginWrapper.PackageFullName, pluginWrapper.Name, string.Empty, string.Empty, true);
+            var setting = new Setting("Plugins/" + pluginWrapper.ExtensionUniqueId, pluginWrapper.ExtensionUniqueId, pluginWrapper.Name, string.Empty, string.Empty, true);
             SettingsList.Add(new ExtensionViewModel(setting, this));
         }
     }

--- a/src/Models/PluginWrapper.cs
+++ b/src/Models/PluginWrapper.cs
@@ -39,6 +39,7 @@ public class PluginWrapper : IPluginWrapper
         Publisher = appExtension.Package.PublisherDisplayName;
         InstalledDate = appExtension.Package.InstalledDate;
         Version = appExtension.Package.Id.Version;
+        ExtensionUniqueId = appExtension.AppUserModelId + "!" + appExtension.Id;
     }
 
     public string Name
@@ -72,6 +73,20 @@ public class PluginWrapper : IPluginWrapper
     }
 
     public PackageVersion Version
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the unique id for this Dev Home extension. The unique id is a concatenation of:
+    /// <list type="number">
+    /// <item>The AppUserModelId (AUMID) of the extension's application. The AUMID is the concatenation of the package
+    /// family name and the application id and uniquely identifies the application containing the extension within
+    /// the package.</item>
+    /// <item>The Extension Id. This is the unique identifier of the extension within the application.</item>
+    /// </list>
+    /// </summary>
+    public string ExtensionUniqueId
     {
         get;
     }

--- a/src/Models/PluginWrapper.cs
+++ b/src/Models/PluginWrapper.cs
@@ -4,6 +4,7 @@
 using System.Runtime.InteropServices;
 using DevHome.Common.Services;
 using Microsoft.Windows.DevHome.SDK;
+using Windows.ApplicationModel;
 using Windows.Win32;
 using Windows.Win32.System.Com;
 using WinRT;
@@ -28,11 +29,22 @@ public class PluginWrapper : IPluginWrapper
 
     private IExtension? _extensionObject;
 
-    public PluginWrapper(string name, string packageFullName, string classId)
+    public PluginWrapper(
+        string name,
+        string packageFullName,
+        string packageFamilyName,
+        string publisher,
+        string classId,
+        DateTimeOffset installedDate,
+        PackageVersion version)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         PackageFullName = packageFullName ?? throw new ArgumentNullException(nameof(packageFullName));
+        PackageFamilyName = packageFamilyName ?? throw new ArgumentNullException(nameof(packageFamilyName));
+        Publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         PluginClassId = classId ?? throw new ArgumentNullException(nameof(classId));
+        InstalledDate = installedDate;
+        Version = version;
     }
 
     public string Name
@@ -45,7 +57,27 @@ public class PluginWrapper : IPluginWrapper
         get;
     }
 
+    public string PackageFamilyName
+    {
+        get;
+    }
+
+    public string Publisher
+    {
+        get;
+    }
+
     public string PluginClassId
+    {
+        get;
+    }
+
+    public DateTimeOffset InstalledDate
+    {
+        get;
+    }
+
+    public PackageVersion Version
     {
         get;
     }

--- a/src/Models/PluginWrapper.cs
+++ b/src/Models/PluginWrapper.cs
@@ -39,7 +39,7 @@ public class PluginWrapper : IPluginWrapper
         Publisher = appExtension.Package.PublisherDisplayName;
         InstalledDate = appExtension.Package.InstalledDate;
         Version = appExtension.Package.Id.Version;
-        ExtensionUniqueId = appExtension.AppUserModelId + "!" + appExtension.Id;
+        ExtensionUniqueId = appExtension.AppInfo.AppUserModelId + "!" + appExtension.Id;
     }
 
     public string Name

--- a/src/Models/PluginWrapper.cs
+++ b/src/Models/PluginWrapper.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using DevHome.Common.Services;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.ApplicationModel;
+using Windows.ApplicationModel.AppExtensions;
 using Windows.Win32;
 using Windows.Win32.System.Com;
 using WinRT;
@@ -29,22 +30,15 @@ public class PluginWrapper : IPluginWrapper
 
     private IExtension? _extensionObject;
 
-    public PluginWrapper(
-        string name,
-        string packageFullName,
-        string packageFamilyName,
-        string publisher,
-        string classId,
-        DateTimeOffset installedDate,
-        PackageVersion version)
+    public PluginWrapper(AppExtension appExtension, string classId)
     {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-        PackageFullName = packageFullName ?? throw new ArgumentNullException(nameof(packageFullName));
-        PackageFamilyName = packageFamilyName ?? throw new ArgumentNullException(nameof(packageFamilyName));
-        Publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        Name = appExtension.DisplayName;
+        PackageFullName = appExtension.Package.Id.FullName;
+        PackageFamilyName = appExtension.Package.Id.FamilyName;
         PluginClassId = classId ?? throw new ArgumentNullException(nameof(classId));
-        InstalledDate = installedDate;
-        Version = version;
+        Publisher = appExtension.Package.PublisherDisplayName;
+        InstalledDate = appExtension.Package.InstalledDate;
+        Version = appExtension.Package.Id.Version;
     }
 
     public string Name
@@ -62,12 +56,12 @@ public class PluginWrapper : IPluginWrapper
         get;
     }
 
-    public string Publisher
+    public string PluginClassId
     {
         get;
     }
 
-    public string PluginClassId
+    public string Publisher
     {
         get;
     }

--- a/src/Services/PluginService.cs
+++ b/src/Services/PluginService.cs
@@ -160,7 +160,14 @@ public class PluginService : IPluginService
                 }
 
                 var name = extension.DisplayName;
-                var pluginWrapper = new PluginWrapper(name, extension.Package.Id.FullName, classId);
+                var pluginWrapper = new PluginWrapper(
+                    name,
+                    extension.Package.Id.FullName,
+                    extension.Package.Id.FamilyName,
+                    extension.Package.PublisherDisplayName,
+                    classId,
+                    extension.Package.InstalledDate,
+                    extension.Package.Id.Version);
 
                 var supportedInterfaces = GetSubPropertySet(devHomeProvider, "SupportedInterfaces");
                 if (supportedInterfaces is not null)

--- a/src/Services/PluginService.cs
+++ b/src/Services/PluginService.cs
@@ -159,15 +159,7 @@ public class PluginService : IPluginService
                     continue;
                 }
 
-                var name = extension.DisplayName;
-                var pluginWrapper = new PluginWrapper(
-                    name,
-                    extension.Package.Id.FullName,
-                    extension.Package.Id.FamilyName,
-                    extension.Package.PublisherDisplayName,
-                    classId,
-                    extension.Package.InstalledDate,
-                    extension.Package.Id.Version);
+                var pluginWrapper = new PluginWrapper(extension, classId);
 
                 var supportedInterfaces = GetSubPropertySet(devHomeProvider, "SupportedInterfaces");
                 if (supportedInterfaces is not null)

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Helpers/Log.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Helpers/Log.cs
@@ -3,8 +3,6 @@
 
 using DevHome.Logging;
 
-#nullable enable
-
 namespace DevHome.Dashboard.Helpers;
 
 public class Log
@@ -13,4 +11,3 @@ public class Log
 
     public static Logger? Logger() => _logger.Logger;
 }
-#nullable disable

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -62,20 +62,28 @@
     <value>Extensions</value>
     <comment>Navigation pane content</comment>
   </data>
-  <data name="ExtensionLibraryPage_Title.Text" xml:space="preserve">
-    <value>Extensions</value>
-    <comment>Header text for Extension Library page</comment>
-  </data>
-  <data name="OnYourPcTextBlock.Text" xml:space="preserve">
-    <value>On your PC</value>
+  <data name="InstalledTextBlock.Text" xml:space="preserve">
+    <value>Installed</value>
     <comment>Header for the list of packages currently installed on the user's computer</comment>
   </data>
   <data name="GetUpdatesButton.Content" xml:space="preserve">
     <value>Get updates</value>
     <comment>Button that allows the user to check if the store has updates for current packages</comment>
   </data>
+  <data name="LastUpdated" xml:space="preserve">
+    <value>Last updated</value>
+    <comment>Text that precedes the date and time a specific package was last updated on the user's computer</comment>
+  </data>
+  <data name="Version" xml:space="preserve">
+    <value>Version</value>
+    <comment>Text that precedes the version number of a specific package</comment>
+  </data>
+  <data name="ManageExtensionCard.Header" xml:space="preserve">
+    <value>Manage extension</value>
+    <comment>Label for the link to that extension's settings</comment>
+  </data>
   <data name="AvailableFromStoreTextBlock.Text" xml:space="preserve">
-    <value>Available from the Store</value>
+    <value>Available in the Microsoft Store</value>
     <comment>Header for the list of packages available for download from the store</comment>
   </data>
   <data name="GetButton.Content" xml:space="preserve">

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -82,6 +82,10 @@
     <value>Manage extension</value>
     <comment>Label for the link to that extension's settings</comment>
   </data>
+  <data name="NoExtensionsAdded.Text" xml:space="preserve">
+    <value>No extensions are installed.</value>
+    <comment>Message shown when the user does not have any Dev Home extensions installed</comment>
+  </data>
   <data name="AvailableFromStoreTextBlock.Text" xml:space="preserve">
     <value>Available in the Microsoft Store</value>
     <comment>Header for the list of packages available for download from the store</comment>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -78,6 +78,10 @@
     <value>Version</value>
     <comment>Text that precedes the version number of a specific package</comment>
   </data>
+  <data name="UninstallItem.Text" xml:space="preserve">
+     <value>Uninstall</value>
+     <comment>Button to uninstall the extension</comment>
+  </data>
   <data name="ManageExtensionCard.Header" xml:space="preserve">
     <value>Manage extension</value>
     <comment>Label for the link to that extension's settings</comment>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -45,9 +45,6 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
         StorePackagesList = new ();
         InstalledPackagesList = new ();
-
-        GetInstalledExtensions();
-        GetAvailablePackages();
     }
 
     [RelayCommand]
@@ -56,22 +53,26 @@ public partial class ExtensionLibraryViewModel : ObservableObject
         await Launcher.LaunchUriAsync(new ("ms-windows-store://downloadsandupdates"));
     }
 
+    [RelayCommand]
+    public async Task LoadedAsync()
+    {
+        await GetInstalledExtensionsAsync();
+        GetAvailablePackages();
+    }
+
     private async void OnPluginsChanged(object? sender, EventArgs e)
     {
-        await _dispatcher.EnqueueAsync(() =>
+        await _dispatcher.EnqueueAsync(async () =>
         {
             ShouldShowStoreError = false;
-            GetInstalledExtensions();
+            await GetInstalledExtensionsAsync();
             GetAvailablePackages();
         });
     }
 
-    private void GetInstalledExtensions()
+    private async Task GetInstalledExtensionsAsync()
     {
-        var extensionWrappers = Task.Run(async () =>
-        {
-            return await _pluginService.GetInstalledPluginsAsync(true);
-        }).Result;
+        var extensionWrappers = await _pluginService.GetInstalledPluginsAsync(true);
 
         InstalledPackagesList.Clear();
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -13,6 +13,7 @@ using DevHome.Common.Services;
 using DevHome.Dashboard.Helpers;
 using DevHome.Settings.ViewModels;
 using Microsoft.UI.Xaml;
+using Microsoft.Windows.DevHome.SDK;
 using Windows.ApplicationModel;
 using Windows.Data.Json;
 using Windows.Storage;
@@ -81,7 +82,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
                 continue;
             }
 
-            var hasSettingsProvider = extensionWrapper.HasProviderType(Microsoft.Windows.DevHome.SDK.ProviderType.Settings);
+            var hasSettingsProvider = extensionWrapper.HasProviderType(ProviderType.Settings);
             var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.PackageFullName, hasSettingsProvider);
 
             // Each extension is shown under the package that contains it. Check if we have the package in the list

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -84,31 +84,22 @@ public partial class ExtensionLibraryViewModel : ObservableObject
             var hasSettingsProvider = extensionWrapper.HasProviderType(Microsoft.Windows.DevHome.SDK.ProviderType.Settings);
             var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.PackageFullName, hasSettingsProvider);
 
-            // Each extension is shown under the package that contains it. Search to see if we have the package in the
-            // list already and add the extension to that package in the list if we do.
-            var foundPackage = false;
-            foreach (var installedPackage in InstalledPackagesList)
+            // Each extension is shown under the package that contains it. Check if we have the package in the list
+            // already and if not, create it and add it to the list of packages. Then add the extension to that
+            // package's list of extensions.
+            var package = InstalledPackagesList.FirstOrDefault(p => p.PackageFamilyName == extensionWrapper.PackageFamilyName);
+            if (package == null)
             {
-                if (installedPackage.PackageFamilyName == extensionWrapper.PackageFamilyName)
-                {
-                    foundPackage = true;
-                    installedPackage.InstalledExtensionsList.Add(extension);
-                    break;
-                }
-            }
-
-            // If the package isn't in the list yet, add it.
-            if (!foundPackage)
-            {
-                var installedPackage = new InstalledPackageViewModel(
+                package = new InstalledPackageViewModel(
                     extensionWrapper.Name,
                     extensionWrapper.Publisher,
                     extensionWrapper.PackageFamilyName,
                     extensionWrapper.InstalledDate,
                     extensionWrapper.Version);
-                installedPackage.InstalledExtensionsList.Add(extension);
-                InstalledPackagesList.Add(installedPackage);
+                InstalledPackagesList.Add(package);
             }
+
+            package.InstalledExtensionsList.Add(extension);
         }
     }
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -84,7 +84,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
             }
 
             var hasSettingsProvider = extensionWrapper.HasProviderType(ProviderType.Settings);
-            var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.PackageFullName, hasSettingsProvider);
+            var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.ExtensionUniqueId, hasSettingsProvider);
 
             // Each extension is shown under the package that contains it. Check if we have the package in the list
             // already and if not, create it and add it to the list of packages. Then add the extension to that

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -25,6 +25,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     private readonly string devHomeProductId = "9N8MHTPHNGVV";
 
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
+    private readonly IPluginService _pluginService;
 
     [ObservableProperty]
     private ObservableCollection<StorePackageViewModel> _storePackagesList = new ();
@@ -35,11 +36,11 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     [ObservableProperty]
     private bool _shouldShowStoreError = false;
 
-    public ExtensionLibraryViewModel()
+    public ExtensionLibraryViewModel(IPluginService pluginService)
     {
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        _pluginService = pluginService;
 
-        var pluginService = Application.Current.GetService<IPluginService>();
         pluginService.OnPluginsChanged -= OnPluginsChanged;
         pluginService.OnPluginsChanged += OnPluginsChanged;
 
@@ -67,8 +68,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     {
         var extensionWrappers = Task.Run(async () =>
         {
-            var pluginService = Application.Current.GetService<IPluginService>();
-            return await pluginService.GetInstalledPluginsAsync(true);
+            return await _pluginService.GetInstalledPluginsAsync(true);
         }).Result;
 
         InstalledPackagesList.Clear();

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -28,11 +28,9 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
     private readonly IPluginService _pluginService;
 
-    [ObservableProperty]
-    private ObservableCollection<StorePackageViewModel> _storePackagesList = new ();
+    public ObservableCollection<StorePackageViewModel> StorePackagesList { get; set; }
 
-    [ObservableProperty]
-    private ObservableCollection<InstalledPackageViewModel> _installedPackagesList = new ();
+    public ObservableCollection<InstalledPackageViewModel> InstalledPackagesList { get; set; }
 
     [ObservableProperty]
     private bool _shouldShowStoreError = false;
@@ -44,6 +42,9 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
         pluginService.OnPluginsChanged -= OnPluginsChanged;
         pluginService.OnPluginsChanged += OnPluginsChanged;
+
+        StorePackagesList = new ();
+        InstalledPackagesList = new ();
 
         GetInstalledExtensions();
         GetAvailablePackages();

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -81,7 +81,8 @@ public partial class ExtensionLibraryViewModel : ObservableObject
                 continue;
             }
 
-            var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.PackageFullName, true /*TODO*/);
+            var hasSettingsProvider = extensionWrapper.HasProviderType(Microsoft.Windows.DevHome.SDK.ProviderType.Settings);
+            var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.PackageFullName, hasSettingsProvider);
 
             // Each extension is shown under the package that contains it. Search to see if we have the package in the
             // list already and add the extension to that package in the list if we do.

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Contracts;
+using DevHome.Common.Extensions;
+using Microsoft.UI.Xaml;
+using Windows.ApplicationModel;
+using Windows.System;
+
+namespace DevHome.ExtensionLibrary.ViewModels;
+public partial class InstalledExtensionViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _displayName;
+
+    [ObservableProperty]
+    private string _packageFullName;
+
+    [ObservableProperty]
+    private bool _hasSettingsProvider;
+
+    [ObservableProperty]
+    private bool _isExtensionEnabled;
+
+    partial void OnIsExtensionEnabledChanging(bool value)
+    {
+        if (IsExtensionEnabled != value)
+        {
+            Task.Run(() =>
+            {
+                var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
+                return localSettingsService.SaveSettingAsync(PackageFullName + "-ExtensionDisabled", !value);
+            }).Wait();
+        }
+    }
+
+    public InstalledExtensionViewModel(string displayName, string packageFullName, bool hasSettingsProvider)
+    {
+        _displayName = displayName;
+        _packageFullName = packageFullName;
+        _hasSettingsProvider = hasSettingsProvider;
+
+        IsExtensionEnabled = GetIsExtensionEnabled();
+    }
+
+    private bool GetIsExtensionEnabled()
+    {
+        var isDisabled = Task.Run(() =>
+        {
+            var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
+            return localSettingsService.ReadSettingAsync<bool>(PackageFullName + "-ExtensionDisabled");
+        }).Result;
+        return !isDisabled;
+    }
+
+    [RelayCommand]
+    private void NavigateSettings()
+    {
+        ////var navigationService = Application.Current.GetService<INavigationService>();
+        ////var segments = path.Split("/");
+        ////navigationService.NavigateTo(typeof(ExtensionSettingsViewModel).FullName!, segments[1]);
+        ////_extensionsViewModel.Navigate(_setting.Path);
+    }
+}
+
+public partial class InstalledPackageViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _title;
+
+    [ObservableProperty]
+    private string _publisher;
+
+    [ObservableProperty]
+    private string _packageFamilyName;
+
+    [ObservableProperty]
+    private DateTimeOffset _installedDate;
+
+    [ObservableProperty]
+    private PackageVersion _version;
+
+    [ObservableProperty]
+    private ObservableCollection<InstalledExtensionViewModel> _installedExtensionsList = new ();
+
+    public InstalledPackageViewModel(string title, string publisher, string packageFamilyName, DateTimeOffset installedDate, PackageVersion version)
+    {
+        _title = title;
+        _publisher = publisher;
+        _packageFamilyName = packageFamilyName;
+        _installedDate = installedDate;
+        _version = version;
+    }
+
+    [RelayCommand]
+    public async Task LaunchStoreButton(string packageId)
+    {
+        var linkString = $"ms-windows-store://pdp/?ProductId={packageId}&mode=mini";
+        await Launcher.LaunchUriAsync(new (linkString));
+    }
+
+    [RelayCommand]
+    public async Task UninstallButton()
+    {
+        await Launcher.LaunchUriAsync(new ("ms-settings:appsfeatures"));
+    }
+
+    public string GeneratePackageDetails(PackageVersion version, string publisher, DateTimeOffset installedDate)
+    {
+        var resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader("DevHome.ExtensionLibrary.pri", "DevHome.ExtensionLibrary/Resources");
+        var versionLabel = resourceLoader.GetString("Version");
+        var lastUpdatedLabel = resourceLoader.GetString("LastUpdated");
+
+        var versionString = $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+
+        return $"{versionLabel} {versionString} | {publisher} | {lastUpdatedLabel} {installedDate.LocalDateTime}";
+    }
+}

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -61,10 +61,7 @@ public partial class InstalledExtensionViewModel : ObservableObject
     [RelayCommand]
     private void NavigateSettings()
     {
-        ////var navigationService = Application.Current.GetService<INavigationService>();
-        ////var segments = path.Split("/");
-        ////navigationService.NavigateTo(typeof(ExtensionSettingsViewModel).FullName!, segments[1]);
-        ////_extensionsViewModel.Navigate(_setting.Path);
+        // TODO: nothing implements ISettingsProvider yet, so this will not be called
     }
 }
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -82,8 +82,7 @@ public partial class InstalledPackageViewModel : ObservableObject
     [ObservableProperty]
     private PackageVersion _version;
 
-    [ObservableProperty]
-    private ObservableCollection<InstalledExtensionViewModel> _installedExtensionsList = new ();
+    public ObservableCollection<InstalledExtensionViewModel> InstalledExtensionsList { get; set; }
 
     public InstalledPackageViewModel(string title, string publisher, string packageFamilyName, DateTimeOffset installedDate, PackageVersion version)
     {
@@ -92,6 +91,7 @@ public partial class InstalledPackageViewModel : ObservableObject
         _packageFamilyName = packageFamilyName;
         _installedDate = installedDate;
         _version = version;
+        InstalledExtensionsList = new ();
     }
 
     [RelayCommand]

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -19,7 +19,7 @@ public partial class InstalledExtensionViewModel : ObservableObject
     private string _displayName;
 
     [ObservableProperty]
-    private string _packageFullName;
+    private string _extensionUniqueId;
 
     [ObservableProperty]
     private bool _hasSettingsProvider;
@@ -34,15 +34,15 @@ public partial class InstalledExtensionViewModel : ObservableObject
             Task.Run(() =>
             {
                 var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-                return localSettingsService.SaveSettingAsync(PackageFullName + "-ExtensionDisabled", !value);
+                return localSettingsService.SaveSettingAsync(ExtensionUniqueId + "-ExtensionDisabled", !value);
             }).Wait();
         }
     }
 
-    public InstalledExtensionViewModel(string displayName, string packageFullName, bool hasSettingsProvider)
+    public InstalledExtensionViewModel(string displayName, string extensionUniqueId, bool hasSettingsProvider)
     {
         _displayName = displayName;
-        _packageFullName = packageFullName;
+        _extensionUniqueId = extensionUniqueId;
         _hasSettingsProvider = hasSettingsProvider;
 
         IsExtensionEnabled = GetIsExtensionEnabled();
@@ -53,7 +53,7 @@ public partial class InstalledExtensionViewModel : ObservableObject
         var isDisabled = Task.Run(() =>
         {
             var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-            return localSettingsService.ReadSettingAsync<bool>(PackageFullName + "-ExtensionDisabled");
+            return localSettingsService.ReadSettingAsync<bool>(ExtensionUniqueId + "-ExtensionDisabled");
         }).Result;
         return !isDisabled;
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -8,25 +8,82 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:viewmodels="using:DevHome.ExtensionLibrary.ViewModels"
     mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Visible" TrueValue="Collapsed" />
+        </ResourceDictionary>
+    </Page.Resources>
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,22,0,0">
             <StackPanel>
 
-                <!-- On your PC items -->
+                <!-- Installed items -->
                 <Grid Margin="{StaticResource SettingsPageSubTitleMargin}">
-                    <TextBlock x:Uid="OnYourPcTextBlock" />
+                    <TextBlock x:Uid="InstalledTextBlock"
+                               Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
+                               VerticalAlignment="Center"/>
                     <Button x:Uid="GetUpdatesButton"
                             HorizontalAlignment="Right"
-                            Style="{ThemeResource AccentButtonStyle}" 
+                            Style="{ThemeResource AccentButtonStyle}"
                             Command="{x:Bind ViewModel.GetUpdatesButtonCommand}"/>
                 </Grid>
+                <ItemsRepeater ItemsSource="{x:Bind ViewModel.InstalledPackagesList, Mode=OneWay}">
+                    <ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="viewmodels:InstalledPackageViewModel">
+                            <labs:SettingsExpander Header="{x:Bind Title}"
+                                                   Description="{x:Bind GeneratePackageDetails(Version,Publisher , InstalledDate), Mode=OneWay}"
+                                                   Margin="{ThemeResource SettingsCardMargin}"
+                                                   ItemsSource="{x:Bind InstalledExtensionsList}"
+                                                   IsExpanded="True">
+                                <labs:SettingsExpander.HeaderIcon>
+                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
+                                </labs:SettingsExpander.HeaderIcon>
+                                <Button Content="&#xe712;"
+                                        Height="36" Width="36"
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}" 
+                                        Background="Transparent"
+                                        BorderThickness="0">
+                                    <Button.Flyout>
+                                        <MenuFlyout>
+                                            <MenuFlyoutItem
+                                                x:Uid="UninstallItem"
+                                                Command="{x:Bind UninstallButtonCommand}">
+                                            </MenuFlyoutItem>
+                                        </MenuFlyout>
+                                    </Button.Flyout>
+                                </Button>
+                                <labs:SettingsExpander.ItemTemplate>
+                                    <DataTemplate x:DataType="viewmodels:InstalledExtensionViewModel">
+                                        <labs:SettingsCard x:Uid="ManageExtensionCard"
+                                                           CornerRadius="0,0,3,3"
+                                                           IsClickEnabled="{x:Bind HasSettingsProvider}"
+                                                           Command="{x:Bind NavigateSettingsCommand}">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                <ToggleSwitch IsOn="{x:Bind IsExtensionEnabled, Mode=TwoWay}"/>
+                                            </StackPanel>
+                                        </labs:SettingsCard>
+                                    </DataTemplate>
+                                </labs:SettingsExpander.ItemTemplate>
+                            </labs:SettingsExpander>
+                        </DataTemplate>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
+                <!-- No extensions message -->
+                <TextBlock x:Uid="NoExtensionsAdded"
+                           Text="No extensions are installed."
+                           Visibility="{x:Bind ViewModel.InstalledPackagesList.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}"
+                           Margin="0,50" 
+                           HorizontalAlignment="Center" />
 
                 <!-- Available items -->
                 <TextBlock x:Uid="AvailableFromStoreTextBlock"
+                           Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
                            Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -53,6 +53,7 @@
                                         <MenuFlyout>
                                             <MenuFlyoutItem
                                                 x:Uid="UninstallItem"
+                                                HorizontalAlignment="Center"
                                                 Command="{x:Bind UninstallButtonCommand}">
                                             </MenuFlyoutItem>
                                         </MenuFlyout>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -76,7 +76,6 @@
                 </ItemsRepeater>
                 <!-- No extensions message -->
                 <TextBlock x:Uid="NoExtensionsAdded"
-                           Text="No extensions are installed."
                            Visibility="{x:Bind ViewModel.InstalledPackagesList.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}"
                            Margin="0,50" 
                            HorizontalAlignment="Center" />

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -11,7 +11,14 @@
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:viewmodels="using:DevHome.ExtensionLibrary.ViewModels"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     mc:Ignorable="d">
+    <i:Interaction.Behaviors>
+        <ic:EventTriggerBehavior EventName="Loaded">
+            <ic:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand}" />
+        </ic:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
 
     <Page.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request

Keep track of the installed extensions and show them on the page. We keep track of the packages, and then keep a list of extensions contained within the package. Allow users to enable and disable the extension from the Extensions page. If the extension implements the ISettingsProvider, then allow them to click through to the L3 settings page for that extension. (Screenshot shows faked enabled settings).

![image](https://github.com/microsoft/devhome/assets/47155823/4541aaf0-50d6-44d9-b1a5-3aca85e50a89)
