### PR TITLE
Give Banners their own ViewModels

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceExtensions
     {
         // View-models
         services.AddSingleton<DashboardViewModel>();
+        services.AddTransient<DashboardBannerViewModel>();
 
         // Services
         services.AddSingleton<IWidgetHostingService, WidgetHostingService>();

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardBannerViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardBannerViewModel.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Windows.Storage;
+using Windows.System;
+
+namespace DevHome.Dashboard.ViewModels;
+
+internal partial class DashboardBannerViewModel : ObservableObject
+{
+    private const string _hideDashboardBannerKey = "HideDashboardBanner";
+
+    [ObservableProperty]
+    private bool _showDashboardBanner;
+
+    public DashboardBannerViewModel()
+    {
+        ShowDashboardBanner = ShouldShowDashboardBanner();
+    }
+
+    [RelayCommand]
+    private async Task DashboardBannerButtonAsync()
+    {
+        await Launcher.LaunchUriAsync(new ("https://go.microsoft.com/fwlink/?linkid=2234395"));
+    }
+
+    [RelayCommand]
+    private void HideDashboardBannerButton()
+    {
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        roamingProperties[_hideDashboardBannerKey] = bool.TrueString;
+        ShowDashboardBanner = false;
+    }
+
+    private bool ShouldShowDashboardBanner()
+    {
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        return !roamingProperties.ContainsKey(_hideDashboardBannerKey);
+    }
+
+#if DEBUG
+    public void ResetDashboardBanner()
+    {
+        ShowDashboardBanner = true;
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        if (roamingProperties.ContainsKey(_hideDashboardBannerKey))
+        {
+            roamingProperties.Remove(_hideDashboardBannerKey);
+        }
+    }
+#endif
+}

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -3,14 +3,10 @@
 
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Services;
 using DevHome.Dashboard.Services;
 using Microsoft.UI.Xaml;
-using Windows.Storage;
-using Windows.System;
 
 namespace DevHome.Dashboard.ViewModels;
 
@@ -22,17 +18,7 @@ public partial class DashboardViewModel : ObservableObject
 
     private readonly IPackageDeploymentService _packageDeploymentService;
 
-    private readonly Version minSupportedVersion400 = new (423, 3800);
-    private readonly Version minSupportedVersion500 = new (523, 3300);
-    private readonly Version version500 = new (500, 0);
-
     private bool _validatedWebExpPack;
-
-    // Banner properties
-    private const string _hideDashboardBannerKey = "HideDashboardBanner";
-
-    [ObservableProperty]
-    private bool _showDashboardBanner;
 
     [ObservableProperty]
     private bool _isLoading;
@@ -45,8 +31,6 @@ public partial class DashboardViewModel : ObservableObject
         _packageDeploymentService = packageDeploymentService;
         WidgetIconService = widgetIconService;
         WidgetHostingService = widgetHostingService;
-
-        ShowDashboardBanner = ShouldShowDashboardBanner();
     }
 
     public bool EnsureWebExperiencePack()
@@ -56,6 +40,10 @@ public partial class DashboardViewModel : ObservableObject
         {
             return true;
         }
+
+        var minSupportedVersion400 = new Version(423, 3800);
+        var minSupportedVersion500 = new Version(523, 3300);
+        var version500 = new Version(500, 0);
 
         // Ensure the application is installed, and the version is high enough.
         const string packageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
@@ -76,39 +64,4 @@ public partial class DashboardViewModel : ObservableObject
 
         return Visibility.Collapsed;
     }
-
-    // =============================================================================================
-    // Banner methods
-    // =============================================================================================
-    [RelayCommand]
-    private async Task DashboardBannerButtonAsync()
-    {
-        await Launcher.LaunchUriAsync(new ("https://go.microsoft.com/fwlink/?linkid=2234395"));
-    }
-
-    [RelayCommand]
-    private void HideDashboardBannerButton()
-    {
-        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        roamingProperties[_hideDashboardBannerKey] = bool.TrueString;
-        ShowDashboardBanner = false;
-    }
-
-    private bool ShouldShowDashboardBanner()
-    {
-        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        return !roamingProperties.ContainsKey(_hideDashboardBannerKey);
-    }
-
-#if DEBUG
-    public void ResetDashboardBanner()
-    {
-        ShowDashboardBanner = true;
-        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        if (roamingProperties.ContainsKey(_hideDashboardBannerKey))
-        {
-            roamingProperties.Remove(_hideDashboardBannerKey);
-        }
-    }
-#endif
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -60,10 +60,10 @@
                 <!-- Top Banner - Default/First run experience - shown until user dismissed -->
                 <commonviews:Banner x:Name="DashboardBanner"
                     TextWidth="450"
-                    Visibility="{x:Bind ViewModel.ShowDashboardBanner,Mode=OneWay}"
+                    Visibility="{x:Bind BannerViewModel.ShowDashboardBanner,Mode=OneWay}"
                     HideButtonVisibility="true"
-                    HideButtonCommand="{x:Bind ViewModel.HideDashboardBannerButtonCommand,Mode=OneWay}"
-                    ButtonCommand="{x:Bind ViewModel.DashboardBannerButtonCommand,Mode=OneWay}"
+                    HideButtonCommand="{x:Bind BannerViewModel.HideDashboardBannerButtonCommand,Mode=OneWay}"
+                    ButtonCommand="{x:Bind BannerViewModel.DashboardBannerButtonCommand,Mode=OneWay}"
                     x:Uid="ms-resource:///DevHome.Dashboard/Resources/DashboardBanner"
                     BackgroundSource="{ThemeResource DashboardBannerBack}"
                     OverlaySource="{ThemeResource DashboardBannerFront}"

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -30,6 +30,8 @@ public partial class DashboardView : ToolPage
 
     public DashboardViewModel ViewModel { get; }
 
+    internal DashboardBannerViewModel BannerViewModel { get; }
+
     public static ObservableCollection<WidgetViewModel> PinnedWidgets { get; set; }
 
     private static Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
@@ -42,6 +44,7 @@ public partial class DashboardView : ToolPage
     public DashboardView()
     {
         ViewModel = Application.Current.GetService<DashboardViewModel>();
+        BannerViewModel = Application.Current.GetService<DashboardBannerViewModel>();
 
         this.InitializeComponent();
 
@@ -582,7 +585,7 @@ public partial class DashboardView : ToolPage
             roamingProperties.Remove("HideDashboardBanner");
         }
 
