### PR TITLE
Fixed typo in SetupToolStyles.xaml

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/SetupToolStyles.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/SetupToolStyles.xaml
@@ -15,7 +15,7 @@
   
     <!--
     TODO UI for the AppManagement page has changed, hence many of the styles in
-    this file are deprecated and should be cleaned when the new UI is
+    this file is deprecated and should be cleaned when the new UI is
     implemented.
     -->
     


### PR DESCRIPTION
## Summary of the pull request
are -> is

## Detailed description of the pull request / Additional comments
Resolved a typing error, `are` to `is`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated