### PR TITLE
Big card adjustment on whats new page

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -137,8 +137,8 @@
                                 </Grid.Resources>
 
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="4*" />
-                                    <ColumnDefinition Width="6*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
 
                                 <Grid.RowDefinitions>
@@ -151,10 +151,10 @@
                                     Source="{ThemeResource ItemImage}"
                                     MaxHeight="188"
                                     MaxWidth="376"
-                                    HorizontalAlignment="Stretch"
+                                    HorizontalAlignment="Left"
                                     VerticalAlignment="Center"/>
 
-                                <StackPanel Grid.Column="1" Padding="65 10 15 0">
+                                <StackPanel Grid.Column="1" Padding="25 10 15 0">
                                     <TextBlock
                                         HorizontalAlignment="Left"
                                         Style="{ThemeResource BodyTextStyle}"
@@ -163,7 +163,9 @@
                                     <TextBlock
                                         Margin="0 8 0 10"
                                         TextWrapping="Wrap"
+                                        MaxWidth="400"
                                         FontSize="12"
+                                        HorizontalAlignment="Left"
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -125,7 +125,7 @@ public sealed partial class WhatsNewPage : Page
 
     private void MoveBigCardsIfNeeded(double newWidth)
     {
-        if (newWidth < 760)
+        if (newWidth < 786)
         {
             ViewModel.SwitchToSmallerView();
         }


### PR DESCRIPTION
## Summary of the pull request

Big card adjustments after feedback on bug bash. Fixed the image on the left side of the card, text next to it with width limited and reduced space between image and text.

Increased the minimum size to chance between small and bigger card so it changes at the exact moment when it changes from 3 to 2 columns.

<img width="597" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/eceebf7e-f473-40ab-b404-49499b8374aa">

<img width="709" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/9bef7beb-b1a1-4bb6-ad8c-513efecf2e89">

<img width="998" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/903b50c7-b7cb-421f-b0b8-5e8f6dcf0e15">


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
