### PR TITLE
Fixed typo in PackageDetailsSettingsCard.xaml

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/PackageDetailsSettingsCard.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/PackageDetailsSettingsCard.xaml
@@ -1,7 +1,7 @@
 <!-- Copyright (c) Microsoft Corporation and Contributors. -->
 <!-- Licensed under the MIT License. -->
 
-<!-- Settings card for package details overwritting default resources and styles -->
+<!-- Settings card for package details overwriting default resources and styles -->
 <ctControls:SettingsCard
     x:Class="DevHome.SetupFlow.Controls.PackageDetailsSettingsCard"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"


### PR DESCRIPTION
## Summary of the pull request
overwritting -> overwriting

## Detailed description of the pull request / Additional comments
Resolved a typing error, `overwritting` to `overwriting`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated