### PR TITLE
Make 'add all' button announce changes to screen reader

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -11,6 +11,7 @@ namespace DevHome.SetupFlow.Services;
 public static class StringResourceKey
 {
     // Keys in this file should be a subset of the ones found in the .resw file.
+    public static readonly string AddAllAnnouncement = nameof(AddAllAnnouncement);
     public static readonly string ApplicationsAddedPlural = nameof(ApplicationsAddedPlural);
     public static readonly string ApplicationsAddedSingular = nameof(ApplicationsAddedSingular);
     public static readonly string Applications = nameof(Applications);
@@ -72,6 +73,7 @@ public static class StringResourceKey
     public static readonly string RestorePackagesDescriptionWithDate = nameof(RestorePackagesDescriptionWithDate);
     public static readonly string Repository = nameof(Repository);
     public static readonly string ReviewNothingToSetUpToolTip = nameof(ReviewNothingToSetUpToolTip);
+    public static readonly string SelectedPackagesText = nameof(SelectedPackagesText);
     public static readonly string SelectedPackagesCount = nameof(SelectedPackagesCount);
     public static readonly string SetUpButton = nameof(SetUpButton);
     public static readonly string SizeWithColon = nameof(SizeWithColon);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -121,6 +121,10 @@
     <value>Add all</value>
     <comment>Label for adding all items for selection</comment>
   </data>
+  <data name="AddAllAnnouncement" xml:space="preserve">
+    <value>Selections added to "{0}" pane</value>
+    <comment>{Locked="{0}"} Screen reader announcement for adding all items for selection</comment>
+  </data>
   <data name="AddPackagesDescription.Text" xml:space="preserve">
     <value>Select packages to restore from your backup, clone from repository, or search with Windows Package Manager.</value>
     <comment>Description for Add packages page</comment>
@@ -632,6 +636,10 @@
   <data name="SelectedPackages.Text" xml:space="preserve">
     <value>Applications to install</value>
     <comment>Label for applications to install</comment>
+  </data>
+  <data name="SelectedPackagesText" xml:space="preserve">
+    <value>Applications to install</value>
+    <comment>Label for applications to install. Should match "SelectedPackages.Text" resource</comment>
   </data>
   <data name="SetupButton" xml:space="preserve">
     <value>Set up</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -29,7 +29,7 @@
             <HyperlinkButton
                 Grid.Column="1"
                 Visibility="{x:Bind Catalog.CanAddAllPackages, Mode=OneWay}"
-                Command="{x:Bind Catalog.AddAllPackagesCommand}">
+                Click="{x:Bind AddAllPackages}">
                 <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/AddAll" />
             </HyperlinkButton>
         </controls:SettingsCard>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
@@ -6,9 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
 using DevHome.SetupFlow.Common.Helpers;
+using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.SetupFlow.Views;
@@ -55,6 +58,27 @@ public sealed partial class PackageCatalogView : UserControl
     public PackageCatalogView()
     {
         this.InitializeComponent();
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new FrameworkElementAutomationPeer(this);
+    }
+
+    public void AddAllPackages()
+    {
+        var autoPeer = FrameworkElementAutomationPeer.FromElement(this);
+        if (autoPeer is not null)
+        {
+            var stringResource = new StringResource("DevHome.SetupFlow/Resources");
+            autoPeer.RaiseNotificationEvent(
+                AutomationNotificationKind.ActionCompleted,
+                AutomationNotificationProcessing.ImportantMostRecent,
+                stringResource.GetLocalized(StringResourceKey.AddAllAnnouncement, StringResourceKey.SelectedPackagesText),
+                "AddAllAnnouncement");
+        }
+
+        Catalog.AddAllPackagesCommand.Execute(null);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary of the pull request
This makes the "Add all" hyperlink button in the "machine configuration" > "end-to-end setup" page make an announcement via the screen reader when a screen reader is attached. 

## References and relevant issues
Closes https://dev.azure.com/microsoft/OS/_workitems/edit/45058508

## Detailed description of the pull request / Additional comments
Most of the interesting bits are in PackageCatalogView.xaml.cs. We formally create an automation peer for the view, then we leverage that automation peer to push an announcement via UI Automation.
