### PR TITLE
Persist dismissed machine config banner

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -42,14 +42,8 @@ public partial class DashboardViewModel : ObservableObject
 
     private bool ShouldShowDashboardBanner()
     {
-        var show = true;
         var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        if (roamingProperties.ContainsKey(_hideDashboardBannerKey))
-        {
-            show = false;
-        }
-
-        return show;
+        return !roamingProperties.ContainsKey(_hideDashboardBannerKey);
     }
 
     public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -70,14 +70,8 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
     private bool ShouldShowExtensionsBanner()
     {
-        var show = true;
         var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        if (roamingProperties.ContainsKey(_hideExtensionsBannerKey))
-        {
-            show = false;
-        }
-
-        return show;
+        return !roamingProperties.ContainsKey(_hideExtensionsBannerKey);
     }
 
     [RelayCommand]

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -29,7 +29,7 @@ namespace DevHome.SetupFlow.ViewModels;
 /// </summary>
 public partial class MainPageViewModel : SetupPageViewModelBase
 {
-    private const string _hideSetupFlowBannerKey = "HideSetupFLowBanner";
+    private const string _hideSetupFlowBannerKey = "HideSetupFlowBanner";
 
     private readonly IHost _host;
     private readonly IWindowsPackageManager _wpm;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -16,8 +16,8 @@ using DevHome.SetupFlow.TaskGroups;
 using DevHome.SetupFlow.Utilities;
 using DevHome.Telemetry;
 using Microsoft.Extensions.Hosting;
+using Windows.Storage;
 using Windows.System;
-using WinRT;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -29,6 +29,8 @@ namespace DevHome.SetupFlow.ViewModels;
 /// </summary>
 public partial class MainPageViewModel : SetupPageViewModelBase
 {
+    private const string _hideSetupFlowBannerKey = "HideSetupFLowBanner";
+
     private readonly IHost _host;
     private readonly IWindowsPackageManager _wpm;
 
@@ -64,6 +66,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase
         IsNavigationBarVisible = false;
         IsStepPage = false;
         ShowDevDriveItem = DevDriveUtil.IsDevDriveFeatureEnabled;
+        ShowBanner = ShouldShowSetupFlowBanner();
     }
 
     protected async override Task OnFirstNavigateToAsync()
@@ -84,6 +87,8 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     private void HideBanner()
     {
         TelemetryFactory.Get<ITelemetry>().LogCritical("MainPage_HideLearnMoreBanner_Event", false, Orchestrator.ActivityId);
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        roamingProperties[_hideSetupFlowBannerKey] = bool.TrueString;
         ShowBanner = false;
     }
 
@@ -200,5 +205,11 @@ public partial class MainPageViewModel : SetupPageViewModelBase
         HideAppInstallerUpdateNotification();
         Log.Logger?.ReportInfo(Log.Component.MainPage, "Opening AppInstaller in the Store app");
         await Launcher.LaunchUriAsync(new Uri($"ms-windows-store://pdp/?productid={WindowsPackageManager.AppInstallerProductId}"));
+    }
+
+    private bool ShouldShowSetupFlowBanner()
+    {
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        return !roamingProperties.ContainsKey(_hideSetupFlowBannerKey);
     }
 }


### PR DESCRIPTION
## Summary of the pull request

- Persist dismissed machine config banner
- Aligned code that checks if banner should be showed in dashboard and rxtensions page

## References and relevant issues
https://github.com/microsoft/devhome/issues/1393

## Detailed description of the pull request / Additional comments

Verified that dismission of the banners in dashboard, machine config and extensions page is persisted when DevHome is restarted.

## Validation steps performed

## PR checklist
- [x] Closes #1393
- [ ] Tests added/passed
- [ ] Documentation updated
