### PR TITLE
Don't show 'No Widgets' message while widgets are loading

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml;
 using Windows.Storage;
 using Windows.System;
 
@@ -16,6 +17,9 @@ public partial class DashboardViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _showDashboardBanner;
+
+    [ObservableProperty]
+    private bool _isLoading;
 
     public DashboardViewModel()
     {
@@ -46,6 +50,16 @@ public partial class DashboardViewModel : ObservableObject
         }
 
         return show;
+    }
+
+    public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)
+    {
+        if (widgetCount == 0 && !isLoading)
+        {
+            return Visibility.Visible;
+        }
+
+        return Visibility.Collapsed;
     }
 
 #if DEBUG

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -124,7 +124,7 @@ public partial class WidgetViewModel : ObservableObject
             cardData = await Widget.GetCardDataAsync();
         }
 
-        if (string.IsNullOrEmpty(cardData))
+        if (string.IsNullOrEmpty(cardData) || string.IsNullOrEmpty(cardTemplate))
         {
             Log.Logger()?.ReportWarn("WidgetViewModel", "Widget.GetCardDataAsync returned empty, cannot render card.");
             ShowErrorCard("WidgetErrorCardDisplayText");

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -107,7 +107,7 @@
 
                 <!-- Widget grid empty message -->
                 <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0"
-                            Visibility="{x:Bind views:DashboardView.PinnedWidgets.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}">
+                            Visibility="{x:Bind ViewModel.GetNoWidgetMessageVisibility(views:DashboardView.PinnedWidgets.Count, ViewModel.IsLoading), Mode=OneWay}">
                     <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
                     <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center">
                         <i:Interaction.Behaviors>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -176,6 +176,7 @@ public partial class DashboardView : ToolPage
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
+        ViewModel.IsLoading = true;
 
         // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
         await _widgetIconCache.CacheAllWidgetIconsAsync(_widgetCatalog);
@@ -185,6 +186,7 @@ public partial class DashboardView : ToolPage
         RestorePinnedWidgets();
 
         LoadingWidgetsProgressRing.Visibility = Visibility.Collapsed;
+        ViewModel.IsLoading = false;
     }
 
     private async void RestorePinnedWidgets()


### PR DESCRIPTION
## Summary of the pull request

- The message telling the user there are no pinned widgets was being shown even if the widgets were still loading. Look at the # of widgets _and_ the loading state to see if we should show the message.
  - The loading ring should bind to the new IsLoading property, but it never shows up if that is the case. Continue setting the visibility the current way until we can debug that.
- A continuable exception is thrown if we try to render a widget with an empty template. Update WidgetViewModel to not try to render in that case.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
