### PR TITLE
Relative paths with a space would crash devhome

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -499,9 +499,19 @@ public partial class AddRepoViewModel : ObservableObject
         // absolute Uri.  UriBuilder prepends the https scheme
         if (!parsedUri.IsAbsoluteUri)
         {
-            var uriBuilder = new UriBuilder(parsedUri.OriginalString);
-            uriBuilder.Port = -1;
-            parsedUri = uriBuilder.Uri;
+            try
+            {
+                var uriBuilder = new UriBuilder(parsedUri.OriginalString);
+                uriBuilder.Port = -1;
+                parsedUri = uriBuilder.Uri;
+            }
+            catch (Exception e)
+            {
+                Log.Logger?.ReportError(Log.Component.RepoConfig, $"Invalid URL {parsedUri.OriginalString}", e);
+                UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlValidationBadUrl);
+                ShouldShowUrlError = Visibility.Visible;
+                return;
+            }
         }
 
         var providerToCloneRepo = _providers.CanAnyProviderSupportThisUri(parsedUri);


### PR DESCRIPTION
## Summary of the pull request
Relative URLs are allowed, but UriBuilder crashes when given something like "a b".  Fix is to surround in try/catch and display expected error state if it didn't work.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
