### PR TITLE
Filter shown widgets to those from packages that also implement the Dev Home extension

### DIFF
--- a/common/Services/IExtensionService.cs
+++ b/common/Services/IExtensionService.cs
@@ -11,6 +11,8 @@ public interface IExtensionService
 {
     Task<IEnumerable<IExtensionWrapper>> GetInstalledExtensionsAsync(bool includeDisabledExtensions = false);
 
+    Task<IEnumerable<string>> GetInstalledDevHomeWidgetPackageFamilyNamesAsync(bool includeDisabledExtensions = false);
+
     Task<IEnumerable<IExtensionWrapper>> GetInstalledExtensionsAsync(Microsoft.Windows.DevHome.SDK.ProviderType providerType, bool includeDisabledExtensions = false);
 
     Task<IEnumerable<IExtensionWrapper>> GetAllExtensionsAsync();

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -25,6 +25,7 @@
         <uap3:Extension Category="windows.appExtensionHost">
           <uap3:AppExtensionHost>
             <uap3:Name>com.microsoft.devhome</uap3:Name>
+            <uap3:Name>com.microsoft.windows.widgets</uap3:Name>
           </uap3:AppExtensionHost>
         </uap3:Extension>
         <uap:Extension Category="windows.protocol">

--- a/src/Services/ExtensionService.cs
+++ b/src/Services/ExtensionService.cs
@@ -20,6 +20,7 @@ public class ExtensionService : IExtensionService, IDisposable
     private static readonly PackageCatalog _catalog = PackageCatalog.OpenForCurrentUser();
     private static readonly object _lock = new ();
     private readonly SemaphoreSlim _getInstalledExtensionsLock = new (1, 1);
+    private readonly SemaphoreSlim _getInstalledWidgetsLock = new (1, 1);
     private bool _disposedValue;
 
 #pragma warning disable IDE0044 // Add readonly modifier
@@ -208,7 +209,7 @@ public class ExtensionService : IExtensionService, IDisposable
 
     private async Task<IEnumerable<string>> GetInstalledWidgetExtensionsAsync()
     {
-        await _getInstalledExtensionsLock.WaitAsync();
+        await _getInstalledWidgetsLock.WaitAsync();
         try
         {
             if (_installedWidgetsPackageFamilyNames.Count == 0)
@@ -224,7 +225,7 @@ public class ExtensionService : IExtensionService, IDisposable
         }
         finally
         {
-            _getInstalledExtensionsLock.Release();
+            _getInstalledWidgetsLock.Release();
         }
     }
 
@@ -293,6 +294,7 @@ public class ExtensionService : IExtensionService, IDisposable
             if (disposing)
             {
                 _getInstalledExtensionsLock.Dispose();
+                _getInstalledWidgetsLock.Dispose();
             }
 
             _disposedValue = true;

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -5,6 +5,9 @@ using System;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using Microsoft.UI.Xaml;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 
@@ -67,10 +70,18 @@ internal class WidgetHelpers
         };
     }
 
-    public static bool IsIncludedWidgetProvider(WidgetProviderDefinition provider)
+    public static async Task<bool> IsIncludedWidgetProviderAsync(WidgetProviderDefinition provider)
     {
-        var include = provider.Id.StartsWith("Microsoft.Windows.DevHome", StringComparison.CurrentCulture);
-        Log.Logger()?.ReportInfo("WidgetHelpers", $"Found provider Id = {provider.Id}, include = {include}");
+        var providerId = provider.Id;
+
+        var extensionService = Application.Current.GetService<IExtensionService>();
+        var enabledWidgetProviderIds = await extensionService.GetInstalledDevHomeWidgetPackageFamilyNamesAsync();
+
+        var endOfPfnIndex = providerId.IndexOf('!', StringComparison.Ordinal);
+        var familyNamePartOfProviderId = providerId[..endOfPfnIndex];
+
+        var include = enabledWidgetProviderIds.ToList().Contains(familyNamePartOfProviderId);
+        Log.Logger()?.ReportInfo("WidgetHelpers", $"Found provider Id = {providerId}, include = {include}");
         return include;
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -72,14 +72,16 @@ internal class WidgetHelpers
 
     public static async Task<bool> IsIncludedWidgetProviderAsync(WidgetProviderDefinition provider)
     {
+        // Cut WidgetProviderDefinition id down to just the package family name.
         var providerId = provider.Id;
-
-        var extensionService = Application.Current.GetService<IExtensionService>();
-        var enabledWidgetProviderIds = await extensionService.GetInstalledDevHomeWidgetPackageFamilyNamesAsync(true);
-
         var endOfPfnIndex = providerId.IndexOf('!', StringComparison.Ordinal);
         var familyNamePartOfProviderId = providerId[..endOfPfnIndex];
 
+        // Get the list of packages that contain Dev Home widgets.
+        var extensionService = Application.Current.GetService<IExtensionService>();
+        var enabledWidgetProviderIds = await extensionService.GetInstalledDevHomeWidgetPackageFamilyNamesAsync(true);
+
+        // Check if the specified widget provider is in the list.
         var include = enabledWidgetProviderIds.ToList().Contains(familyNamePartOfProviderId);
         Log.Logger()?.ReportInfo("WidgetHelpers", $"Found provider Id = {providerId}, include = {include}");
         return include;

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -75,7 +75,7 @@ internal class WidgetHelpers
         var providerId = provider.Id;
 
         var extensionService = Application.Current.GetService<IExtensionService>();
-        var enabledWidgetProviderIds = await extensionService.GetInstalledDevHomeWidgetPackageFamilyNamesAsync();
+        var enabledWidgetProviderIds = await extensionService.GetInstalledDevHomeWidgetPackageFamilyNamesAsync(true);
 
         var endOfPfnIndex = providerId.IndexOf('!', StringComparison.Ordinal);
         var familyNamePartOfProviderId = providerId[..endOfPfnIndex];

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetIconCache.cs
@@ -54,7 +54,7 @@ internal class WidgetIconCache
     public async Task AddIconsToCacheAsync(WidgetDefinition widgetDef)
     {
         // Only cache icons for providers that we're including.
-        if (WidgetHelpers.IsIncludedWidgetProvider(widgetDef.ProviderDefinition))
+        if (await WidgetHelpers.IsIncludedWidgetProviderAsync(widgetDef.ProviderDefinition))
         {
             var widgetDefId = widgetDef.Id;
             try

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -83,7 +83,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         // the widget if it is selected later.
         foreach (var providerDef in providerDefs)
         {
-            if (WidgetHelpers.IsIncludedWidgetProvider(providerDef))
+            if (await WidgetHelpers.IsIncludedWidgetProviderAsync(providerDef))
             {
                 var navItem = new NavigationViewItem
                 {


### PR DESCRIPTION
## Summary of the pull request
We want to open up the widgets we show as available to the user, but we still want to limit the widgets to ones specifically meant to be shown in Dev Home. So instead of filtering on widget provider name, instead we will show widgets that _also_ implement the Dev Home extension.

We do this by finding all installed packages that implement `com.microsoft.windows.widgets' in the same way we find those that implement `com.microsoft.devhome`. In order to do this, we need to add com.microsoft.windows.widgets as a AppExtensionHost in the appxmanifest. Then we can take the intersection of the two lists, and a list of the PackageFamilyNames of that intersection.

We use the PackageFamilyName since that will match the first part of the Widget Provider's Id, so we can compare that Id to the list and know that the widget came from a package we want to include.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #908
- [ ] Tests added/passed
- [ ] Documentation updated
