### PR TITLE
Include Widget Service info in bug reports

### DIFF
--- a/common/Services/IPackageDeploymentService.cs
+++ b/common/Services/IPackageDeploymentService.cs
@@ -26,6 +26,7 @@ public interface IPackageDeploymentService
     /// <summary>
     /// Find packages for the current user. If maxVersion is specified, package versions must be
     /// between minVersion and maxVersion. If maxVersion is null, packages must be above minVersion.
+    /// If no minVersion is specified, returns packages of any version.
     /// </summary>
     /// <returns>An IEnumerable containing the installed packages that meet the version criteria.</returns>
     public IEnumerable<Package> FindPackagesForCurrentUser(string packageFamilyName, params (Version minVersion, Version? maxVersion)[] ranges);

--- a/common/Services/PackageDeploymentService.cs
+++ b/common/Services/PackageDeploymentService.cs
@@ -47,11 +47,13 @@ public class PackageDeploymentService : IPackageDeploymentService
                 var version = package.Id.Version;
                 var major = version.Major;
                 var minor = version.Minor;
+                var build = version.Build;
+                var revision = version.Revision;
 
                 Log.Logger()?.ReportInfo("PackageDeploymentService", $"Found package {package.Id.FullName}");
 
                 // Create System.Version type from PackageVersion to test. System.Version supports CompareTo() for easy comparisons.
-                if (IsVersionSupported(new (major, minor), ranges))
+                if (IsVersionSupported(new (major, minor, build, revision), ranges))
                 {
                     versionedPackages.Add(package);
                 }
@@ -79,6 +81,12 @@ public class PackageDeploymentService : IPackageDeploymentService
 
     private bool IsVersionSupported(Version target, params (Version minVersion, Version? maxVersion)[] ranges)
     {
+        // If a min version wasn't specified, any version is fine.
+        if (ranges.Length == 0)
+        {
+            return true;
+        }
+
         foreach (var (minVersion, maxVersion) in ranges)
         {
             if (maxVersion == null)

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -268,8 +268,8 @@
     <comment>Opt into including experimentation information into your issue template</comment>
   </data>
   <data name="Settings_Feedback_ReportBug_IncludeExtensions.Content" xml:space="preserve">
-    <value>Include installed Dev Home extensions</value>
-    <comment>Opt into including information on extensions into your issue template</comment>
+    <value>Include installed Dev Home extensions and related packages</value>
+    <comment>Opt into including information on extensions and related packages into your issue template</comment>
   </data>
   <data name="Settings_Feedback_ReportBug_IncludeSystemInfo.Content" xml:space="preserve">
     <value>Include my system information</value>
@@ -451,6 +451,10 @@
   <data name="Settings_Feedback_Extensions" xml:space="preserve">
     <value>Extensions</value>
     <comment>Label for displaying device's installed extensions</comment>
+  </data>
+  <data name="Settings_Feedback_WidgetService" xml:space="preserve">
+    <value>Widget Service</value>
+    <comment>Label for displaying device's installed widget service</comment>
   </data>
   <data name="Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText" xml:space="preserve">
     <value>Cancel</value>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -56,6 +56,7 @@
                                     <Expander.Content>
                                         <StackPanel>
                                             <TextBlock x:Name="ReportBugIncludeExtensionsList" />
+                                            <TextBlock x:Name="WidgetServiceInfo"/>
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -136,7 +136,7 @@ public sealed partial class FeedbackPage : Page
             var extensionsInfo = string.Empty;
             if (ReportBugIncludeExtensions.IsChecked.GetValueOrDefault())
             {
-                extensionsInfo = HttpUtility.UrlEncode(GetExtensions());
+                extensionsInfo = HttpUtility.UrlEncode(GetExtensions() + "\n" + GetWidgetService());
             }
 
             var otherSoftwareText = "OS Build Version: " + GetOSVersion() + "\n.NET Version: " + GetDotNetVersion();
@@ -196,6 +196,7 @@ public sealed partial class FeedbackPage : Page
     private void ShowExtensionsInfoExpander_Expanding(Expander sender, ExpanderExpandingEventArgs args)
     {
         ReportBugIncludeExtensionsList.Text = GetExtensions();
+        WidgetServiceInfo.Text = GetWidgetService();
     }
 
     private async void Reload()
@@ -326,6 +327,30 @@ public sealed partial class FeedbackPage : Page
         }
 
         return extensionsStr;
+    }
+
+    private string GetWidgetService()
+    {
+        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var widgetServiceString = stringResource.GetLocalized("Settings_Feedback_WidgetService") + ": \n";
+        var packageDeploymentService = Application.Current.GetService<IPackageDeploymentService>();
+
+        // Only one package is expected in total from these two queries, but print anything just in case.
+        const string webExperienceFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
+        var webPackages = packageDeploymentService.FindPackagesForCurrentUser(webExperienceFamilyName);
+        foreach (var package in webPackages)
+        {
+            widgetServiceString += package.Id.FullName + "\n";
+        }
+
+        const string widgetServiceFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
+        var widgetPackages = packageDeploymentService.FindPackagesForCurrentUser(widgetServiceFamilyName);
+        foreach (var package in widgetPackages)
+        {
+            widgetServiceString += package.Id.FullName + "\n";
+        }
+
+        return widgetServiceString;
     }
 
     private async void BuildExtensionButtonClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request
Includes either package that could contain the widget service in bug reports.

Also, makes an enhancement and a fix in how we compare versions in the `PackageDeploymentService`:
- Enhancement: if the user does not specify a min version, `FindPackagesForCurrentUser()` will now return all versions (rather than none)
- Fix: `FindPackagesForCurrentUser()` can now appropriately compare versions where Build and Release numbers are specified. Before this change, version comparison only worked when major and minor numbers where specified.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
