### PR TITLE
Move HasValidWebExperiencePack from DashboardViewModel to WidgetHostingService

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -8,6 +8,8 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
+    public bool HasValidWebExperiencePack();
+
     public Task<WidgetHost> GetWidgetHostAsync();
 
     public Task<WidgetCatalog> GetWidgetCatalogAsync();

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using DevHome.Common.Services;
 using DevHome.Dashboard.Helpers;
 using Microsoft.Windows.Widgets.Hosts;
 
@@ -10,11 +12,29 @@ namespace DevHome.Dashboard.Services;
 
 public class WidgetHostingService : IWidgetHostingService
 {
+    private readonly IPackageDeploymentService _packageDeploymentService;
+
     private WidgetHost _widgetHost;
     private WidgetCatalog _widgetCatalog;
 
-    public WidgetHostingService()
+    public WidgetHostingService(IPackageDeploymentService packageDeploymentService)
     {
+        _packageDeploymentService = packageDeploymentService;
+    }
+
+    public bool HasValidWebExperiencePack()
+    {
+        var minSupportedVersion400 = new Version(423, 3800);
+        var minSupportedVersion500 = new Version(523, 3300);
+        var version500 = new Version(500, 0);
+
+        // Ensure the application is installed, and the version is high enough.
+        const string packageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(
+            packageFamilyName,
+            (minSupportedVersion400, version500),
+            (minSupportedVersion500, null));
+        return packages.Any();
     }
 
     public async Task<WidgetHost> GetWidgetHostAsync()

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
-using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
-using DevHome.Common.Services;
 using DevHome.Dashboard.Services;
 using Microsoft.UI.Xaml;
 
@@ -16,19 +13,15 @@ public partial class DashboardViewModel : ObservableObject
 
     public IWidgetIconService WidgetIconService { get; }
 
-    private readonly IPackageDeploymentService _packageDeploymentService;
-
     private bool _validatedWebExpPack;
 
     [ObservableProperty]
     private bool _isLoading;
 
     public DashboardViewModel(
-        IPackageDeploymentService packageDeploymentService,
         IWidgetHostingService widgetHostingService,
         IWidgetIconService widgetIconService)
     {
-        _packageDeploymentService = packageDeploymentService;
         WidgetIconService = widgetIconService;
         WidgetHostingService = widgetHostingService;
     }
@@ -41,17 +34,7 @@ public partial class DashboardViewModel : ObservableObject
             return true;
         }
 
-        var minSupportedVersion400 = new Version(423, 3800);
-        var minSupportedVersion500 = new Version(523, 3300);
-        var version500 = new Version(500, 0);
-
-        // Ensure the application is installed, and the version is high enough.
-        const string packageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
-        var packages = _packageDeploymentService.FindPackagesForCurrentUser(
-            packageFamilyName,
-            (minSupportedVersion400, version500),
-            (minSupportedVersion500, null));
-        _validatedWebExpPack = packages.Any();
+        _validatedWebExpPack = WidgetHostingService.HasValidWebExperiencePack();
         return _validatedWebExpPack;
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -13,8 +13,6 @@
     xmlns:views="using:DevHome.Dashboard.Views"
     xmlns:controls="using:DevHome.Dashboard.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
@@ -45,13 +43,7 @@
         <Grid Grid.Row="0" Margin="0,0,0,22">
             <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="Click">
-                            <ic:InvokeCommandAction Command="{x:Bind AddWidgetClickCommand}"/>
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </Button>
+                <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right" Command="{x:Bind AddWidgetClickCommand}" />
             </StackPanel>
         </Grid>
 
@@ -109,13 +101,7 @@
                 <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0"
                             Visibility="{x:Bind ViewModel.GetNoWidgetMessageVisibility(views:DashboardView.PinnedWidgets.Count, ViewModel.IsLoading), Mode=OneWay}">
                     <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
-                    <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center">
-                        <i:Interaction.Behaviors>
-                            <ic:EventTriggerBehavior EventName="Click">
-                                <ic:InvokeCommandAction Command="{x:Bind AddWidgetClickCommand}"/>
-                            </ic:EventTriggerBehavior>
-                        </i:Interaction.Behaviors>
-                    </HyperlinkButton>
+                    <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center" Command="{x:Bind AddWidgetClickCommand}" />
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
## Summary of the pull request
Moves and simplifies some code in preparation for more changes going on top.
- Moves the `HasValidWebExperiencePack()` method from the DashboardViewModel to the more appropriate WidgetHostingService.
- Simplifies Commands in the DashboardView. Since both objects with Commands are Buttons, we can place the command directly on the button.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
