### PR TITLE
Fixed typo in Resources.resw

### DIFF
--- a/tools/SampleTool/src/Strings/en-us/Resources.resw
+++ b/tools/SampleTool/src/Strings/en-us/Resources.resw
@@ -5,7 +5,7 @@
     
     Version 2.0
     
-    The primary goals of this format is to allow a simple XML format 
+    The primary goal of this format is to allow a simple XML format 
     that is mostly human readable. The generation and parsing of the 
     various data types are done through the TypeConverter classes 
     associated with the data types.


### PR DESCRIPTION
## Summary of the pull request
goals -> goal

## Detailed description of the pull request / Additional comments
Resolved a grammatical issue, `goals` to `goal`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated