### PR TITLE
Install Windows 10 widget service

### DIFF
--- a/common/Helpers/RuntimeHelper.cs
+++ b/common/Helpers/RuntimeHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using System;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 
@@ -15,6 +16,15 @@ public static class RuntimeHelper
             uint length = 0;
 
             return PInvoke.GetCurrentPackageFullName(ref length, null) != WIN32_ERROR.APPMODEL_ERROR_NO_PACKAGE;
+        }
+    }
+
+    public static bool RunningOnWindows11
+    {
+        get
+        {
+            var version = Environment.OSVersion.Version;
+            return version.Major >= 10 && version.Build >= 22000;
         }
     }
 }

--- a/common/Helpers/RuntimeHelper.cs
+++ b/common/Helpers/RuntimeHelper.cs
@@ -19,7 +19,7 @@ public static class RuntimeHelper
         }
     }
 
-    public static bool RunningOnWindows11
+    public static bool IsOnWindows11
     {
         get
         {

--- a/src/Services/ActivationService.cs
+++ b/src/Services/ActivationService.cs
@@ -41,7 +41,7 @@ public class ActivationService : IActivationService
             // We can skip the initialization page if it's not our first run and we're on Windows 11.
             // If we're on Windows 10, we need to go to the initialization page to install the WidgetService if we don't have it already.
             var skipInitialization = await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstRun)
-                && RuntimeHelper.RunningOnWindows11;
+                && RuntimeHelper.IsOnWindows11;
 
             // Set the MainWindow Content.
             App.MainWindow.Content = skipInitialization

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -3,25 +3,36 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
-using DevHome.Common.Services;
 using DevHome.Contracts.Services;
+using DevHome.Dashboard.Services;
+using DevHome.Logging;
 using DevHome.Views;
 using Microsoft.UI.Xaml;
 
 namespace DevHome.ViewModels;
+
 public class InitializationViewModel : ObservableObject
 {
     private readonly IThemeSelectorService _themeSelector;
-    private readonly IExtensionService _extensionService;
+    private readonly IWidgetHostingService _widgetHostingService;
 
-    public InitializationViewModel(IThemeSelectorService themeSelector, IExtensionService extensionService)
+    public InitializationViewModel(IThemeSelectorService themeSelector, IWidgetHostingService widgetHostingService)
     {
         _themeSelector = themeSelector;
-        _extensionService = extensionService;
+        _widgetHostingService = widgetHostingService;
     }
 
-    public void OnPageLoaded()
+    public async void OnPageLoaded()
     {
+        try
+        {
+            await _widgetHostingService.EnsureWidgetServiceAsync();
+        }
+        catch (Exception ex)
+        {
+            GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Installing WidgetService failed: ", ex);
+        }
+
         App.MainWindow.Content = Application.Current.GetService<ShellPage>();
 
         _themeSelector.SetRequestedTheme();

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.230907" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -3,12 +3,15 @@
 
 using System.Threading.Tasks;
 using Microsoft.Windows.Widgets.Hosts;
+using static DevHome.Dashboard.Services.WidgetHostingService;
 
 namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
-    public bool HasValidWebExperiencePack();
+    public Task<bool> EnsureWidgetServiceAsync();
+
+    public WidgetServiceStates GetWidgetServiceState();
 
     public Task<WidgetHost> GetWidgetHostAsync();
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -17,7 +17,7 @@ public class WidgetHostingService : IWidgetHostingService
     private readonly IPackageDeploymentService _packageDeploymentService;
 
     private static readonly string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
-    private const int StoreInstallTimeout = 60_000;
+    private static readonly TimeSpan StoreInstallTimeout = new (0, 0, 60);
 
     private WidgetHost _widgetHost;
     private WidgetCatalog _widgetCatalog;
@@ -43,7 +43,7 @@ public class WidgetHostingService : IWidgetHostingService
     public async Task<bool> EnsureWidgetServiceAsync()
     {
         // If we're on Windows 11, check if we have the right WebExperiencePack version of the WidgetService.
-        if (RuntimeHelper.RunningOnWindows11)
+        if (RuntimeHelper.IsOnWindows11)
         {
             if (HasValidWebExperiencePack())
             {
@@ -117,7 +117,7 @@ public class WidgetHostingService : IWidgetHostingService
         {
             var installTask = InstallWidgetServicePackageAsync(WidgetServiceStorePackageId);
 
-            // Wait for a maximum of StoreInstallTimeout milliseconds.
+            // Wait for a maximum of StoreInstallTimeout (60 seconds).
             var completedTask = await Task.WhenAny(installTask, Task.Delay(StoreInstallTimeout));
 
             if (completedTask.Exception != null)

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -130,6 +130,18 @@
     <value>+ Add new widget</value>
     <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't added any widgets.</comment>
   </data>
+  <data name="RestartDevHomeMessage.Text" xml:space="preserve">
+    <value>We're having trouble displaying widgets. Restarting Dev Home may help.</value>
+    <comment>Message shown when there's no widget service and the user should restart Dev Home.</comment>
+  </data>
+  <data name="UpdateWidgetsMessage.Text" xml:space="preserve">
+    <value>You do not have the required version of the Windows Web Experience Pack to display widgets. Please ensure you have the latest version installed and then restart Dev Home.</value>
+    <comment>Message shown when no widgets have been added to the Dashboard</comment>
+  </data>
+  <data name="UpdateWidgetsMessageLink.Content" xml:space="preserve">
+    <value>Get in Store app</value>
+    <comment>Button text to go to store listing</comment>
+  </data>
   <data name="WidgetErrorCardDisplayText" xml:space="preserve">
     <value>This widget could not be displayed</value>
     <comment>Message shown in the widget if the widget was given bad data and can't be rendered.</comment>

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -13,10 +13,11 @@ public partial class DashboardViewModel : ObservableObject
 
     public IWidgetIconService WidgetIconService { get; }
 
-    private bool _validatedWebExpPack;
-
     [ObservableProperty]
     private bool _isLoading;
+
+    [ObservableProperty]
+    private bool _hasWidgetService;
 
     public DashboardViewModel(
         IWidgetHostingService widgetHostingService,
@@ -26,21 +27,9 @@ public partial class DashboardViewModel : ObservableObject
         WidgetHostingService = widgetHostingService;
     }
 
-    public bool EnsureWebExperiencePack()
-    {
-        // If already validated there's a good version, don't check again.
-        if (_validatedWebExpPack)
-        {
-            return true;
-        }
-
-        _validatedWebExpPack = WidgetHostingService.HasValidWebExperiencePack();
-        return _validatedWebExpPack;
-    }
-
     public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)
     {
-        if (widgetCount == 0 && !isLoading)
+        if (widgetCount == 0 && !isLoading && HasWidgetService)
         {
             return Visibility.Visible;
         }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -43,7 +43,11 @@
         <Grid Grid.Row="0" Margin="0,0,0,22">
             <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button x:Name="AddWidgetButton" x:Uid="AddWidget" HorizontalAlignment="Right" Command="{x:Bind AddWidgetClickCommand}" />
+                <Button x:Name="AddWidgetButton"
+                        x:Uid="AddWidget"
+                        HorizontalAlignment="Right"
+                        Command="{x:Bind AddWidgetClickCommand}"
+                        IsEnabled="{x:Bind ViewModel.HasWidgetService, Mode=OneWay}"/>
             </StackPanel>
         </Grid>
 
@@ -102,6 +106,18 @@
                             Visibility="{x:Bind ViewModel.GetNoWidgetMessageVisibility(views:DashboardView.PinnedWidgets.Count, ViewModel.IsLoading), Mode=OneWay}">
                     <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
                     <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center" Command="{x:Bind AddWidgetClickCommand}" />
+                </StackPanel>
+
+                <!-- Widget messages -->
+                <StackPanel x:Name="RestartDevHomeMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                    <TextBlock x:Uid="RestartDevHomeMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
+                </StackPanel>
+                <StackPanel x:Name="UpdateWidgetsMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                    <TextBlock x:Uid="UpdateWidgetsMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
+                    <HyperlinkButton x:Name="UpdateWidgetsMessageLink"
+                                     x:Uid="UpdateWidgetsMessageLink"
+                                     HorizontalAlignment="Center"
+                                     Command="{x:Bind GoToWidgetsInStoreCommand}" />
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -130,7 +130,7 @@ public partial class DashboardView : ToolPage
         else
         {
             var widgetServiceState = ViewModel.WidgetHostingService.GetWidgetServiceState();
-            if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasNoStoreWidgetService)
+            if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
             {
                 // Show error message that restarting Dev Home may help
                 RestartDevHomeMessageStackPanel.Visibility = Visibility.Visible;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -45,8 +45,6 @@ public partial class DashboardView : ToolPage
 
     private static Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
 
-    private static bool _widgetHostInitialized;
-
     private const string DraggedWidget = "DraggedWidget";
     private const string DraggedIndex = "DraggedIndex";
 
@@ -114,25 +112,16 @@ public partial class DashboardView : ToolPage
         await InitializeDashboard();
     }
 
-    private async Task<bool> EnsureHostingInitializedAsync()
-    {
-        if (_widgetHostInitialized)
-        {
-            return _widgetHostInitialized;
-        }
-
-        _widgetHostInitialized = ViewModel.EnsureWebExperiencePack() && await SubscribeToWidgetCatalogEventsAsync();
-
-        return _widgetHostInitialized;
-    }
-
-    private async Task<bool> InitializeDashboard()
+    private async Task InitializeDashboard()
     {
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
         ViewModel.IsLoading = true;
 
-        if (await EnsureHostingInitializedAsync())
+        if (await ViewModel.WidgetHostingService.EnsureWidgetServiceAsync())
         {
+            ViewModel.HasWidgetService = true;
+            await SubscribeToWidgetCatalogEventsAsync();
+
             // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
             await ViewModel.WidgetIconService.CacheAllWidgetIconsAsync();
 
@@ -140,13 +129,26 @@ public partial class DashboardView : ToolPage
         }
         else
         {
-            Log.Logger()?.ReportWarn("DashboardView", $"Initialization failed");
+            var widgetServiceState = ViewModel.WidgetHostingService.GetWidgetServiceState();
+            if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasNoStoreWidgetService)
+            {
+                // Show error message that restarting Dev Home may help
+                RestartDevHomeMessageStackPanel.Visibility = Visibility.Visible;
+            }
+            else if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasWebExperienceNoOrBadVersion)
+            {
+                // Show error message that updating may help
+                UpdateWidgetsMessageStackPanel.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                Log.Logger()?.ReportError("DashboardView", $"Initialization failed, WidgetServiceState unknown");
+                RestartDevHomeMessageStackPanel.Visibility = Visibility.Visible;
+            }
         }
 
         LoadingWidgetsProgressRing.Visibility = Visibility.Collapsed;
         ViewModel.IsLoading = false;
-
-        return _widgetHostInitialized;
     }
 
     private async Task RestorePinnedWidgetsAsync()
@@ -249,35 +251,14 @@ public partial class DashboardView : ToolPage
     }
 
     [RelayCommand]
+    public async Task GoToWidgetsInStoreAsync()
+    {
+        await Launcher.LaunchUriAsync(new ("ms-windows-store://pdp/?productid=9MSSGKG348SP"));
+    }
+
+    [RelayCommand]
     public async Task AddWidgetClickAsync()
     {
-        // If this is the first time we're initializing the Dashboard, or if initialization failed last time, initialize now.
-        if (!_widgetHostInitialized)
-        {
-            var initialized = await InitializeDashboard();
-            if (!initialized)
-            {
-                var resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
-
-                var errorDialog = new ContentDialog()
-                {
-                    XamlRoot = this.XamlRoot,
-                    RequestedTheme = this.ActualTheme,
-                    Content = resourceLoader.GetString("UpdateWebExpContent"),
-                    CloseButtonText = resourceLoader.GetString("UpdateWebExpCancel"),
-                    PrimaryButtonText = resourceLoader.GetString("UpdateWebExpUpdate"),
-                    PrimaryButtonStyle = Application.Current.Resources["AccentButtonStyle"] as Style,
-                };
-                errorDialog.PrimaryButtonClick += async (ContentDialog sender, ContentDialogButtonClickEventArgs args) =>
-                {
-                    await Launcher.LaunchUriAsync(new ("ms-windows-store://pdp/?productid=9MSSGKG348SP"));
-                    sender.Hide();
-                };
-                _ = await errorDialog.ShowAsync();
-                return;
-            }
-        }
-
         var dialog = new AddWidgetDialog(_dispatcher, ActualTheme)
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.


### PR DESCRIPTION
## Summary of the pull request
Meant to go in after #2042

On startup, checks if we're on Windows 10, and if so, checks if we have the WidgetService package from the store. If not, tries to install it. This is done during the "getting things ready for you" screen.

If we're still on Windows 11, doesn't install the store package. We check the state of the Windows Web Experience Pack when we go to the Dashboard.

If we have a valid widget service, we continue on with rendering the Dashboard. If not, we show an error message. If either service is installed or updated after we already decided we aren't showing the Dashboard, we require the user to restart. The previous way we would try to re-initialize the widget service on the fly was complicated, and would have been made even more so by introducing the second possible service. Let's go with requiring a restart for now, but when we move to one possible widget service, we can revisit this.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
