### PR TITLE
Localize missed strings

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -440,6 +440,18 @@
     <value>https://go.microsoft.com/fwlink/?linkid=2236981</value>
     <comment>This is the microsoft code of conduct link.</comment>
   </data>
+  <data name="Settings_Feedback_PhysicalMemory" xml:space="preserve">
+    <value>Physical Memory</value>
+    <comment>Label for displaying device's memory</comment>
+  </data>
+  <data name="Settings_Feedback_ProcessorArchitecture" xml:space="preserve">
+    <value>Processor Architecture</value>
+    <comment>Label for displaying device's processor architecture</comment>
+  </data>
+  <data name="Settings_Feedback_Extensions" xml:space="preserve">
+    <value>Extensions</value>
+    <comment>Label for displaying device's installed extensions</comment>
+  </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -285,6 +285,7 @@ public sealed partial class FeedbackPage : Page
     {
         SYSTEM_INFO sysInfo;
         PInvoke.GetSystemInfo(out sysInfo);
+        var stringResource = new StringResource("DevHome.Settings/Resources");
         return stringResource.GetLocalized("Settings_Feedback_ProcessorArchitecture") + ": " + DetermineArchitecture((int)sysInfo.Anonymous.Anonymous.wProcessorArchitecture);
     }
 
@@ -317,6 +318,7 @@ public sealed partial class FeedbackPage : Page
     {
         var extensionService = Application.Current.GetService<IExtensionService>();
         var extensions = extensionService.GetInstalledExtensionsAsync(true).Result;
+        var stringResource = new StringResource("DevHome.Settings/Resources");
         var extensionsStr = stringResource.GetLocalized("Settings_Feedback_Extensions") + ": \n";
         foreach (var extension in extensions)
         {

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -277,14 +277,15 @@ public sealed partial class FeedbackPage : Page
         var availMemKbToGb = Math.Round(memStatus.ullAvailPhys / ByteSizeGB, 2);
         var totalMemKbToGb = Math.Round(memStatus.ullTotalPhys / ByteSizeGB, 2);
 
-        return "Physical Memory: " + totalMemKbToGb.ToString(cultures) + "GB (" + availMemKbToGb.ToString(cultures) + "GB free)";
+        var stringResource = new StringResource("DevHome.Settings/Resources");
+        return stringResource.GetLocalized("Settings_Feedback_PhysicalMemory") + ": " + totalMemKbToGb.ToString(cultures) + "GB (" + availMemKbToGb.ToString(cultures) + "GB free)";
     }
 
     private string GetProcessorArchitecture()
     {
         SYSTEM_INFO sysInfo;
         PInvoke.GetSystemInfo(out sysInfo);
-        return "Processor Architecture: " + DetermineArchitecture((int)sysInfo.Anonymous.Anonymous.wProcessorArchitecture);
+        return stringResource.GetLocalized("Settings_Feedback_ProcessorArchitecture") + ": " + DetermineArchitecture((int)sysInfo.Anonymous.Anonymous.wProcessorArchitecture);
     }
 
     private string DetermineArchitecture(int value)
@@ -316,7 +317,7 @@ public sealed partial class FeedbackPage : Page
     {
         var extensionService = Application.Current.GetService<IExtensionService>();
         var extensions = extensionService.GetInstalledExtensionsAsync(true).Result;
-        var extensionsStr = "Extensions: \n";
+        var extensionsStr = stringResource.GetLocalized("Settings_Feedback_Extensions") + ": \n";
         foreach (var extension in extensions)
         {
             extensionsStr += extension.PackageFullName + "\n";

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -143,7 +143,7 @@
   </data>
   <data name="AppListBackupBanner.Description" xml:space="preserve">
     <value>Use Dev Home to quickly transfer your development machine settings from another PC to get back to coding.</value>
-    <comment>{Locked="Dev Home"}Description text of an instruction banner section for transferring settings from a developer machine</comment>
+    <comment>Description text of an instruction banner section for transferring settings from a developer machine</comment>
   </data>
   <data name="AppListBackupBanner.ButtonText" xml:space="preserve">
     <value>Get started</value>
@@ -259,7 +259,7 @@
   </data>
   <data name="DefaultBanner.Description" xml:space="preserve">
     <value>Find out how you can use Dev Home to quickly set up your development machine.</value>
-    <comment>{Locked="Dev Home"}Description text of an instruction banner section for setting up a development machine</comment>
+    <comment>Description text of an instruction banner section for setting up a development machine</comment>
   </data>
   <data name="DefaultBanner.ButtonText" xml:space="preserve">
     <value>Learn more</value>
@@ -1246,5 +1246,9 @@
   <data name="DevDriveWindowByteUnitComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Size Unit</value>
     <comment>Name for the combo box</comment>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Next</value>
+    <comment>Button to go to next screen</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
There are a few strings that were not getting localized.
1. Next button in Machine Configuration
2. "Dev Home" in Machine Configuration banner
3. "Physical Memory", "Processor Architecture", and "Extensions" in Feedback

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
