### PR TITLE
Dev Home no longer registers for the DeveloperId provider

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -48,6 +48,17 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription">
+            <uap3:Properties>
+              <DevHomeProvider>
+                <Activation>
+                  <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
+                </Activation>
+              </DevHomeProvider>
+            </uap3:Properties>
+          </uap3:AppExtension>
+        </uap3:Extension>
+        <uap3:Extension Category="windows.appExtension">
           <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -48,20 +48,6 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription">
-            <uap3:Properties>
-              <DevHomeProvider>
-                <Activation>
-                  <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
-                </Activation>
-                <SupportedInterfaces>
-                  <DeveloperId />
-                </SupportedInterfaces>
-              </DevHomeProvider>
-            </uap3:Properties>
-          </uap3:AppExtension>
-        </uap3:Extension>
-        <uap3:Extension Category="windows.appExtension">
           <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>


### PR DESCRIPTION
## Summary of the pull request
Dev Home was registering DeveloperIDProvider, but never actually created one.  This was leftover code from when core widgets were initially created.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
