### PR TITLE
Fix for secondary window's not respecting app's theme.

### DIFF
--- a/common/Windows/SecondaryWindow.cs
+++ b/common/Windows/SecondaryWindow.cs
@@ -176,6 +176,12 @@ public class SecondaryWindow : WindowEx
 
     public SecondaryWindow()
     {
+        // Set the theme of the secondary window before creating the window template.
+        // This must be done before creation of the template or else the secondary window
+        // will continue to follow the Windows system theme and not respect the theme
+        // set by the app itself.
+        UseAppTheme = true;
+
         // Initialize window content template
         _windowTemplate = new (this);
         WindowContent = _windowTemplate;
@@ -187,7 +193,7 @@ public class SecondaryWindow : WindowEx
         // Set default window configuration
         PrimaryWindow = MainWindow;
         SystemBackdrop = PrimaryWindow.SystemBackdrop;
-        UseAppTheme = true;
+
         Title = AppInfo.GetAppNameLocalized();
         this.SetIcon(AppInfo.IconPath);
 

--- a/common/Windows/SecondaryWindow.cs
+++ b/common/Windows/SecondaryWindow.cs
@@ -177,8 +177,8 @@ public class SecondaryWindow : WindowEx
     public SecondaryWindow()
     {
         // Set the theme of the secondary window before creating the window template.
-        // This must be done before creation of the template or else the secondary window
-        // will continue to follow the Windows system theme and not respect the theme
+        // This must be done before the creation of the template, or else the secondary window
+        // will continue to follow the Windows system theme, and not respect the theme
         // set by the app itself.
         UseAppTheme = true;
 

--- a/common/Windows/SecondaryWindowTemplate.xaml
+++ b/common/Windows/SecondaryWindowTemplate.xaml
@@ -1,4 +1,4 @@
-<UserControl
+  <UserControl
     x:Class="DevHome.Common.Windows.SecondaryWindowTemplate"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,7 +6,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Loaded="OnLoaded"
     mc:Ignorable="d">
-    <Grid>
+    <Grid
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>

--- a/common/Windows/SecondaryWindowTemplate.xaml
+++ b/common/Windows/SecondaryWindowTemplate.xaml
@@ -1,4 +1,4 @@
-  <UserControl
+<UserControl
     x:Class="DevHome.Common.Windows.SecondaryWindowTemplate"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/common/Windows/SecondaryWindowTemplate.xaml
+++ b/common/Windows/SecondaryWindowTemplate.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Loaded="OnLoaded"
     mc:Ignorable="d">
     <Grid
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/common/Windows/SecondaryWindowTemplate.xaml.cs
+++ b/common/Windows/SecondaryWindowTemplate.xaml.cs
@@ -28,15 +28,15 @@ internal sealed partial class SecondaryWindowTemplate : UserControl
     public SecondaryWindowTemplate(SecondaryWindow window)
     {
         _secondaryWindow = window;
-        this.InitializeComponent();
-    }
 
-    private void OnLoaded(object sender, RoutedEventArgs e)
-    {
         // A custom title bar is required for full window theme and Mica support.
         // https://docs.microsoft.com/windows/apps/develop/title-bar?tabs=winui3#full-customization
+        // Note: We need to add the titlebar before the template loads or else the titlebar will flicker
+        // from the default Windows app title bar to our own titlebar custom titlebar.
         _secondaryWindow.ExtendsContentIntoTitleBar = true;
         _secondaryWindow.SetTitleBar(this.WindowTitleBar);
+
+        this.InitializeComponent();
     }
 
     private static readonly DependencyProperty TitleBarProperty = DependencyProperty.Register(nameof(TitleBar), typeof(WindowTitleBar), typeof(SecondaryWindowTemplate), new PropertyMetadata(null));

--- a/common/Windows/SecondaryWindowTemplate.xaml.cs
+++ b/common/Windows/SecondaryWindowTemplate.xaml.cs
@@ -31,12 +31,14 @@ internal sealed partial class SecondaryWindowTemplate : UserControl
 
         // A custom title bar is required for full window theme and Mica support.
         // https://docs.microsoft.com/windows/apps/develop/title-bar?tabs=winui3#full-customization
-        // Note: We need to add the title bar before the template loads, or else the title bar will flicker
-        // between the default Windows title bar and our own custom title bar.
+        // Note: We need to extend the title bar before we create the template or else the title bar
+        // will flicker between the default Windows title bar and our own custom title bar.
         _secondaryWindow.ExtendsContentIntoTitleBar = true;
-        _secondaryWindow.SetTitleBar(this.WindowTitleBar);
 
         this.InitializeComponent();
+
+        // Set title bar only after we know the component is initialized.
+        _secondaryWindow.SetTitleBar(this.WindowTitleBar);
     }
 
     private static readonly DependencyProperty TitleBarProperty = DependencyProperty.Register(nameof(TitleBar), typeof(WindowTitleBar), typeof(SecondaryWindowTemplate), new PropertyMetadata(null));

--- a/common/Windows/SecondaryWindowTemplate.xaml.cs
+++ b/common/Windows/SecondaryWindowTemplate.xaml.cs
@@ -31,8 +31,8 @@ internal sealed partial class SecondaryWindowTemplate : UserControl
 
         // A custom title bar is required for full window theme and Mica support.
         // https://docs.microsoft.com/windows/apps/develop/title-bar?tabs=winui3#full-customization
-        // Note: We need to add the titlebar before the template loads or else the titlebar will flicker
-        // from the default Windows app title bar to our own titlebar custom titlebar.
+        // Note: We need to add the title bar before the template loads, or else the title bar will flicker
+        // between the default Windows title bar and our own custom title bar.
         _secondaryWindow.ExtendsContentIntoTitleBar = true;
         _secondaryWindow.SetTitleBar(this.WindowTitleBar);
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -391,6 +391,9 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
         ResetErrors();
         DevDriveWindowContainer = new (this);
         DevDriveWindowContainer.Closed += ViewContainerClosed;
+
+        // Setting this before the window activates prevents the window from showing up on the screen,
+        // then moving abruptly to the center.
         DevDriveWindowContainer.CenterOnWindow();
         DevDriveWindowContainer.Activate();
         IsDevDriveWindowOpen = true;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -391,8 +391,8 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
         ResetErrors();
         DevDriveWindowContainer = new (this);
         DevDriveWindowContainer.Closed += ViewContainerClosed;
-        DevDriveWindowContainer.Activate();
         DevDriveWindowContainer.CenterOnWindow();
+        DevDriveWindowContainer.Activate();
         IsDevDriveWindowOpen = true;
         RefreshDriveLetterToSizeMapping();
         DriveLetters.Clear();

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/DevDriveView.xaml
@@ -10,9 +10,7 @@
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:util="using:DevHome.SetupFlow.Utilities"
     xmlns:services="using:DevHome.Common.Services"
-    mc:Ignorable="d"
-    Background="{ThemeResource ContentDialogBackground}"
-    Foreground="{ThemeResource ContentDialogForeground}">
+    mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:EmptyObjectToObjectConverter x:Key="EmptyObjectToObjectConverter" NotEmptyValue="Visible" EmptyValue="Collapsed"/>


### PR DESCRIPTION
## Summary of the pull request

1. Fixes issue where the secondary windows do not respect the app's theme when its set in the Dev Home settings page. Without this fix the secondary windows continue to keep the Windows system theme, and change when the system theme is changed. For example if Dev Home's theme was set to light theme in the app, but the system theme is dark theme, the secondary window will be in dark theme. Now with this fix, the secondary windows respect the theme set by Dev Home, whether that be light, dark or windows default.
2. Fixes secondary window's titlebar  flickering between the Windows default titlebar and our custom titlebar when the window activates.
3. Fixes issue where secondary window is not using a background, and thus appearing to be transparent.

here is a video of how the secondary window works with theme changes after this change.

https://github.com/microsoft/devhome/assets/105318831/06f2f58f-47b6-4962-b3fa-6b51dfe1ca05



## References and relevant issues
Notice in this video at the end, the last time I close and relaunch the Dev Drive window, the minimize, maximize and close buttons, look like they have a light theme foreground. I checked the Dev Home app itself and it looks like an issue with all the windows of the app currently in Dev builds. So, I opened this issue #1882 

## Detailed description of the pull request / Additional comments

## Validation steps performed
tested this locally.
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
