### PR TITLE
Hide disabled widget size options

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.ViewModels;
@@ -115,50 +116,47 @@ public sealed partial class WidgetControl : UserControl
     {
         var widgetDefinition = WidgetCatalog.GetDefault().GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
         var capabilities = widgetDefinition.GetWidgetCapabilities();
+        var sizeMenuItems = new List<MenuFlyoutItem>();
 
         // Add the three possible sizes. Each side should only be enabled if it is included in the widget's capabilities.
-        var menuItemSmall = new MenuFlyoutItem
+        if (capabilities.Any(cap => cap.Size == WidgetSize.Small))
         {
-            Tag = WidgetSize.Small,
-            Text = resourceLoader.GetString("SmallWidgetMenuText"),
-            IsEnabled = capabilities.Any(cap => cap.Size == WidgetSize.Small),
-        };
-        menuItemSmall.Click += OnMenuItemSizeClick;
-        widgetMenuFlyout.Items.Add(menuItemSmall);
-
-        var menuItemMedium = new MenuFlyoutItem
-        {
-            Tag = WidgetSize.Medium,
-            Text = resourceLoader.GetString("MediumWidgetMenuText"),
-            IsEnabled = capabilities.Any(cap => cap.Size == WidgetSize.Medium),
-        };
-        menuItemMedium.Click += OnMenuItemSizeClick;
-        widgetMenuFlyout.Items.Add(menuItemMedium);
-
-        var menuItemLarge = new MenuFlyoutItem
-        {
-            Tag = WidgetSize.Large,
-            Text = resourceLoader.GetString("LargeWidgetMenuText"),
-            IsEnabled = capabilities.Any(cap => cap.Size == WidgetSize.Large),
-        };
-        menuItemLarge.Click += OnMenuItemSizeClick;
-        widgetMenuFlyout.Items.Add(menuItemLarge);
-
-        // Mark current widget size.
-        var size = widgetViewModel.WidgetSize;
-        switch (size)
-        {
-            case WidgetSize.Small:
-                _currentSelectedSize = menuItemSmall;
-                break;
-            case WidgetSize.Medium:
-                _currentSelectedSize = menuItemMedium;
-                break;
-            case WidgetSize.Large:
-                _currentSelectedSize = menuItemLarge;
-                break;
+            var menuItemSmall = new MenuFlyoutItem
+            {
+                Tag = WidgetSize.Small,
+                Text = resourceLoader.GetString("SmallWidgetMenuText"),
+            };
+            menuItemSmall.Click += OnMenuItemSizeClick;
+            widgetMenuFlyout.Items.Add(menuItemSmall);
+            sizeMenuItems.Add(menuItemSmall);
         }
 
+        if (capabilities.Any(cap => cap.Size == WidgetSize.Medium))
+        {
+            var menuItemMedium = new MenuFlyoutItem
+            {
+                Tag = WidgetSize.Medium,
+                Text = resourceLoader.GetString("MediumWidgetMenuText"),
+            };
+            menuItemMedium.Click += OnMenuItemSizeClick;
+            widgetMenuFlyout.Items.Add(menuItemMedium);
+            sizeMenuItems.Add(menuItemMedium);
+        }
+
+        if (capabilities.Any(cap => cap.Size == WidgetSize.Large))
+        {
+            var menuItemLarge = new MenuFlyoutItem
+            {
+                Tag = WidgetSize.Large,
+                Text = resourceLoader.GetString("LargeWidgetMenuText"),
+            };
+            menuItemLarge.Click += OnMenuItemSizeClick;
+            widgetMenuFlyout.Items.Add(menuItemLarge);
+            sizeMenuItems.Add(menuItemLarge);
+        }
+
+        // Mark current widget size.
+        _currentSelectedSize = sizeMenuItems.FirstOrDefault(x => (WidgetSize)x.Tag == widgetViewModel.WidgetSize);
         MarkSize(_currentSelectedSize);
     }
 


### PR DESCRIPTION
## Summary of the pull request
In the widget context menu ("..." menu), if a widget doesn't allow for a size, don't show it as an option (rather than current behavior of disabling it). New behavior matches Windows widget panel.

## References and relevant issues
#1527

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #1527
- [ ] Tests added/passed
- [ ] Documentation updated
