### PR TITLE
Update CommunityToolkit versions

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.3" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230907" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta">
       <PrivateAssets>all</PrivateAssets>

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -16,10 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.3" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.WinUI.Animations" Version="8.0.230907" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.230907" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/common/Renderers/LabelGroup.cs
+++ b/common/Renderers/LabelGroup.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
-using CommunityToolkit.WinUI.UI.Controls;
+using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Data.Json;

--- a/settings/DevHome.Settings/DevHome.Settings.csproj
+++ b/settings/DevHome.Settings/DevHome.Settings.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.230907" />
+    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.230907" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
   </ItemGroup>
 
   <ItemGroup>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
@@ -24,16 +24,16 @@
             ItemsSource="{x:Bind Breadcrumbs}" />
 
         <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
-            <labs:SettingsExpander x:Uid="Settings_About_Card" IsExpanded="True">
-                <labs:SettingsExpander.HeaderIcon>
+            <ctControls:SettingsExpander x:Uid="Settings_About_Card" IsExpanded="True">
+                <ctControls:SettingsExpander.HeaderIcon>
                     <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/DevHome.ico" />
-                </labs:SettingsExpander.HeaderIcon>
+                </ctControls:SettingsExpander.HeaderIcon>
                 <TextBlock
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     IsTextSelectionEnabled="True"
                     Text="{x:Bind ViewModel.VersionDescription, Mode=OneWay}" />
-                <labs:SettingsExpander.Items>
-                    <labs:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
+                <ctControls:SettingsExpander.Items>
+                    <ctControls:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
                         <StackPanel Orientation="Vertical">
                             <TextBlock x:Uid="Settings_About_RelatedLinks" Margin="{StaticResource XSmallTopBottomMargin}" />
                             <HyperlinkButton x:Uid="SettingsPage_SourceCodeLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
@@ -41,9 +41,9 @@
                             <HyperlinkButton x:Uid="SettingsPage_ReleaseNotesLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
                             <HyperlinkButton x:Uid="SettingsPage_PrivacyPolicyLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
                         </StackPanel>
-                    </labs:SettingsCard>
-                </labs:SettingsExpander.Items>
-            </labs:SettingsExpander>
+                    </ctControls:SettingsCard>
+                </ctControls:SettingsExpander.Items>
+            </ctControls:SettingsExpander>
         </ScrollViewer>
     </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:models="using:DevHome.Settings.Models"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -7,7 +7,7 @@
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:models="using:DevHome.Settings.Models"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
@@ -29,9 +29,9 @@
         </DataTemplate>
 
         <DataTemplate x:Key="AccountsViewTemplate" x:DataType="models:Account">
-            <labs:SettingsCard Header="{x:Bind LoginId}" Margin="{StaticResource SettingsCardMargin}">
+            <ctControls:SettingsCard Header="{x:Bind LoginId}" Margin="{StaticResource SettingsCardMargin}">
                 <Button Tag="{x:Bind}" x:Uid="Settings_Accounts_LogoutButton" Click="Logout_Click"/>
-            </labs:SettingsCard>
+            </ctControls:SettingsCard>
         </DataTemplate>
     </Page.Resources>
 
@@ -51,10 +51,10 @@
 
         <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
             <StackPanel>
-                <labs:SettingsCard x:Uid="Settings_Accounts_AddAccount">
-                    <labs:SettingsCard.HeaderIcon>
+                <ctControls:SettingsCard x:Uid="Settings_Accounts_AddAccount">
+                    <ctControls:SettingsCard.HeaderIcon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8fa;"/>
-                    </labs:SettingsCard.HeaderIcon>
+                    </ctControls:SettingsCard.HeaderIcon>
                     <Button x:Uid="Settings_Accounts_AddAccountButton" HorizontalAlignment="Right" Click="AddAccountButton_Click">
                         <Button.Resources>
                             <Flyout x:Name="AccountsProvidersFlyout" Placement="Bottom">
