### PR TITLE
Add AdaptiveCardRenderingService

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
@@ -46,8 +46,8 @@
   },
   "containerStyles": {
     "default": {
-      "backgroundColor": "#06FFFFFF",
-      "borderColor": "#06FFFFFF",
+      "backgroundColor": "#00000000",
+      "borderColor": "#00000000",
       "foregroundColors": {
         "default": {
           "default": "#FFFFFF",

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
@@ -46,8 +46,8 @@
   },
   "containerStyles": {
     "default": {
-      "backgroundColor": "#B4FFFFFF",
-      "borderColor": "#B4FFFFFF",
+      "backgroundColor": "#00000000",
+      "borderColor": "#00000000",
       "foregroundColors": {
         "default": {
           "default": "#E6000000",

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -16,23 +16,25 @@
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <Color x:Key="WidgetBorderColor">#0F000000</Color>
+                    <Color x:Key="WidgetBackgroundColor">#B4FFFFFF</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <Color x:Key="WidgetBorderColor">#1A000000</Color>
+                    <Color x:Key="WidgetBackgroundColor">#0CFFFFFF</Color>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize), Mode=OneWay}" 
-          CornerRadius="7" BorderBrush="{ThemeResource WidgetBorderColor}" BorderThickness="1">
+          CornerRadius="7" BorderBrush="{ThemeResource WidgetBorderColor}" Background="{ThemeResource WidgetBackgroundColor}" BorderThickness="1">
         <Grid.RowDefinitions>
             <RowDefinition Height="36" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <!-- Widget header: icon, title, menu -->
-        <Grid Grid.Row="0" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" CornerRadius="7">
+        <Grid Grid.Row="0" CornerRadius="7">
             <StackPanel Orientation="Horizontal" Margin="16,10,0,0" Spacing="8">
                 <Rectangle Width="16" Height="16" x:Name="WidgetHeaderIcon" />
                 <TextBlock AutomationProperties.AutomationId="WidgetTitle"
@@ -56,9 +58,9 @@
         </Grid>
 
         <!-- Widget content -->
-        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridLeft" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="7"
+        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridLeft" Width="7"
                       HorizontalAlignment="Left" />
-        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridRight" Background="{x:Bind WidgetSource.WidgetBackground, Mode=OneWay}" Width="7"
+        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridRight" Width="7"
                       HorizontalAlignment="Right" />
         <ScrollViewer Grid.Row="1" x:Name="WidgetScrollViewer" Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}"
                       VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" Padding="7,0" />

--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceExtensions
         // Services
         services.AddSingleton<IWidgetHostingService, WidgetHostingService>();
         services.AddSingleton<IWidgetIconService, WidgetIconService>();
+        services.AddSingleton<IAdaptiveCardRenderingService, AdaptiveCardRenderingService>();
 
         return services;
     }

--- a/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using AdaptiveCards.Rendering.WinUI3;
+using DevHome.Common.Renderers;
+using DevHome.Contracts.Services;
+using DevHome.Dashboard.Helpers;
+using Microsoft.UI.Xaml;
+using Windows.Storage;
+using WinUIEx;
+
+namespace DevHome.Dashboard.Services;
+
+public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService
+{
+    private readonly WindowEx _windowEx;
+
+    private readonly IThemeSelectorService _themeSelectorService;
+
+    private AdaptiveCardRenderer _renderer;
+
+    public AdaptiveCardRenderingService(WindowEx windowEx, IThemeSelectorService themeSelectorService)
+    {
+        _windowEx = windowEx;
+        _themeSelectorService = themeSelectorService;
+        _themeSelectorService.ThemeChanged += OnThemeChanged;
+    }
+
+    public async Task<AdaptiveCardRenderer> GetRenderer()
+    {
+        if (_renderer == null)
+        {
+            _renderer = new AdaptiveCardRenderer();
+            await ConfigureWidgetRenderer();
+        }
+
+        return _renderer;
+    }
+
+    private async Task ConfigureWidgetRenderer()
+    {
+        // Add custom Adaptive Card renderer.
+        _renderer.ElementRenderers.Set(LabelGroup.CustomTypeString, new LabelGroupRenderer());
+
+        // A different host config is used to render widgets (adaptive cards) in light and dark themes.
+        await UpdateHostConfig();
+    }
+
+    public async Task UpdateHostConfig()
+    {
+        if (_renderer != null)
+        {
+            // Add host config for current theme.
+            var hostConfigContents = string.Empty;
+            var hostConfigFileName = _themeSelectorService.IsDarkTheme() ? "HostConfigDark.json" : "HostConfigLight.json";
+            try
+            {
+                Log.Logger()?.ReportInfo("DashboardView", $"Get HostConfig file '{hostConfigFileName}'");
+                var uri = new Uri($"ms-appx:///DevHome.Dashboard/Assets/{hostConfigFileName}");
+                var file = await StorageFile.GetFileFromApplicationUriAsync(uri).AsTask().ConfigureAwait(false);
+                hostConfigContents = await FileIO.ReadTextAsync(file);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportError("DashboardView", "Error retrieving HostConfig", ex);
+            }
+
+            _windowEx.DispatcherQueue.TryEnqueue(() =>
+            {
+                if (!string.IsNullOrEmpty(hostConfigContents))
+                {
+                    _renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
+                }
+                else
+                {
+                    Log.Logger()?.ReportError("DashboardView", $"HostConfig contents are {hostConfigContents}");
+                }
+            });
+        }
+    }
+
+    private async void OnThemeChanged(object sender, ElementTheme e)
+    {
+        await UpdateHostConfig();
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/Services/IAdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IAdaptiveCardRenderingService.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System.Threading.Tasks;
+using AdaptiveCards.Rendering.WinUI3;
+
+namespace DevHome.Dashboard.Services;
+
+internal interface IAdaptiveCardRenderingService
+{
+    public Task<AdaptiveCardRenderer> GetRenderer();
+
+    public Task UpdateHostConfig();
+}

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -76,7 +76,6 @@
 
                 <ScrollViewer Grid.Row="1"
                               x:Name="ConfigurationContentViewer"
-                              Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}"
                               VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch">
                     <Frame x:Name="ConfigurationContentFrame" Margin="45,45,45,150"
                            Content="{x:Bind ViewModel.WidgetFrameworkElement, Mode=OneWay}" />
@@ -84,8 +83,7 @@
 
                 <!-- Pin button -->
                 <Grid Grid.Row="2"
-                      x:Name="PinRow"
-                      Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
+                      x:Name="PinRow">
                     <Button x:Name="PinButton"
                             Style="{ThemeResource AccentButtonStyle}"
                             VerticalAlignment="Bottom" HorizontalAlignment="Center"

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -35,11 +35,10 @@ public sealed partial class AddWidgetDialog : ContentDialog
     private readonly IWidgetIconService _widgetIconService;
 
     public AddWidgetDialog(
-        AdaptiveCardRenderer renderer,
         DispatcherQueue dispatcher,
         ElementTheme theme)
     {
-        ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, null, renderer, dispatcher);
+        ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, null, dispatcher);
         _hostingService = Application.Current.GetService<IWidgetHostingService>();
         _widgetIconService = Application.Current.GetService<IWidgetIconService>();
 
@@ -254,8 +253,6 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
         else if (selectedTag as WidgetProviderDefinition is not null)
         {
-            // Null out the view model background so we don't bind to the old one.
-            ViewModel.WidgetBackground = null;
             ConfigurationContentFrame.Content = null;
             PinButton.Visibility = Visibility.Collapsed;
         }

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml
@@ -23,7 +23,7 @@
         <converters:BoolNegationConverter x:Key="BoolNegation"/>
     </ContentDialog.Resources>
 
-    <StackPanel Background="{x:Bind ViewModel.WidgetBackground, Mode=OneWay}">
+    <StackPanel>
         <!-- Close button -->
         <Grid x:Name="CustomizeWidgetTitleBar">
             <TextBlock x:Uid="CustomizeWidgetTitle" HorizontalAlignment="Left" Margin="16,10,0,0" />

--- a/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/CustomizeWidgetDialog.xaml.cs
@@ -26,9 +26,9 @@ public sealed partial class CustomizeWidgetDialog : ContentDialog
     private readonly WidgetDefinition _widgetDefinition;
     private static DispatcherQueue _dispatcher;
 
-    public CustomizeWidgetDialog(AdaptiveCardRenderer renderer, DispatcherQueue dispatcher, WidgetDefinition widgetDefinition)
+    public CustomizeWidgetDialog(DispatcherQueue dispatcher, WidgetDefinition widgetDefinition)
     {
-        ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, widgetDefinition, renderer, dispatcher);
+        ViewModel = new WidgetViewModel(null, Microsoft.Windows.Widgets.WidgetSize.Large, widgetDefinition, dispatcher);
         ViewModel.IsInEditMode = true;
 
         _hostingService = Application.Current.GetService<IWidgetHostingService>();


### PR DESCRIPTION
## Summary of the pull request
This PR has two changes:
- Instead of holding an adapter card renderer object in `DashboardView` and passing it around, create an `AdaptiveCardRenderingService` that holds a singleton renderer that the `WidgetViewModel` can query for
- Instead of setting the widget background in the renderer's host config, set the background on the `WidgetControl` itself. This makes everything a lot simpler. It allows us to use one renderer for everything, instead of a different one with a different host config for add/edit dialogs where we wanted a different background. 

## References and relevant issues

#1692

## Detailed description of the pull request / Additional comments

- Minor change: make the widget background in dark mode a little more opaque.
- Add theme changed listeners on both the Service and DashboardView to capture theme changes from both Dev Home Preference and Windows theme changes.

