### PR TITLE
Added telemetry events for DevID entry points

### DIFF
--- a/common/TelemetryEvents/DeveloperId/DeveloperIdEvent.cs
+++ b/common/TelemetryEvents/DeveloperId/DeveloperIdEvent.cs
@@ -10,28 +10,26 @@ using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace DevHome.Common.TelemetryEvents;
+namespace DevHome.Common.TelemetryEvents.DeveloperId;
 
 [EventData]
 public class DeveloperIdEvent : EventBase
 {
     public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
 
-#pragma warning disable SA1300 // Element should begin with upper-case letter
-    public string developerId
+    public string DeveloperId
     {
         get;
     }
-#pragma warning restore SA1300 // Element should begin with upper-case letter
 
     public DeveloperIdEvent(string providerName, IDeveloperId devId)
     {
-        this.developerId = DeveloperIdHelper.GetHashedDeveloperId(providerName, devId);
+        DeveloperId = DeveloperIdHelper.GetHashedDeveloperId(providerName, devId);
     }
 
     public DeveloperIdEvent(string providerName, IEnumerable<IDeveloperId> devIds)
     {
-        this.developerId = string.Join(" , ", devIds.Select(devId => DeveloperIdHelper.GetHashedDeveloperId(providerName, devId)));
+        DeveloperId = string.Join(" , ", devIds.Select(devId => DeveloperIdHelper.GetHashedDeveloperId(providerName, devId)));
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/common/TelemetryEvents/DeveloperId/DeveloperIdHelper.cs
+++ b/common/TelemetryEvents/DeveloperId/DeveloperIdHelper.cs
@@ -6,7 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Windows.DevHome.SDK;
 
-namespace DevHome.Common.TelemetryEvents;
+namespace DevHome.Common.TelemetryEvents.DeveloperId;
 public static class DeveloperIdHelper
 {
     public static string GetHashedDeveloperId(string providerName, IDeveloperId devId)

--- a/common/TelemetryEvents/DeveloperId/EntryPointEvent.cs
+++ b/common/TelemetryEvents/DeveloperId/EntryPointEvent.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents.DeveloperId;
+
+[EventData]
+public class EntryPointEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public string EntryPointName
+    {
+        get;
+    }
+
+    public enum EntryPoint
+    {
+        None = 0,
+        Settings = 1,
+        SetupFlow = 2,
+        WhatsNewPage = 3,
+        Widget = 4,
+    }
+
+    private readonly string[] entryPointNames =
+    {
+        string.Empty,
+        "Settings",
+        "SetupFlow",
+        "WhatsNewPage",
+        "Widget",
+    };
+
+    public EntryPointEvent(EntryPoint entryPoint)
+    {
+        EntryPointName = entryPointNames[(int)entryPoint];
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // There are no sensitive strings
+    }
+}

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Security.Cryptography;
 using System.Text;
+using DevHome.Common.TelemetryEvents.DeveloperId;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/RepoCloneEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/RepoCloneEvent.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using DevHome.Common.TelemetryEvents.DeveloperId;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -10,10 +10,12 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Common.Renderers;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents.DeveloperId;
 using DevHome.Common.Views;
 using DevHome.Logging;
 using DevHome.Settings.Models;
 using DevHome.Settings.ViewModels;
+using DevHome.Telemetry;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -225,6 +227,11 @@ public sealed partial class AccountsPage : Page
 
     private async Task InitiateAddAccountUserExperienceAsync(Page parentPage, AccountsProviderViewModel accountProvider)
     {
+        TelemetryFactory.Get<ITelemetry>().Log(
+                                                "EntryPoint_DevId_Event",
+                                                LogLevel.Critical,
+                                                new EntryPointEvent(EntryPointEvent.EntryPoint.Settings));
+
         var authenticationFlow = accountProvider.DeveloperIdProvider.GetAuthenticationExperienceKind();
         if (authenticationFlow == AuthenticationExperienceKind.CardSession)
         {
@@ -232,8 +239,8 @@ public sealed partial class AccountsPage : Page
         }
         else if (authenticationFlow == AuthenticationExperienceKind.CustomProvider)
         {
-            IntPtr windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
-            WindowId windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
+            var windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
+            var windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
             try
             {
                 var developerIdResult = await accountProvider.DeveloperIdProvider.ShowLogonSession(windowPtr);

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -3,12 +3,10 @@
 
 using System.Diagnostics;
 using DevHome.Common.Contracts.Services;
-using DevHome.Common.Extensions;
 using DevHome.Common.Services;
-using DevHome.Common.TelemetryEvents;
+using DevHome.Common.TelemetryEvents.DeveloperId;
 using DevHome.Logging;
 using DevHome.Telemetry;
-using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Win32;
 using Windows.Win32.Foundation;

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -6,6 +6,7 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents;
+using DevHome.Common.TelemetryEvents.DeveloperId;
 using DevHome.Models;
 using DevHome.SetupFlow.Utilities;
 using DevHome.Telemetry;
@@ -21,6 +22,7 @@ public sealed partial class WhatsNewPage : Page
     private readonly Uri _devDrivePageKeyUri = new ("ms-settings:disksandvolumes");
     private readonly Uri _devDriveLearnMoreLinkUri = new ("https://go.microsoft.com/fwlink/?linkid=2236041");
     private const string _devDriveLinkResourceKey = "WhatsNewPage_DevDriveCard/Link";
+    private const string _accountsPageNavigationLink = "DevHome.Settings.ViewModels.AccountsViewModel";
 
     public WhatsNewViewModel ViewModel
     {
@@ -110,6 +112,14 @@ public sealed partial class WhatsNewPage : Page
         }
         else
         {
+            if (pageKey.Equals(_accountsPageNavigationLink, StringComparison.OrdinalIgnoreCase))
+            {
+                TelemetryFactory.Get<ITelemetry>().Log(
+                                                        "EntryPoint_DevId_Event",
+                                                        LogLevel.Critical,
+                                                        new EntryPointEvent(EntryPointEvent.EntryPoint.WhatsNewPage));
+            }
+
             var navigationService = Application.Current.GetService<INavigationService>();
             navigationService.NavigateTo(pageKey!);
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProviders.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProviders.cs
@@ -5,10 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents.DeveloperId;
 using DevHome.Common.Views;
 using DevHome.SetupFlow.Common.Helpers;
+using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.SetupFlow.Models;
@@ -103,6 +104,10 @@ internal class RepositoryProviders
 
     public ExtensionAdaptiveCardPanel GetLoginUi(string providerName, ElementTheme elementTheme)
     {
+        TelemetryFactory.Get<ITelemetry>().Log(
+                                                "EntryPoint_DevId_Event",
+                                                LogLevel.Critical,
+                                                new EntryPointEvent(EntryPointEvent.EntryPoint.SetupFlow));
         Log.Logger?.ReportInfo(Log.Component.RepoConfig, $"Getting login UI {providerName}");
         return _providers.GetValueOrDefault(providerName)?.GetLoginUi(elementTheme);
     }


### PR DESCRIPTION
## Summary of the pull request
Added Critical telemetry events for 3 DevID entry points: SetupFlow, Settings, WhatsNewPage.

## Detailed description of the pull request / Additional comments
- Added EntryPointEvent.cs file which defines the fields for the EtnryPoint_DevId_Event Telemetry event
- Fixed up some code style

## Validation steps performed
Checked on TRTT that the 3 entry points fire the new telemetry event. 

{
    "ver": "4.0",
    "name": "Microsoft.Windows.DevHome.EntryPoint_DevId_Event",
    "data": {
        "EntryPointName": "SetupFlow"
    }
}
{
    "ver": "4.0",
    "name": "Microsoft.Windows.DevHome.EntryPoint_DevId_Event",
    "data": {
        "EntryPointName": "Settings"
    }
}

{
    "ver": "4.0",
    "name": "Microsoft.Windows.DevHome.EntryPoint_DevId_Event",
    "data": {
        "EntryPointName": "WhatsNewPage"
    }
}