@@ -72,7 +72,7 @@
                             </Flyout>
                         </Button.Resources>
                     </Button>
-                </labs:SettingsCard>
+                </ctControls:SettingsCard>
                 
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.AccountsProviders}"
                                ItemTemplate="{StaticResource AccountsProviderViewTemplate}"

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -10,7 +10,7 @@
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:settings="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
     <Page.Resources>

--- a/settings/DevHome.Settings/Views/ExtensionsPage.xaml
+++ b/settings/DevHome.Settings/Views/ExtensionsPage.xaml
@@ -7,7 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:settings="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
@@ -40,12 +40,12 @@
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="settings:ExtensionViewModel">
-                            <labs:SettingsCard Header="{x:Bind Header}"
-                                               Margin="{ThemeResource SettingsCardMargin}"
-                                               IsClickEnabled="{x:Bind HasSettingsProvider}" Command="{x:Bind NavigateSettingsCommand}">
+                        <ctControls:SettingsCard Header="{x:Bind Header}"
+                                                 Margin="{ThemeResource SettingsCardMargin}"
+                                                 IsClickEnabled="{x:Bind HasSettingsProvider}" Command="{x:Bind NavigateSettingsCommand}">
                                 <ToggleSwitch Visibility="{x:Bind HasToggleSwitch}"
                                               IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
-                            </labs:SettingsCard>
+                        </ctControls:SettingsCard>
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -7,7 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors" 
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
@@ -96,51 +96,51 @@
                     </Hyperlink>
                 </TextBlock>
                 <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
-                    <labs:SettingsCard x:Uid="Settings_Feedback_ReportBug">
-                        <labs:SettingsCard.HeaderIcon>
+                    <ctControls:SettingsCard x:Uid="Settings_Feedback_ReportBug">
+                        <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xebe8;"/>
-                        </labs:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard.HeaderIcon>
                         <Button x:Uid="Settings_Feedback_ReportBug_Button" Click="DisplayReportBugDialog" MinWidth="150" />
-                    </labs:SettingsCard>
-                    <labs:SettingsCard x:Uid="Settings_Feedback_FeatureImprovement">
-                        <labs:SettingsCard.HeaderIcon>
+                    </ctControls:SettingsCard>
+                    <ctControls:SettingsCard x:Uid="Settings_Feedback_FeatureImprovement">
+                        <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xea80;"/>
-                        </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_FeatureImprovement_Button" Click="DisplaySuggestFeature"  MinWidth="150" />
-                    </labs:SettingsCard>
-                    <labs:SettingsCard x:Uid="Settings_Feedback_LocalizationIssue">
-                        <labs:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard.HeaderIcon>
+                        <Button x:Uid="Settings_Feedback_FeatureImprovement_Button" Click="DisplaySuggestFeature" MinWidth="150" />
+                    </ctControls:SettingsCard>
+                    <ctControls:SettingsCard x:Uid="Settings_Feedback_LocalizationIssue">
+                        <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xE909;"/>
-                        </labs:SettingsCard.HeaderIcon>
-                        <Button x:Uid="Settings_Feedback_LocalizationIssue_Button" Click="DisplayLocalizationIssueDialog"  MinWidth="150" />
-                    </labs:SettingsCard>
-                    <labs:SettingsCard x:Uid="Settings_Feedback_BuildExtension">
-                        <labs:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard.HeaderIcon>
+                        <Button x:Uid="Settings_Feedback_LocalizationIssue_Button" Click="DisplayLocalizationIssueDialog" MinWidth="150" />
+                    </ctControls:SettingsCard>
+                    <ctControls:SettingsCard x:Uid="Settings_Feedback_BuildExtension">
+                        <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xea86;"/>
-                        </labs:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard.HeaderIcon>
                         <Button Click="BuildExtensionButtonClicked" MinWidth="150">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <TextBlock x:Uid="Settings_Feedback_BuildExtension_Button" />
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" FontSize="12" />
                             </StackPanel>
                         </Button>
