### PR TITLE
Telemetry when a clone fails.

### DIFF
--- a/common/TelemetryEvents/ExceptionEvent.cs
+++ b/common/TelemetryEvents/ExceptionEvent.cs
@@ -16,9 +16,21 @@ public class ExceptionEvent : EventBase
 
     public int HResult { get; }
 
+    public string Message
+    {
+        get; private set;
+    }
+
     public ExceptionEvent(int hresult)
     {
         HResult = hresult;
+        Message = string.Empty;
+    }
+
+    public ExceptionEvent(int hresult, string message)
+    {
+        HResult = hresult;
+        Message = message;
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
@@ -214,6 +214,8 @@ public partial class CloneRepoTask : ObservableObject, ISetupTask
 
                 if (result.Status == ProviderOperationStatus.Failure)
                 {
+                    TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_CouldNotClone_Event", LogLevel.Critical, new ExceptionEvent(result.ExtendedError.HResult, result.DisplayMessage));
+
                     _actionCenterErrorMessage.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.CloneRepoErrorForActionCenter, RepositoryToClone.DisplayName, result.DisplayMessage);
                     WasCloningSuccessful = false;
                     return TaskFinishedState.Failure;


### PR DESCRIPTION
## Summary of the pull request
Now that the SDK returns error messages, DevHome can log correct failure messages when cloning fails.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
