### PR TITLE
Clean up partially created widget on Esc

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -249,6 +249,17 @@ public partial class DashboardView : ToolPage
             XamlRoot = this.XamlRoot,
             RequestedTheme = this.ActualTheme,
         };
+
+        // If the dialog was closed in a way we don't already handle (for example, pressing Esc),
+        // delete the partially created widget.
+        dialog.Closed += async (sender, args) =>
+        {
+            if (dialog.AddedWidget == null && dialog.ViewModel.Widget != null)
+            {
+                await dialog.ViewModel.Widget.DeleteAsync();
+            }
+        };
+
         _ = await dialog.ShowAsync();
 
         var newWidget = dialog.AddedWidget;
@@ -450,6 +461,16 @@ public partial class DashboardView : ToolPage
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.
             XamlRoot = this.XamlRoot,
             RequestedTheme = this.ActualTheme,
+        };
+
+        // If the dialog was closed in a way we don't already handle (for example, pressing Esc),
+        // delete the partially created widget.
+        dialog.Closed += async (sender, args) =>
+        {
+            if (dialog.EditedWidget == null && dialog.ViewModel.Widget != null)
+            {
+                await dialog.ViewModel.Widget.DeleteAsync();
+            }
         };
         _ = await dialog.ShowAsync();
 


### PR DESCRIPTION
## Summary of the pull request
If the user exits a widget dialog by pressing the Escape key, they will be left with a phantom widget. Delete these widgets when the dialog closes. If the user pressed the X to exit, we'll try to delete the widget twice but this should be fine, the second time just silently fails.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
