### PR TITLE
Fix build warning in InstallationNotesView and spelling errors

### DIFF
--- a/common/Helpers/ResultHelper.cs
+++ b/common/Helpers/ResultHelper.cs
@@ -5,15 +5,7 @@ using System;
 
 namespace DevHome.Common.ResultHelper;
 
-public class HresultException : Exception
-{
-    public HresultException(int errorCode)
-    {
-        HResult = errorCode;
-    }
-}
-
-public static class Result
+public static class ResultHelper
 {
     /// <summary>
     /// Throw an exception if <paramref name="hresult"/> is an error.
@@ -24,6 +16,14 @@ public static class Result
         if (hresult < 0)
         {
             throw new HresultException(hresult);
+        }
+    }
+
+    public class HresultException : Exception
+    {
+        public HresultException(int errorCode)
+        {
+            HResult = errorCode;
         }
     }
 }

--- a/common/TelemetryEvents/ExceptionEvent.cs
+++ b/common/TelemetryEvents/ExceptionEvent.cs
@@ -23,6 +23,6 @@ public class ExceptionEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // Only storing Hresult.  No sensitive information.
+        // Only storing HRESULT. No sensitive information.
     }
 }

--- a/common/TelemetryEvents/NavigationViewItemEvent.cs
+++ b/common/TelemetryEvents/NavigationViewItemEvent.cs
@@ -26,6 +26,6 @@ public class NavigationViewItemEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // Only storing Hresult.  No sensitive information.
+        // Only storing HRESULT. No sensitive information.
     }
 }

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -19,3 +19,9 @@
 ﻿downloadsandupdates
 ﻿appsfeatures
 ﻿winget
+﻿virtdisk
+﻿ntddisk
+﻿hresult
+﻿appsettings
+﻿yaml
+﻿awaitable

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -18,3 +18,4 @@
 ﻿enums
 ﻿downloadsandupdates
 ﻿appsfeatures
+﻿winget

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevDriveFormatter/DevDriveFormatter.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevDriveFormatter/DevDriveFormatter.cs
@@ -27,7 +27,7 @@ public class DevDriveFormatter
     /// </summary>
     /// <param name="curDriveLetter">The drive letter the method will use when attempting to find a volume and format it</param>
     /// <param name="driveLabel">The new drive label the Dev Drive will have after formatting completes.</param>
-    /// <returns>An Hresult as an int that indicates whether the operation succeeded or failed</returns>
+    /// <returns>An HRESULT as an int that indicates whether the operation succeeded or failed</returns>
     public int FormatPartitionAsDevDrive(char curDriveLetter, string driveLabel)
     {
         Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"Creating CimSession and calling QueryInstances to search for volume whose Drive letter is {curDriveLetter}:");
@@ -46,7 +46,7 @@ public class DevDriveFormatter
                     && curDriveLetter == foundALetter &&
                     !string.IsNullOrEmpty(objectId))
                 {
-                    Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"Starting WMI Storage API Format on ObjectId: {objectId} with Driveletter: {curDriveLetter}, using args: DeveloperVolume: true, FileSystem: ReFS, FileSystemLabel: {driveLabel}, AllocationUnitSize: {FourKb}");
+                    Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"Starting WMI Storage API Format on ObjectId: {objectId} with DriveLetter: {curDriveLetter}, using args: DeveloperVolume: true, FileSystem: ReFS, FileSystemLabel: {driveLabel}, AllocationUnitSize: {FourKb}");
 
                     // Obtain in-parameters for the method
                     var inParams = new CimMethodParametersCollection
@@ -65,16 +65,16 @@ public class DevDriveFormatter
                     var returnValue = (uint)outParams.ReturnValue.Value;
                     if (returnValue == 0)
                     {
-                        Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"WMI Storage API Format on ObjectId: {objectId} with Driveletter: {curDriveLetter} finished Successfully");
+                        Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"WMI Storage API Format on ObjectId: {objectId} with DriveLetter: {curDriveLetter} finished Successfully");
                         return 0;
                     }
 
-                    Log.Logger?.ReportError(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"WMI Storage API Format on ObjectId: {objectId} with Driveletter: {curDriveLetter}, failed with wmi error: {returnValue}");
+                    Log.Logger?.ReportError(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"WMI Storage API Format on ObjectId: {objectId} with DriveLetter: {curDriveLetter}, failed with wmi error: {returnValue}");
                     break;
                 }
 
                 var notCorrectDriveLetter = (letter is char ) ? ((char)letter).ToString() : "none";
-                Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"CimSession.QueryInstances found ObjectId: {objectId} but its Driveletter: {notCorrectDriveLetter}: is not correct, continuing search...");
+                Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"CimSession.QueryInstances found ObjectId: {objectId} but its DriveLetter: {notCorrectDriveLetter}: is not correct, continuing search...");
             }
 
             // ReturnValue was not successful. Give this a specific error but this will need

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/DevDriveStorageOperator.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/DevDriveStorageOperator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 using DevHome.SetupFlow.Common.DevDriveFormatter;
 using DevHome.SetupFlow.Common.Helpers;
@@ -37,7 +36,7 @@ public sealed class DevDriveStorageOperator
     }
 
     /// <summary>
-    /// Manually make this macro because CsWin32 does not generate it from Ntddisk.h.
+    /// Manually make this macro because CsWin32 does not generate it from ntddisk.h.
     /// The IOCTL_DISK_ARE_VOLUMES_READY when used with ioDeviceControl, is used so that DevHome
     /// waits until all volumes have completed any work assigned to them before using them.
     /// e.g creating the partition, before trying to use it again.
@@ -72,7 +71,7 @@ public sealed class DevDriveStorageOperator
     /// <param name="sizeInBytes">The size the drive will be created with</param>
     /// <param name="newDriveLetter">The drive letter to format the new drive</param>
     /// <param name="driveLabel">The label that will be given to the drive during formatting</param>
