### PR TITLE
Allow Pin button to expand with text scaling

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -90,7 +90,7 @@
                             VerticalAlignment="Bottom" HorizontalAlignment="Center"
                             Visibility="Collapsed"
                             IsEnabled="{x:Bind ViewModel.Configuring, Mode=OneWay, Converter={StaticResource BoolNegation}}"
-                            Height="32" Width="118"
+                            MinHeight="32" MinWidth="118"
                             Click="PinButton_Click"
                             Margin="0,40">
                         <StackPanel Orientation="Horizontal" Spacing="8">


### PR DESCRIPTION
## Summary of the pull request
Pin button gets cut off when text scaling is up. Allow the button to expand to show the whole text.

## References and relevant issues
http://task.ms/46727087

## Detailed description of the pull request / Additional comments

## Validation steps performed
Verified locally.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
