### PR TITLE
Fix alignment of expander in Report Bug

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -36,7 +36,7 @@
                                 <TextBox x:Name="ReportBugReproSteps" x:Uid="Settings_Feedback_ReportBug_ReproSteps" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugExpectedBehavior" x:Uid="Settings_Feedback_ReportBug_ExpectedBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
                                 <TextBox x:Name="ReportBugActualBehavior" x:Uid="Settings_Feedback_ReportBug_ActualBehavior" TextWrapping="Wrap" Height="{StaticResource FeedbackTextBoxHeight}" Margin="{StaticResource SmallTopMargin}" AcceptsReturn="True"/>
-                                <Expander x:Name="ReportBugSysInfoExpander" Expanding="ShowSysInfoExpander_Expanding" Margin="{StaticResource SmallTopMargin}" HorizontalAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
+                                <Expander x:Name="ReportBugSysInfoExpander" Expanding="ShowSysInfoExpander_Expanding" Margin="{StaticResource SmallTopMargin}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
                                     <Expander.Header>
                                         <CheckBox x:Name="ReportBugIncludeSystemInfo" x:Uid="Settings_Feedback_ReportBug_IncludeSystemInfo" IsChecked="True"/>
                                     </Expander.Header>
@@ -48,7 +48,7 @@
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>
-                                <Expander x:Name="ReportBugExtensionsExpander" Expanding="ShowExtensionsInfoExpander_Expanding" HorizontalAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
+                                <Expander x:Name="ReportBugExtensionsExpander" Expanding="ShowExtensionsInfoExpander_Expanding" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
                                     <Expander.Header>
                                         <CheckBox x:Name="ReportBugIncludeExtensions" x:Uid="Settings_Feedback_ReportBug_IncludeExtensions" IsChecked="True"/>
                                     </Expander.Header>
@@ -58,7 +58,7 @@
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>
-                                <Expander x:Name="ReportBugExperimentInfoExpander" HorizontalAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
+                                <Expander x:Name="ReportBugExperimentInfoExpander" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" MinWidth="{StaticResource FeedbackExpanderWidth}">
                                     <Expander.Header>
                                         <CheckBox x:Name="ReportBugIncludeExperimentInfo" x:Uid="Settings_Feedback_ReportBug_IncludeExperimentInfo" IsChecked="True"/>
                                     </Expander.Header>


### PR DESCRIPTION
## Summary of the pull request
In "Report a bug" dialog, horizontally aligned the expanded text to match the overall UI.

## References and relevant issues
https://github.com/microsoft/devhome/issues/1745
## Detailed description of the pull request / Additional comments
For all three Expander, set the `HorizontalContentAlignment` attribute to `Stretch`

## Validation steps performed
![image](https://github.com/microsoft/devhome/assets/77397009/0b815c36-3ef3-4306-9d67-5bec33d5aa61)

## PR checklist
- [x] Closes #1745
- [ ] Tests added/passed
- [ ] Documentation updated
