### PR TITLE
Fix margins on report bug dialog

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -30,13 +30,13 @@
             <StackPanel>
                 <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                     <Grid>
-                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
                             <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
                                 <TextBox x:Name="ReportBugIssueTitle" x:Uid="Settings_Feedback_ReportBug_IssueTitle" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugReproSteps" x:Uid="Settings_Feedback_ReportBug_ReproSteps" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugExpectedBehavior" x:Uid="Settings_Feedback_ReportBug_ExpectedBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugActualBehavior" x:Uid="Settings_Feedback_ReportBug_ActualBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
-                                <Expander x:Name="ReportBugSysInfoExpander" Expanding="ShowSysInfoExpander_Expanding" Margin="{StaticResource SmallTopMargin}" Width="{StaticResource FeedbackExpanderWidth}">
+                                <Expander x:Name="ReportBugSysInfoExpander" Expanding="ShowSysInfoExpander_Expanding" Margin="{StaticResource SmallTopMargin}" HorizontalAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
                                     <Expander.Header>
                                         <CheckBox x:Name="ReportBugIncludeSystemInfo" x:Uid="Settings_Feedback_ReportBug_IncludeSystemInfo" IsChecked="True"/>
                                     </Expander.Header>
@@ -48,7 +48,7 @@
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>
-                                <Expander x:Name="ReportBugPluginsExpander" Expanding="ShowPluginsInfoExpander_Expanding" Width="{StaticResource FeedbackExpanderWidth}">
+                                <Expander x:Name="ReportBugPluginsExpander" Expanding="ShowPluginsInfoExpander_Expanding" HorizontalAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
                                     <Expander.Header>
                                         <CheckBox x:Name="ReportBugIncludePlugins" x:Uid="Settings_Feedback_ReportBug_IncludePlugins" IsChecked="True"/>
                                     </Expander.Header>
@@ -58,7 +58,7 @@
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>
-                                <Expander x:Name="ReportBugExperimentInfoExpander" Width="{StaticResource FeedbackExpanderWidth}">
+                                <Expander x:Name="ReportBugExperimentInfoExpander" HorizontalAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
                                     <Expander.Header>
                                         <CheckBox x:Name="ReportBugIncludeExperimentInfo" x:Uid="Settings_Feedback_ReportBug_IncludeExperimentInfo" IsChecked="True"/>
                                     </Expander.Header>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -30,9 +30,9 @@
             <StackPanel>
                 <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                     <Grid>
-                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
-                            <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
-                                <TextBox x:Name="ReportBugIssueTitle" x:Uid="Settings_Feedback_ReportBug_IssueTitle" AcceptsReturn="True"/>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <TextBox x:Name="ReportBugIssueTitle" x:Uid="Settings_Feedback_ReportBug_IssueTitle" AcceptsReturn="True" />
                                 <TextBox x:Name="ReportBugReproSteps" x:Uid="Settings_Feedback_ReportBug_ReproSteps" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugExpectedBehavior" x:Uid="Settings_Feedback_ReportBug_ExpectedBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugActualBehavior" x:Uid="Settings_Feedback_ReportBug_ActualBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
@@ -69,8 +69,8 @@
                 </ContentDialog>
                 <ContentDialog x:Name="LocalizationIssueDialog" x:Uid="Settings_Feedback_LocalizationIssue_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                     <Grid>
-                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
-                            <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
                                 <TextBox x:Name="LocalizationIssueTitle" x:Uid="Settings_Feedback_LocalizationIssue_IssueTitle" AcceptsReturn="True"/>
                                 <TextBox x:Name="LocalizationIssueLanguageAffected" x:Uid="Settings_Feedback_LocalizationIssue_LanguageAffected" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                             </StackPanel>
@@ -79,8 +79,8 @@
                 </ContentDialog>
                 <ContentDialog x:Name="suggestFeatureDialog" x:Uid="Settings_Feedback_SuggestFeature_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                     <Grid>
-                        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="{StaticResource FeedbackScrollViewerMargin}">
-                            <StackPanel Margin="{StaticResource FeedbackScrollViewerContentMargin}">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
                                 <TextBox x:Name="SuggestFeatureTitle" x:Uid="Settings_Feedback_SuggestFeature_IssueTitle" AcceptsReturn="True"/>
                                 <TextBox x:Name="SuggestFeatureDescription" x:Uid="Settings_Feedback_SuggestFeature_Description" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
                                 <TextBox x:Name="SuggestFeatureScenario" x:Uid="Settings_Feedback_SuggestFeature_Scenario" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>

--- a/src/Styles/Feedback_ThemeResources.xaml
+++ b/src/Styles/Feedback_ThemeResources.xaml
@@ -5,12 +5,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Thickness x:Key="FeedbackScrollViewerMargin">0,40,-25,0</Thickness>
-
-    <Thickness x:Key="FeedbackScrollViewerContentMargin">0,0,30,0</Thickness>
-
-    <Thickness x:Key="FeedbackTitleMargin">0,-20,0,0</Thickness>
-
     <x:Double x:Key="FeedbackTextBoxHeight">100</x:Double>
 
     <x:Double x:Key="FeedbackExpanderWidth">430</x:Double>


### PR DESCRIPTION
## Summary of the pull request
Fix the margins and expanders in the report bug dialog to no longer have blank space on the right side

## References and relevant issues
#1503

## Validation steps performed
<img width="408" alt="image" src="https://github.com/microsoft/devhome/assets/26824113/28189a14-5b92-4813-b464-fa7ef4d9be86">

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
