### PR TITLE
Adding various fixes

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -24,7 +24,7 @@ parameters:
 
 variables:
   # MSIXVersion's second part should always be odd to account for stub app's version
-  MSIXVersion: '0.401'
+  MSIXVersion: '0.501'
   VersionOfSDK: '0.100'
   solution: '**/DevHome.sln'
   appxPackageDir: 'AppxPackages'

--- a/build/scripts/CreateBuildInfo.ps1
+++ b/build/scripts/CreateBuildInfo.ps1
@@ -6,7 +6,7 @@ Param(
 )
 
 $Major = "0"
-$Minor = "4"
+$Minor = "5"
 $Patch = "99" # default to 99 for local builds
 
 $versionSplit = $Version.Split(".");

--- a/common/Services/IPluginService.cs
+++ b/common/Services/IPluginService.cs
@@ -20,4 +20,8 @@ public interface IPluginService
     Task<IEnumerable<AppExtension>> GetInstalledAppExtensionsAsync();
 
     public event EventHandler OnPluginsChanged;
+
+    public void EnableExtension(string extensionUniqueId);
+
+    public void DisableExtension(string extensionUniqueId);
 }

--- a/settings/DevHome.Settings/Models/Setting.cs
+++ b/settings/DevHome.Settings/Models/Setting.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
 using Microsoft.UI.Xaml;
 
 namespace DevHome.Settings.Models;
@@ -13,7 +14,7 @@ public class Setting
 
     public string Path { get; }
 
-    public string FullName { get; }
+    public string UniqueId { get; }
 
     public string Header { get; }
 
@@ -36,18 +37,28 @@ public class Setting
                 Task.Run(() =>
                 {
                     var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-                    return localSettingsService.SaveSettingAsync(FullName + "-ExtensionDisabled", !value);
+                    return localSettingsService.SaveSettingAsync(UniqueId + "-ExtensionDisabled", !value);
                 }).Wait();
 
                 _isExtensionEnabled = value;
+
+                var pluginService = Application.Current.GetService<IPluginService>();
+                if (_isExtensionEnabled)
+                {
+                    pluginService.EnableExtension(UniqueId);
+                }
+                else
+                {
+                    pluginService.DisableExtension(UniqueId);
+                }
             }
         }
     }
 
-    public Setting(string path, string fullName, string header, string description, string glyph, bool hasToggleSwitch, bool hasSettingsProvider)
+    public Setting(string path, string uniqueId, string header, string description, string glyph, bool hasToggleSwitch, bool hasSettingsProvider)
     {
         Path = path;
-        FullName = fullName;
+        UniqueId = uniqueId;
         Header = header;
         Description = description;
         Glyph = glyph;
@@ -62,7 +73,7 @@ public class Setting
         var isDisabled = Task.Run(() =>
         {
             var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-            return localSettingsService.ReadSettingAsync<bool>(FullName + "-ExtensionDisabled");
+            return localSettingsService.ReadSettingAsync<bool>(UniqueId + "-ExtensionDisabled");
         }).Result;
         return !isDisabled;
     }

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -268,8 +268,8 @@
     <comment>Opt into including experimentation information into your issue template</comment>
   </data>
   <data name="Settings_Feedback_ReportBug_IncludePlugins.Content" xml:space="preserve">
-    <value>Include installed Dev Home plugins</value>
-    <comment>Opt into including information on plugins into your issue template</comment>
+    <value>Include installed Dev Home extensions</value>
+    <comment>Opt into including information on extensions into your issue template</comment>
   </data>
   <data name="Settings_Feedback_ReportBug_IncludeSystemInfo.Content" xml:space="preserve">
     <value>Include my system information</value>

--- a/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExtensionsViewModel.cs
@@ -89,7 +89,7 @@ public partial class ExtensionsViewModel : ObservableObject
             }
 
             var hasSettingsProvider = pluginWrapper.HasProviderType(Microsoft.Windows.DevHome.SDK.ProviderType.Settings);
