### PR TITLE
[Accessibility] Allow areas to expand so buttons are not hidden

### DIFF
--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:commonviews="using:DevHome.Common.Views"
     mc:Ignorable="d">
-    <Grid x:Name="BannerGrid" MinHeight="214">
+    <Grid x:Name="BannerGrid" Height="214">
         <Grid.Background>
             <ImageBrush Stretch="Fill" ImageSource="{x:Bind BackgroundSource, Mode=OneWay}" />
         </Grid.Background>
@@ -19,24 +19,22 @@
                MinWidth="{ThemeResource MaxPageContentWidth}"
                FlowDirection="{x:Bind FlowDirection}" />
 
-        <!-- Scrollable content -->
-        <ScrollViewer Height="{Binding ElementName=BannerGrid, Path=Height}">
-            <StackPanel VerticalAlignment="Center" Margin="38 0 0 0" Spacing="12">
-                <TextBlock MaxWidth="{x:Bind TextWidth}"
-                           HorizontalAlignment="Left"
-                           Style="{ThemeResource SubtitleTextBlockStyle}"
-                           Text="{x:Bind Title}"/>
-                <TextBlock MaxWidth="{x:Bind TextWidth}"
-                           HorizontalAlignment="Left"
-                           TextWrapping="Wrap"
-                           Text="{x:Bind Description}"/>
-                <Button Margin="0 15 0 0"
-                        Padding="25 4 25 6"
-                        MinWidth="120"
-                        Command="{x:Bind ButtonCommand}"
-                        Content="{x:Bind ButtonText}"/>
-            </StackPanel>
-        </ScrollViewer>
+        <!-- Content -->
+        <StackPanel x:Name="PanelTextContent" VerticalAlignment="Center" Margin="38 0 0 0" Spacing="12" SizeChanged="PanelTextContent_SizeChanged">
+            <TextBlock MaxWidth="{x:Bind TextWidth}"
+                       HorizontalAlignment="Left"
+                       Style="{ThemeResource SubtitleTextBlockStyle}"
+                       Text="{x:Bind Title}"/>
+            <TextBlock MaxWidth="{x:Bind TextWidth}"
+                       HorizontalAlignment="Left"
+                       TextWrapping="Wrap"
+                       Text="{x:Bind Description}"/>
+            <Button Margin="0 15 0 0"
+                    Padding="25 4 25 6"
+                    MinWidth="120"
+                    Command="{x:Bind ButtonCommand}"
+                    Content="{x:Bind ButtonText}"/>
+        </StackPanel>
 
         <!-- Hide Banner Button -->
         <commonviews:CloseButton Margin="5"

--- a/common/Views/Banner.xaml
+++ b/common/Views/Banner.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:commonviews="using:DevHome.Common.Views"
     mc:Ignorable="d">
-    <Grid x:Name="BannerGrid" Height="214">
+    <Grid x:Name="BannerGrid" MinHeight="214">
         <Grid.Background>
             <ImageBrush Stretch="Fill" ImageSource="{x:Bind BackgroundSource, Mode=OneWay}" />
         </Grid.Background>

--- a/common/Views/Banner.xaml.cs
+++ b/common/Views/Banner.xaml.cs
@@ -122,4 +122,13 @@ public sealed partial class Banner : UserControl
     public static readonly DependencyProperty ButtonCommandProperty = DependencyProperty.Register(nameof(ButtonCommand), typeof(ICommand), typeof(Banner), new PropertyMetadata(null));
     public static readonly DependencyProperty HideButtonVisibilityProperty = DependencyProperty.Register(nameof(HideButtonVisibility), typeof(bool), typeof(Banner), new PropertyMetadata(true));
     public static readonly DependencyProperty HideButtonCommandProperty = DependencyProperty.Register(nameof(HideButtonCommand), typeof(ICommand), typeof(Banner), new PropertyMetadata(null));
+
+    // If the text and button don't fit in the default height of banner, stretch the banner vertically.
+    // Set height this way rather than setting MinHeight on the banner, since the banner image assets
+    // are taller than the default height and would stretch the banner regardless of the text.
+    private void PanelTextContent_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        var defaultBannerHeight = 214;
+        BannerGrid.Height = (e.NewSize.Height <= defaultBannerHeight) ? defaultBannerHeight : e.NewSize.Height;
+    }
 }

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -39,7 +39,7 @@
             </Grid>
             <Grid x:Name="ContentArea" Padding="35 0 35 30" HorizontalAlignment="Center">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="325" />
+                    <RowDefinition MinHeight="325" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>


### PR DESCRIPTION
## Summary of the pull request
Fixes two accessibility bugs:
- [Bug 46725346](https://task.ms/46725346) "Get Started" button in "Introducing Dev Home" page is completely clipped
- [Bug 46725605](https://task.ms/46725605) "Learn More" button in "Extensions/Machine Configuration/Dashboard" page is not visible on applying text scaling

After change, the buttons are visible without scrolling.

Screenshots at about 200% scaling:
![image](https://github.com/microsoft/devhome/assets/47155823/34553303-6cee-4ecd-bb43-988f0ff6a74c)

![image](https://github.com/microsoft/devhome/assets/47155823/5b7a7eae-2d6c-4e91-a49d-b310200828c6)

## References and relevant issues
- https://task.ms/46725346
- https://task.ms/46725605
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
