### PR TITLE
Move WidgetHost and WidgetCatalog call to their own tasks

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -50,7 +50,7 @@
                     FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{ThemeResource CaptionTextBlockFontSize}"
                     VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10,16,0" BorderThickness="0" Padding="5"
                     Background="Transparent"
-                    Click="OpenWidgetMenu">
+                    Click="OpenWidgetMenuAsync">
                 <Button.Flyout>
                     <MenuFlyout/>
                 </Button.Flyout>

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -14,7 +14,6 @@ using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.Widgets;
-using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Controls;
 
@@ -117,7 +116,7 @@ public sealed partial class WidgetControl : UserControl
 
     private void AddSizesToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
     {
-        var widgetDefinition = WidgetCatalog.GetDefault().GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
+        var widgetDefinition = Application.Current.GetService<IWidgetHostingService>().GetWidgetCatalog().GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
         var capabilities = widgetDefinition.GetWidgetCapabilities();
         var sizeMenuItems = new List<MenuFlyoutItem>();
 

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -118,7 +118,7 @@ public sealed partial class WidgetControl : UserControl
     private async Task AddSizesToWidgetMenuAsync(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
     {
         var widgetCatalog = await Application.Current.GetService<IWidgetHostingService>().GetWidgetCatalogAsync();
-        var widgetDefinition = widgetCatalog.GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
+        var widgetDefinition = await Task.Run(() => widgetCatalog.GetWidgetDefinition(widgetViewModel.Widget.DefinitionId));
         var capabilities = widgetDefinition.GetWidgetCapabilities();
         var sizeMenuItems = new List<MenuFlyoutItem>();
 

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using DevHome.Common.Extensions;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
@@ -46,7 +47,7 @@ public sealed partial class WidgetControl : UserControl
         ActualThemeChanged += OnActualThemeChanged;
     }
 
-    private void OpenWidgetMenu(object sender, RoutedEventArgs e)
+    private async void OpenWidgetMenuAsync(object sender, RoutedEventArgs e)
     {
         if (sender as Button is Button widgetMenuButton)
         {
@@ -59,7 +60,7 @@ public sealed partial class WidgetControl : UserControl
                 {
                     var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
 
-                    AddSizesToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
+                    await AddSizesToWidgetMenuAsync(widgetMenuFlyout, widgetViewModel, resourceLoader);
                     widgetMenuFlyout.Items.Add(new MenuFlyoutSeparator());
                     AddCustomizeToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
                     AddRemoveToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
@@ -114,9 +115,10 @@ public sealed partial class WidgetControl : UserControl
         }
     }
 
-    private void AddSizesToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
+    private async Task AddSizesToWidgetMenuAsync(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
     {
-        var widgetDefinition = Application.Current.GetService<IWidgetHostingService>().GetWidgetCatalog().GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
+        var widgetCatalog = await Application.Current.GetService<IWidgetHostingService>().GetWidgetCatalogAsync();
+        var widgetDefinition = widgetCatalog.GetWidgetDefinition(widgetViewModel.Widget.DefinitionId);
         var capabilities = widgetDefinition.GetWidgetCapabilities();
         var sizeMenuItems = new List<MenuFlyoutItem>();
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System.Threading.Tasks;
 using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
-    public WidgetHost GetWidgetHost();
+    public Task<WidgetHost> GetWidgetHostAsync();
 
-    public WidgetCatalog GetWidgetCatalog();
+    public Task<WidgetCatalog> GetWidgetCatalogAsync();
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Threading.Tasks;
 using DevHome.Dashboard.Helpers;
 using Microsoft.Windows.Widgets.Hosts;
 
@@ -16,13 +17,13 @@ public class WidgetHostingService : IWidgetHostingService
     {
     }
 
-    public WidgetHost GetWidgetHost()
+    public async Task<WidgetHost> GetWidgetHostAsync()
     {
         if (_widgetHost == null)
         {
             try
             {
-                _widgetHost = WidgetHost.Register(new WidgetHostContext("BAA93438-9B07-4554-AD09-7ACCD7D4F031"));
+                _widgetHost = await Task.Run(() => WidgetHost.Register(new WidgetHostContext("BAA93438-9B07-4554-AD09-7ACCD7D4F031")));
             }
             catch (Exception ex)
             {
@@ -33,13 +34,13 @@ public class WidgetHostingService : IWidgetHostingService
         return _widgetHost;
     }
 
-    public WidgetCatalog GetWidgetCatalog()
+    public async Task<WidgetCatalog> GetWidgetCatalogAsync()
     {
         if (_widgetCatalog == null)
         {
             try
             {
-                _widgetCatalog = WidgetCatalog.GetDefault();
+                _widgetCatalog = await Task.Run(() => WidgetCatalog.GetDefault());
             }
             catch (Exception ex)
             {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -38,7 +38,8 @@ public class WidgetIconService : IWidgetIconService
     public async Task CacheAllWidgetIconsAsync()
     {
         var cacheTasks = new List<Task>();
-        var widgetDefinitions = _widgetHostingService.GetWidgetCatalog()!.GetWidgetDefinitions();
+        var widgetCatalog = await _widgetHostingService.GetWidgetCatalogAsync();
+        var widgetDefinitions = widgetCatalog?.GetWidgetDefinitions();
         foreach (var widgetDef in widgetDefinitions ?? Array.Empty<WidgetDefinition>())
         {
             var task = AddIconsToCacheAsync(widgetDef);

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -39,7 +39,7 @@ public class WidgetIconService : IWidgetIconService
     {
         var cacheTasks = new List<Task>();
         var widgetCatalog = await _widgetHostingService.GetWidgetCatalogAsync();
-        var widgetDefinitions = widgetCatalog?.GetWidgetDefinitions();
+        var widgetDefinitions = await Task.Run(() => widgetCatalog?.GetWidgetDefinitions());
         foreach (var widgetDef in widgetDefinitions ?? Array.Empty<WidgetDefinition>())
         {
             var task = AddIconsToCacheAsync(widgetDef);

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -153,7 +153,7 @@ public partial class DashboardView : ToolPage
     {
         Log.Logger()?.ReportInfo("DashboardView", "Get widgets for current host");
         var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
-        var hostWidgets = widgetHost?.GetWidgets();
+        var hostWidgets = await Task.Run(() => widgetHost?.GetWidgets());
 
         if (hostWidgets == null)
         {
@@ -229,13 +229,14 @@ public partial class DashboardView : ToolPage
 
     private async Task DeleteAbandonedWidgetAsync(Widget widget, WidgetHost widgetHost)
     {
-        var length = widgetHost!.GetWidgets().Length;
+        var length = await Task.Run(() => widgetHost!.GetWidgets().Length);
         Log.Logger()?.ReportInfo("DashboardView", $"Found abandoned widget, try to delete it...");
         Log.Logger()?.ReportInfo("DashboardView", $"Before delete, {length} widgets for this host");
 
         await widget.DeleteAsync();
 
-        length = (widgetHost.GetWidgets() == null) ? 0 : widgetHost.GetWidgets().Length;
+        var newWidgetList = await Task.Run(() => widgetHost.GetWidgets());
+        length = (newWidgetList == null) ? 0 : newWidgetList.Length;
         Log.Logger()?.ReportInfo("DashboardView", $"After delete, {length} widgets for this host");
     }
 
@@ -308,7 +309,7 @@ public partial class DashboardView : ToolPage
 
             // Put new widget on the Dashboard.
             var widgetCatalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
-            var widgetDefinition = widgetCatalog?.GetWidgetDefinition(newWidget.DefinitionId);
+            var widgetDefinition = await Task.Run(() => widgetCatalog?.GetWidgetDefinition(newWidget.DefinitionId));
             if (widgetDefinition is not null)
             {
                 var size = WidgetHelpers.GetDefaultWidgetSize(widgetDefinition.GetWidgetCapabilities());
@@ -325,7 +326,7 @@ public partial class DashboardView : ToolPage
             var widgetDefinitionId = widget.DefinitionId;
             var widgetId = widget.Id;
             var widgetCatalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
-            var widgetDefinition = widgetCatalog?.GetWidgetDefinition(widgetDefinitionId);
+            var widgetDefinition = await Task.Run(() => widgetCatalog?.GetWidgetDefinition(widgetDefinitionId));
 
             if (widgetDefinition != null)
             {

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -70,17 +70,23 @@ public partial class DashboardView : ToolPage
 #endif
     }
 
-    private bool SubscribeToWidgetCatalogEvents()
+    private async Task<bool> SubscribeToWidgetCatalogEventsAsync()
     {
         Log.Logger()?.ReportInfo("DashboardView", "SubscribeToWidgetCatalogEvents");
 
         try
         {
-            ViewModel.WidgetHostingService.GetWidgetCatalog()!.WidgetProviderDefinitionAdded += WidgetCatalog_WidgetProviderDefinitionAdded;
-            ViewModel.WidgetHostingService.GetWidgetCatalog()!.WidgetProviderDefinitionDeleted += WidgetCatalog_WidgetProviderDefinitionDeleted;
-            ViewModel.WidgetHostingService.GetWidgetCatalog()!.WidgetDefinitionAdded += WidgetCatalog_WidgetDefinitionAdded;
-            ViewModel.WidgetHostingService.GetWidgetCatalog()!.WidgetDefinitionUpdated += WidgetCatalog_WidgetDefinitionUpdated;
-            ViewModel.WidgetHostingService.GetWidgetCatalog()!.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
+            var widgetCatalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
+            if (widgetCatalog == null)
+            {
+                return false;
+            }
+
+            widgetCatalog!.WidgetProviderDefinitionAdded += WidgetCatalog_WidgetProviderDefinitionAdded;
+            widgetCatalog!.WidgetProviderDefinitionDeleted += WidgetCatalog_WidgetProviderDefinitionDeleted;
+            widgetCatalog!.WidgetDefinitionAdded += WidgetCatalog_WidgetDefinitionAdded;
+            widgetCatalog!.WidgetDefinitionUpdated += WidgetCatalog_WidgetDefinitionUpdated;
+            widgetCatalog!.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
         }
         catch (Exception ex)
         {
@@ -108,14 +114,14 @@ public partial class DashboardView : ToolPage
         await InitializeDashboard();
     }
 
-    private bool EnsureHostingInitialized()
+    private async Task<bool> EnsureHostingInitializedAsync()
     {
         if (_widgetHostInitialized)
         {
             return _widgetHostInitialized;
         }
 
-        _widgetHostInitialized = ViewModel.EnsureWebExperiencePack() && ViewModel.WidgetHostingService.GetWidgetCatalog() != null && SubscribeToWidgetCatalogEvents();
+        _widgetHostInitialized = ViewModel.EnsureWebExperiencePack() && await SubscribeToWidgetCatalogEventsAsync();
 
         return _widgetHostInitialized;
     }
@@ -125,7 +131,7 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
         ViewModel.IsLoading = true;
 
-        if (EnsureHostingInitialized())
+        if (await EnsureHostingInitializedAsync())
         {
             // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
             await ViewModel.WidgetIconService.CacheAllWidgetIconsAsync();
@@ -146,7 +152,8 @@ public partial class DashboardView : ToolPage
     private async Task RestorePinnedWidgetsAsync()
     {
         Log.Logger()?.ReportInfo("DashboardView", "Get widgets for current host");
-        var hostWidgets = ViewModel.WidgetHostingService.GetWidgetHost()?.GetWidgets();
+        var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
+        var hostWidgets = widgetHost?.GetWidgets();
 
         if (hostWidgets == null)
         {
@@ -173,7 +180,7 @@ public partial class DashboardView : ToolPage
                 {
                     // If we have a widget with no state, Dev Home does not consider it a valid widget
                     // and should delete it, rather than letting it run invisibly in the background.
-                    await DeleteAbandonedWidgetAsync(widget);
+                    await DeleteAbandonedWidgetAsync(widget, widgetHost);
                     continue;
                 }
 
@@ -220,15 +227,15 @@ public partial class DashboardView : ToolPage
         }
     }
 
-    private async Task DeleteAbandonedWidgetAsync(Widget widget)
+    private async Task DeleteAbandonedWidgetAsync(Widget widget, WidgetHost widgetHost)
     {
-        var length = ViewModel.WidgetHostingService.GetWidgetHost()!.GetWidgets().Length;
+        var length = widgetHost!.GetWidgets().Length;
         Log.Logger()?.ReportInfo("DashboardView", $"Found abandoned widget, try to delete it...");
         Log.Logger()?.ReportInfo("DashboardView", $"Before delete, {length} widgets for this host");
 
         await widget.DeleteAsync();
 
-        length = ViewModel.WidgetHostingService.GetWidgetHost()!.GetWidgets().Length;
+        length = (widgetHost.GetWidgets() == null) ? 0 : widgetHost.GetWidgets().Length;
         Log.Logger()?.ReportInfo("DashboardView", $"After delete, {length} widgets for this host");
     }
 
@@ -300,10 +307,11 @@ public partial class DashboardView : ToolPage
             await newWidget.SetCustomStateAsync(newCustomState);
 
             // Put new widget on the Dashboard.
-            var widgetDef = ViewModel.WidgetHostingService.GetWidgetCatalog()!.GetWidgetDefinition(newWidget.DefinitionId);
-            if (widgetDef is not null)
+            var widgetCatalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
+            var widgetDefinition = widgetCatalog?.GetWidgetDefinition(newWidget.DefinitionId);
+            if (widgetDefinition is not null)
             {
-                var size = WidgetHelpers.GetDefaultWidgetSize(widgetDef.GetWidgetCapabilities());
+                var size = WidgetHelpers.GetDefaultWidgetSize(widgetDefinition.GetWidgetCapabilities());
                 await newWidget.SetSizeAsync(size);
                 await InsertWidgetInPinnedWidgetsAsync(newWidget, size, position);
             }
@@ -316,7 +324,8 @@ public partial class DashboardView : ToolPage
         {
             var widgetDefinitionId = widget.DefinitionId;
             var widgetId = widget.Id;
-            var widgetDefinition = ViewModel.WidgetHostingService.GetWidgetCatalog()!.GetWidgetDefinition(widgetDefinitionId);
+            var widgetCatalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
+            var widgetDefinition = widgetCatalog?.GetWidgetDefinition(widgetDefinitionId);
 
             if (widgetDefinition != null)
             {


### PR DESCRIPTION
## Summary of the pull request
Dev Home currently sees many crashes due to Xaml reentrancy. These are at least partially caused by the COM calls to the widget DLLs from the Dashboard. The reentrancy can be prevented by moving these calls to a clean stack. This PR specifically takes the calls out to the WidgetHost and WidgetCatalog COM objects and moves them onto a clean stack by wrapping them in Task.Run(). Calls to Widget and other widget objects will be moved in a separate PR.

A note about this mitigation strategy is that if the COM object being used is single-threaded, that background task will just end up proxying back to the UI thread and wait for the call to finish there. That's fine from a functionality perspective but could have slightly different performance.

## References and relevant issues
http://task.ms/44969531

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
