### PR TITLE
Changing the A tag because the event is not about usage

### DIFF
--- a/common/TelemetryEvents/SetupFlow/RepoTool/ExtensionEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/ExtensionEvent.cs
@@ -12,7 +12,7 @@ namespace DevHome.Common.TelemetryEvents.SetupFlow;
 [EventData]
 public class ExtensionEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public int NumberOfProviders
     {

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/GetReposEvent.cs
@@ -14,7 +14,7 @@ namespace DevHome.Common.TelemetryEvents.SetupFlow;
 [EventData]
 public class GetReposEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public string StageName { get; }
 

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/RepoDialogGetAccountEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoDialog/RepoDialogGetAccountEvent.cs
@@ -12,7 +12,7 @@ namespace DevHome.Common.TelemetryEvents.SetupFlow;
 [EventData]
 public class RepoDialogGetAccountEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public string ProviderName
     {

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoToolEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoToolEvent.cs
@@ -12,7 +12,7 @@ namespace DevHome.Common.TelemetryEvents.SetupFlow;
 [EventData]
 public class RepoToolEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public string Action
     {

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoToolFinalReposToAddEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoToolFinalReposToAddEvent.cs
@@ -30,7 +30,7 @@ public class FinalRepoResult
 [EventData]
 public class RepoToolFinalReposToAddEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public List<FinalRepoResult> FinalAddedRepos { get; }
 


### PR DESCRIPTION
## Summary of the pull request
Some of the events are more about performance than usage.
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