-                    </labs:SettingsCard>
-                    <labs:SettingsCard x:Uid="Settings_Feedback_ReportSecurity">
-                        <labs:SettingsCard.HeaderIcon>
+                    </ctControls:SettingsCard>
+                    <ctControls:SettingsCard x:Uid="Settings_Feedback_ReportSecurity">
+                        <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xf552;"/>
-                        </labs:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard.HeaderIcon>
                         <Button Click="ReportSecurityButtonClicked" MinWidth="150">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <TextBlock x:Uid="Settings_Feedback_ReportSecurity_Button" />
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" FontSize="12" />
                             </StackPanel>
                         </Button>
-                    </labs:SettingsCard>
+                    </ctControls:SettingsCard>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:i="using:Microsoft.Xaml.Interactivity" 
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
@@ -28,10 +28,10 @@
             ItemsSource="{x:Bind Breadcrumbs}" />
 
         <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
-            <labs:SettingsCard x:Uid="Settings_Theme">
-                <labs:SettingsCard.HeaderIcon>
+            <ctControls:SettingsCard x:Uid="Settings_Theme">
+                <ctControls:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE790;" />
-                </labs:SettingsCard.HeaderIcon>
+                </ctControls:SettingsCard.HeaderIcon>
                 <ComboBox x:Name="ThemeSelectionComboBox">
                     <ComboBoxItem x:Uid="Settings_Theme_Default" Tag="{x:Bind xaml:ElementTheme.Default}" />
                     <ComboBoxItem x:Uid="Settings_Theme_Light" Tag="{x:Bind xaml:ElementTheme.Light}" />
@@ -43,7 +43,7 @@
                         </ic:EventTriggerBehavior>
                     </i:Interaction.Behaviors>
                 </ComboBox>
-            </labs:SettingsCard>
+            </ctControls:SettingsCard>
         </ScrollViewer>
     </Grid>
 </Page>

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -7,7 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:settings="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
@@ -31,12 +31,12 @@
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="settings:SettingViewModel">
-                        <labs:SettingsCard Header="{x:Bind Header}" Description="{x:Bind Description}"
+                        <ctControls:SettingsCard Header="{x:Bind Header}" Description="{x:Bind Description}"
                                        IsClickEnabled="True" Command="{x:Bind NavigateSettingsCommand}" Margin="{ThemeResource SettingsCardMargin}">
-                            <labs:SettingsCard.HeaderIcon>
+                            <ctControls:SettingsCard.HeaderIcon>
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="{x:Bind Glyph}"/>
-                            </labs:SettingsCard.HeaderIcon>
-                        </labs:SettingsCard>
+                            </ctControls:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard>
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -33,13 +33,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.230907" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
         <PackageReference Include="WinUIEx" Version="1.8.0" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" GeneratePathProperty="true">
             <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:animations="using:CommunityToolkit.WinUI.UI.Animations"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls" 
     xmlns:models="using:DevHome.Models"
     xmlns:behaviors="using:DevHome.Common.Behaviors"

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -19,8 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.230907" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -8,7 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:commonviews="using:DevHome.Common.Views"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     mc:Ignorable="d"

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -8,7 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:commonviews="using:DevHome.Common.Views"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}"
     SizeChanged="ContentDialog_SizeChanged">

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -15,7 +15,7 @@
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.230907" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -8,7 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:viewmodels="using:DevHome.ExtensionLibrary.ViewModels"
     xmlns:i="using:Microsoft.Xaml.Interactivity"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -9,7 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:viewmodels="using:DevHome.ExtensionLibrary.ViewModels"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