-            var setting = new Setting("Plugins/" + pluginWrapper.ExtensionUniqueId, pluginWrapper.ExtensionUniqueId, pluginWrapper.Name, string.Empty, string.Empty, true, hasSettingsProvider);
+            var setting = new Setting("Extensions/" + pluginWrapper.ExtensionUniqueId, pluginWrapper.ExtensionUniqueId, pluginWrapper.Name, string.Empty, string.Empty, true, hasSettingsProvider);
             SettingsList.Add(new ExtensionViewModel(setting, this));
         }
     }

--- a/src/Services/PluginService.cs
+++ b/src/Services/PluginService.cs
@@ -185,7 +185,8 @@ public class PluginService : IPluginService, IDisposable
                     }
 
                     var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
-                    var isPluginDisabled = await localSettingsService.ReadSettingAsync<bool>(extension.Package.Id.FullName + "-ExtensionDisabled");
+                    var extensionUniqueId = extension.AppInfo.AppUserModelId + "!" + extension.Id;
+                    var isPluginDisabled = await localSettingsService.ReadSettingAsync<bool>(extensionUniqueId + "-ExtensionDisabled");
 
                     _installedPlugins.Add(pluginWrapper);
                     if (!isPluginDisabled)
@@ -272,5 +273,17 @@ public class PluginService : IPluginService, IDisposable
     private string? GetProperty(IPropertySet propSet, string name)
     {
         return propSet[name] as string;
+    }
+
+    public void EnableExtension(string extensionUniqueId)
+    {
+        var extension = _installedPlugins.Where(plugin => plugin.ExtensionUniqueId == extensionUniqueId);
+        _enabledPlugins.Add(extension.First());
+    }
+
+    public void DisableExtension(string extensionUniqueId)
+    {
+        var extension = _enabledPlugins.Where(plugin => plugin.ExtensionUniqueId == extensionUniqueId);
+        _enabledPlugins.Remove(extension.First());
     }
 }

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -235,7 +235,7 @@
     <comment>Name of app when run as administrator</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Button" xml:space="preserve">
-    <value>Explore Extensions</value>
+    <value>Explore extensions</value>
     <comment>Button on extensions card on "whats new" page</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Description" xml:space="preserve">

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -65,7 +65,7 @@ internal class RepositoryProvider
     {
         // The task.run inside GetProvider makes a deadlock when .Result is called.
         // https://stackoverflow.com/a/17248813.  Solution is to wrap in Task.Run().
-        Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Starting DevId and Repository provider plugins");
+        Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Starting DevId and Repository provider extensions");
         _devIdProvider = Task.Run(() => _pluginWrapper.GetProviderAsync<IDeveloperIdProvider>()).Result;
         _repositoryProvider = Task.Run(() => _pluginWrapper.GetProviderAsync<IRepositoryProvider>()).Result;
         var myName = _repositoryProvider.DisplayName;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -269,7 +269,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// </remarks>
     public void GetPlugins()
     {
-        Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Getting installed plugins with Repository and DevId providers");
+        Log.Logger?.ReportInfo(Log.Component.RepoConfig, "Getting installed extensions with Repository and DevId providers");
         var pluginService = Application.Current.GetService<IPluginService>();
         var pluginWrappers = pluginService.GetInstalledPluginsAsync().Result;
 
@@ -310,6 +310,8 @@ public partial class AddRepoViewModel : ObservableObject
         CurrentPage = PageKind.AddViaAccount;
         PrimaryButtonText = _stringResource.GetLocalized(StringResourceKey.RepoAccountPagePrimaryButtonText);
 
+        // List of extensions needs to be refreshed before accessing
+        GetPlugins();
         if (ProviderNames.Count == 1)
         {
             _providers.StartIfNotRunning(ProviderNames[0]);


### PR DESCRIPTION
## Summary of the pull request
1. Dev Home settings are now saved to "extensions" path instead of "plugins"
2. Version is updated to 0.5
3. Updated a couple strings to say "extensions" instead of "plugins"
4. Enable/Disable extensions now correctly works without restarting Dev Home
5. Add repo by account dialog no longer caches list of extensions
6. Updated a setting to correctly use extensionUniqueId instead of PackageFullName

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
