### PR TITLE
DevHomeSDK: Add to AuthenticationState enum

### DIFF
--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -1,6 +1,6 @@
 namespace Microsoft.Windows.DevHome.SDK
 {
-    [contractversion(1)]
+    [contractversion(2)]
     apicontract DevHomeContract {}
 
     [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]
@@ -141,10 +141,13 @@ namespace Microsoft.Windows.DevHome.SDK
         };
     };
 
-    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)] 
     enum AuthenticationState {
         LoggedIn = 0,
-        LoggedOut = 1
+        LoggedOut = 1,
+
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 2)] 
+        FixAccount = 2
     };
 
     [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -141,7 +141,7 @@ namespace Microsoft.Windows.DevHome.SDK
         };
     };
 
-    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)] 
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]
     enum AuthenticationState {
         LoggedIn = 0,
         LoggedOut = 1,


### PR DESCRIPTION
## Summary of the pull request
The PR adds FixAccount to the existing AuthenticationState enum. 

## References and relevant issues

## Detailed description of the pull request / Additional comments
The PR makes an additive DevHome SDK change. It adds to the AuthenticationState enum and updates the contract version accordingly. This enum value will be used for account remediation scenarios. 

## Validation steps performed
Local release build of Dev Home SDK. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
