### PR TITLE
No longer show the account provider after sign out

### DIFF
--- a/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
@@ -19,9 +19,6 @@ public partial class AccountsProviderViewModel : ObservableObject
 
     public ObservableCollection<Account> LoggedInAccounts { get; } = new ();
 
-    [ObservableProperty]
-    private bool _hasLoggedInAccounts;
-
     public AccountsProviderViewModel(IDeveloperIdProvider devIdProvider)
     {
         DeveloperIdProvider = devIdProvider;
@@ -35,7 +32,6 @@ public partial class AccountsProviderViewModel : ObservableObject
         {
             LoggedInAccounts.Add(new Account(this, devId));
         });
-        HasLoggedInAccounts = LoggedInAccounts.Count > 0;
     }
 
     public void RemoveAccount(string loginId)

--- a/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
@@ -19,6 +19,9 @@ public partial class AccountsProviderViewModel : ObservableObject
 
     public ObservableCollection<Account> LoggedInAccounts { get; } = new ();
 
+    [ObservableProperty]
+    private bool _hasLoggedInAccounts;
+
     public AccountsProviderViewModel(IDeveloperIdProvider devIdProvider)
     {
         DeveloperIdProvider = devIdProvider;
@@ -32,6 +35,7 @@ public partial class AccountsProviderViewModel : ObservableObject
         {
             LoggedInAccounts.Add(new Account(this, devId));
         });
+        HasLoggedInAccounts = LoggedInAccounts.Count > 0;
     }
 
     public void RemoveAccount(string loginId)

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -18,8 +18,8 @@
         </DataTemplate>
 
         <DataTemplate x:Key="AccountsProviderViewTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
-            <StackPanel>
-                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}" Visibility="{x:Bind HasLoggedInAccounts, Mode=OneWay}"/>
+            <StackPanel Visibility="{x:Bind HasLoggedInAccounts, Mode=OneWay}">
+                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}" />
                 <ItemsRepeater ItemsSource="{x:Bind LoggedInAccounts}" ItemTemplate="{StaticResource AccountsViewTemplate}"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" />
             </StackPanel>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:models="using:DevHome.Settings.Models"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
@@ -11,6 +12,8 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>
+        <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Collapsed" TrueValue="Visible"/>
+
         <DataTemplate x:Key="AccountsProviderButtonTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
             <StackPanel>
                 <Button Content="{x:Bind ProviderName}" HorizontalAlignment="Stretch" Click="AddDeveloperId_Click" Tag="{x:Bind}" />
@@ -18,7 +21,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="AccountsProviderViewTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
-            <StackPanel Visibility="{x:Bind HasLoggedInAccounts, Mode=OneWay}">
+            <StackPanel Visibility="{x:Bind LoggedInAccounts.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}">
                 <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}"/>
                 <ItemsRepeater ItemsSource="{x:Bind LoggedInAccounts}" ItemTemplate="{StaticResource AccountsViewTemplate}"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" />

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -19,7 +19,7 @@
 
         <DataTemplate x:Key="AccountsProviderViewTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
             <StackPanel Visibility="{x:Bind HasLoggedInAccounts, Mode=OneWay}">
-                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}" />
+                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}"/>
                 <ItemsRepeater ItemsSource="{x:Bind LoggedInAccounts}" ItemTemplate="{StaticResource AccountsViewTemplate}"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" />
             </StackPanel>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -19,7 +19,7 @@
 
         <DataTemplate x:Key="AccountsProviderViewTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
             <StackPanel>
-                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}"/>
+                <TextBlock Text="{x:Bind ProviderName}" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}" Visibility="{x:Bind HasLoggedInAccounts, Mode=OneWay}"/>
                 <ItemsRepeater ItemsSource="{x:Bind LoggedInAccounts}" ItemTemplate="{StaticResource AccountsViewTemplate}"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" />
             </StackPanel>


### PR DESCRIPTION
## Summary of the pull request
Bind the visibility of the AccountProviderView stack panel to the count of the LoggedInAccounts - if there are no logged in accounts we set the visibility of the stack panel to collapsed.

## References and relevant issues
#1500

## Validation steps performed
Signed out and signed in and the page updates appropriately

## PR checklist
- [x] Closes #1500 
- [ ] Tests added/passed
- [ ] Documentation updated
