### PR TITLE
Make widget charts shorter to fit better; lock chart values

### DIFF
--- a/CoreWidgetProvider/Helpers/CPUStats.cs
+++ b/CoreWidgetProvider/Helpers/CPUStats.cs
@@ -51,9 +51,12 @@ internal class CPUStats : IDisposable
         CpuUsage = procPerf.NextValue() / 100;
         CpuSpeed = procFrequency.NextValue() * (procPerformance.NextValue() / 100);
 
-        ChartHelper.AddNextChartValue(CpuUsage * 100, CpuChartValues);
+        lock (CpuChartValues)
+        {
+            ChartHelper.AddNextChartValue(CpuUsage * 100, CpuChartValues);
+        }
 
-        Dictionary<Process, float> processCPUUsages = new Dictionary<Process, float>();
+        var processCPUUsages = new Dictionary<Process, float>();
 
         foreach (var processCounter in cpuCounters)
         {

--- a/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -17,7 +17,7 @@ internal class ChartHelper
         Net,
     }
 
-    public const int ChartHeight = 102;
+    public const int ChartHeight = 86;
     public const int ChartWidth = 264;
 
     private const string LightGrayBoxStyle = "fill:none;stroke:lightgrey;stroke-width:1";
@@ -60,8 +60,6 @@ internal class ChartHelper
     private const string IdAttr = "id";
 
     private const int MaxChartValues = 30;
-
-    private static readonly object _lock = new ();
 
     public static string CreateImageUrl(List<float> chartValues, ChartType type)
     {
@@ -112,7 +110,7 @@ internal class ChartHelper
 
         var chartDoc = new XDocument();
 
-        lock (_lock)
+        lock (chartValues)
         {
             var svgElement = CreateBlankSvg(ChartHeight, ChartWidth);
 
@@ -240,7 +238,13 @@ internal class ChartHelper
         finalX = startX;
         foreach (var origY in chartValues)
         {
-            var finalY = ChartHeight - 1 - origY;
+            // We receive the height as a number up from the X axis (bottom of the chart), but we have to invert it
+            // since the Y coordinate is relative to the top of the chart.
+            var invertedHeight = 100 - origY;
+
+            // Scale the final Y to whatever the chart height is.
+            var finalY = (invertedHeight * (ChartHeight / 100.0)) - 1;
+
             points.Append(CultureInfo.InvariantCulture, $"{finalX},{finalY} ");
             finalX += pxBetweenPoints;
         }

--- a/CoreWidgetProvider/Helpers/GPUStats.cs
+++ b/CoreWidgetProvider/Helpers/GPUStats.cs
@@ -104,7 +104,10 @@ internal class GPUStats : IDisposable
                     // NextValue() can throw an InvalidOperationException if the counter is no longer there.
                     var sum = counters?.Sum(x => x.NextValue()) ?? 0;
                     gpu.Usage = sum / 100;
-                    ChartHelper.AddNextChartValue(sum, gpu.GpuChartValues);
+                    lock (gpu.GpuChartValues)
+                    {
+                        ChartHelper.AddNextChartValue(sum, gpu.GpuChartValues);
+                    }
                 }
                 catch (InvalidOperationException ex)
                 {

--- a/CoreWidgetProvider/Helpers/MemoryStats.cs
+++ b/CoreWidgetProvider/Helpers/MemoryStats.cs
@@ -68,7 +68,10 @@ internal class MemoryStats : IDisposable
             UsedMem = AllMem - availableMem;
 
             MemUsage = (float)UsedMem / AllMem;
-            ChartHelper.AddNextChartValue(MemUsage * 100, MemChartValues);
+            lock (MemChartValues)
+            {
+                ChartHelper.AddNextChartValue(MemUsage * 100, MemChartValues);
+            }
         }
 
         MemCached = (ulong)memCached.NextValue();

--- a/CoreWidgetProvider/Helpers/NetworkStats.cs
+++ b/CoreWidgetProvider/Helpers/NetworkStats.cs
@@ -74,7 +74,10 @@ internal class NetworkStats : IDisposable
                 NetworkUsages[name].Usage = usage;
 
                 List<float> chartValues = NetChartValues[name];
-                ChartHelper.AddNextChartValue(usage * 100, chartValues);
+                lock (chartValues)
+                {
+                    ChartHelper.AddNextChartValue(usage * 100, chartValues);
+                }
 
                 if (usage > maxUsage)
                 {

--- a/CoreWidgetProvider/Program.cs
+++ b/CoreWidgetProvider/Program.cs
@@ -83,7 +83,7 @@ public sealed class Program
         widgetServer.RegisterWidget(() => widgetProviderInstance);
 
         // This will make the main thread wait until the event is signalled by the extension class.
-        // Since we have single instance of the extension object, we exit as sooon as it is disposed.
+        // Since we have single instance of the extension object, we exit as soon as it is disposed.
         extensionDisposedEvent.WaitOne();
         Log.Logger()?.ReportInfo($"Extension is disposed.");
     }


### PR DESCRIPTION
## Summary of the pull request
Make the charts shorter so the Dev Home widgets don't need scroll bars in the medium size.
![image](https://github.com/microsoft/devhome/assets/47155823/39353022-36a1-41e1-9ac8-c1a2aa3a5832)

Also, lock chart values when reading and writing, since it was possible to get a System.InvalidOperationException: 'Collection was modified; enumeration operation may not execute.' due to simultaneous access.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
