### PR TITLE
[New functionality] DevHome uses ShowLogonSession

### DIFF
--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -221,7 +221,13 @@ public sealed partial class AccountsPage : Page
         {
             IntPtr windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
             WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
-            await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
+            var developerIdResult = await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
+            if (developerIdResult.Result.Status == ProviderOperationStatus.Failure)
+            {
+                GlobalLog.Logger?.ReportError($"{developerIdResult.Result.DisplayMessage} - {developerIdResult.Result.DiagnosticText}");
+                return;
+            }
+
             accountProvider.RefreshLoggedInAccounts();
         }
     }

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -222,11 +222,18 @@ public sealed partial class AccountsPage : Page
         {
             IntPtr windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
             WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
-            var developerIdResult = await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
-            if (developerIdResult.Result.Status == ProviderOperationStatus.Failure)
+            try
             {
-                GlobalLog.Logger?.ReportError($"{developerIdResult.Result.DisplayMessage} - {developerIdResult.Result.DiagnosticText}");
-                return;
+                var developerIdResult = await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);
+                if (developerIdResult.Result.Status == ProviderOperationStatus.Failure)
+                {
+                    GlobalLog.Logger?.ReportError($"{developerIdResult.Result.DisplayMessage} - {developerIdResult.Result.DiagnosticText}");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                GlobalLog.Logger?.ReportError($"Exception thrown while calling DeveloperIdProvider.ShowLogonSession: ", ex);
             }
 
             accountProvider.RefreshLoggedInAccounts();

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -213,11 +213,12 @@ public sealed partial class AccountsPage : Page
 
     private async Task InitiateAddAccountUserExperienceAsync(Page parentPage, AccountsProviderViewModel accountProvider)
     {
-        if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
+        var authenticationFlow = accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind();
+        if (authenticationFlow == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
         {
             await ShowLoginUIAsync("Settings", parentPage, accountProvider);
         }
-        else if (accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind() == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
+        else if (authenticationFlow == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
         {
             IntPtr windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
             WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -214,11 +214,11 @@ public sealed partial class AccountsPage : Page
     private async Task InitiateAddAccountUserExperienceAsync(Page parentPage, AccountsProviderViewModel accountProvider)
     {
         var authenticationFlow = accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind();
-        if (authenticationFlow == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CardSession)
+        if (authenticationFlow == AuthenticationExperienceKind.CardSession)
         {
             await ShowLoginUIAsync("Settings", parentPage, accountProvider);
         }
-        else if (authenticationFlow == Microsoft.Windows.DevHome.SDK.AuthenticationExperienceKind.CustomProvider)
+        else if (authenticationFlow == AuthenticationExperienceKind.CustomProvider)
         {
             IntPtr windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
             WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
@@ -233,7 +233,7 @@ public sealed partial class AccountsPage : Page
             }
             catch (Exception ex)
             {
-                GlobalLog.Logger?.ReportError($"Exception thrown while calling DeveloperIdProvider.ShowLogonSession: ", ex);
+                GlobalLog.Logger?.ReportError($"Exception thrown while calling {nameof(accountProvider.DeveloperIdProvider)}.{nameof(accountProvider.DeveloperIdProvider.ShowLogonSession)}: ", ex);
             }
 
             accountProvider.RefreshLoggedInAccounts();


### PR DESCRIPTION
## Summary of the pull request
This pull request uses ShowLogonSession in the connect developer account user flow.

## References and relevant issues
https://github.com/microsoft/devhome/pull/1410

## Detailed description of the pull request / Additional comments
The purpose of the new interface is to provide plugins the flexibility of driving a custom user experience if desired. In conjunction with the AuthenticationExperienceKind enums defined, this method may be called instead of using the AdaptiveCard for user interaction.

## Validation steps performed
Manual Testing

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
