### PR TITLE
Added installation notes in the summary page

### DIFF
--- a/common/Extensions/SecondaryWindowExtension.cs
+++ b/common/Extensions/SecondaryWindowExtension.cs
@@ -8,8 +8,10 @@ using DevHome.Common.Services;
 using DevHome.Common.Views;
 using DevHome.Contracts.Services;
 using Microsoft.UI;
+using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using WinUIEx;
@@ -87,23 +89,30 @@ public partial class SecondaryWindowExtension : WindowEx
         Backdrop = PrimaryWindow.Backdrop;
         Closed += OnSecondaryWindowClosed;
         Activated += OnSecondaryWindowActivated;
-        CenterAndElevateWindow();
     }
 
-    public void CenterAndElevateWindow()
+    public void CenterOnWindow()
     {
         if (PrimaryWindow != null)
         {
-            // First, get a quarter of the size of the of the current window then get the center point
-            // of the primary window. Subtract primary window's Y by a quarter of the secondary window's
-            // Y to move the secondary window upwards. This will show the secondary window in the center
-            // of the main window, slightly elevated above the content.
-            var secondaryY = Height / 4D;
-            var primaryX = (double)PrimaryWindow.AppWindow.Position.X;
-            var primaryY = (double)PrimaryWindow.AppWindow.Position.Y;
-            primaryX += PrimaryWindow.Width / 2D;
-            primaryY += PrimaryWindow.Height / 2D;
-            this.MoveAndResize(primaryX, primaryY - secondaryY, Width, Height);
+            // Get DPI for primary widow
+            const float defaultDPI = 96f;
+            var dpi = HwndExtensions.GetDpiForWindow(PrimaryWindow.GetWindowHandle()) / defaultDPI;
+
+            // Extract primary window dimensions
+            var primaryWindowLeftOffset = PrimaryWindow.AppWindow.Position.X;
+            var primaryWindowTopOffset = PrimaryWindow.AppWindow.Position.Y;
+            var primaryWindowHalfWidth = (PrimaryWindow.Width * dpi) / 2;
+            var primaryWindowHalfHeight = (PrimaryWindow.Height * dpi) / 2;
+
+            // Derive secondary window dimensions
+            var secondaryWindowHalfWidth = (Width * dpi) / 2;
+            var secondaryWindowHalfHeight = (Height * dpi) / 2;
+            var secondaryWindowLeftOffset = primaryWindowLeftOffset + primaryWindowHalfWidth - secondaryWindowHalfWidth;
+            var secondaryWindowTopOffset = primaryWindowTopOffset + primaryWindowHalfHeight - secondaryWindowHalfHeight;
+
+            // Move and resize secondary window
+            this.MoveAndResize(secondaryWindowLeftOffset, secondaryWindowTopOffset, Width, Height);
         }
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -44,6 +44,9 @@
     <None Update="Assets\AppManagementPackages.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="Views\InstallationNotesView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Content Update="Assets\DevHomeFluentIcons.ttf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -64,6 +67,7 @@
     <None Remove="Views\DevDriveReviewView.xaml" />
     <None Remove="Views\DevDriveView.xaml" />
     <None Remove="Views\EditClonePathDialog.xaml" />
+    <None Remove="Views\InstallationNotesView.xaml" />
     <None Remove="Views\LoadingView.xaml" />
     <None Remove="Views\MainPageView.xaml" />
     <None Remove="Views\RepoConfigReviewView.xaml" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/IWinGetPackage.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/IWinGetPackage.cs
@@ -126,6 +126,14 @@ public interface IWinGetPackage
     }
 
     /// <summary>
+    /// Gets the package installation notes
+    /// </summary>
+    public string InstallationNotes
+    {
+        get;
+    }
+
+    /// <summary>
     /// Create an install task for this package
     /// </summary>
     /// <param name="wpm">Windows package manager service</param>

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
@@ -107,7 +107,7 @@ public class WinGetPackage : IWinGetPackage
 
     /// <summary>
     /// Gets the package metadata from the current culture name (e.g. 'en-US')
-    /// </summaryDescription</TextBlock>>
+    /// </summary>
     /// <typeparam name="T">Type of the return value</typeparam>
     /// <param name="metadataFunction">Function called with the package metadata as input</param>
     /// <param name="metadataFieldName">Name of the metadata field we want to get; used for logging</param>

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
@@ -20,6 +20,7 @@ public class WinGetPackage : IWinGetPackage
     private readonly Lazy<Uri> _packageUrl;
     private readonly Lazy<Uri> _publisherUrl;
     private readonly Lazy<string> _publisherName;
