### PR TITLE
Remove "to do" comment no longer needed

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -56,10 +56,6 @@
                          Foreground="{ThemeResource TextFillColorSecondary}">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel>
-                <!-- TODO: We should use the labs:SettingsExpander to get some of the styling for
-                           free, but it crashes when the content is not a SettingsCard, and
-                           SettingsCards are hard to style to use the full width. 
-                           https://github.com/microsoft/devhome/issues/626-->
                 <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
                           IsExpanded="true"
                           MinHeight="64" CornerRadius="4" Padding="24,0,24,7" >


### PR DESCRIPTION
"TODO" comment in ReviewPage.xaml calls for using a SettingsExpander instead of a regular Expander to get some styling on the header for free. Doesn't seem worth doing since we already have the header styling as we want it, and the styling in the content it brings is not what we want.

Closes #626