### PR TITLE
Prevent crash on widget creation failing

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -229,7 +229,16 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
             // Create the widget for configuration. We will need to delete it if the user closes the dialog
             // without pinning, or selects a different widget.
-            var widget = await _hostingService.GetWidgetHost()?.CreateWidgetAsync(selectedWidgetDefinition.Id, size);
+            Widget widget = null;
+            try
+            {
+                widget = await _hostingService.GetWidgetHost()?.CreateWidgetAsync(selectedWidgetDefinition.Id, size);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportWarn("AddWidgetDialog", $"CreateWidgetAsync failed: ", ex);
+            }
+
             if (widget is not null)
             {
                 Log.Logger()?.ReportInfo("AddWidgetDialog", $"Created Widget {widget.Id}");


### PR DESCRIPTION
## Summary of the pull request
There is a possibility that widget creation could fail, and we should prevent Dev Home from crashing in this scenario. I was able to reproduce this by stopping the provider's process, and it wasn't able to restart itself on widget creation. We already have the error message displayed to users in this scenario.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
