### PR TITLE
Add "Documentation issue" option

### DIFF
--- a/.github/ISSUE_TEMPLATE/Documentation_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Documentation_Issue.yml
@@ -3,7 +3,8 @@ description: Report issues on our documentation
 labels: 
 - Issue-Docs 
 body:
-- type: textarea
+- id: description
+  type: textarea
   attributes: 
     label: Provide a description of requested docs changes
     placeholder: Briefly describe which document needs to be corrected and why.

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -327,6 +327,43 @@
     <value>Enter title</value>
     <comment>The topic of the issue that the user wants to report</comment>
   </data>
+  <data name="Settings_Feedback_DocumentationIssue.Header" xml:space="preserve">
+    <value>Report a documentation issue</value>
+    <comment>DocumentationIssue is for reporting an issue in documentation</comment>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue.Description" xml:space="preserve">
+    <value>Report issues on our documentation</value>
+    <comment>Details about when this option should be used</comment>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_Button.Content" xml:space="preserve">
+    <value>New report</value>
+    <comment>Begin to fill out the documentation issue content dialog</comment>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_Dialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Close out of the content dialog</comment>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_Dialog.PrimaryButtonText" xml:space="preserve">
+    <value>Preview on GitHub</value>
+    <comment>Navigate to the GitHub issue to see the issue form</comment>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_Dialog.Title" xml:space="preserve">
+    <value>Report a documentation issue</value>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_IssueTitle.Header" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_IssueTitle.PlaceholderText" xml:space="preserve">
+    <value>Enter title</value>
+    <comment>Documentation issue title</comment>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_Description.Header" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Settings_Feedback_DocumentationIssue_Description.PlaceholderText" xml:space="preserve">
+    <value>Briefly describe which document needs to be corrected and why.</value>
+    <comment>Documentation issue description</comment>
+  </data>
   <data name="Settings_Feedback_ReportSecurity.Description" xml:space="preserve">
     <value>Read our security policy and learn how to report vulnerabilities</value>
     <comment>Look at the guidance on security</comment>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -90,6 +90,16 @@
                         </ScrollViewer>
                     </Grid>
                 </ContentDialog>
+                <ContentDialog x:Name="DocumentationIssueDialog" x:Uid="Settings_Feedback_DocumentationIssue_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
+                    <Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <TextBox x:Name="DocumentationIssueTitle" x:Uid="Settings_Feedback_DocumentationIssue_IssueTitle" AcceptsReturn="True"/>
+                                <TextBox x:Name="DocumentationIssueDescription" x:Uid="Settings_Feedback_DocumentationIssue_Description" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </ContentDialog>
                 <TextBlock Margin="{StaticResource MediumBottomMargin}" TextWrapping="WrapWholeWords">
                     <Run x:Uid="Settings_Feedback_OpenSource"/>
                     <Hyperlink x:Uid="Settings_Feedback_OpenSource_Link" TextDecorations="None">
@@ -117,6 +127,13 @@
                                   Glyph="&#xE909;"/>
                         </ctControls:SettingsCard.HeaderIcon>
                         <Button x:Uid="Settings_Feedback_LocalizationIssue_Button" Click="DisplayLocalizationIssueDialog" MinWidth="150" />
+                    </ctControls:SettingsCard>
+                    <ctControls:SettingsCard x:Uid="Settings_Feedback_DocumentationIssue">
+                        <ctControls:SettingsCard.HeaderIcon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
+                                Glyph="&#xe736;"/>
+                        </ctControls:SettingsCard.HeaderIcon>
+                        <Button x:Uid="Settings_Feedback_DocumentationIssue_Button" Click="DisplayDocumentationIssueDialog" MinWidth="150" />
                     </ctControls:SettingsCard>
                     <ctControls:SettingsCard x:Uid="Settings_Feedback_BuildExtension">
                         <ctControls:SettingsCard.HeaderIcon>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -165,6 +165,27 @@ public sealed partial class FeedbackPage : Page
         ReportBugIssueTitle.Text = ReportBugReproSteps.Text = ReportBugExpectedBehavior.Text = ReportBugActualBehavior.Text = string.Empty;
     }
 
+    private async void DisplayDocumentationIssueDialog(object sender, RoutedEventArgs e)
+    {
+        var result = await DocumentationIssueDialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            var issueTitle = HttpUtility.UrlEncode(DocumentationIssueTitle.Text);
+            var issueDescription = HttpUtility.UrlEncode(DocumentationIssueDescription.Text);
+            var gitHubURL = "https://github.com/microsoft/devhome/issues/new?title=" + issueTitle +
+                "&labels=Issue-Docs&projects=&template=Documentation_Issue.yml&description=" + issueDescription;
+
+            // Make sure any changes are consistent with the documentation issue template on GitHub
+            await Windows.System.Launcher.LaunchUriAsync(new Uri(gitHubURL));
+        }
+        else
+        {
+            DocumentationIssueDialog.Hide();
+        }
+
+        DocumentationIssueTitle.Text = DocumentationIssueDescription.Text = string.Empty;
+    }
+
     private void ShowSysInfoExpander_Expanding(Expander sender, ExpanderExpandingEventArgs args)
     {
         PhysicalMemory.Text = GetPhysicalMemory();


### PR DESCRIPTION
## Summary of the pull request
Added a new option "Report a documentation issue" in Settings > Feedback section.

## References and relevant issues
https://github.com/microsoft/devhome/issues/1115
https://github.com/microsoft/devhome/pull/1741#pullrequestreview-1708741241

## Detailed description of the pull request / Additional comments

## Validation steps performed
![image](https://github.com/microsoft/devhome/assets/77397009/bb3aba3d-c3e0-4011-a768-c92457f24892)

![image](https://github.com/microsoft/devhome/assets/77397009/477f5554-14b9-41a2-b53e-5b9dcc02f86b)

When you enter the description in DevHome and preview it on GitHub, the issue's description field is currently not populated because its ID was missing from the Github issue template. I have now included the ID in the issue template. Once the PR is merged, the description field will be populated as expected.

## PR checklist
- [X] Closes #1115
- [ ] Tests added/passed
- [ ] Documentation updated