+    private readonly Lazy<string> _installationNotes;
     private readonly PackageUniqueKey _uniqueKey;
 
     public WinGetPackage(CatalogPackage package)
@@ -28,6 +29,7 @@ public class WinGetPackage : IWinGetPackage
         _packageUrl = new (() => GetMetadataValue(metadata => new Uri(metadata.PackageUrl), nameof(CatalogPackageMetadata.PackageUrl), null));
         _publisherUrl = new (() => GetMetadataValue(metadata => new Uri(metadata.PublisherUrl), nameof(CatalogPackageMetadata.PublisherUrl), null));
         _publisherName = new (() => GetMetadataValue(metadata => metadata.Publisher, nameof(CatalogPackageMetadata.Publisher), null));
+        _installationNotes = new (() => GetMetadataValue(metadata => metadata.InstallationNotes, nameof(CatalogPackageMetadata.InstallationNotes), null));
         _uniqueKey = new (Id, CatalogId);
     }
 
@@ -62,6 +64,8 @@ public class WinGetPackage : IWinGetPackage
     public Uri PublisherUrl => _publisherUrl.Value;
 
     public string PublisherName => _publisherName.Value;
+
+    public string InstallationNotes => _installationNotes.Value;
 
     public InstallPackageTask CreateInstallTask(
         IWindowsPackageManager wpm,
@@ -103,7 +107,7 @@ public class WinGetPackage : IWinGetPackage
 
     /// <summary>
     /// Gets the package metadata from the current culture name (e.g. 'en-US')
-    /// </summary>
+    /// </summaryDescription</TextBlock>>
     /// <typeparam name="T">Type of the return value</typeparam>
     /// <param name="metadataFunction">Function called with the package metadata as input</param>
     /// <param name="metadataFieldName">Name of the metadata field we want to get; used for logging</param>

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -55,6 +55,7 @@ public static class StringResourceKey
     public static readonly string InstalledPackage = nameof(InstalledPackage);
     public static readonly string InstalledPackageReboot = nameof(InstalledPackageReboot);
     public static readonly string InstallingPackage = nameof(InstallingPackage);
+    public static readonly string InstallationNotesTitle = nameof(InstallationNotesTitle);
     public static readonly string Next = nameof(Next);
     public static readonly string NoSearchResultsFoundTitle = nameof(NoSearchResultsFoundTitle);
     public static readonly string PackagesCount = nameof(PackagesCount);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1020,6 +1020,14 @@
     <value>Summary</value>
     <comment>Title for a section in the summary page</comment>
   </data>
+  <data name="SummaryPage_ViewAll.Content" xml:space="preserve">
+    <value>View all</value>
+    <comment>Hyperlink button text for revealing the remainder of a trimmed message</comment>
+  </data>
+  <data name="InstallationNotesTitle" xml:space="preserve">
+    <value>{0} Installation Notes</value>
+    <comment>{Locked="{0}"} Title for a window displaying installation notes for an application. {0} is replaced by the application name.</comment>
+  </data>
   <data name="DevDriveErrorWithReason" xml:space="preserve">
     <value>Dev Drive couldn't be created error: {0}</value>
     <comment>Message when the dev drive could not be created. Param: reason.</comment>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -390,6 +390,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
         Log.Logger?.ReportInfo(Log.Component.DevDrive, "Launching window to set up Dev Drive");
         ResetErrors();
         DevDriveWindowContainer = new (this);
+        DevDriveWindowContainer.CenterOnWindow();
         DevDriveWindowContainer.Closed += ViewContainerClosed;
         DevDriveWindowContainer.Activate();
         IsDevDriveWindowOpen = true;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
@@ -79,6 +79,7 @@ public partial class PackageViewModel : ObservableObject
         IsInstalled = _package.IsInstalled;
         CatalogName = _package.CatalogName;
         PublisherName = !string.IsNullOrEmpty(_package.PublisherName) ? _package.PublisherName : PublisherNameNotAvailable;
+        InstallationNotes = _package.InstallationNotes;
 
         // Lazy-initialize optional or expensive view model members
         _packageDarkThemeIcon = new Lazy<BitmapImage>(() => GetIconByTheme(RestoreApplicationIconTheme.Dark));
@@ -102,6 +103,8 @@ public partial class PackageViewModel : ObservableObject
     public string CatalogName { get; }
 
     public string PublisherName { get; }
+
+    public string InstallationNotes { get; }
 
     public string PackageTitle => Name;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -61,17 +61,6 @@ public partial class SetupFlowViewModel : ObservableObject
     {
         _host.GetService<IDevDriveManager>().RemoveAllDevDrives();
         List<SetupPageViewModelBase> flowPages = new ();
-        flowPages.AddRange(Orchestrator.TaskGroups.Select(flow => flow.GetSetupPageViewModel()).Where(page => page is not null));
-
-        // Check if the review page should be added as a step
-        if (Orchestrator.TaskGroups.Any(flow => flow.GetReviewTabViewModel() != null))
-        {
-            flowPages.Add(_host.GetService<ReviewViewModel>());
-        }
-        else
-        {
-            Log.Logger?.ReportInfo(Log.Component.Orchestrator, "Review page will be skipped for this flow");
-        }
 
         // The Loading page can advance to the next page
         // without user interaction once it is complete

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -61,6 +61,17 @@ public partial class SetupFlowViewModel : ObservableObject
     {
         _host.GetService<IDevDriveManager>().RemoveAllDevDrives();
         List<SetupPageViewModelBase> flowPages = new ();
+        flowPages.AddRange(Orchestrator.TaskGroups.Select(flow => flow.GetSetupPageViewModel()).Where(page => page is not null));
+
+        // Check if the review page should be added as a step
+        if (Orchestrator.TaskGroups.Any(flow => flow.GetReviewTabViewModel() != null))
+        {
+            flowPages.Add(_host.GetService<ReviewViewModel>());
+        }
+        else
+        {
+            Log.Logger?.ReportInfo(Log.Component.Orchestrator, "Review page will be skipped for this flow");
+        }
 
         // The Loading page can advance to the next page
         // without user interaction once it is complete

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -67,17 +67,15 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         get
         {
             var packagesInstalled = new ObservableCollection<PackageViewModel>();
-            var packages = _packageProvider.SelectedPackages.Where(sp => sp.InstallPackageTask.WasInstallSuccessful == true);
-            foreach (var package in packages)
-            {
-                packagesInstalled.Add(package);
-            }
-
+            var packages = _packageProvider.SelectedPackages.Where(sp => sp.InstallPackageTask.WasInstallSuccessful == true).ToList();
+            packages.ForEach(p => packagesInstalled.Add(p));
             var localizedHeader = (packagesInstalled.Count == 1) ? StringResourceKey.SummaryPageOneApplicationInstalled : StringResourceKey.SummaryPageAppsDownloadedCount;
             ApplicationsClonedText = StringResource.GetLocalized(localizedHeader);
             return packagesInstalled;
         }
     }
+
+    public List<PackageViewModel> AppsDownloadedInstallationNotes => AppsDownloaded.Where(p => !string.IsNullOrEmpty(p.InstallationNotes)).ToList();
 
     public IList<ConfigurationUnitResultViewModel> ConfigurationUnitResults => _configurationUnitResults.Value;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
@@ -35,7 +35,7 @@
                     HorizontalAlignment="Left"
                     Width="16"
                     Height="20" 
-                    Margin="10 5 5 0"/>
+                    Margin="15,5,5,0"/>
                 <TextBlock x:Name="AppTitleBarText"
                     VerticalAlignment="Center"
                     TextWrapping="NoWrap"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml
@@ -20,7 +20,7 @@
                 HorizontalAlignment="Left"
                 Width="16"
                 Height="20" 
-                Margin="10 5 5 0"/>
+                Margin="15,5,5,0"/>
             <TextBlock x:Name="AppTitleBarText"
                 VerticalAlignment="Center"
                 TextWrapping="NoWrap"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="DevHome.SetupFlow.Views.InstallationNotesView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid Name="FullPage">
+        <!-- Extended TitleBar -->
+        <Grid x:Name="AppTitleBar"
+              Canvas.ZIndex="0"
+              Height="30"
+              IsHitTestVisible="True"
+              VerticalAlignment="Top">
+            <Image 
+                Source="{x:Bind DevHomeIconPath, Mode=OneWay}"
+                HorizontalAlignment="Left"
+                Width="16"
+                Height="20" 
+                Margin="10 5 5 0"/>
+            <TextBlock x:Name="AppTitleBarText"
+                VerticalAlignment="Center"
+                TextWrapping="NoWrap"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{x:Bind PackageTitle, Mode=OneWay}"
+                Margin="35,5,5,0"/>
+        </Grid>
+        <Grid Margin="0,48,0,0">
+            <StackPanel Padding="24,0">
+                <TextBlock Padding="0,8" Style="{ThemeResource SubtitleTextBlockStyle}" Text="{x:Bind PackageTitle}"/>
+                <TextBlock Grid.Row="1" IsTextSelectionEnabled="True" Text="{x:Bind InstallationNotes}" TextWrapping="WrapWholeWords"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Page>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace DevHome.SetupFlow.Views;
+
+public sealed partial class InstallationNotesView : Page
+{
+    public string DevHomeIconPath => Path.Combine(AppContext.BaseDirectory, "Assets/DevHome.ico");
+
+    public string PackageTitle { get; }
+
+    public string InstallationNotes { get; }
+
+    public Grid TitleBar => AppTitleBar;
+
+    public InstallationNotesView(string packageTitle, string installationNotes)
+    {
+        PackageTitle = packageTitle;
+        InstallationNotes = installationNotes;
+
+        this.InitializeComponent();
+    }
+
+    public void UpdateTitleBarTextForeground(SolidColorBrush brush)
+    {
+        AppTitleBarText.Foreground = brush;
+    }
+}

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -224,122 +224,127 @@
                 </StackPanel>
 
                 <!-- Displays the repos cloned and apps downloaded -->
-                <StackPanel Grid.Column="1" Orientation="Vertical">
+                <StackPanel Grid.Column="1" Orientation="Vertical" x:Name="TaskGroupSections">
+                    <StackPanel.Resources>
+                        <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                        <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                        <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
+                        <Style TargetType="Expander">
+                            <Setter Property="IsExpanded" Value="True"/>
+                            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                        </Style>
+                    </StackPanel.Resources>
 
                     <!-- Repos cloned -->
-                    <Grid
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                        BorderThickness="0,0,0,1">
-                        <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Padding="0">
-                            <Expander.Resources>
-                                <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                                <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
-                            </Expander.Resources>
+                    <Grid Padding="0,12" Visibility="{x:Bind ViewModel.RepositoriesCloned, Converter={StaticResource CollectionVisibilityConverter}}">
+                        <Expander>
                             <Expander.Header>
-                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,28"/>
+                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12"/>
                             </Expander.Header>
-                        <StackPanel>
-                            <StackPanel.Resources>
-                                <StackLayout x:Name="LayoutForRepos" Orientation="Vertical" Spacing="10"/>
-                                <DataTemplate x:Key="repoTemplate" x:DataType="models:RepoViewListItem">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <FontIcon Grid.Column="0"  Margin="3 0 5 0" FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
-                                        <TextBlock 
-                                            Grid.Column="1"
-                                            Text="{x:Bind RepoName}"
-                                            Margin="5 0 0 0"
-                                            TextWrapping="Wrap"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </StackPanel.Resources>
-                            <ItemsRepeater x:Name="TasksItemsRepeater" ItemsSource="{x:Bind ViewModel.RepositoriesCloned, Mode=OneWay}"
-                               Layout="{StaticResource LayoutForRepos}" 
-                               ItemTemplate="{StaticResource repoTemplate}">
-                            </ItemsRepeater>
-                        </StackPanel>
+                            <StackPanel>
+                                <StackPanel.Resources>
+                                    <StackLayout x:Name="LayoutForRepos" Orientation="Vertical" Spacing="10"/>
+                                    <DataTemplate x:Key="repoTemplate" x:DataType="models:RepoViewListItem">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <FontIcon Grid.Column="0"  Margin="3 0 5 0" FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
+                                            <TextBlock 
+                                                Grid.Column="1"
+                                                Text="{x:Bind RepoName}"
+                                                Margin="5 0 0 0"
+                                                TextWrapping="Wrap"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </StackPanel.Resources>
+                                <ItemsRepeater x:Name="TasksItemsRepeater" ItemsSource="{x:Bind ViewModel.RepositoriesCloned, Mode=OneWay}"
+                                   Layout="{StaticResource LayoutForRepos}" 
+                                   ItemTemplate="{StaticResource repoTemplate}">
+                                </ItemsRepeater>
+                            </StackPanel>
                         </Expander>
                     </Grid>
 
                     <!-- Apps downloaded -->
-                    <Grid
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                        BorderThickness="0,0,0,1">
-                        <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                            <Expander.Resources>
-                                <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                                <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
-                                <Thickness x:Key="ExpanderHeaderPadding">0,28</Thickness>
-                            </Expander.Resources>
+                    <Grid Padding="0,12" Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}">
+                        <Expander>
                             <Expander.Header>
-                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_AppsDownlodedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,28"/>
+                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_AppsDownlodedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12"/>
                             </Expander.Header>
-                        <GridView
-                            ItemsSource="{x:Bind ViewModel.AppsDownloaded, Mode=OneWay}"
-                            SelectionMode="None">
-                            <GridView.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal" />
-                                </ItemsPanelTemplate>
-                            </GridView.ItemsPanel>
-                            <GridView.ItemTemplate>
-                                <DataTemplate x:DataType="viewModels:PackageViewModel">
-                                    <ctControls:SettingsCard Width="250" Padding="5" Background="Transparent">
-                                        <ctControls:SettingsCard.Resources>
-                                            <Thickness x:Key="SettingsCardBorderThickness">0</Thickness>
-                                            <Thickness x:Key="SettingsCardPadding">0</Thickness>
-                                            <x:Double x:Key="SettingsCardMinHeight">0</x:Double>
-                                            <x:Double x:Key="SettingsCardMinWidth">0</x:Double>
-                                            <x:Double x:Key="SettingsCardWrapThreshold">0</x:Double>
-                                            <x:Double x:Key="SettingsCardWrapNoIconThreshold">0</x:Double>
-                                            <x:Double x:Key="SettingsCardHeaderIconMaxSize">24</x:Double>
-                                        </ctControls:SettingsCard.Resources>
-                                        <ctControls:SettingsCard.Header>
-                                            <TextBlock Text="{x:Bind Name, Mode=OneWay}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
-                                        </ctControls:SettingsCard.Header>
-                                        <ctControls:SettingsCard.Description>
-                                            <TextBlock Text="{x:Bind Version, Mode=OneWay}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
-                                        </ctControls:SettingsCard.Description>
-                                        <ctControls:SettingsCard.HeaderIcon>
-                                            <ImageIcon Source="{x:Bind Icon, Mode=OneWay}"/>
-                                        </ctControls:SettingsCard.HeaderIcon>
-                                    </ctControls:SettingsCard>
-                                </DataTemplate>
-                            </GridView.ItemTemplate>
-                        </GridView>
+                            <GridView ItemsSource="{x:Bind ViewModel.AppsDownloaded, Mode=OneWay}" SelectionMode="None">
+                                <GridView.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal" />
+                                    </ItemsPanelTemplate>
+                                </GridView.ItemsPanel>
+                                <GridView.ItemTemplate>
+                                    <DataTemplate x:DataType="viewModels:PackageViewModel">
+                                        <ctControls:SettingsCard Width="250" Padding="5" Background="Transparent">
+                                            <ctControls:SettingsCard.Resources>
+                                                <Thickness x:Key="SettingsCardBorderThickness">0</Thickness>
+                                                <Thickness x:Key="SettingsCardPadding">0</Thickness>
+                                                <x:Double x:Key="SettingsCardMinHeight">0</x:Double>
+                                                <x:Double x:Key="SettingsCardMinWidth">0</x:Double>
+                                                <x:Double x:Key="SettingsCardWrapThreshold">0</x:Double>
+                                                <x:Double x:Key="SettingsCardWrapNoIconThreshold">0</x:Double>
+                                                <x:Double x:Key="SettingsCardHeaderIconMaxSize">24</x:Double>
+                                            </ctControls:SettingsCard.Resources>
+                                            <ctControls:SettingsCard.Header>
+                                                <TextBlock Text="{x:Bind Name, Mode=OneWay}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
+                                            </ctControls:SettingsCard.Header>
+                                            <ctControls:SettingsCard.Description>
+                                                <TextBlock Text="{x:Bind Version, Mode=OneWay}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" />
+                                            </ctControls:SettingsCard.Description>
+                                            <ctControls:SettingsCard.HeaderIcon>
+                                                <ImageIcon Source="{x:Bind Icon, Mode=OneWay}"/>
+                                            </ctControls:SettingsCard.HeaderIcon>
+                                        </ctControls:SettingsCard>
+                                    </DataTemplate>
+                                </GridView.ItemTemplate>
+                            </GridView>
                         </Expander>
                     </Grid>
 
                     <!-- Installation notes -->
-                    <Grid>
-                        <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Padding="0">
-                            <Expander.Resources>
-                                <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                                <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
-                            </Expander.Resources>
+                    <Grid Padding="0,12" Visibility="{x:Bind ViewModel.AppsDownloadedInstallationNotes, Converter={StaticResource CollectionVisibilityConverter}}">
+                        <Expander>
                             <Expander.Header>
-                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,28">Installation Notes</TextBlock>
+                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12">Installation Notes</TextBlock>
                             </Expander.Header>
-                            <ListView SelectionMode="None">
+                            <ListView SelectionMode="None" ItemsSource="{x:Bind ViewModel.AppsDownloadedInstallationNotes}">
                                 <ListView.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Margin="0,0,0,4" CornerRadius="8" Padding="18,20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
-                                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}">Xbox SDK</TextBlock>
-                                            <TextBlock TextWrapping="WrapWholeWords" Foreground="{ThemeResource TextFillColorSecondaryBrush}">GDK Visual Studio extensions require configuring the target Visual Studio instance with the Game development with C++ workload before.</TextBlock>
-                                            <HyperlinkButton Style="{ThemeResource TextBlockButtonStyle}">View all</HyperlinkButton>
-                                        </StackPanel>
+                                    <DataTemplate x:DataType="viewModels:PackageViewModel">
+                                        <Grid ColumnSpacing="12" Margin="0,0,0,4" CornerRadius="8" Padding="18,20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <ImageIcon Width="24" VerticalAlignment="Top" Source="{x:Bind Icon}"/>
+                                            <StackPanel Grid.Column="1">
+                                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="{x:Bind PackageTitle}"/>
+                                                <TextBlock
+                                                    MaxLines="2"
+                                                    IsTextSelectionEnabled="True"
+                                                    TextWrapping="WrapWholeWords"
+                                                    TextTrimming="WordEllipsis"
+                                                    IsTextTrimmedChanged="InstallationNotes_IsTextTrimmedChanged"
+                                                    Tag="{Binding ElementName=ViewAllButton}"
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Text="{x:Bind InstallationNotes}"/>
+                                                <HyperlinkButton
+                                                    Name="ViewAllButton"
+                                                    Visibility="Collapsed"
+                                                    Click="ViewAllButton_Click"
+                                                    Style="{ThemeResource TextBlockButtonStyle}"
+                                                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ViewAll"
+                                                    Tag="{x:Bind}"/>
+                                            </StackPanel>
+                                        </Grid>
                                     </DataTemplate>
                                 </ListView.ItemTemplate>
-                                <x:String>A</x:String>
-                                <x:String>A</x:String>
-                                <x:String>A</x:String>
-                                <x:String>A</x:String>
                             </ListView>
                         </Expander>
                     </Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -226,9 +226,10 @@
                 <!-- Displays the repos cloned and apps downloaded -->
                 <StackPanel Grid.Column="1" Orientation="Vertical" x:Name="TaskGroupSections">
                     <StackPanel.Resources>
-                        <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
-                        <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
                         <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
+                        <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent" />
+                        <SolidColorBrush x:Key="ExpanderContentBackground" Color="Transparent" />
+                        <SolidColorBrush x:Key="ExpanderContentBorderBrush" Color="Transparent" />
                         <Style TargetType="Expander">
                             <Setter Property="IsExpanded" Value="True"/>
                             <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -260,9 +261,11 @@
                                         </Grid>
                                     </DataTemplate>
                                 </StackPanel.Resources>
-                                <ItemsRepeater x:Name="TasksItemsRepeater" ItemsSource="{x:Bind ViewModel.RepositoriesCloned, Mode=OneWay}"
-                                   Layout="{StaticResource LayoutForRepos}" 
-                                   ItemTemplate="{StaticResource repoTemplate}">
+                                <ItemsRepeater
+                                    x:Name="TasksItemsRepeater"
+                                    ItemsSource="{x:Bind ViewModel.RepositoriesCloned, Mode=OneWay}"
+                                    Layout="{StaticResource LayoutForRepos}" 
+                                    ItemTemplate="{StaticResource repoTemplate}">
                                 </ItemsRepeater>
                             </StackPanel>
                         </Expander>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -161,15 +161,17 @@
                 <StackPanel Grid.Column="0" Orientation="Vertical" Spacing="30">
 
                     <!-- Number of apps and repos cloned.-->
-                    <StackPanel 
+                    <StackPanel
                         BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
                         BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}" 
                         HorizontalAlignment="Center" 
                         Padding="30,15,30,0" 
                         MinWidth="250">
-                        <Grid
-                            ColumnDefinitions="Auto, Auto"
-                            HorizontalAlignment="Center">
+                        <Grid HorizontalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto"/>
+                                <ColumnDefinition Width="auto"/>
+                            </Grid.ColumnDefinitions>
                             <Grid
                                 Grid.Column="0"
                                 Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}"
@@ -221,21 +223,22 @@
                     <ContentControl Template="{ThemeResource LinksTemplate}" />
                 </StackPanel>
 
-
                 <!-- Displays the repos cloned and apps downloaded -->
                 <StackPanel Grid.Column="1" Orientation="Vertical">
+
                     <!-- Repos cloned -->
-                    <StackPanel 
-                        Orientation="Vertical" 
-                        Spacing="20" 
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}"
-                        Visibility="{x:Bind ViewModel.RepositoriesCloned, Converter={StaticResource CollectionVisibilityConverter}}"
-                        Margin="0,0,0,30">
-                        <TextBlock 
-                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" 
-                            Style="{ThemeResource BodyStrongTextBlockStyle}" 
-                            Padding="0, 20, 0, 0"/>
+                    <Grid
+                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                        BorderThickness="0,0,0,1">
+                        <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Padding="0">
+                            <Expander.Resources>
+                                <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                                <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
+                            </Expander.Resources>
+                            <Expander.Header>
+                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,28"/>
+                            </Expander.Header>
                         <StackPanel>
                             <StackPanel.Resources>
                                 <StackLayout x:Name="LayoutForRepos" Orientation="Vertical" Spacing="10"/>
