### PR TITLE
Prevent concurrent calls when clicking 'add repo' buttons

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -14,10 +14,6 @@
         <converters:StringVisibilityConverter x:Key="StringVisibilityConverter" />
         <converters:BoolToObjectConverter x:Key="StepperBoolToGlyphBrushConverter" TrueValue="{ThemeResource AccentFillColorDisabledBrush}" FalseValue="{ThemeResource AccentFillColorDefaultBrush}" />
         <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
-        <!-- If no custom header template was provided, display a TextBlock -->
-        <ControlTemplate x:Name="defaultHeaderTemplate">
-            <ContentPresenter />
-        </ControlTemplate>
     </UserControl.Resources>
     <Grid RowSpacing="6" x:Name="ShellContent">
         <Grid.RowDefinitions>
@@ -92,7 +88,7 @@
                 Grid.Column="1"
                 IsTabStop="False"
                 HorizontalAlignment="Right"
-                Template="{x:Bind HeaderTemplate, Mode=OneWay}" />
+                Content="{x:Bind Header, Mode=OneWay}" />
         </Grid>
         <!-- Description -->
         <TextBlock

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -48,6 +48,10 @@
                 <ColumnDefinition Width="auto"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
+            <!--
+                TODO: https://github.com/microsoft/devhome/issues/1621
+                Promote stepper to a separate control
+            -->
             <!-- Stepper showing the progress within the flow -->
             <StackPanel Margin="0, 20, 0, 0" Visibility="{x:Bind Orchestrator.CurrentPageViewModel.IsStepPage, Mode=OneWay}">
                 <ItemsRepeater ItemsSource="{x:Bind Orchestrator.SetupStepPages, Mode=OneWay}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml.cs
@@ -29,10 +29,10 @@ public sealed partial class SetupShell : UserControl
         set => SetValue(DescriptionProperty, value);
     }
 
-    public ControlTemplate HeaderTemplate
+    public object Header
     {
-        get => (ControlTemplate)GetValue(HeaderTemplateProperty) ?? defaultHeaderTemplate;
-        set => SetValue(HeaderTemplateProperty, value);
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
     }
 
     public object SetupShellContent
@@ -57,7 +57,7 @@ public sealed partial class SetupShell : UserControl
     public static readonly DependencyProperty TitleProperty = DependencyProperty.RegisterAttached(nameof(Title), typeof(string), typeof(SetupShell), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty DescriptionProperty = DependencyProperty.RegisterAttached(nameof(Description), typeof(string), typeof(SetupShell), new PropertyMetadata(string.Empty));
     public static readonly DependencyProperty SetupShellContentProperty = DependencyProperty.RegisterAttached(nameof(SetupShellContent), typeof(object), typeof(SetupShell), new PropertyMetadata(null));
-    public static readonly DependencyProperty HeaderTemplateProperty = DependencyProperty.RegisterAttached(nameof(HeaderTemplate), typeof(ControlTemplate), typeof(SetupShell), new PropertyMetadata(null));
+    public static readonly DependencyProperty HeaderProperty = DependencyProperty.RegisterAttached(nameof(Header), typeof(object), typeof(SetupShell), new PropertyMetadata(null));
     public static readonly DependencyProperty OrchestratorProperty = DependencyProperty.RegisterAttached(nameof(Orchestrator), typeof(SetupFlowOrchestrator), typeof(SetupShell), new PropertyMetadata(null));
 
     private async void OnLoaded(object sender, RoutedEventArgs e)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -38,7 +38,7 @@
             <Button
                 AutomationProperties.AutomationId="AddRepositoriesButton"
                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_RepoReview_AddRepository"
-                Command="{x:Bind AddRepoButtonCommand}" />
+                Command="{x:Bind AddRepoCommand}" />
         </setupControls:SetupShell.Header>
         <Grid x:Name="RepoConfigGrid" RowSpacing="10">
             <ListView ScrollViewer.VerticalScrollBarVisibility="Auto" 
@@ -158,7 +158,7 @@
                     Grid.Row="1"
                     AutomationProperties.AutomationId="AddRepoHyperLinkButton"
                     HorizontalAlignment="Center"
-                    Command="{x:Bind AddRepoButtonCommand}"
+                    Command="{x:Bind AddRepoCommand}"
                     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelectedLink" />
             </Grid>
         </Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -34,11 +34,12 @@
 
     <setupControls:SetupShell x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SetupShell_RepoConfig"
                                Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}" >
-        <setupControls:SetupShell.HeaderTemplate>
-            <ControlTemplate>
-                <Button x:Name="AddRepositoriesButton" Click="AddRepoButton_Click" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_RepoReview_AddRepository"/>
-            </ControlTemplate>
-        </setupControls:SetupShell.HeaderTemplate>
+        <setupControls:SetupShell.Header>
+            <Button
+                AutomationProperties.AutomationId="AddRepositoriesButton"
+                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_RepoReview_AddRepository"
+                Command="{x:Bind AddRepoButtonCommand}" />
+        </setupControls:SetupShell.Header>
         <Grid x:Name="RepoConfigGrid" RowSpacing="10">
             <ListView ScrollViewer.VerticalScrollBarVisibility="Auto" 
                       ScrollViewer.VerticalScrollMode="Auto" 
@@ -153,7 +154,12 @@
                     <RowDefinition/>
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelected"/>
-                <HyperlinkButton x:Name="AddRepoHyperLinkButton" Grid.Row="1" Click="AddRepoButton_Click" HorizontalAlignment="Center" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelectedLink" />
+                <HyperlinkButton
+                    Grid.Row="1"
+                    AutomationProperties.AutomationId="AddRepoHyperLinkButton"
+                    HorizontalAlignment="Center"
+                    Command="{x:Bind AddRepoButtonCommand}"
+                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelectedLink" />
             </Grid>
         </Grid>
     </setupControls:SetupShell>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -2,18 +2,17 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.Contracts.Services;
 using DevHome.SetupFlow.Models;
-using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
 using DevHome.Telemetry;
-using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -22,6 +21,7 @@ namespace DevHome.SetupFlow.Views;
 /// <summary>
 /// Shows the user the repositories they have selected.
 /// </summary>
+[INotifyPropertyChanged]
 public sealed partial class RepoConfigView : UserControl
 {
     private readonly IThemeSelectorService _themeSelectorService;
@@ -53,7 +53,8 @@ public sealed partial class RepoConfigView : UserControl
     /// <summary>
     /// User wants to add a repo.  Bring up the tool.
     /// </summary>
-    private async void AddRepoButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    [RelayCommand]
+    private async Task AddRepoButtonAsync()
     {
         // hold information for telemetry calls
         const string EventName = "RepoTool_AddRepos_Event";
@@ -61,14 +62,6 @@ public sealed partial class RepoConfigView : UserControl
         var telemetryLogger = TelemetryFactory.Get<ITelemetry>();
 
         telemetryLogger.Log(EventName, LogLevel.Critical, new DialogEvent("Open", dialogName), ActivityId);
-
-        // Both the hyperlink button and button call this.
-        // disable the button to prevent users from double clicking it.
-        var senderAsButton = sender as Button;
-        if (senderAsButton != null)
-        {
-            senderAsButton.IsEnabled = false;
-        }
 
         var addRepoDialog = new AddRepoDialog(ViewModel.DevDriveManager, ViewModel.LocalStringResource, ViewModel.RepoReviewItems.ToList(), _themeSelectorService.Theme, ActivityId);
         var getExtensionsTask = addRepoDialog.GetExtensionsAsync();
@@ -85,11 +78,6 @@ public sealed partial class RepoConfigView : UserControl
         }
 
         var result = await addRepoDialog.ShowAsync(ContentDialogPlacement.InPlace);
-
-        if (senderAsButton != null)
-        {
-            senderAsButton.IsEnabled = true;
-        }
 
         var devDrive = addRepoDialog.EditDevDriveViewModel.DevDrive;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -54,7 +54,7 @@ public sealed partial class RepoConfigView : UserControl
     /// User wants to add a repo.  Bring up the tool.
     /// </summary>
     [RelayCommand]
-    private async Task AddRepoButtonAsync()
+    private async Task AddRepoAsync()
     {
         // hold information for telemetry calls
         const string EventName = "RepoTool_AddRepos_Event";


### PR DESCRIPTION
## Summary of the pull request
- Make 'Add repo' button click events non-concurrent by using `RelayCommand` which defaults to `AllowConcurrentExecutions=false` ([Link to docs](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/generators/relaycommand#handling-concurrent-executions))
- Replace `SetupShell` header control template by a control content to enable `{x:Bind}` binding to code-behind identifiers.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
