### PR TITLE
Changing to PNG encoder

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -162,7 +162,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         }
 
         var reversedStream = new InMemoryRandomAccessStream();
-        var encoder = BitmapEncoder.CreateAsync(BitmapEncoder.BmpEncoderId, reversedStream).AsTask().Result;
+        var encoder = BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, reversedStream).AsTask().Result;
         encoder.SetPixelData(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Straight, decoder.PixelWidth, decoder.PixelHeight, decoder.DpiX, decoder.DpiY, pixels);
         encoder.FlushAsync().AsTask().Wait();
 


### PR DESCRIPTION
## Summary of the pull request
Because the encoder was incorrect, the transparency was ignored in icons.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![MakingbackgroundTransparent](https://github.com/microsoft/devhome/assets/2517139/bda8ff01-2d88-404a-a12f-2c780bf1bf9c)
