### PR TITLE
Enable cloning to two locations and re-enable previously selected repos.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -6,6 +6,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
 using DevHome.Contracts.Services;
+using DevHome.SetupFlow.Common.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.DevHome.SDK;
@@ -89,7 +90,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
             // Currently the only providers are Github and the generic provider.  The provider type
             // for the generic provider is git.
             // TODO: Remove when extensions have a GetIcon method.
-            if (RepositoryProvider.DisplayName.Equals("github", StringComparison.OrdinalIgnoreCase))
+            if (RepositoryProviderDisplayName.Equals("github", StringComparison.OrdinalIgnoreCase))
             {
                 RepositoryTypeIcon = DarkGithub;
             }
@@ -100,7 +101,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         }
         else
         {
-            if (RepositoryProvider.DisplayName.Equals("github", StringComparison.OrdinalIgnoreCase))
+            if (RepositoryProviderDisplayName.Equals("github", StringComparison.OrdinalIgnoreCase))
             {
                 RepositoryTypeIcon = LightGithub;
             }
@@ -173,6 +174,28 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
     {
         get; set;
     }
+
+    public string RepositoryProviderDisplayName
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_repositoryProviderDisplayName))
+            {
+                try
+                {
+                    _repositoryProviderDisplayName = RepositoryProvider.DisplayName;
+                }
+                catch (Exception e)
+                {
+                    Log.Logger?.ReportError(_repositoryProviderDisplayName, e);
+                }
+            }
+
+            return _repositoryProviderDisplayName;
+        }
+    }
+
+    private string _repositoryProviderDisplayName = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CloningInformation"/> class.

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -89,7 +89,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
             // Currently the only providers are Github and the generic provider.  The provider type
             // for the generic provider is git.
             // TODO: Remove when extensions have a GetIcon method.
-            if (ProviderName.Equals("github", StringComparison.OrdinalIgnoreCase))
+            if (RepositoryProvider.DisplayName.Equals("github", StringComparison.OrdinalIgnoreCase))
             {
                 RepositoryTypeIcon = DarkGithub;
             }
@@ -100,7 +100,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         }
         else
         {
-            if (ProviderName.Equals("github", StringComparison.OrdinalIgnoreCase))
+            if (RepositoryProvider.DisplayName.Equals("github", StringComparison.OrdinalIgnoreCase))
             {
                 RepositoryTypeIcon = LightGithub;
             }

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -69,11 +69,11 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
             CloneRepoTask task;
             if (cloningInformation.OwningAccount == null)
             {
-                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, _stringResource, cloningInformation.ProviderName, _activityId);
+                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, _stringResource, cloningInformation.RepositoryProvider.DisplayName, _activityId);
             }
             else
             {
-                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, cloningInformation.OwningAccount, _stringResource, cloningInformation.ProviderName, _activityId);
+                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, cloningInformation.OwningAccount, _stringResource, cloningInformation.RepositoryProvider.DisplayName, _activityId);
             }
 
             if (cloningInformation.CloneToDevDrive)

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/RepoConfigTaskGroup.cs
@@ -69,11 +69,11 @@ public class RepoConfigTaskGroup : ISetupTaskGroup
             CloneRepoTask task;
             if (cloningInformation.OwningAccount == null)
             {
-                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, _stringResource, cloningInformation.RepositoryProvider.DisplayName, _activityId);
+                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, _stringResource, cloningInformation.RepositoryProviderDisplayName, _activityId);
             }
             else
             {
-                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, cloningInformation.OwningAccount, _stringResource, cloningInformation.RepositoryProvider.DisplayName, _activityId);
+                task = new CloneRepoTask(cloningInformation.RepositoryProvider, new DirectoryInfo(cloningInformation.ClonePath), cloningInformation.RepositoryToClone, cloningInformation.OwningAccount, _stringResource, cloningInformation.RepositoryProviderDisplayName, _activityId);
             }
 
             if (cloningInformation.CloneToDevDrive)

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -795,6 +795,7 @@ public partial class AddRepoViewModel : ObservableObject
         Log.Logger?.ReportInfo(Log.Component.RepoConfig, $"Setting the clone location for all repositories to {cloneLocation}");
         foreach (var cloningInformation in EverythingToClone)
         {
+            // N^2 algorithm.  Shouldn't be too slow unless at least 100 repos are added.
             if (!_previouslySelectedRepos.Any(x => x == cloningInformation))
             {
                 cloningInformation.CloningLocation = new DirectoryInfo(cloneLocation);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -518,7 +518,7 @@ public partial class AddRepoViewModel : ObservableObject
             }
 
             var cloningInformation = new CloningInformation(repoToRemove);
-            cloningInformation.ProviderName = _providers.DisplayName(providerName);
+            cloningInformation.ProviderName = providerName;
             cloningInformation.OwningAccount = developerId;
 
             EverythingToClone.Remove(cloningInformation);
@@ -535,7 +535,7 @@ public partial class AddRepoViewModel : ObservableObject
 
             var cloningInformation = new CloningInformation(repoToAdd);
             cloningInformation.RepositoryProvider = _providers.GetSDKProvider(providerName);
-            cloningInformation.ProviderName = _providers.DisplayName(providerName);
+            cloningInformation.ProviderName = providerName;
             cloningInformation.OwningAccount = developerId;
             cloningInformation.EditClonePathAutomationName = _stringResource.GetLocalized(StringResourceKey.RepoPageEditClonePathAutomationProperties, $"{providerName}/{repositoryToAdd}");
             cloningInformation.RemoveFromCloningAutomationName = _stringResource.GetLocalized(StringResourceKey.RepoPageRemoveRepoAutomationProperties, $"{providerName}/{repositoryToAdd}");
@@ -781,7 +781,7 @@ public partial class AddRepoViewModel : ObservableObject
         Repositories = new ObservableCollection<RepoViewListItem>(OrderRepos(_repositoriesForAccount));
 
         return _previouslySelectedRepos.Where(x => x.OwningAccount != null)
-            .Where(x => x.RepositoryProvider.DisplayName.Equals(repositoryProvider, StringComparison.OrdinalIgnoreCase)
+            .Where(x => x.ProviderName.Equals(repositoryProvider, StringComparison.OrdinalIgnoreCase)
             && x.OwningAccount.LoginId.Equals(loginId, StringComparison.OrdinalIgnoreCase))
             .Select(x => new RepoViewListItem(x.RepositoryToClone));
     }
@@ -795,7 +795,10 @@ public partial class AddRepoViewModel : ObservableObject
         Log.Logger?.ReportInfo(Log.Component.RepoConfig, $"Setting the clone location for all repositories to {cloneLocation}");
         foreach (var cloningInformation in EverythingToClone)
         {
-            cloningInformation.CloningLocation = new DirectoryInfo(cloneLocation);
+            if (!_previouslySelectedRepos.Any(x => x == cloningInformation))
+            {
+                cloningInformation.CloningLocation = new DirectoryInfo(cloneLocation);
+            }
         }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -176,28 +176,6 @@ internal partial class AddRepoDialog : ContentDialog
     }
 
     /// <summary>