@@ -259,16 +262,23 @@
                                ItemTemplate="{StaticResource repoTemplate}">
                             </ItemsRepeater>
                         </StackPanel>
-                    </StackPanel>
+                        </Expander>
+                    </Grid>
 
                     <!-- Apps downloaded -->
-                    <StackPanel 
-                        Orientation="Vertical" 
-                        Spacing="20" 
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}"
-                        Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}">
-                        <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_AppsDownlodedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0, 20, 0, 0"/>
+                    <Grid
+                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                        BorderThickness="0,0,0,1">
+                        <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                            <Expander.Resources>
+                                <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                                <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
+                                <Thickness x:Key="ExpanderHeaderPadding">0,28</Thickness>
+                            </Expander.Resources>
+                            <Expander.Header>
+                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_AppsDownlodedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,28"/>
+                            </Expander.Header>
                         <GridView
                             ItemsSource="{x:Bind ViewModel.AppsDownloaded, Mode=OneWay}"
                             SelectionMode="None">
@@ -302,7 +312,37 @@
                                 </DataTemplate>
                             </GridView.ItemTemplate>
                         </GridView>
-                    </StackPanel>
+                        </Expander>
+                    </Grid>
+
+                    <!-- Installation notes -->
+                    <Grid>
+                        <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Padding="0">
+                            <Expander.Resources>
+                                <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                                <StaticResource x:Key="ExpanderContentBackground" ResourceKey="ControlFillColorTransparentBrush" />
+                                <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
+                            </Expander.Resources>
+                            <Expander.Header>
+                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,28">Installation Notes</TextBlock>
+                            </Expander.Header>
+                            <ListView SelectionMode="None">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,4" CornerRadius="8" Padding="18,20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}">Xbox SDK</TextBlock>
+                                            <TextBlock TextWrapping="WrapWholeWords" Foreground="{ThemeResource TextFillColorSecondaryBrush}">GDK Visual Studio extensions require configuring the target Visual Studio instance with the Game development with C++ workload before.</TextBlock>
+                                            <HyperlinkButton Style="{ThemeResource TextBlockButtonStyle}">View all</HyperlinkButton>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                                <x:String>A</x:String>
+                                <x:String>A</x:String>
+                                <x:String>A</x:String>
+                                <x:String>A</x:String>
+                            </ListView>
+                        </Expander>
+                    </Grid>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 using DevHome.SetupFlow.ViewModels;
+using DevHome.SetupFlow.Windows;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace DevHome.SetupFlow.Views;
 
@@ -11,7 +14,38 @@ public sealed partial class SummaryView : UserControl
     public SummaryView()
     {
         this.InitializeComponent();
+
+        // Add separator dynamically between task group sections
+        var sections = TaskGroupSections.Children;
+        for (var i = 0; i < sections.Count - 1; ++i)
+        {
+            if (sections[i] is Grid sectionGrid)
+            {
+                sectionGrid.BorderBrush = (SolidColorBrush)Application.Current.Resources["DividerStrokeColorDefaultBrush"];
+                sectionGrid.BorderThickness = new Thickness(0, 0, 0, 1);
+            }
+        }
     }
 
     public SummaryViewModel ViewModel => (SummaryViewModel)this.DataContext;
+
+    private void ViewAllButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        // When installation notes' 'view all' hyperlink is clicked, open a new window with the full text
+        if (sender is HyperlinkButton hyperlinkButton && hyperlinkButton.Tag is PackageViewModel package)
+        {
+            var window = new InstallationNotesWindow(package.PackageTitle, package.InstallationNotes);
+            window.CenterOnWindow();
+            window.Activate();
+        }
+    }
+
+    private void InstallationNotes_IsTextTrimmedChanged(TextBlock sender, IsTextTrimmedChangedEventArgs args)
+    {
+        // Show 'view all' hyperlink if installation notes text is trimmed, otherwise hide it.
+        if (sender?.Tag is HyperlinkButton viewAllButton)
+        {
+            viewAllButton.Visibility = sender.IsTextTrimmed ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Windows/InstallationNotesWindow.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Windows/InstallationNotesWindow.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using DevHome.Common.Extensions;
+using DevHome.Common.Helpers;
+using DevHome.SetupFlow.Services;
+using DevHome.SetupFlow.Views;
+using Microsoft.UI.Xaml;
+using WinUIEx;
+
+namespace DevHome.SetupFlow.Windows;
+public sealed partial class InstallationNotesWindow : SecondaryWindowExtension
+{
+    private readonly InstallationNotesView _installationNotesView;
+
+    private const double InitialHeight = 385;
+    private const double InitialWidth = 501;
+
+    public InstallationNotesWindow(string packageTitle, string installationNotes)
+    {
+        var stringResource = Application.Current.GetService<ISetupFlowStringResource>();
+        var title = stringResource.GetLocalized(StringResourceKey.InstallationNotesTitle, packageTitle);
+
+        // Populate content
+        _installationNotesView = new (title, installationNotes);
+        Title = title;
+        Content = _installationNotesView;
+
+        // Configure layout
+        ExtendsContentIntoTitleBar = true;
+        this.SetIcon(_installationNotesView.DevHomeIconPath);
+        SetTitleBar(_installationNotesView.TitleBar);
+        UseAppTheme = true;
+        Activated += UpdateTitleBarTextColors;
+
+        // Configure dimensions
+        MinHeight = InitialHeight;
+        Height = InitialHeight;
+        MinWidth = InitialWidth;
+        Width = InitialWidth;
+    }
+
+    public void UpdateTitleBarTextColors(object sender, WindowActivatedEventArgs args)
+    {
+        var colorBrush = TitleBarHelper.GetTitleBarTextColorBrush(args.WindowActivationState);
+        _installationNotesView.UpdateTitleBarTextForeground(colorBrush);
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
- Added installation notes in the summary page
- Updated the summary page task group sections to be collapsable
- Created installation notes window for when the text is too long (and trimmed)
- Updated the computation for the secondary window to be centered and consistent on multi-monitor setup.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
<img src="https://github.com/microsoft/devhome/assets/104940545/8d237557-5300-4c8d-8a91-a73467a8b691" Width="500" />
<img src="https://github.com/microsoft/devhome/assets/104940545/ae1a23be-e3ae-44a2-907f-8e7b72b78918" WIdth="500" />

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
