### PR TITLE
Fixed typo in GetReposEvent.cs

### DIFF
--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
@@ -56,6 +56,6 @@ public class GetReposEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // The only sensitive strings is the developerID.  GetHashedDeveloperId is used to hash the developerId.
+        // The only sensitive string is the developerID.  GetHashedDeveloperId is used to hash the developerId.
     }
 }


### PR DESCRIPTION
## Summary of the pull request
strings -> string

## Detailed description of the pull request / Additional comments
Resolved a grammatical issue, `strings` to `string`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated