### PR TITLE
Allow keyboard access to entire NavigationView by moving it down

### DIFF
--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -24,7 +24,7 @@
 
     <Thickness x:Key="NavigationViewContentGridBorderThickness">1,1,0,0</Thickness>
     <CornerRadius x:Key="NavigationViewContentGridCornerRadius">8,0,0,0</CornerRadius>
-    <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>
+    <Thickness x:Key="NavigationViewContentMargin">0,8,0,0</Thickness>
     <Thickness x:Key="NavigationViewHeaderMargin">40,0,0,0</Thickness>
 
     <Thickness x:Key="ContentPageMargin">40,0,40,0</Thickness>

--- a/src/Views/ShellPage.xaml
+++ b/src/Views/ShellPage.xaml
@@ -9,15 +9,22 @@
     Loaded="OnLoaded">
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
         <windows:WindowTitleBar
+            Grid.Row="0"
             x:Name="AppTitleBar"
             Title="{x:Bind ViewModel.Title}"
             Height="{x:Bind NavigationViewControl.CompactPaneLength}" />
 
         <NavigationView
+            Grid.Row="1"
             x:Name="NavigationViewControl"
             Canvas.ZIndex="0"
             IsBackButtonVisible="Collapsed"
+            IsTitleBarAutoPaddingEnabled="True"
             SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"
             IsSettingsVisible="True"
             ExpandedModeThresholdWidth="1280"

--- a/src/Views/ShellPage.xaml.cs
+++ b/src/Views/ShellPage.xaml.cs
@@ -63,14 +63,6 @@ public sealed partial class ShellPage : Page
 
     private void NavigationViewControl_DisplayModeChanged(NavigationView sender, NavigationViewDisplayModeChangedEventArgs args)
     {
-        AppTitleBar.Margin = new Thickness()
-        {
-            Left = sender.CompactPaneLength,
-            Top = AppTitleBar.Margin.Top,
-            Right = AppTitleBar.Margin.Right,
-            Bottom = AppTitleBar.Margin.Bottom,
-        };
-
         ShellInfoBar.Margin = new Thickness()
         {
             Left = ShellInfoBar.Margin.Left,


### PR DESCRIPTION
## Summary of the pull request
The NavigationView was badly interacting with the custom title bar, and it was impossible to tab to the top option ("Dashboard"). We solve the problem by moving the whole NavigationView down, under the title bar.

![image](https://github.com/microsoft/devhome/assets/47155823/d35dd0bd-0284-491d-80b1-51b0cfc6f3cb)

## References and relevant issues
https://task.ms/46742514

## Detailed description of the pull request / Additional comments
- Since we're moving all page content down, NavigationViewContentMargin doesn't need to be as big. New thickness aligns the header with the hamburger menu.
- Use a grid to move the page underneath the Title Bar
- Since we're no longer putting NavView content (hamburger icon) in the title bar, set IsTitleBarAutoPaddingEnabled="True". See https://learn.microsoft.com/en-us/windows/apps/design/controls/navigationview#top-whitespace
- Move title bar content left where hamburger was, so no need to set a margin in NavigationViewControl_DisplayModeChanged. This may need to get put back when we implement the back button (#551)

## Validation steps performed

## PR checklist
- [x] Closes #1803
- [ ] Tests added/passed
- [ ] Documentation updated
