### PR TITLE
Hide Extensions 'Get updates' button when there are no extensions installed

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -24,6 +24,7 @@
     <Page.Resources>
         <ResourceDictionary>
             <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Visible" TrueValue="Collapsed" />
+            <converters:DoubleToVisibilityConverter x:Key="InverseCountToVisibilityConverter" GreaterThan="0" FalseValue="Collapsed" TrueValue="Visible" />
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <x:String x:Key="ExtensionsBannerFront">ms-appx:///DevHome.ExtensionLibrary/Assets/ExtensionsBannerFrontLight.png</x:String>
@@ -58,6 +59,7 @@
                     <Button x:Uid="GetUpdatesButton"
                             HorizontalAlignment="Right"
                             Style="{ThemeResource AccentButtonStyle}"
+                            Visibility="{x:Bind ViewModel.InstalledPackagesList.Count, Converter={StaticResource InverseCountToVisibilityConverter}, Mode=OneWay}"
                             Command="{x:Bind ViewModel.GetUpdatesButtonCommand}"/>
                 </Grid>
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.InstalledPackagesList, Mode=OneWay}">


### PR DESCRIPTION
## Summary of the pull request

Hide 'Get updates button' when there are no extensions installed.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
