### PR TITLE
Give buttons accessible names

### DIFF
--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -62,4 +62,8 @@
     <value>Close</value>
     <comment>Name of the button that hides the banner</comment>
   </data>
+  <data name="CloseButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Close</value>
+    <comment>Name of the button that closes a view</comment>
+  </data>
 </root>

--- a/common/Views/CloseButton.xaml
+++ b/common/Views/CloseButton.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
+    x:Uid="CloseButton"
     Style="{StaticResource DefaultButtonStyle}"
     HorizontalAlignment="Right"
     VerticalAlignment="Top"
@@ -12,7 +13,7 @@
     Background="Transparent"
     Padding="10">
 
-    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                FontSize="{ThemeResource BodyTextBlockFontSize}" 
-                Text="&#xE711;" />
+    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
+               FontSize="{ThemeResource BodyTextBlockFontSize}"
+               Text="&#xE711;" />
 </Button>

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -86,6 +86,10 @@
     <value>Pin</value>
     <comment>Label for button that pins the widget</comment>
   </data>
+  <data name="PinButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Pin</value>
+    <comment>Name of the button that pins the widget</comment>
+  </data>
   <data name="UpdateWidgetButton.Content" xml:space="preserve">
     <value>Update</value>
     <comment>Label for button that updates the widget</comment>

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -85,6 +85,7 @@
                 <Grid Grid.Row="2"
                       x:Name="PinRow">
                     <Button x:Name="PinButton"
+                            x:Uid="PinButton"
                             Style="{ThemeResource AccentButtonStyle}"
                             VerticalAlignment="Bottom" HorizontalAlignment="Center"
                             Visibility="Collapsed"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -126,4 +126,8 @@
     <value>Extensions Banner</value>
     <comment>Name of the Extensions banner for automation</comment>
   </data>
+  <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>More options</value>
+    <comment>Name of the button that brings up the "More options" menu</comment>
+  </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -41,12 +41,12 @@
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,22,0,0">
             <StackPanel>
-                <commonviews:Banner TextWidth="350"
+                <commonviews:Banner x:Uid="ExtensionsBanner"
+                                    TextWidth="350"
                                     Visibility="{x:Bind BannerViewModel.ShowExtensionsBanner,Mode=OneWay}"
                                     HideButtonVisibility="true"
                                     HideButtonCommand="{x:Bind BannerViewModel.HideExtensionsBannerButtonCommand,Mode=OneWay}"
                                     ButtonCommand="{x:Bind BannerViewModel.ExtensionsBannerButtonCommand,Mode=OneWay}"
-                                    x:Uid="ExtensionsBanner"
                                     BackgroundSource="{ThemeResource ExtensionsBannerBack}"
                                     OverlaySource="{ThemeResource ExtensionsBannerFront}"
                                     Margin="0,0,0,28" />
@@ -73,7 +73,8 @@
                                 <ctControls:SettingsExpander.HeaderIcon>
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
                                 </ctControls:SettingsExpander.HeaderIcon>
-                                <Button Content="&#xe712;"
+                                <Button x:Uid="MoreOptionsButton"
+                                        Content="&#xe712;"
                                         Height="36" Width="36"
                                         FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                         Background="Transparent"


### PR DESCRIPTION
## Summary of the pull request
Gives accessible names, that can be read by Narrator, to three buttons:
- "Pin" button in the Add Widget dialog
- "More options" button in the Extensions list
- "Close" buttons, used in the Add Widget dialog and other places.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #1961
- [ ] Tests added/passed
- [ ] Documentation updated
