### PR TITLE
Enable navigation to Extension Settings pages from Extensions page

### DIFF
--- a/settings/DevHome.Settings/DevHome.Settings.csproj
+++ b/settings/DevHome.Settings/DevHome.Settings.csproj
@@ -67,4 +67,8 @@
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TelemetryEvents\" />
+  </ItemGroup>
 </Project>

--- a/settings/DevHome.Settings/TelemetryEvents/NavigateFromSummaryEvent.cs
+++ b/settings/DevHome.Settings/TelemetryEvents/NavigateFromSummaryEvent.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Settings.TelemetryEvents;
+
+[EventData]
+public class NavigateToExtensionSettingsEvent : EventBase
+{
+    public string StartingPage
+    {
+        get;
+    }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public NavigateToExtensionSettingsEvent(string startingPage)
+    {
+        StartingPage = startingPage;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
@@ -10,6 +10,8 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Settings.Models;
+using DevHome.Settings.TelemetryEvents;
+using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 using Windows.ApplicationModel;
 
@@ -99,6 +101,8 @@ public partial class ExtensionsViewModel : ObservableObject
 
     public void Navigate(string path)
     {
+        TelemetryFactory.Get<ITelemetry>().Log("ExtensionsSettings_Navigate_Event", LogLevel.Critical, new NavigateToExtensionSettingsEvent("ExtensionsViewModel"));
+
         var navigationService = Application.Current.GetService<INavigationService>();
         var segments = path.Split("/");
         navigationService.NavigateTo(typeof(ExtensionSettingsViewModel).FullName!, segments[1]);

--- a/settings/DevHome.Settings/Views/ExtensionSettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionSettingsPage.xaml
@@ -14,13 +14,19 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <Grid
+        MaxWidth="{ThemeResource MaxPageContentWidth}"
+        Margin="{ThemeResource ContentPageMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <BreadcrumbBar x:Name="BreadcrumbBar" Margin="0,0,0,16" ItemClicked="BreadcrumbBar_ItemClicked" ItemsSource="{x:Bind ViewModel.Breadcrumbs}" />
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind ViewModel.Breadcrumbs}" />
 
         <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
             <StackPanel>

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -8,6 +8,7 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
+using DevHome.ExtensionLibrary.Extensions;
 using DevHome.Helpers;
 using DevHome.Services;
 using DevHome.Settings.Extensions;

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -52,7 +52,13 @@ public partial class ShellViewModel : ObservableObject
 
     private void OnNavigated(object sender, NavigationEventArgs e)
     {
-        if (IsSettingsPage(e.SourcePageType.FullName))
+        if (IsExtensionSettingsPage(e.SourcePageType.FullName))
+        {
+            // If we navigate to the L3 settings page for an extension, leave the selected NavigationView item as it
+            // was, since we might be coming from Settings or Extensions.
+            return;
+        }
+        else if (IsSettingsPage(e.SourcePageType.FullName))
         {
             Selected = NavigationViewService.SettingsItem;
             return;
@@ -65,6 +71,16 @@ public partial class ShellViewModel : ObservableObject
         }
     }
 
+    private bool IsExtensionSettingsPage(string? pageType)
+    {
+        if (string.IsNullOrEmpty(pageType))
+        {
+            return false;
+        }
+
+        return pageType.StartsWith("DevHome.Settings.Views.ExtensionSettingsPage", StringComparison.Ordinal);
+    }
+
     private bool IsSettingsPage(string? pageType)
     {
         if (string.IsNullOrEmpty(pageType))
@@ -72,8 +88,6 @@ public partial class ShellViewModel : ObservableObject
             return false;
         }
 
-#pragma warning disable CA1310 // Specify StringComparison for correctness
-        return pageType.StartsWith("DevHome.Settings");
-#pragma warning restore CA1310 // Specify StringComparison for correctness
+        return pageType.StartsWith("DevHome.Settings", StringComparison.Ordinal);
     }
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/ServiceExtensions.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/ServiceExtensions.cs
@@ -5,7 +5,7 @@ using DevHome.ExtensionLibrary.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace DevHome.Settings.Extensions;
+namespace DevHome.ExtensionLibrary.Extensions;
 public static class ServiceExtensions
 {
     public static IServiceCollection AddExtensionLibrary(this IServiceCollection services, HostBuilderContext context)

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -8,6 +8,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using DevHome.Settings.ViewModels;
 using Microsoft.UI.Xaml;
 using Windows.ApplicationModel;
 using Windows.System;
@@ -61,7 +63,8 @@ public partial class InstalledExtensionViewModel : ObservableObject
     [RelayCommand]
     private void NavigateSettings()
     {
-        // TODO: nothing implements ISettingsProvider yet, so this will not be called
+        var navigationService = Application.Current.GetService<INavigationService>();
+        navigationService.NavigateTo(typeof(ExtensionSettingsViewModel).FullName!, ExtensionUniqueId);
     }
 }
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -9,7 +9,9 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
+using DevHome.Settings.TelemetryEvents;
 using DevHome.Settings.ViewModels;
+using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 using Windows.ApplicationModel;
 using Windows.System;
@@ -63,6 +65,8 @@ public partial class InstalledExtensionViewModel : ObservableObject
     [RelayCommand]
     private void NavigateSettings()
     {
+        TelemetryFactory.Get<ITelemetry>().Log("ExtensionsSettings_Navigate_Event", LogLevel.Critical, new NavigateToExtensionSettingsEvent("InstalledExtensionViewModel"));
+
         var navigationService = Application.Current.GetService<INavigationService>();
         navigationService.NavigateTo(typeof(ExtensionSettingsViewModel).FullName!, ExtensionUniqueId);
     }


### PR DESCRIPTION
## Summary of the pull request
Enable navigation from the Extension page to the L3 Settings page for the Extension itself. Include telemetry.

Since now the page can be reached from different places, the creation of the BreadcrumbBar must be changed.

![image](https://github.com/microsoft/devhome/assets/47155823/497d971c-0deb-4083-8df8-f001254574cc)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
