### PR TITLE
Align colors with theme in RepoConfigView

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -34,7 +34,7 @@
 
     <setupControls:SetupShell x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SetupShell_RepoConfig"
                                Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}"
-                               Foreground="{StaticResource TextFillColorSecondary}"                               >
+                               Foreground="{ThemeResource TextFillColorSecondary}">
         <setupControls:SetupShell.Header>
             <Button
                 AutomationProperties.AutomationId="AddRepositoriesButton"


### PR DESCRIPTION
## Summary of the pull request
Fixed a small bug introduced in a recent PR https://github.com/microsoft/devhome/pull/1644. The text color of "Clone Repositories" page doesn’t align with the dark theme.

This is how the RepoConfigView looks like in the latest GitHub repository's state:

![image](https://github.com/microsoft/devhome/assets/77397009/fd4a39b7-a559-48ad-93b8-438ce86bdd78)

## References and relevant issues

## Detailed description of the pull request / Additional comments
Changed `StaticResource` to `ThemeResource`.

## Validation steps performed
Dark theme:

![image](https://github.com/microsoft/devhome/assets/77397009/95de6575-8b48-4ff0-814e-9ac5252f3f2e)

Light theme:

![image](https://github.com/microsoft/devhome/assets/77397009/a85d01a6-564d-445b-851e-c113b43b7fd3)

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