@@ -63,14 +63,14 @@
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.InstalledPackagesList, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewmodels:InstalledPackageViewModel">
-                            <labs:SettingsExpander Header="{x:Bind Title}"
+                            <ctControls:SettingsExpander Header="{x:Bind Title}"
                                                    Description="{x:Bind GeneratePackageDetails(Version,Publisher , InstalledDate), Mode=OneWay}"
                                                    Margin="{ThemeResource SettingsCardMargin}"
                                                    ItemsSource="{x:Bind InstalledExtensionsList}"
                                                    IsExpanded="True">
-                                <labs:SettingsExpander.HeaderIcon>
+                                <ctControls:SettingsExpander.HeaderIcon>
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
-                                </labs:SettingsExpander.HeaderIcon>
+                                </ctControls:SettingsExpander.HeaderIcon>
                                 <Button Content="&#xe712;"
                                         Height="36" Width="36"
                                         FontFamily="{StaticResource SymbolThemeFontFamily}" 
@@ -86,19 +86,19 @@
                                         </MenuFlyout>
                                     </Button.Flyout>
                                 </Button>
-                                <labs:SettingsExpander.ItemTemplate>
+                                <ctControls:SettingsExpander.ItemTemplate>
                                     <DataTemplate x:DataType="viewmodels:InstalledExtensionViewModel">
-                                        <labs:SettingsCard x:Uid="ManageExtensionCard"
+                                        <ctControls:SettingsCard x:Uid="ManageExtensionCard"
                                                            CornerRadius="0,0,3,3"
                                                            IsClickEnabled="{x:Bind HasSettingsProvider}"
                                                            Command="{x:Bind NavigateSettingsCommand}">
                                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                                 <ToggleSwitch IsOn="{x:Bind IsExtensionEnabled, Mode=TwoWay}"/>
                                             </StackPanel>
-                                        </labs:SettingsCard>
+                                        </ctControls:SettingsCard>
                                     </DataTemplate>
-                                </labs:SettingsExpander.ItemTemplate>
-                            </labs:SettingsExpander>
+                                </ctControls:SettingsExpander.ItemTemplate>
+                            </ctControls:SettingsExpander>
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
@@ -115,20 +115,20 @@
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewmodels:StorePackageViewModel">
-                            <labs:SettingsCard Header="{x:Bind Title}"
+                            <ctControls:SettingsCard Header="{x:Bind Title}"
                                                Description="{x:Bind Publisher}"
                                                Margin="{ThemeResource SettingsCardMargin}"
                                                CornerRadius="3"
                                                IsClickEnabled="False">
-                                <labs:SettingsCard.HeaderIcon>
+                                <ctControls:SettingsCard.HeaderIcon>
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
-                                </labs:SettingsCard.HeaderIcon>
+                                </ctControls:SettingsCard.HeaderIcon>
                                 <Button x:Uid="GetButton"
                                         Padding="25 4 25 6"
                                         MinWidth="118"
                                         Command="{x:Bind LaunchStoreButtonCommand}"
                                         CommandParameter="{x:Bind ProductId}" />
-                            </labs:SettingsCard>
+                            </ctControls:SettingsCard>
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewModels="using:DevHome.SetupFlow.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:i="using:Microsoft.Xaml.Interactivity"

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -9,11 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.3" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Shimmer" Version="0.0.1" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.230907" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -9,13 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.14" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Shimmer" Version="0.0.1" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.230907" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Primitives" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="0.0.5" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" GeneratePathProperty="true">
         <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -6,7 +6,7 @@
                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-               xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+               xmlns:converters="using:CommunityToolkit.WinUI.Converters"
                xmlns:labs="using:CommunityToolkit.Labs.WinUI"
                xmlns:models="using:DevHome.SetupFlow.Models"
                mc:Ignorable="d"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementReviewView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ctControls="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     mc:Ignorable="d">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementReviewView.xaml
@@ -8,7 +8,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     mc:Ignorable="d">
     <UserControl.Resources>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ctControls="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:selectors="using:DevHome.SetupFlow.Selectors"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
