### PR TITLE
Eliminate type ambiguity in setup flow

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Web.Services.Description;
 using DevHome.Activation;
 using DevHome.Common.Contracts;
 using DevHome.Common.Contracts.Services;
@@ -55,6 +56,10 @@ public partial class App : Application, IApp
         Host = Microsoft.Extensions.Hosting.Host.
         CreateDefaultBuilder().
         UseContentRoot(AppContext.BaseDirectory).
+        UseDefaultServiceProvider((context, options) =>
+        {
+            options.ValidateOnBuild = true;
+        }).
         ConfigureServices((context, services) =>
         {
             // Default Activation Handler

--- a/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
@@ -94,7 +94,9 @@ public static class ServiceExtensions
     {
         // View models
         services.AddTransient<DevDriveViewModel>();
-        services.AddTransient<DevDriveReviewViewModel>();
+
+        // TODO https://github.com/microsoft/devhome/issues/631
+        // services.AddTransient<DevDriveReviewViewModel>();
 
         // Services
         services.AddTransient<DevDriveTaskGroup>();
@@ -121,9 +123,9 @@ public static class ServiceExtensions
 
     private static IServiceCollection AddRepoConfig(this IServiceCollection services)
     {
-        // View models
-        services.AddTransient<RepoConfigViewModel>();
-        services.AddTransient<RepoConfigReviewViewModel>();
+        // TODO https://github.com/microsoft/devhome/issues/631
+        // services.AddTransient<RepoConfigViewModel>();
+        // services.AddTransient<RepoConfigReviewViewModel>();
 
         // Services
         services.AddTransient<RepoConfigTaskGroup>();

--- a/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
@@ -48,10 +48,8 @@ public static class ServiceExtensions
         // View models
         services.AddTransient<ShimmerSearchViewModel>();
         services.AddTransient<SearchViewModel>();
-        services.AddTransient<PackageViewModel>();
         services.AddTransient<PackageCatalogListViewModel>();
         services.AddTransient<AppManagementViewModel>();
-        services.AddTransient<PackageCatalogViewModel>();
         services.AddTransient<AppManagementReviewViewModel>();
 
         // Services
@@ -124,7 +122,6 @@ public static class ServiceExtensions
     private static IServiceCollection AddRepoConfig(this IServiceCollection services)
     {
         // View models
-        services.AddTransient<AddRepoViewModel>();
         services.AddTransient<RepoConfigViewModel>();
         services.AddTransient<RepoConfigReviewViewModel>();
 

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/DevDriveTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/DevDriveTaskGroup.cs
@@ -25,11 +25,8 @@ public class DevDriveTaskGroup : ISetupTaskGroup
     {
         _host = host;
 
-        // TODO Remove `this` argument from CreateInstance since this task
-        // group is a registered type. This requires updating dependent classes
-        // correspondingly.
-        // https://github.com/microsoft/devhome/issues/631
-        _devDriveReviewViewModel = new (() => _host.CreateInstance<DevDriveReviewViewModel>(this));
+        // TODO https://github.com/microsoft/devhome/issues/631
+        _devDriveReviewViewModel = new (() => new DevDriveReviewViewModel(host, stringResource, this));
         _stringResource = stringResource;
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Models;
@@ -28,7 +29,7 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
 
     private readonly ISetupFlowStringResource _stringResource;
 
-    public RepoConfigTaskGroup(IHost host, ISetupFlowStringResource stringResource, SetupFlowOrchestrator setupFlowOrchestrator)
+    public RepoConfigTaskGroup(IHost host, ISetupFlowStringResource stringResource, SetupFlowOrchestrator setupFlowOrchestrator, IDevDriveManager devDriveManager)
     {
         _host = host;
         _stringResource = stringResource;
@@ -37,7 +38,7 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
         // group is a registered type. This requires updating dependent classes
         // correspondingly.
         // https://github.com/microsoft/devhome/issues/631
-        _repoConfigViewModel = new (() => _host.CreateInstance<RepoConfigViewModel>(this));
+        _repoConfigViewModel = new (() => new RepoConfigViewModel(stringResource, setupFlowOrchestrator, devDriveManager, this, host));
         _repoConfigReviewViewModel = new (() => _host.CreateInstance<RepoConfigReviewViewModel>(this));
         _activityId = setupFlowOrchestrator.ActivityId;
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -32,10 +32,7 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
         _host = host;
         _stringResource = stringResource;
 
-        // TODO Remove `this` argument from CreateInstance since this task
-        // group is a registered type. This requires updating dependent classes
-        // correspondingly.
-        // https://github.com/microsoft/devhome/issues/631
+        // TODO https://github.com/microsoft/devhome/issues/631
         _repoConfigViewModel = new (() => new RepoConfigViewModel(stringResource, setupFlowOrchestrator, devDriveManager, this, host));
         _repoConfigReviewViewModel = new (() => new RepoConfigReviewViewModel(stringResource, this));
         _activityId = setupFlowOrchestrator.ActivityId;

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.SetupFlow.Common.Helpers;
@@ -13,7 +12,6 @@ using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
 using DevHome.Telemetry;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.SetupFlow.TaskGroups;
 
@@ -39,7 +37,7 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
         // correspondingly.
         // https://github.com/microsoft/devhome/issues/631
         _repoConfigViewModel = new (() => new RepoConfigViewModel(stringResource, setupFlowOrchestrator, devDriveManager, this, host));
-        _repoConfigReviewViewModel = new (() => _host.CreateInstance<RepoConfigReviewViewModel>(this));
+        _repoConfigReviewViewModel = new (() => new RepoConfigReviewViewModel(stringResource, this));
         _activityId = setupFlowOrchestrator.ActivityId;
     }
 


### PR DESCRIPTION
## Summary of the pull request
- When the environment variable `DOTNET_ENVIRONMENT=Development` is set on the user's machine, the DI performs a validation on build (when the app starts) causing a crash on start.
- Reason: When `ActivatorUtilities.CreateInstance()` attempts to create an instances, the registered type constructor arguments defined explicitly shouldn't be registered types as those become ambiguous and are expected to be resolved from the service provider.
- Programmatically added DI build validation to ensure the latter is applied by default.
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
