### PR TITLE
Make error messages selectable

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -142,7 +142,7 @@
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="commonModels:ActionCenterMessages">
                             <Grid Margin="0, 0, 0, 10" Background="{ThemeResource CardBackgroundFillColorDefault}" CornerRadius="10" Padding="20">
-                                <TextBlock Text="{x:Bind PrimaryMessage}" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock Text="{x:Bind PrimaryMessage}" Style="{StaticResource BodyStrongTextBlockStyle}" IsTextSelectionEnabled="True"/>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -150,7 +150,7 @@
                                 <DataTemplate x:DataType="viewModels:ConfigurationUnitResultViewModel">
                                     <StackPanel>
                                         <TextBlock Text="{x:Bind Title}"/>
-                                        <TextBlock Margin="20,0,0,0" Text="{x:Bind ApplyResult}">
+                                        <TextBlock Margin="20,0,0,0" Text="{x:Bind ApplyResult}" IsTextSelectionEnabled="{x:Bind IsError}">
                                             <i:Interaction.Behaviors>
                                                 <ic:DataTriggerBehavior Binding="{x:Bind IsError}" Value="True">
                                                     <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorCriticalBrush}"/>


### PR DESCRIPTION
## Summary of the pull request
Made the error messages selectable so that users can copy error messages on failed tasks.

## References and relevant issues
https://github.com/microsoft/devhome/issues/1652

## Detailed description of the pull request / Additional comments
Set `IsTextSelectionEnabled` property of error messages TextBlock to `True`

## Validation steps performed
1. Provided a non-existent repository URL for cloning (deliberately causing the clone to fail)

![repo-clone](https://github.com/microsoft/devhome/assets/77397009/694df609-ca43-430d-8000-42f1cfe26180)

2. Omitted granting administrative privileges to the configuration file (YAML), which required such privileges for successful execution (deliberately causing the failure of configurations)

![configuration-file](https://github.com/microsoft/devhome/assets/77397009/5a181ea8-660b-4cdf-97e3-3e78866d758e)

## PR checklist
- [x] Closes #1652
- [ ] Tests added/passed
- [ ] Documentation updated