@@ -8,7 +8,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:selectors="using:DevHome.SetupFlow.Selectors"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveReviewView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     mc:Ignorable="d">
     <UserControl.Resources>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:util="using:DevHome.SetupFlow.Utilities"
     xmlns:services="using:DevHome.Common.Services"
     mc:Ignorable="d"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/EditClonePathDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/EditClonePathDialog.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/EditClonePathDialog"
     mc:Ignorable="d"
     IsPrimaryButtonEnabled="{x:Bind EditClonePathViewModel.IsPrimaryButtonEnabled, Mode=OneWay}"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -10,7 +10,7 @@
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     xmlns:commonModels="using:DevHome.SetupFlow.Models"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     setupFlowBehaviors:SetupFlowNavigationBehavior.CancelVisibility="Collapsed"
     setupFlowBehaviors:SetupFlowNavigationBehavior.PreviousVisibility="Collapsed"
     mc:Ignorable="d">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
@@ -83,7 +83,7 @@
                         <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_EnvironmentSetup" />
                         <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
                         <Grid Background="Transparent">
-                            <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
+                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
                                                AutomationProperties.AutomationId="EndToEndSetupButton"
                                                IsClickEnabled="True"
                                                Command="{x:Bind ViewModel.StartSetupCommand}"
@@ -92,12 +92,12 @@
                                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                                AutomationProperties.AccessibilityView="Control"
                                                ActionIcon="{x:Null}" >
-                                <labs:SettingsCard.HeaderIcon>
+                                <ctControls:SettingsCard.HeaderIcon>
                                     <ImageIcon
                                         Opacity="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
                                         Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_EndToEnd.png" />
-                                </labs:SettingsCard.HeaderIcon>
-                            </labs:SettingsCard>
+                                </ctControls:SettingsCard.HeaderIcon>
+                            </ctControls:SettingsCard>
 
                             <!-- Tooltip visible when the settings card is disabled -->
                             <ToolTipService.ToolTip>
@@ -106,7 +106,7 @@
                                     IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem,Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
                             </ToolTipService.ToolTip>
                         </Grid>
-                        <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_ConfigurationFile"
+                        <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_ConfigurationFile"
                                            AutomationProperties.AutomationId="DSCConfigurationButton"
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
@@ -114,15 +114,15 @@
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                            AutomationProperties.AccessibilityView="Control"
                                            ActionIcon="{x:Null}" >
-                            <labs:SettingsCard.HeaderIcon>
+                            <ctControls:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_ConfigurationFile.png" />
-                            </labs:SettingsCard.HeaderIcon>
-                        </labs:SettingsCard>
+                            </ctControls:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard>
                     </StackPanel>
 
                     <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
                         <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_QuickConfiguration" />
-                        <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
+                        <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
                                            AutomationProperties.AutomationId="CloneRepoButton"
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartRepoConfigCommand}"
@@ -130,13 +130,13 @@
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                            AutomationProperties.AccessibilityView="Control"
                                            ActionIcon="{x:Null}" >
-                            <labs:SettingsCard.HeaderIcon>
+                            <ctControls:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
-                            </labs:SettingsCard.HeaderIcon>
-                        </labs:SettingsCard>
+                            </ctControls:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard>
                         <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
                         <Grid Background="Transparent">
-                            <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
+                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
                                                IsClickEnabled="True"
                                                AutomationProperties.AutomationId="InstallAppsButton"
                                                Command="{x:Bind ViewModel.StartAppManagementCommand}"
@@ -145,12 +145,12 @@
                                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                                AutomationProperties.AccessibilityView="Control"
                                                ActionIcon="{x:Null}" >
-                                <labs:SettingsCard.HeaderIcon>
+                                <ctControls:SettingsCard.HeaderIcon>
                                     <ImageIcon
                                         Opacity="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
                                         Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_AppManagement.png" />
-                                </labs:SettingsCard.HeaderIcon>
-                            </labs:SettingsCard>
+                                </ctControls:SettingsCard.HeaderIcon>
+                            </ctControls:SettingsCard>
 
                             <!-- Tooltip visible when the settings card is disabled -->
                             <ToolTipService.ToolTip>
@@ -159,20 +159,20 @@
                                     IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem,Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
                             </ToolTipService.ToolTip>
                         </Grid>
-                        <labs:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
+                        <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
                                            AutomationProperties.AutomationId="DevDriveButton"
                                            IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                            AutomationProperties.AccessibilityView="Control"
                                            Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
-                            <labs:SettingsCard.ActionIcon>
+                            <ctControls:SettingsCard.ActionIcon>
                                 <!-- The open new window icon -->
                                 <FontIcon Glyph="&#xE8A7;" />
-                            </labs:SettingsCard.ActionIcon>
-                            <labs:SettingsCard.HeaderIcon>
+                            </ctControls:SettingsCard.ActionIcon>
+                            <ctControls:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_DevDrive.png" />
-                            </labs:SettingsCard.HeaderIcon>
-                        </labs:SettingsCard>
+                            </ctControls:SettingsCard.HeaderIcon>
+                        </ctControls:SettingsCard>
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -8,7 +8,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     mc:Ignorable="d">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -4,28 +4,28 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     xmlns:views="using:DevHome.SetupFlow.Views"
     mc:Ignorable="d">
     <StackPanel>
         <!-- Card header -->
-        <controls:SettingsCard
+        <ctControls:SettingsCard
             SizeChanged="SettingsCard_SizeChanged"
             Background="Transparent"
             Header="{x:Bind Catalog.Name}"
             Description="{x:Bind Catalog.Description}">
-            <controls:SettingsCard.Resources>
+            <ctControls:SettingsCard.Resources>
                 <Thickness x:Key="SettingsCardBorderThickness">0</Thickness>
                 <Thickness x:Key="SettingsCardPadding">0,0,0,15</Thickness>
                 <x:Double x:Key="SettingsCardMinHeight">0</x:Double>
                 <x:Double x:Key="SettingsCardMinWidth">0</x:Double>
                 <x:Double x:Key="SettingsCardWrapThreshold">0</x:Double>
                 <x:Double x:Key="SettingsCardWrapNoIconThreshold">0</x:Double>
-            </controls:SettingsCard.Resources>
-            <controls:SettingsCard.ActionIcon>
+            </ctControls:SettingsCard.Resources>
+            <ctControls:SettingsCard.ActionIcon>
                 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE711;"/>
-            </controls:SettingsCard.ActionIcon>
+            </ctControls:SettingsCard.ActionIcon>
             <HyperlinkButton
                 Grid.Column="1"
                 AutomationProperties.AutomationControlType="Button"
@@ -33,7 +33,7 @@
                 Command="{x:Bind Catalog.AddAllPackagesCommand}">
                 <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/AddAll" />
             </HyperlinkButton>
-        </controls:SettingsCard>
+        </ctControls:SettingsCard>
 
         <!-- Packages flip view -->
         <FlipView

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
-using DevHome.Common.Extensions;
 using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.ViewModels;
 using Microsoft.UI.Xaml;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     AutomationProperties.Name="{Binding PackageTitle}"
     mc:Ignorable="d">
     <UserControl.Resources>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigReviewView.xaml
@@ -8,7 +8,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctControls="using:CommunityToolkit.Labs.WinUI"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:models="using:DevHome.SetupFlow.Models"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:setupControls="using:DevHome.SetupFlow.Controls"
     xmlns:models="using:DevHome.SetupFlow.Models"
     mc:Ignorable="d">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
     xmlns:controls="using:DevHome.SetupFlow.Controls"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     mc:Ignorable="d">
     <UserControl.Resources>
         <converters:CollectionVisibilityConverter x:Name="CollectionVisibilityConverter" EmptyValue="Visible" NotEmptyValue="Collapsed" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d">
     <UserControl.Resources>