-    /// Logs the user into the provider if they aren't already.
-    /// Changes the page to show all repositories for the user.
-    /// </summary>
-    /// <remarks>
-    /// Fired when the combo box on the account page is changed.
-    /// </remarks>
-    private void RepositoryProviderNamesComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        var repositoryProviderName = (string)RepositoryProviderComboBox.SelectedItem;
-        if (!string.IsNullOrEmpty(repositoryProviderName))
-        {
-            PrimaryButtonStyle = AddRepoStackPanel.Resources["ContentDialogLogInButtonStyle"] as Style;
-            AddRepoViewModel.ShouldEnablePrimaryButton = true;
-        }
-        else
-        {
-            PrimaryButtonStyle = Application.Current.Resources["DefaultButtonStyle"] as Style;
-            AddRepoViewModel.ShouldEnablePrimaryButton = false;
-        }
-    }
-
-    /// <summary>
     /// Open up the folder picker for choosing a clone location.
     /// </summary>
     private async void ChooseCloneLocationButton_Click(object sender, RoutedEventArgs e)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -101,7 +101,7 @@
                                         Width="16"
                                         Height="16"
                                         Source="{x:Bind RepositoryTypeIcon, Mode=OneWay}"/>
-                                    <TextBlock Text="{x:Bind ProviderName}" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="{x:Bind RepositoryProvider.DisplayName}" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" TextTrimming="CharacterEllipsis"/>
                                 </Grid>
                             </Border>
                             <Border Style="{StaticResource BorderStyle}"  Grid.Column="1" BorderThickness="0, 1, 1, 0">


### PR DESCRIPTION
## Summary of the pull request
The repo tool updates the cloning location of all repos, including ones selected in a previous instance of the dialog.  This prevents users from cloning in more than one location.

The fix was to not update the clone location of any previously selected repos.

The second issue was a regression issue.  Because of the change of names used in the UI vs the extension, the ability for previously selected repos to appear selected regressed.  I've re-added the behavior.

## References and relevant issues


## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1763
- [ ] Closes #1387
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![CloningToDifferentLocations](https://github.com/microsoft/devhome/assets/2517139/7e728345-d437-48eb-9a19-90476b2fa3b3)
