### PR TITLE
Don't clip text under Settings -> Feedback on applying text scaling

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -89,7 +89,7 @@
                         </ScrollViewer>
                     </Grid>
                 </ContentDialog>
-                <TextBlock Margin="{StaticResource MediumBottomMargin}">
+                <TextBlock Margin="{StaticResource MediumBottomMargin}" TextWrapping="WrapWholeWords">
                     <Run x:Uid="Settings_Feedback_OpenSource"/>
                     <Hyperlink x:Uid="Settings_Feedback_OpenSource_Link" TextDecorations="None">
                         <Run x:Uid="Settings_Feedback_OpenSource_LinkText" />


### PR DESCRIPTION
## Summary of the pull request
Allow text to wrap so that it doesn't get clipped when text scaling is >100% or the window is narrower than the text.

## References and relevant issues
#1755
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes 
- [ ] Tests added/passed
- [ ] Documentation updated
