### PR TITLE
Delete abandoned widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -187,6 +187,8 @@ public partial class DashboardView : ToolPage
                     }
                     else
                     {
+                        // If we have a widget with no state, Dev Home does not consider it a valid widget
+                        // and should delete it, rather than letting it run invisibly in the background.
                         await DeleteAbandonedWidget(widget);
                     }
                 }
@@ -216,14 +218,13 @@ public partial class DashboardView : ToolPage
 
     private async Task DeleteAbandonedWidget(Widget widget)
     {
-        var length = ViewModel.WidgetHostingService.GetWidgetHost()?.GetWidgets().Length;
+        var length = ViewModel.WidgetHostingService.GetWidgetHost()!.GetWidgets().Length;
         Log.Logger()?.ReportInfo("DashboardView", $"Found abandoned widget, try to delete it...");
         Log.Logger()?.ReportInfo("DashboardView", $"Before delete, {length} widgets for this host");
 
-        // If we have an abandoned widget, delete it.
         await widget.DeleteAsync();
 
-        length = ViewModel.WidgetHostingService.GetWidgetHost()?.GetWidgets().Length;
+        length = ViewModel.WidgetHostingService.GetWidgetHost()!.GetWidgets().Length;
         Log.Logger()?.ReportInfo("DashboardView", $"After delete, {length} widgets for this host");
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -189,7 +189,7 @@ public partial class DashboardView : ToolPage
                     {
                         // If we have a widget with no state, Dev Home does not consider it a valid widget
                         // and should delete it, rather than letting it run invisibly in the background.
-                        await DeleteAbandonedWidget(widget);
+                        await DeleteAbandonedWidgetAsync(widget);
                     }
                 }
                 catch (Exception ex)
@@ -216,7 +216,7 @@ public partial class DashboardView : ToolPage
         }
     }
 
-    private async Task DeleteAbandonedWidget(Widget widget)
+    private async Task DeleteAbandonedWidgetAsync(Widget widget)
     {
         var length = ViewModel.WidgetHostingService.GetWidgetHost()!.GetWidgets().Length;
         Log.Logger()?.ReportInfo("DashboardView", $"Found abandoned widget, try to delete it...");


### PR DESCRIPTION
## Summary of the pull request
Widgets can get into a state where they're valid from the Widget Platform's point of view, but Dev Home doesn't consider them complete. If the user has any of these widgets on Dashboard launch, delete them. This shouldn't affect the user, as Dev Home wasn't showing these widgets anyway. Should improve performance if user had many of these abandoned widgets.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1712
- [ ] Tests added/passed
- [ ] Documentation updated
