### PR TITLE
Show message on Settings > Extensions when no extensions are installed

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -86,6 +86,10 @@
     <value>View and manage Dev Home extensions.</value>
     <comment>Description at the top of the Extensions page</comment>
   </data>
+  <data name="Settings_Extensions_NoneInstalled.Text" xml:space="preserve">
+    <value>No extensions are installed.</value>
+    <comment>Message shown when the user does not have any Dev Home extensions installed</comment>
+  </data>
   <data name="Settings_About_Description" xml:space="preserve">
     <value>Info, Privacy Statement</value>
     <comment>Body text description for a card than when clicked takes the user to the About settings page</comment>

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -10,8 +10,14 @@
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:settings="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
+    <Page.Resources>
+        <ResourceDictionary>
+            <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Visible" TrueValue="Collapsed" />
+        </ResourceDictionary>
+    </Page.Resources>
 
     <Grid
         MaxWidth="{ThemeResource MaxPageContentWidth}"
@@ -43,6 +49,10 @@
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
+                <TextBlock x:Uid="Settings_Extensions_NoneInstalled"
+                           Visibility="{x:Bind ViewModel.SettingsList.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}"
+                           Margin="0,50" 
+                           HorizontalAlignment="Center" />
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
## Summary of the pull request

When no extensions are installed, the blank page looks bad. Show a message. Wording borrowed from approved wording on Extensions page.

![image](https://github.com/microsoft/devhome/assets/47155823/09a897b2-e549-4a12-9d8f-c260d95ee7cc)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