-    /// <returns>An int which is the Hresult code that indicates whether the operation succeeded or failed</returns>
+    /// <returns>An int which is the HRESULT code that indicates whether the operation succeeded or failed</returns>
     public int CreateDevDrive(string virtDiskPath, ulong sizeInBytes, char newDriveLetter, string driveLabel)
     {
         // Create the location if it doesn't exist.
@@ -120,7 +119,7 @@ public sealed class DevDriveStorageOperator
     /// <param name="virtDiskPath">The place in the file system the vhdx file will be saved to</param>
     /// <param name="sizeInBytes">The size the drive will be created with</param>
     /// <param name="virtDiskPhysicalPath">The logical representation of the virtual disks physical path on the system</param>
-    /// <returns>An Hresult that indicates whether the operation succeeded or failed</returns>
+    /// <returns>An HRESULT that indicates whether the operation succeeded or failed</returns>
     private HRESULT CreateAndAttachVhdx(string virtDiskPath, ulong sizeInBytes, out string virtDiskPhysicalPath)
     {
         virtDiskPhysicalPath = string.Empty;
@@ -204,8 +203,8 @@ public sealed class DevDriveStorageOperator
     /// </summary>
     /// <param name="virtDiskPhysicalPath">The logical representation of the virtual disks physical path on the system</param>
     /// <param name="diskNumber">The current number of the new virtual disk</param>
-    /// <returns>An Hresult that indicates whether the operation succeeded or failed</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1119:Statement should not use unnecessary parenthesis", Justification = "For math, 10 - 3 - 7 is alot different than 10  - (3 - 7)")]
+    /// <returns>An HRESULT that indicates whether the operation succeeded or failed</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1119:Statement should not use unnecessary parenthesis", Justification = "For math, 10 - 3 - 7 is a lot different than 10  - (3 - 7)")]
     private HRESULT CreatePartition(string virtDiskPhysicalPath, out uint diskNumber)
     {
         diskNumber = 0;
@@ -397,7 +396,7 @@ public sealed class DevDriveStorageOperator
     /// </summary>
     /// <param name="diskNumber">The disk number the method uses to located the correct disk</param>
     /// <param name="newDriveLetter">The new drive letter provided by the caller</param>
-    /// <returns>An Hresult that indicates whether the operation succeeded or failed</returns>
+    /// <returns>An HRESULT that indicates whether the operation succeeded or failed</returns>
     private HRESULT AssignDriveLetterToPartition(uint diskNumber, char newDriveLetter)
     {
         // Just created the virtual disk and created a single partition. Don't have to worry about there
@@ -429,8 +428,8 @@ public sealed class DevDriveStorageOperator
                     // The call to createFile succeeds with the trailing backslash, however when getting the device info
                     // using that handle fails. Remove it before the call, and add it back later.
                     var volumeGuidPathAfterTrim = volumeGuidPathBeforeTrim.Trim('\0');
-                    var hasTrailingbackslash = volumeGuidPathAfterTrim.Last() == '\\';
-                    if (hasTrailingbackslash)
+                    var hasTrailingBackslash = volumeGuidPathAfterTrim.Last() == '\\';
+                    if (hasTrailingBackslash)
                     {
                         volumeGuidPathAfterTrim = volumeGuidPathAfterTrim.TrimEnd('\\');
                     }
@@ -490,7 +489,7 @@ public sealed class DevDriveStorageOperator
                         continue;
                     }
 
-                    volumeGuidPathBeforeTrim = hasTrailingbackslash ? volumeGuidPathBeforeTrim : volumeGuidPathAfterTrim;
+                    volumeGuidPathBeforeTrim = hasTrailingBackslash ? volumeGuidPathBeforeTrim : volumeGuidPathAfterTrim;
                     Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(AssignDriveLetterToPartition), $"Finding old drive letter for volume: {volumeGuidPathBeforeTrim}");
 
                     // At this point there will most likely be a default drive letter
@@ -561,7 +560,7 @@ public sealed class DevDriveStorageOperator
     /// <summary>
     /// Helper method that results in the HRESULT class wrapping GetHRForLastWin32Error return value.
     /// </summary>
-    /// <returns>Returns errorcode indicating success or failure</returns>
+    /// <returns>Returns error code indicating success or failure</returns>
     private HRESULT ReturnLastErrorAsHR()
     {
         return new HRESULT(Marshal.GetHRForLastWin32Error());
@@ -573,7 +572,7 @@ public sealed class DevDriveStorageOperator
     /// </summary>
     /// <param name="curDriveLetter">The drive letter the method will use when attempting to find a volume and format it</param>
     /// <param name="driveLabel">The new drive label the Dev Drive will have after formatting completes.</param>
-    /// <returns>An Hresult that indicates whether the operation succeeded or failed</returns>
+    /// <returns>An HRESULT that indicates whether the operation succeeded or failed</returns>
     private int FormatPartitionAsDevDrive(char curDriveLetter, string driveLabel)
     {
         Log.Logger?.ReportInfo(Log.Component.DevDrive, nameof(FormatPartitionAsDevDrive), $"Creating DevDriveFormatter");

--- a/tools/SetupFlow/DevHome.SetupFlow.UnitTest/BaseSetupFlowTest.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.UnitTest/BaseSetupFlowTest.cs
@@ -75,7 +75,7 @@ public class BaseSetupFlowTest
                 services.AddSingleton<WindowsPackageManagerFactory>(new WindowsPackageManagerDefaultFactory());
                 services.AddSingleton<IAppManagementInitializer, AppManagementInitializer>();
                 services.AddSingleton<WinGetPackageDataSource, WinGetPackageRestoreDataSource>();
-                services.AddSingleton<CatalogDataSourceLoacder>();
+                services.AddSingleton<CatalogDataSourceLoader>();
                 services.AddSingleton<IScreenReaderService>(new Mock<IScreenReaderService>().Object);
 
                 // DI factory pattern

--- a/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
@@ -60,7 +60,7 @@ public static class ServiceExtensions
         services.AddSingleton<IRestoreInfo, RestoreInfo>();
         services.AddSingleton<PackageProvider>();
         services.AddTransient<AppManagementTaskGroup>();
-        services.AddSingleton<CatalogDataSourceLoacder>();
+        services.AddSingleton<CatalogDataSourceLoader>();
         services.AddSingleton<IAppManagementInitializer, AppManagementInitializer>();
 
         services.AddSingleton<WinGetPackageDataSource, WinGetPackageRestoreDataSource>();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
@@ -118,7 +118,7 @@ public partial class CloneRepoTask : ObservableObject, ISetupTask
 
     // Because AddMessage is defined in ISetupTask every setup task needs to have their own local copy.
     // If a task does not need to add any messages, for example, this class, warning 67 pops up stating that
-    // AddMessage event is not used and failing compliation.  Adding this pragma supresses the warning.
+    // AddMessage event is not used and failing compilation. Adding this pragma suppresses the warning.
     // When this task needs to insert messages into the loading screen this pragma can be removed.
 #pragma warning disable 67
     public event ISetupTask.ChangeMessageHandler AddMessage;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
@@ -114,7 +114,7 @@ internal class CreateDevDriveTask : ISetupTask
                     return TaskFinishedState.Failure;
                 }
 
-                Result.ThrowIfFailed(await elevatedComponentOperation.CreateDevDriveAsync());
+                ResultHelper.ThrowIfFailed(await elevatedComponentOperation.CreateDevDriveAsync());
                 return TaskFinishedState.Success;
             }
             catch (Exception ex)

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/AppManagementInitializer.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/AppManagementInitializer.cs
@@ -8,11 +8,11 @@ namespace DevHome.SetupFlow.Services;
 public class AppManagementInitializer : IAppManagementInitializer
 {
     private readonly IWindowsPackageManager _wpm;
-    private readonly CatalogDataSourceLoacder _catalogDataSourceLoader;
+    private readonly CatalogDataSourceLoader _catalogDataSourceLoader;
 
     public AppManagementInitializer(
         IWindowsPackageManager wpm,
-        CatalogDataSourceLoacder catalogDataSourceLoader)
+        CatalogDataSourceLoader catalogDataSourceLoader)
     {
         _wpm = wpm;
         _catalogDataSourceLoader = catalogDataSourceLoader;

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/AppManagementInitializer.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/AppManagementInitializer.cs
@@ -67,7 +67,7 @@ public class AppManagementInitializer : IAppManagementInitializer
             return true;
         }
 
-        Log.Logger?.ReportInfo(Log.Component.AppManagement, "WinGet COM Server is not availbale. AppInstaller might be staged but not registered, attempting to register it to fix the issue");
+        Log.Logger?.ReportInfo(Log.Component.AppManagement, "WinGet COM Server is not available. AppInstaller might be staged but not registered, attempting to register it to fix the issue");
         if (await _wpm.RegisterAppInstallerAsync())
         {
             if (await _wpm.IsCOMServerAvailableAsync())

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/CatalogDataSourceLoader.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/CatalogDataSourceLoader.cs
@@ -10,14 +10,14 @@ using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Models;
 
 namespace DevHome.SetupFlow.Services;
-public class CatalogDataSourceLoacder : IDisposable
+public class CatalogDataSourceLoader : IDisposable
 {
     private readonly SemaphoreSlim _lock = new (initialCount: 1, maxCount: 1);
     private readonly IEnumerable<WinGetPackageDataSource> _dataSources;
     private readonly Dictionary<WinGetPackageDataSource, IList<PackageCatalog>> _catalogsMap = new ();
     private bool _disposedValue;
 
-    public CatalogDataSourceLoacder(IEnumerable<WinGetPackageDataSource> dataSources)
+    public CatalogDataSourceLoader(IEnumerable<WinGetPackageDataSource> dataSources)
     {
         _dataSources = dataSources;
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/IDevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/IDevDriveManager.cs
@@ -106,7 +106,7 @@ public interface IDevDriveManager
     public void RequestToCloseDevDriveWindow(IDevDrive devDrive);
 
     /// <summary>
-    /// Event that the Dev Drive view model can subscribe to, to know if a requester wants them to close the window, without the user explicity
+    /// Event that the Dev Drive view model can subscribe to, to know if a requester wants them to close the window, without the user explicitly
     /// closing the window themselves, through actions like clicking the close button.
     /// </summary>
     public event EventHandler<IDevDrive> RequestToCloseViewModelWindow;

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/ISetupFlowStringResource.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/ISetupFlowStringResource.cs
@@ -13,7 +13,7 @@ public interface ISetupFlowStringResource : IStringResource
     /// <param name="errorCode">Error code</param>
     /// <param name="logComponent">Component string used for tagging log messages with the appropriate caller domain</param>
     /// <returns>
-    /// Localized string error message from Hresult if exists on the system else just the error code in Hexidecimal format
+    /// Localized string error message from HResult if exists on the system else just the error code in Hexadecimal format
     /// </returns>
     public string GetLocalizedErrorMsg(int errorCode, string logComponent);
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WindowsPackageManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WindowsPackageManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DevHome.Common.Exceptions;
-using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Services;
 using DevHome.SetupFlow.Common.Extensions;
@@ -13,7 +12,6 @@ using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Common.WindowsPackageManager;
 using DevHome.SetupFlow.Exceptions;
 using DevHome.SetupFlow.Models;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Management.Deployment;
 using Windows.Win32.Foundation;
 
@@ -176,7 +174,7 @@ public class WindowsPackageManager : IWindowsPackageManager
         {
             Log.Logger?.ReportInfo(Log.Component.AppManagement, "Starting AppInstaller registration ...");
             await _packageDeploymentService.RegisterPackageForCurrentUserAsync(AppInstallerPackageFamilyName);
-            Log.Logger?.ReportInfo(Log.Component.AppManagement, $"AppInstaller registered succcessfully");
+            Log.Logger?.ReportInfo(Log.Component.AppManagement, $"AppInstaller registered successfully");
             return true;
         }
         catch (RegisterPackageException e)

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1181,7 +1181,7 @@
   </data>
   <data name="CloneRepoErrorForActionCenter" xml:space="preserve">
     <value>Couldn't clone {0} because {1}</value>
-    <comment>{Locked="{0}","{1}"}Action center message to give the hresult as to why the repo could not be cloned {0}: name of repo {1}:Hresult as a hex</comment>
+    <comment>{Locked="{0}","{1}"}Action center message to give the hresult as to why the repo could not be cloned {0}: name of repo {1}: hresult as a hex</comment>
   </data>
   <data name="ClonePathForTextBlock.Text" xml:space="preserve">
     <value>Path</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
@@ -97,7 +97,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         var mainWindow = Application.Current.GetService<WindowEx>();
 
         // Create and configure file picker
-        Log.Logger?.ReportInfo(Log.Component.Configuration, "Launching file picker to select configurationf file");
+        Log.Logger?.ReportInfo(Log.Component.Configuration, "Launching file picker to select configuration file");
         var file = await mainWindow.OpenFilePickerAsync(Log.Logger, ("*.yaml;*.yml", StringResource.GetLocalized(StringResourceKey.FilePickerFileTypeOption, "YAML")));
 
         // Check if a file was selected

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -13,7 +13,7 @@ namespace DevHome.SetupFlow.ViewModels;
 public partial class PackageCatalogListViewModel : ObservableObject
 {
     private readonly IWindowsPackageManager _wpm;
-    private readonly CatalogDataSourceLoacder _catalogDataSourceLoacder;
+    private readonly CatalogDataSourceLoader _catalogDataSourceLoader;
     private readonly PackageCatalogViewModelFactory _packageCatalogViewModelFactory;
     private bool _initialized;
 
@@ -29,11 +29,11 @@ public partial class PackageCatalogListViewModel : ObservableObject
     public ObservableCollection<int> PackageCatalogShimmers { get; } = new ();
 
     public PackageCatalogListViewModel(
-        CatalogDataSourceLoacder catalogDataSourceLoacder,
+        CatalogDataSourceLoader catalogDataSourceLoader,
         IWindowsPackageManager wpm,
         PackageCatalogViewModelFactory packageCatalogViewModelFactory)
     {
-        _catalogDataSourceLoacder = catalogDataSourceLoacder;
+        _catalogDataSourceLoader = catalogDataSourceLoader;
         _wpm = wpm;
         _packageCatalogViewModelFactory = packageCatalogViewModelFactory;
     }
@@ -46,11 +46,11 @@ public partial class PackageCatalogListViewModel : ObservableObject
         if (!_initialized)
         {
             _initialized = true;
-            AddShimmers(_catalogDataSourceLoacder.CatalogCount);
+            AddShimmers(_catalogDataSourceLoader.CatalogCount);
             try
             {
                 await Task.Run(async () => await _wpm.WinGetCatalog.ConnectAsync());
-                await foreach (var dataSourceCatalogs in _catalogDataSourceLoacder.LoadCatalogsAsync())
+                await foreach (var dataSourceCatalogs in _catalogDataSourceLoader.LoadCatalogsAsync())
                 {
                     foreach (var catalog in dataSourceCatalogs)
                     {
@@ -70,7 +70,7 @@ public partial class PackageCatalogListViewModel : ObservableObject
             // Remove any remaining shimmers:
             // This can happen if for example a catalog was detected but not
             // displayed (e.g. catalog with no packages to display)
-            RemoveShimmers(_catalogDataSourceLoacder.CatalogCount);
+            RemoveShimmers(_catalogDataSourceLoader.CatalogCount);
         }
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -33,7 +33,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     private readonly ConfigurationUnitResultViewModelFactory _configurationUnitResultViewModelFactory;
     private readonly IWindowsPackageManager _wpm;
     private readonly PackageProvider _packageProvider;
-    private readonly CatalogDataSourceLoacder _catalogDataSourceLoacder;
+    private readonly CatalogDataSourceLoader _catalogDataSourceLoader;
 
     [ObservableProperty]
     private Visibility _showRestartNeeded;
@@ -155,7 +155,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         ConfigurationUnitResultViewModelFactory configurationUnitResultViewModelFactory,
         IWindowsPackageManager wpm,
         PackageProvider packageProvider,
-        CatalogDataSourceLoacder catalogDataSourceLoader)
+        CatalogDataSourceLoader catalogDataSourceLoader)
         : base(stringResource, orchestrator)
     {
         _orchestrator = orchestrator;
@@ -164,7 +164,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         _configurationUnitResultViewModelFactory = configurationUnitResultViewModelFactory;
         _wpm = wpm;
         _packageProvider = packageProvider;
-        _catalogDataSourceLoacder = catalogDataSourceLoader;
+        _catalogDataSourceLoader = catalogDataSourceLoader;
         _configurationUnitResults = new (GetConfigurationUnitResults);
         _showRestartNeeded = Visibility.Collapsed;
 
@@ -192,8 +192,8 @@ public partial class SummaryViewModel : SetupPageViewModelBase
                 await _wpm.ConnectToAllCatalogsAsync(force: true);
 
                 Log.Logger?.ReportInfo(Log.Component.Summary, $"Reloading catalogs from all data sources");
-                _catalogDataSourceLoacder.Clear();
-                await foreach (var dataSourceCatalogs in _catalogDataSourceLoacder.LoadCatalogsAsync())
+                _catalogDataSourceLoader.Clear();
+                await foreach (var dataSourceCatalogs in _catalogDataSourceLoader.LoadCatalogsAsync())
                 {
                     Log.Logger?.ReportInfo(Log.Component.Summary, $"Reloaded {dataSourceCatalogs.Count} catalog(s)");
                 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/InstallationNotesView.xaml
@@ -16,7 +16,7 @@
               IsHitTestVisible="True"
               VerticalAlignment="Top">
             <Image 
-                Source="{x:Bind DevHomeIconPath, Mode=OneWay}"
+                Source="{x:Bind DevHomeIconPath, Mode=OneTime}"
                 HorizontalAlignment="Left"
                 Width="16"
                 Height="20" 
@@ -25,7 +25,7 @@
                 VerticalAlignment="Center"
                 TextWrapping="NoWrap"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{x:Bind PackageTitle, Mode=OneWay}"
+                Text="{x:Bind PackageTitle, Mode=OneTime}"
                 Margin="35,5,5,0"/>
         </Grid>
         <Grid Margin="0,48,0,0">


### PR DESCRIPTION
## Summary of the pull request
* Fix build warning in InstallationNotesView.xaml. We had a OneWay binding to a value that never changed, switch to OneTime
* Typo in type `CatalogDataSourceLoacder`. Rename to `CatalogDataSourceLoader`
* Rename Result class to ResultHelper  to match the file name and move HresultException into the class to clarify where it is used. This will also prevent StyleCop issues if we upgrade StyleCop in the future.
* Miscellaneous spell check fixes in the area

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
