### PR TITLE
Fixed typo in DevDriveReviewViewModel.cs

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveReviewViewModel.cs
@@ -29,7 +29,7 @@ public partial class DevDriveReviewViewModel : ReviewTabViewModelBase
     public override bool HasItems => Application.Current.GetService<IDevDriveManager>().DevDrivesMarkedForCreation.Any();
 
     /// <summary>
-    /// Gets the a collection of <see cref="DevDriveReviewTabItem"/> to be displayed on the Basics review tab in the
+    /// Gets a collection of <see cref="DevDriveReviewTabItem"/> to be displayed on the Basics review tab in the
     /// setup flow review page.
     /// </summary>
     public ObservableCollection<DevDriveReviewTabItem> DevDrives


### PR DESCRIPTION
## Summary of the pull request
the a -> a

## Detailed description of the pull request / Additional comments
Resolved a grammatical issue, `the a` to `a`.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated