### PR TITLE
Update sign out confirmation dialog to match figma

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -151,16 +151,16 @@
     <value>Logout successful!</value>
   </data>
   <data name="Settings_Accounts_ConfirmLogoutContentDialog_Content" xml:space="preserve">
-    <value>Dev Home will no longer be able to access online resources that use this account.</value>
+    <value>You won't be able to access different features in Dev Home that use this account until you sign in again.</value>
   </data>
   <data name="Settings_Accounts_ConfirmLogoutContentDialog_PrimaryButtonText" xml:space="preserve">
-    <value>Yes</value>
+    <value>Sign out</value>
   </data>
   <data name="Settings_Accounts_ConfirmLogoutContentDialog_SecondaryButtonText" xml:space="preserve">
-    <value>No</value>
+    <value>Cancel</value>
   </data>
   <data name="Settings_Accounts_ConfirmLogoutContentDialog_Title" xml:space="preserve">
-    <value>Are you sure?</value>
+    <value>Are you sure you want to sign out?</value>
   </data>
   <data name="Settings_Accounts_LogoutButton.Content" xml:space="preserve">
     <value>Sign out</value>


### PR DESCRIPTION
## Summary of the pull request
Updates the resource strings used for the sign out confirmation dialog to match the figma

## References and relevant issues
#1499

## Validation steps performed
<img width="424" alt="image" src="https://github.com/microsoft/devhome/assets/26824113/3298155a-9d42-4221-bc30-2ec2900f9c0e">

## PR checklist
- [x] Closes #1499
- [ ] Tests added/passed
- [ ] Documentation updated
