### PR TITLE
Showing error if a user is logged in, but can't access the repo.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -631,6 +631,7 @@ public partial class AddRepoViewModel : ObservableObject
 
         EverythingToClone.Add(cloningInformation);
         ShouldEnablePrimaryButton = true;
+        ShouldShowUrlError = Visibility.Collapsed;
     }
 
     /// <summary>
@@ -693,6 +694,7 @@ public partial class AddRepoViewModel : ObservableObject
             UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlNoAccountsHaveAccess);
             ShouldShowUrlError = Visibility.Visible;
 
+            InitiateAddAccountUserExperienceAsync(provider, loginFrame);
             return null;
         }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -338,7 +338,6 @@ internal partial class AddRepoDialog : ContentDialog
             if (numberOfReposToCloneCount == AddRepoViewModel.EverythingToClone.Count)
             {
                 AddRepoViewModel.AddRepositoryViaUri(AddRepoViewModel.Url, FolderPickerViewModel.CloneLocation, LoginUIContent);
-                AddRepoViewModel.ShouldShowUrlError = Visibility.Collapsed;
             }
 
             if (AddRepoViewModel.ShouldShowUrlError == Visibility.Visible)


### PR DESCRIPTION
## Summary of the pull request
If a user is logged in, but can't access the repo via the URL tab, the user would not be notified and the window would close.

Now users are notified that no user can access the repo and the dialog does not close.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
