### PR TITLE
Fixed typo in GetReposEvent.cs

### DIFF
--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
@@ -56,6 +56,6 @@ public class GetReposEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // The only sensitive strings is the developerID.  GetHashedDeveloperId is used to hash the developerId.
+        // The only sensitive string is the developerID.  GetHashedDeveloperId is used to hash the developerId.
     }
 }

--- a/common/Views/HyperlinkTextBlock.xaml.cs
+++ b/common/Views/HyperlinkTextBlock.xaml.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Controls;
 namespace DevHome.Common.Views;
 
 /// <summary>
-/// Custom control for a text block that contains an hyperlink in the text.
+/// Custom control for a text block that contains a hyperlink in the text.
 /// </summary>
 /// <remarks>
 /// The <see cref="Text"/> property must contain a substring enclosed in square


### PR DESCRIPTION
## Summary of the pull request
strings -> string

## Detailed description of the pull request / Additional comments
Resolved a grammatical issue, `strings` to `string`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
