### PR TITLE
Align error logs text color with theme

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -210,10 +210,10 @@
                                     <RowDefinition/>
                                     <RowDefinition/>
                                 </Grid.RowDefinitions>
-                                <TextBlock Text="Error logs" Grid.Row="0" Grid.Column="0" Margin="0, 5, 0, 0" Foreground="{StaticResource TextFillColorPrimary}"/>
+                                <TextBlock Text="Error logs" Grid.Row="0" Grid.Column="0" Margin="0, 5, 0, 0"/>
                                 <StackPanel Orientation="Horizontal" Spacing="5" Grid.Row="1" Grid.Column="0">
-                                    <TextBlock Text="{x:Bind ViewModel.FailedTasks.Count}" Foreground="{StaticResource TextFillColorSecondary}"/>
-                                    <TextBlock Text="installation errors" Foreground="{StaticResource TextFillColorSecondary}"/>
+                                    <TextBlock Text="{x:Bind ViewModel.FailedTasks.Count}" Foreground="{ThemeResource TextFillColorSecondary}"/>
+                                    <TextBlock Text="installation errors" Foreground="{ThemeResource TextFillColorSecondary}"/>
                                 </StackPanel>
                             </Grid>
                             <HyperlinkButton Content="View log" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{x:Bind ViewModel.ShowLogFilesCommand, Mode=OneWay}"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -227,7 +227,7 @@
                                             </Grid.ColumnDefinitions>
                                             <ImageIcon
                                                  Source="{x:Bind StatusSymbolIcon, Mode=OneWay}" Grid.Column="0"/>
-                                            <TextBlock Text="{x:Bind MessageToShow, Mode=OneWay}" Grid.Column="1" TextTrimming="CharacterEllipsis" Foreground="{StaticResource SystemErrorTextColor}">
+                                            <TextBlock Text="{x:Bind MessageToShow, Mode=OneWay}" Grid.Column="1" TextTrimming="CharacterEllipsis" Foreground="{ThemeResource SystemErrorTextColor}">
                                                 <ToolTipService.ToolTip>
                                                     <ToolTip IsEnabled="{x:Bind IsMessageTrimmed, Mode=OneWay}" Content="{x:Bind MessageToShow}"/>
                                                 </ToolTipService.ToolTip>


### PR DESCRIPTION
## Summary of the pull request
The text color for the heading and caption of error logs in the summary section of cloned repositories has been adjusted to match the selected theme.

## References and relevant issues
https://github.com/microsoft/devhome/issues/1631

## Detailed description of the pull request / Additional comments

## Validation steps performed
Setup a repository with failed cloning and observed the summary page in light and dark mode.

Dark theme:
![image](https://github.com/microsoft/devhome/assets/77397009/7e24b7c2-9439-4427-9364-8d4f3fcb35f9)

Light theme:
![image](https://github.com/microsoft/devhome/assets/77397009/898b3b6d-118d-4130-94ea-39a3e6b217a2)

## PR checklist
- [x] Closes #1631
- [ ] Tests added/passed
- [ ] Documentation updated