-        ViewModel.ResetDashboardBanner();
+        BannerViewModel.ResetDashboardBanner();
     }
 #endif
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/ServiceExtensions.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/ServiceExtensions.cs
@@ -6,12 +6,14 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace DevHome.ExtensionLibrary.Extensions;
+
 public static class ServiceExtensions
 {
     public static IServiceCollection AddExtensionLibrary(this IServiceCollection services, HostBuilderContext context)
     {
         // View-models
         services.AddTransient<ExtensionLibraryViewModel>();
+        services.AddTransient<ExtensionLibraryBannerViewModel>();
 
         return services;
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryBannerViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryBannerViewModel.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Windows.Storage;
+using Windows.System;
+
+namespace DevHome.ExtensionLibrary.ViewModels;
+
+internal partial class ExtensionLibraryBannerViewModel : ObservableObject
+{
+    private const string _hideExtensionsBannerKey = "HideExtensionsBanner";
+
+    [ObservableProperty]
+    private bool _showExtensionsBanner;
+
+    public ExtensionLibraryBannerViewModel()
+    {
+        ShowExtensionsBanner = ShouldShowExtensionsBanner();
+    }
+
+    [RelayCommand]
+    private async Task ExtensionsBannerButtonAsync()
+    {
+        await Launcher.LaunchUriAsync(new ("https://go.microsoft.com/fwlink/?linkid=2247301"));
+    }
+
+    [RelayCommand]
+    private void HideExtensionsBannerButton()
+    {
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        roamingProperties[_hideExtensionsBannerKey] = bool.TrueString;
+        ShowExtensionsBanner = false;
+    }
+
+    private bool ShouldShowExtensionsBanner()
+    {
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        return !roamingProperties.ContainsKey(_hideExtensionsBannerKey);
+    }
+}

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -23,8 +23,6 @@ namespace DevHome.ExtensionLibrary.ViewModels;
 
 public partial class ExtensionLibraryViewModel : ObservableObject
 {
-    private const string _hideExtensionsBannerKey = "HideExtensionsBanner";
-
     private readonly string devHomeProductId = "9N8MHTPHNGVV";
 
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
@@ -33,9 +31,6 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     public ObservableCollection<StorePackageViewModel> StorePackagesList { get; set; }
 
     public ObservableCollection<InstalledPackageViewModel> InstalledPackagesList { get; set; }
-
-    [ObservableProperty]
-    private bool _showExtensionsBanner;
 
     [ObservableProperty]
     private bool _shouldShowStoreError = false;
@@ -50,28 +45,6 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
         StorePackagesList = new ();
         InstalledPackagesList = new ();
-
-        ShowExtensionsBanner = ShouldShowExtensionsBanner();
-    }
-
-    [RelayCommand]
-    private async Task ExtensionsBannerButtonAsync()
-    {
-        await Launcher.LaunchUriAsync(new ("https://go.microsoft.com/fwlink/?linkid=2247301"));
-    }
-
-    [RelayCommand]
-    private void HideExtensionsBannerButton()
-    {
-        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        roamingProperties[_hideExtensionsBannerKey] = bool.TrueString;
-        ShowExtensionsBanner = false;
-    }
-
-    private bool ShouldShowExtensionsBanner()
-    {
-        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
-        return !roamingProperties.ContainsKey(_hideExtensionsBannerKey);
     }
 
     [RelayCommand]

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -42,10 +42,10 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,22,0,0">
             <StackPanel>
                 <commonviews:Banner TextWidth="350"
-                                    Visibility="{x:Bind ViewModel.ShowExtensionsBanner,Mode=OneWay}"
+                                    Visibility="{x:Bind BannerViewModel.ShowExtensionsBanner,Mode=OneWay}"
                                     HideButtonVisibility="true"
-                                    HideButtonCommand="{x:Bind ViewModel.HideExtensionsBannerButtonCommand,Mode=OneWay}"
-                                    ButtonCommand="{x:Bind ViewModel.ExtensionsBannerButtonCommand,Mode=OneWay}"
+                                    HideButtonCommand="{x:Bind BannerViewModel.HideExtensionsBannerButtonCommand,Mode=OneWay}"
+                                    ButtonCommand="{x:Bind BannerViewModel.ExtensionsBannerButtonCommand,Mode=OneWay}"
                                     x:Uid="ExtensionsBanner"
                                     BackgroundSource="{ThemeResource ExtensionsBannerBack}"
                                     OverlaySource="{ThemeResource ExtensionsBannerFront}"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml.cs
@@ -14,9 +14,12 @@ public partial class ExtensionLibraryView : ToolPage
 
     public ExtensionLibraryViewModel ViewModel { get; }
 
+    internal ExtensionLibraryBannerViewModel BannerViewModel { get; }
+
     public ExtensionLibraryView()
     {
         ViewModel = Application.Current.GetService<ExtensionLibraryViewModel>();
+        BannerViewModel = Application.Current.GetService<ExtensionLibraryBannerViewModel>();
         this.InitializeComponent();
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Extensions/ServiceExtensions.cs
@@ -117,6 +117,7 @@ public static class ServiceExtensions
     {
         // View models
         services.AddTransient<MainPageViewModel>();
+        services.AddTransient<MainPageBannerViewModel>();
 
         return services;
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageBannerViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageBannerViewModel.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DevHome.SetupFlow.Services;
+using DevHome.Telemetry;
+using Windows.Storage;
+using Windows.System;
+
+namespace DevHome.SetupFlow.ViewModels;
+
+public partial class MainPageBannerViewModel : ObservableObject
+{
+    private readonly SetupFlowOrchestrator _orchestrator;
+
+    private const string _hideSetupFlowBannerKey = "HideSetupFlowBanner";
+
+    [ObservableProperty]
+    private bool _showBanner = true;
+
+    public MainPageBannerViewModel(SetupFlowOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+        ShowBanner = ShouldShowSetupFlowBanner();
+    }
+
+    [RelayCommand]
+    private async Task BannerButtonAsync()
+    {
+        await Launcher.LaunchUriAsync(new ("https://go.microsoft.com/fwlink/?linkid=2235076"));
+    }
+
+    [RelayCommand]
+    private void HideBanner()
+    {
+        TelemetryFactory.Get<ITelemetry>().LogCritical("MainPage_HideLearnMoreBanner_Event", false, _orchestrator.ActivityId);
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        roamingProperties[_hideSetupFlowBannerKey] = bool.TrueString;
+        ShowBanner = false;
+    }
+
+    private bool ShouldShowSetupFlowBanner()
+    {
+        var roamingProperties = ApplicationData.Current.RoamingSettings.Values;
+        return !roamingProperties.ContainsKey(_hideSetupFlowBannerKey);
+    }
+}

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -72,9 +72,9 @@
                     <commonviews:Banner
                         TextWidth="345"
                         HideButtonVisibility="True"
-                        HideButtonCommand="{x:Bind ViewModel.HideBannerCommand}"
-                        Visibility="{x:Bind ViewModel.ShowBanner, Mode=OneWay}"
-                        ButtonCommand="{x:Bind ViewModel.BannerButtonCommand, Mode=OneWay}"
+                        HideButtonCommand="{x:Bind ViewModel.BannerViewModel.HideBannerCommand}"
+                        Visibility="{x:Bind ViewModel.BannerViewModel.ShowBanner, Mode=OneWay}"
+                        ButtonCommand="{x:Bind ViewModel.BannerViewModel.BannerButtonCommand, Mode=OneWay}"
                         x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DefaultBanner"
                         BackgroundSource="{ThemeResource Setup_Banner_Back}"
                         OverlaySource="{ThemeResource Setup_Banner_Front}" />


### PR DESCRIPTION
## Summary of the pull request
I'm going to be putting more stuff in DashboardViewModel, so I decided to pull out Banner logic into its own DashboardBannerViewModel to keep things tidy. Then I pulled the other two Banners their own viewmodels, too. Code is really just moving, not changing. This separation will also make it easier if we ever want to replace the banners with something else.

## References and relevant issues
#1692

## Detailed description of the pull request / Additional comments

## Validation steps performed
Locally validated.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
