### PR TITLE
Update window title bar text foreground

### DIFF
--- a/common/Helpers/TitleBarHelper.cs
+++ b/common/Helpers/TitleBarHelper.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
-using System.Runtime.InteropServices;
-
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -17,16 +14,6 @@ namespace DevHome.Common.Helpers;
 // https://github.com/microsoft/TemplateStudio/issues/4516
 public class TitleBarHelper
 {
-    private const int WAINACTIVE = 0x00;
-    private const int WAACTIVE = 0x01;
-    private const int WMACTIVATE = 0x0006;
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetActiveWindow();
-
-    [DllImport("user32.dll", CharSet = CharSet.Auto)]
-    private static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, IntPtr lParam);
-
     public static void UpdateTitleBar(Window window, ElementTheme theme)
     {
         if (window.ExtendsContentIntoTitleBar)

--- a/common/Helpers/TitleBarHelper.cs
+++ b/common/Helpers/TitleBarHelper.cs
@@ -96,11 +96,11 @@ public class TitleBarHelper
     /// <summary>
     /// Gets the title bar text color brush based on the window activation state.
     /// </summary>
-    /// <param name="state">Window activation state</param>
+    /// <param name="isWindowActive">Window activation state</param>
     /// <returns>Corresponding color brush for the title bar text</returns>
-    public static SolidColorBrush GetTitleBarTextColorBrush(WindowActivationState state)
+    public static SolidColorBrush GetTitleBarTextColorBrush(bool isWindowActive)
     {
-        var resource = state == WindowActivationState.Deactivated ? "WindowCaptionForegroundDisabled" : "WindowCaptionForeground";
+        var resource = isWindowActive ? "WindowCaptionForeground" : "WindowCaptionForegroundDisabled";
         return (SolidColorBrush)Application.Current.Resources[resource];
     }
 }

--- a/common/Helpers/TitleBarHelper.cs
+++ b/common/Helpers/TitleBarHelper.cs
@@ -78,18 +78,6 @@ public class TitleBarHelper
 
             Application.Current.Resources["WindowCaptionBackground"] = new SolidColorBrush(Colors.Transparent);
             Application.Current.Resources["WindowCaptionBackgroundDisabled"] = new SolidColorBrush(Colors.Transparent);
-
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
-            if (hwnd == GetActiveWindow())
-            {
-                SendMessage(hwnd, WMACTIVATE, WAINACTIVE, IntPtr.Zero);
-                SendMessage(hwnd, WMACTIVATE, WAACTIVE, IntPtr.Zero);
-            }
-            else
-            {
-                SendMessage(hwnd, WMACTIVATE, WAACTIVE, IntPtr.Zero);
-                SendMessage(hwnd, WMACTIVATE, WAINACTIVE, IntPtr.Zero);
-            }
         }
     }
 

--- a/common/Windows/WindowTitleBar.xaml
+++ b/common/Windows/WindowTitleBar.xaml
@@ -20,10 +20,6 @@
                 x:Key="IconContainerConverter"
                 FalseValue="auto"
                 TrueValue="0"/>
-            <converters:BoolToObjectConverter
-                x:Key="ActiveTitleForegroundConverter"
-                FalseValue="{ThemeResource WindowCaptionForegroundDisabled}"
-                TrueValue="{ThemeResource WindowCaptionForeground}" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -56,8 +52,8 @@
 
         <!-- Title -->
         <TextBlock
+            x:Name="TitleTextBlock"
             Grid.Column="1"
-            Foreground="{x:Bind IsActive, Mode=OneWay, Converter={StaticResource ActiveTitleForegroundConverter}}"
             Text="{x:Bind Title, Mode=OneWay}"
             Style="{ThemeResource CaptionTextBlockStyle}"
             VerticalAlignment="Center"

--- a/common/Windows/WindowTitleBar.xaml.cs
+++ b/common/Windows/WindowTitleBar.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using DevHome.Common.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -58,8 +59,16 @@ public sealed partial class WindowTitleBar : UserControl
         windowTitleBar.TitleChanged?.Invoke(windowTitleBar, newValue);
     }
 
+    private static void OnIsActiveChanged(WindowTitleBar windowTitleBar, bool newValue)
+    {
+        // Update the title text block foreground from code behind after the
+        // window activation state has changed and after the WindowCaption*
+        // brushes have been updated. More details in TitleBarHelper.UpdateTitleBar method.
+        windowTitleBar.TitleTextBlock.Foreground = TitleBarHelper.GetTitleBarTextColorBrush(newValue);
+    }
+
     private static readonly DependencyProperty TitleProperty = DependencyProperty.Register(nameof(Title), typeof(string), typeof(WindowTitleBar), new PropertyMetadata(null, (s, e) => OnTitleChanged((WindowTitleBar)s, (string)e.NewValue)));
     private static readonly DependencyProperty IconProperty = DependencyProperty.Register(nameof(Icon), typeof(IconElement), typeof(WindowTitleBar), new PropertyMetadata(null));
     private static readonly DependencyProperty HideIconProperty = DependencyProperty.Register(nameof(HideIcon), typeof(bool), typeof(WindowTitleBar), new PropertyMetadata(false));
-    private static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register(nameof(IsActive), typeof(bool), typeof(WindowTitleBar), new PropertyMetadata(true));
+    private static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register(nameof(IsActive), typeof(bool), typeof(WindowTitleBar), new PropertyMetadata(true, (s, e) => OnIsActiveChanged((WindowTitleBar)s, (bool)e.NewValue)));
 }

--- a/common/Windows/WindowTitleBar.xaml.cs
+++ b/common/Windows/WindowTitleBar.xaml.cs
@@ -54,6 +54,14 @@ public sealed partial class WindowTitleBar : UserControl
         this.InitializeComponent();
     }
 
+    public void Repaint()
+    {
+        // Update the title text block foreground from code behind after the
+        // window activation state or system theme has changed, and after the WindowCaption*
+        // brushes have been updated. More details in TitleBarHelper.UpdateTitleBar method.
+        TitleTextBlock.Foreground = TitleBarHelper.GetTitleBarTextColorBrush(IsActive);
+    }
+
     private static void OnTitleChanged(WindowTitleBar windowTitleBar, string newValue)
     {
         windowTitleBar.TitleChanged?.Invoke(windowTitleBar, newValue);
@@ -61,10 +69,7 @@ public sealed partial class WindowTitleBar : UserControl
 
     private static void OnIsActiveChanged(WindowTitleBar windowTitleBar, bool newValue)
     {
-        // Update the title text block foreground from code behind after the
-        // window activation state has changed and after the WindowCaption*
-        // brushes have been updated. More details in TitleBarHelper.UpdateTitleBar method.
-        windowTitleBar.TitleTextBlock.Foreground = TitleBarHelper.GetTitleBarTextColorBrush(newValue);
+        windowTitleBar.Repaint();
     }
 
     private static readonly DependencyProperty TitleProperty = DependencyProperty.Register(nameof(Title), typeof(string), typeof(WindowTitleBar), new PropertyMetadata(null, (s, e) => OnTitleChanged((WindowTitleBar)s, (string)e.NewValue)));

--- a/src/Views/ShellPage.xaml.cs
+++ b/src/Views/ShellPage.xaml.cs
@@ -52,6 +52,7 @@ public sealed partial class ShellPage : Page
     {
         // Update the title bar if the system theme changes.
         TitleBarHelper.UpdateTitleBar(App.MainWindow, ActualTheme);
+        AppTitleBar.Repaint();
     }
 
     private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)


### PR DESCRIPTION
## Summary of the pull request
- Before this change, the window title bar text foreground would not sync with the currently selected theme. That's because the custom theme resources are only updated after the theme has been applied, which is too late as the text block has already been rendered.
- To fix this issue, update the foreground from code behind after the theme change is applied and the custom title bar brushes has also been updated by [TitleBarHelper.UpdateTitleBar(Window window, ElementTheme theme)](https://github.com/microsoft/devhome/blob/f25b3b9c06421c507489b2693557c33935f116ad/common/Helpers/TitleBarHelper.cs#L30C10-L30C10)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #1760
- [ ] Tests added/passed
- [ ] Documentation updated
