### PR TITLE
Use bigger Dev Home icon for widget screenshots

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -102,7 +102,7 @@
                         <Icon Path="Widgets\Assets\ssh_keychain_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Assets\Preview\StoreLogo.png" DisplayAltText="For accessibility" />
+                        <Screenshot Path="Assets\Preview\StoreDisplay-300.png" DisplayAltText="Dev Home icon" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
@@ -129,7 +129,7 @@
                         <Icon Path="Widgets\Assets\mem_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Assets\Preview\StoreLogo.png" DisplayAltText="For accessibility" />
+                        <Screenshot Path="Assets\Preview\StoreDisplay-300.png" DisplayAltText="Dev Home icon" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
@@ -156,7 +156,7 @@
                         <Icon Path="Widgets\Assets\net_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Assets\Preview\StoreLogo.png" DisplayAltText="For accessibility" />
+                        <Screenshot Path="Assets\Preview\StoreDisplay-300.png" DisplayAltText="Dev Home icon" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
@@ -183,7 +183,7 @@
                         <Icon Path="Widgets\Assets\gpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Assets\Preview\StoreLogo.png" DisplayAltText="For accessibility" />
+                        <Screenshot Path="Assets\Preview\StoreDisplay-300.png" DisplayAltText="Dev Home icon" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
@@ -210,7 +210,7 @@
                         <Icon Path="Widgets\Assets\cpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Assets\Preview\StoreLogo.png" DisplayAltText="For accessibility" />
+                        <Screenshot Path="Assets\Preview\StoreDisplay-300.png" DisplayAltText="Dev Home icon" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>


### PR DESCRIPTION
## Summary of the pull request
We don't technically support Dev Home widgets in the Windows Widget panel, but the picker should look less bad.
Having trouble taking screenshots of the picker to paste here.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1991
- [ ] Tests added/passed
- [ ] Documentation updated
