### PR TITLE
Show progress rings before widgets have data to show

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -220,7 +220,7 @@ public partial class WidgetViewModel : ObservableObject
         }
     }
 
-    // Used to show a message instead of Adaptive Card content in a widget.
+    // Used to show a loading ring when we don't have widget content.
     public void ShowLoadingCard()
     {
         _dispatcher.TryEnqueue(() =>
@@ -229,7 +229,7 @@ public partial class WidgetViewModel : ObservableObject
         });
     }
 
-    // Used to show a loading ring when we don't have widget content.
+    // Used to show a message instead of Adaptive Card content in a widget.
     public void ShowErrorCard(string error, string subError = null)
     {
         _dispatcher.TryEnqueue(() =>

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -229,7 +229,7 @@ public partial class WidgetViewModel : ObservableObject
         });
     }
 
-    // Used to show a message instead of Adaptive Card content in a widget.
+    // Used to show a loading ring when we don't have widget content.
     public void ShowErrorCard(string error, string subError = null)
     {
         _dispatcher.TryEnqueue(() =>

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -69,8 +69,8 @@ public partial class WidgetViewModel : ObservableObject
     {
         if (Widget != null)
         {
+            ShowLoadingCard();
             Widget.WidgetUpdated += HandleWidgetUpdated;
-            _ = RenderWidgetFrameworkElementAsync();
         }
     }
 
@@ -218,6 +218,15 @@ public partial class WidgetViewModel : ObservableObject
                 Configuring = isConfiguring;
             });
         }
+    }
+
+    // Used to show a message instead of Adaptive Card content in a widget.
+    public void ShowLoadingCard()
+    {
+        _dispatcher.TryEnqueue(() =>
+        {
+            WidgetFrameworkElement = new ProgressRing();
+        });
     }
 
     // Used to show a message instead of Adaptive Card content in a widget.

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -243,7 +243,6 @@ public sealed partial class AddWidgetDialog : ContentDialog
             {
                 Log.Logger()?.ReportInfo("AddWidgetDialog", $"Created Widget {widget.Id}");
 
-                ViewModel.ShowLoadingCard();
                 ViewModel.Widget = widget;
                 ViewModel.IsInAddMode = true;
                 PinButton.Visibility = Visibility.Visible;

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -243,6 +243,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
             {
                 Log.Logger()?.ReportInfo("AddWidgetDialog", $"Created Widget {widget.Id}");
 
+                ViewModel.ShowLoadingCard();
                 ViewModel.Widget = widget;
                 ViewModel.IsInAddMode = true;
                 PinButton.Visibility = Visibility.Visible;


### PR DESCRIPTION
## Summary of the pull request
Widgets should do their best to have a valid template and data as soon as possible. However, it sometimes takes some time for the extension to start up. Instead of showing an error, we should show a ProgressRing.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #722
- [ ] Tests added/passed
- [ ] Documentation updated
