### PR TITLE
Add DevHomeClosed Telemetry Event

### DIFF
--- a/common/Helpers/Deployment.cs
+++ b/common/Helpers/Deployment.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using DevHome.Logging;
+using Windows.Storage;
+
+namespace DevHome.Common.Helpers;
+
+public static class Deployment
+{
+    private static readonly string DeploymentIdentifierKeyName = "DevHomeDeploymentIdentifier";
+
+    // This creates and returns a Guid associated with this deployment of DevHome. This uniquely
+    // identifies this deployment across multiple launches and will be different per Windows user.
+    // This will persist across updates, but will be removed upon package removal, or when
+    // ApplicationData is reset via settings. The purpose of this identifier is to correlate
+    // telemetry events across multiple launches for product usage metrics.
+    public static Guid Identifier
+    {
+        get
+        {
+            try
+            {
+                var localSettings = ApplicationData.Current.LocalSettings;
+                if (localSettings.Values.ContainsKey(DeploymentIdentifierKeyName))
+                {
+                    return (Guid)localSettings.Values[DeploymentIdentifierKeyName];
+                }
+
+                var newGuid = Guid.NewGuid();
+                localSettings.Values[DeploymentIdentifierKeyName] = newGuid;
+                return newGuid;
+            }
+            catch (Exception ex)
+            {
+                // We do not want this identifer's access to ever create a problem in the
+                // application, so if we can't get it, return empty guid. An empty guid is also a
+                // signal that the data is unknown for filtering purposes.
+                GlobalLog.Logger?.ReportError($"Failed getting Deployment Identifier", ex);
+                return Guid.Empty;
+            }
+        }
+    }
+}

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -4,12 +4,16 @@
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Helpers;
+using DevHome.Telemetry;
+using DevHome.TelemetryEvents;
 using Microsoft.UI.Xaml;
 
 namespace DevHome;
 
 public sealed partial class MainWindow : WindowEx
 {
+    private readonly DateTime mainWindowCreated;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -17,10 +21,12 @@ public sealed partial class MainWindow : WindowEx
         AppWindow.SetIcon(Path.Combine(AppContext.BaseDirectory, "Assets/DevHome.ico"));
         Content = null;
         Title = Application.Current.GetService<IAppInfoService>().GetAppNameLocalized();
+        mainWindowCreated = DateTime.UtcNow;
     }
 
     private void MainWindow_Closed(object sender, Microsoft.UI.Xaml.WindowEventArgs args)
     {
         Application.Current.GetService<IExtensionService>().SignalStopExtensionsAsync();
+        TelemetryFactory.Get<ITelemetry>().Log("DevHome_MainWindow_Closed_Event", LogLevel.Critical, new DevHomeClosedEvent(mainWindowCreated));
     }
 }

--- a/src/TelemetryEvents/DevHomeClosedEvent.cs
+++ b/src/TelemetryEvents/DevHomeClosedEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Diagnostics.Tracing;
+using DevHome.Common.Helpers;
 using DevHome.Logging;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
@@ -17,12 +18,18 @@ public class DevHomeClosedEvent : EventBase
         get;
     }
 
+    public Guid DeploymentIdentifier
+    {
+        get;
+    }
+
     public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
 
     public DevHomeClosedEvent(DateTime startTime)
     {
         ElapsedTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
-        GlobalLog.Logger?.ReportDebug($"DevHome Closed Event, ElapsedTime: {ElapsedTime}ms");
+        DeploymentIdentifier = Deployment.Identifier;
+        GlobalLog.Logger?.ReportDebug($"DevHome Closed Event, ElapsedTime: {ElapsedTime}ms  Identifier: {DeploymentIdentifier}");
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/src/TelemetryEvents/DevHomeClosedEvent.cs
+++ b/src/TelemetryEvents/DevHomeClosedEvent.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Diagnostics.Tracing;
+using DevHome.Logging;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.TelemetryEvents;
+
+[EventData]
+public class DevHomeClosedEvent : EventBase
+{
+    public double ElapsedTime
+    {
+        get;
+    }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public DevHomeClosedEvent(DateTime startTime)
+    {
+        ElapsedTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
+        GlobalLog.Logger?.ReportDebug($"DevHome Closed Event, ElapsedTime: {ElapsedTime}ms");
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
Adds telemetry event for DevHome's MainWindow being closed. This is triggered when the app is closed by any means, including the close "X" button and close from Taskbar.

## References and relevant issues

## Detailed description of the pull request / Additional comments
Added Telemetry Event for DevHomeClosedEvent that has a Guid identifier of the deployment and the elapsed time before the MainWindow was closed..
Added start time capture to the MainWindow.
Added TelemetryEvent log to the MainWindow Closed method sending the TelemetryEvent.
Added Deployment Identifier Guid that persists across application launches for correlation of Closed events.

## Validation steps performed
Built and launched DevHome in Debug and observed the debug log write for the close event happened and appeared to correctly capture the elapsed time via taskbar close and X button close.
 
## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
