### PR TITLE
Report missing CPU info in bug reports

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -10,6 +10,7 @@
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors" 
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    Loaded="Page_Loaded"
     mc:Ignorable="d">
 
     <Grid


### PR DESCRIPTION
## Summary of the pull request
When the Feedback page moved in #1072, we lost the registration of the OnLoaded event handler for that page. That call was what filled in the CPU info, so without it, the CPU info isn't getting reported. Put the call back.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Tested locally.

## PR checklist
- [x] Closes #1747
- [ ] Tests added/passed
- [ ] Documentation updated
