### PR TITLE
Fixed typo in ExtensionEvent.cs

### DIFF
--- a/common/TelemetryEvents/SetupFlow/RepoTool/ExtensionEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/ExtensionEvent.cs
@@ -26,6 +26,6 @@ public class ExtensionEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // No sensitive strings to replace.s
+        // No sensitive strings to replace.
     }
 }


### PR DESCRIPTION
## Summary of the pull request
replace.s -> replace

## Detailed description of the pull request / Additional comments
Resolved a typing error, `replace.s` to `replace`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated