### PR TITLE
Save RenderedAdaptiveCard to Panel

### DIFF
--- a/common/Models/ExtensionAdaptiveCard.cs
+++ b/common/Models/ExtensionAdaptiveCard.cs
@@ -44,10 +44,7 @@ public class ExtensionAdaptiveCard : IExtensionAdaptiveCard
         DataJson = dataJson ?? DataJson;
         State = state ?? State;
 
-        if (UiUpdate is not null)
-        {
-            UiUpdate.Invoke(this, parseResult.AdaptiveCard);
-        }
+        UiUpdate?.Invoke(this, parseResult.AdaptiveCard);
 
         return new ProviderOperationResult(ProviderOperationStatus.Success, null, "IExtensionAdaptiveCard.Update succeeds", "IExtensionAdaptiveCard.Update succeeds");
     }

--- a/common/Views/ExtensionAdaptiveCardPanel.cs
+++ b/common/Views/ExtensionAdaptiveCardPanel.cs
@@ -20,6 +20,13 @@ public class ExtensionAdaptiveCardPanel : StackPanel
 {
     public event EventHandler<FrameworkElement>? UiUpdate;
 
+    // The rendered adaptive card is stored here so that it does not go out of scope.
+    // There should only be one rendered adaptive card at a time for one ExtensionAdaptiveCardPanel.
+    public RenderedAdaptiveCard? RenderedAdaptiveCard
+    {
+        get; set;
+    }
+
     public void Bind(IExtensionAdaptiveCardSession extensionAdaptiveCardSession, AdaptiveCardRenderer? customRenderer)
     {
         var adaptiveCardRenderer = customRenderer ?? new AdaptiveCardRenderer();
@@ -49,6 +56,8 @@ public class ExtensionAdaptiveCardPanel : StackPanel
                 {
                     this.UiUpdate.Invoke(this, renderedAdaptiveCard.FrameworkElement);
                 }
+
+                RenderedAdaptiveCard = renderedAdaptiveCard;
             });
         };
 

--- a/common/Views/ExtensionAdaptiveCardPanel.cs
+++ b/common/Views/ExtensionAdaptiveCardPanel.cs
@@ -42,7 +42,7 @@ public class ExtensionAdaptiveCardPanel : StackPanel
                 _renderedAdaptiveCard = adaptiveCardRenderer.RenderAdaptiveCard(adaptiveCard);
                 _renderedAdaptiveCard.Action += async (RenderedAdaptiveCard? sender, AdaptiveActionEventArgs args) =>
                 {
-                    GlobalLog.Logger?.ReportInfo($"RenderedAdaptiveCard.Action(): Called for {args.Action.Title}");
+                    GlobalLog.Logger?.ReportInfo($"RenderedAdaptiveCard.Action(): Called for {args.Action.Id}");
                     await extensionAdaptiveCardSession.OnAction(args.Action.ToJson().Stringify(), args.Inputs.AsJson().Stringify());
                 };
 


### PR DESCRIPTION
## Summary of the pull request
"Missing button action on click" problem which occurs sporadically might be due to the parent object going out of scope and getting GC'd. We can save the RenderedAdaptiveCard object to avoid this.

## References and relevant issues
https://github.com/microsoft/devhomegithubextension/issues/108

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually ran the button action several times. 

## PR checklist
- [ ] Closes https://github.com/microsoft/devhomegithubextension/issues/108
- [ ] Tests added/passed
- [ ] Documentation updated
