### PR TITLE
Fixed typo in RepositoryProvider.cs

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -51,7 +51,7 @@ internal class RepositoryProvider
     private IDeveloperIdProvider _devIdProvider;
 
     /// <summary>
-    /// Provider used to clone a repsitory.
+    /// Provider used to clone a repository.
     /// </summary>
     private IRepositoryProvider _repositoryProvider;
 


### PR DESCRIPTION
## Summary of the pull request
repsitory -> repository

## Detailed description of the pull request / Additional comments
Resolved a typing error, `repsitory` to `repository`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated