### PR TITLE
Update app install package card height

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/PackageDetailsTooltip.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/PackageDetailsTooltip.xaml
@@ -12,6 +12,7 @@
     <ToolTip.Resources>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondary}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
     </ToolTip.Resources>
     <StackPanel>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogView.xaml
@@ -33,16 +33,14 @@
             <ItemsRepeater.Layout>
                 <UniformGridLayout
                     Orientation="Horizontal"
-                    MinItemWidth="190"
                     MaximumRowsOrColumns="3"
                     MinRowSpacing="4"
                     MinColumnSpacing="4"
-                    MinItemHeight="140"
                     ItemsStretch="Fill" />
             </ItemsRepeater.Layout>
             <ItemsRepeater.ItemTemplate>
                 <DataTemplate x:DataType="viewmodels:PackageViewModel">
-                    <views:PackageView Height="140" />
+                    <views:PackageView MinHeight="140" />
                 </DataTemplate>
             </ItemsRepeater.ItemTemplate>
         </ItemsRepeater>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ShimmerPackageCatalogView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ShimmerPackageCatalogView.xaml
@@ -16,16 +16,14 @@
             <ItemsRepeater.Layout>
                 <UniformGridLayout
                     Orientation="Horizontal"
-                    MinItemWidth="190"
                     MaximumRowsOrColumns="3"
                     MinRowSpacing="4"
                     MinColumnSpacing="4"
-                    MinItemHeight="140"
                     ItemsStretch="Fill" />
             </ItemsRepeater.Layout>
             <ItemsRepeater.ItemTemplate>
                 <DataTemplate>
-                    <labs:Shimmer Height="140" />
+                    <labs:Shimmer MinHeight="140" />
                 </DataTemplate>
             </ItemsRepeater.ItemTemplate>
         </ItemsRepeater>


### PR DESCRIPTION
## Summary of the pull request
Removed the fixed height constraint on the app install package card allowing the package title to be displayed in text-size=200%

## References and relevant issues
- https://task.ms/46726939

## Detailed description of the pull request / Additional comments

## Validation steps performed
### Text size 100%
<img src="https://github.com/microsoft/devhome/assets/104940545/c574a482-73b3-4bbd-95c8-c3be44282f02" width="500" />

### Text size 200%
<img src="https://github.com/microsoft/devhome/assets/104940545/9c8856f7-22ab-450f-a393-6339fe5dd486" width="500" />

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