@@ -95,14 +95,14 @@
                                         </VisualStateGroup>
                                     </VisualStateManager.VisualStateGroups>
 
-                                    <controls:SettingsCard Background="Transparent" BorderThickness="0">
-                                        <controls:SettingsCard.Resources>
+                                    <ctControls:SettingsCard Background="Transparent" BorderThickness="0">
+                                        <ctControls:SettingsCard.Resources>
                                             <Thickness x:Key="SettingsCardPadding">0, 10</Thickness>
                                             <Thickness x:Key="SettingsCardMinHeight">0</Thickness>
                                             <x:Double x:Key="SettingsCardWrapThreshold">0</x:Double>
                                             <x:Double x:Key="SettingsCardWrapNoIconThreshold">0</x:Double>
                                             <x:Double x:Key="SettingsCardHeaderIconMaxSize">24</x:Double>
-                                        </controls:SettingsCard.Resources>
+                                        </ctControls:SettingsCard.Resources>
                                         <ToolTipService.ToolTip>
                                             <ToolTip>
                                                 <StackPanel>
@@ -122,15 +122,15 @@
                                                 </StackPanel>
                                             </ToolTip>
                                         </ToolTipService.ToolTip>
-                                        <controls:SettingsCard.Header>
+                                        <ctControls:SettingsCard.Header>
                                             <TextBlock
                                                 Name="Title"
                                                 TextTrimming="CharacterEllipsis"
                                                 MaxLines="1"
                                                 Style="{ThemeResource CaptionTextBlockStyle}"
                                                 Text="{Binding PackageTitle}"/>
-                                        </controls:SettingsCard.Header>
-                                        <controls:SettingsCard.Description>
+                                        </ctControls:SettingsCard.Header>
+                                        <ctControls:SettingsCard.Description>
                                             <TextBlock
                                                 Name="Version"
                                                 TextTrimming="CharacterEllipsis"
@@ -138,10 +138,10 @@
                                                 Foreground="{ThemeResource TextFillColorSecondary}"
                                                 Style="{ThemeResource CaptionTextBlockStyle}"
                                                 Text="{Binding PackageDescription}"/>
-                                        </controls:SettingsCard.Description>
-                                        <controls:SettingsCard.HeaderIcon>
+                                        </ctControls:SettingsCard.Description>
+                                        <ctControls:SettingsCard.HeaderIcon>
                                             <ImageIcon Name="Image" Source="{Binding Icon, Mode=OneWay}"/>
-                                        </controls:SettingsCard.HeaderIcon>
+                                        </ctControls:SettingsCard.HeaderIcon>
                                         <StackPanel Orientation="Horizontal" Spacing="10">
                                             <ContentControl IsTabStop="False" Content="{Binding IsInstalled, Converter={StaticResource LearnMoreInstalledConverter}}" />
                                             <Button
@@ -154,7 +154,7 @@
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
                                             </Button>
                                         </StackPanel>
-                                    </controls:SettingsCard>
+                                    </ctControls:SettingsCard>
                                 </Grid>
                             </ControlTemplate>
                         </Setter.Value>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:pg="using:DevHome.Common"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -4,7 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ctControls="using:CommunityToolkit.Labs.WinUI"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     xmlns:viewModels="using:DevHome.SetupFlow.ViewModels"
     xmlns:i="using:Microsoft.Xaml.Interactivity"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewModels="using:DevHome.SetupFlow.ViewModels"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"


### PR DESCRIPTION
## Summary of the pull request
We need to move as much as we can to the new published CommunityToolkit 8.0. This fixes a crash in the SettingsExpander that affected the Extensions page, as well as accessibility issues.

Specific changes can be found in the commit log.

DataGrid has not been included in the 8.0 release, so it says as a Labs. Also leaving SegmentedControl and Shimmer as labs.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
