### PR TITLE
Add IWidgetHostingService

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -16,7 +16,7 @@ public static class ServiceExtensions
         services.AddSingleton<DashboardViewModel>();
 
         // Services
-        services.AddSingleton<WidgetHostingService>();
+        services.AddSingleton<IWidgetHostingService, WidgetHostingService>();
 
         return services;
     }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using Microsoft.Windows.Widgets.Hosts;
+
+namespace DevHome.Dashboard.Services;
+
+public interface IWidgetHostingService
+{
+    public WidgetHost GetWidgetHost();
+
+    public WidgetCatalog GetWidgetCatalog();
+}

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -7,7 +7,7 @@ using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Services;
 
-public class WidgetHostingService
+public class WidgetHostingService : IWidgetHostingService
 {
     private WidgetHost _widgetHost;
     private WidgetCatalog _widgetCatalog;

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -16,7 +16,7 @@ namespace DevHome.Dashboard.ViewModels;
 
 public partial class DashboardViewModel : ObservableObject
 {
-    public WidgetHostingService WidgetHostingService { get; }
+    public IWidgetHostingService WidgetHostingService { get; }
 
     private readonly IPackageDeploymentService _packageDeploymentService;
 
@@ -35,7 +35,7 @@ public partial class DashboardViewModel : ObservableObject
     [ObservableProperty]
     private bool _isLoading;
 
-    public DashboardViewModel(IPackageDeploymentService packageDeploymentService, WidgetHostingService widgetHostingService)
+    public DashboardViewModel(IPackageDeploymentService packageDeploymentService, IWidgetHostingService widgetHostingService)
     {
         _packageDeploymentService = packageDeploymentService;
         WidgetHostingService = widgetHostingService;

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     public WidgetViewModel ViewModel { get; set; }
 
-    private readonly WidgetHostingService _hostingService;
+    private readonly IWidgetHostingService _hostingService;
 
     public AddWidgetDialog(
         AdaptiveCardRenderer renderer,
@@ -39,7 +39,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         ElementTheme theme)
     {
         ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, null, renderer, dispatcher);
-        _hostingService = Application.Current.GetService<WidgetHostingService>();
+        _hostingService = Application.Current.GetService<IWidgetHostingService>();
 
         this.InitializeComponent();
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
@@ -21,7 +21,7 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
 
     public WidgetViewModel ViewModel { get; set; }
 
-    private readonly WidgetHostingService _hostingService;
+    private readonly IWidgetHostingService _hostingService;
 
     private readonly WidgetDefinition _widgetDefinition;
     private static DispatcherQueue _dispatcher;
@@ -31,7 +31,7 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
         ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, widgetDefinition, renderer, dispatcher);
         ViewModel.IsInEditMode = true;
 
-        _hostingService = Application.Current.GetService<WidgetHostingService>();
+        _hostingService = Application.Current.GetService<IWidgetHostingService>();
 
         this.InitializeComponent();
 


### PR DESCRIPTION
## Summary of the pull request
https://github.com/microsoft/devhome/pull/1691#discussion_r1364215090

In order for the classes that depend on WidgetHostingService to be testable, the latter should be mockable. To do that, we register IWidgetHostingService to map to WidgetHostingService.

## References and relevant issues
#1692
