### PR TITLE
Move 'Feedback' row lower on the Settings page

### DIFF
--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -55,8 +55,8 @@ public partial class SettingsViewModel : ObservableObject
             new Setting("Accounts", string.Empty, stringResource.GetLocalized("Settings_Accounts_Header"), stringResource.GetLocalized("Settings_Accounts_Description"), "\ue77b", false, false),
             new Setting("Extensions", string.Empty, stringResource.GetLocalized("Settings_Extensions_Header"), stringResource.GetLocalized("Settings_Extensions_Description"), "\ued35", false, false),
             new Setting("About", string.Empty, stringResource.GetLocalized("Settings_About_Header"), stringResource.GetLocalized("Settings_About_Description"), "\ue946", false, false),
-            new Setting("Feedback", string.Empty, stringResource.GetLocalized("Settings_Feedback_Header"), stringResource.GetLocalized("Settings_Feedback_Description"), "\ued15", false, false),
             new Setting("ExperimentalFeatures", string.Empty, stringResource.GetLocalized("Settings_ExperimentalFeatures_Header"), stringResource.GetLocalized("Settings_ExperimentalFeatures_Description"), "\ue74c", false, false),
+            new Setting("Feedback", string.Empty, stringResource.GetLocalized("Settings_Feedback_Header"), stringResource.GetLocalized("Settings_Feedback_Description"), "\ued15", false, false),
         };
 
         foreach (var setting in settings)


### PR DESCRIPTION
## Summary of the pull request
Request was made and agreed upon for the "Feedback" row to be moved to the bottom of the Settings view. This simple PR makes that change. 

## References and relevant issues
#1956 

## Detailed description of the pull request / Additional comments
The SettingsViewModel class that populates that view has an array of Setting objects. I moved the "Feedback" Setting object to the end of the array which renders it last. 

## Validation steps performed
Manually verified UI renders the "Feedback" row last.
![image](https://github.com/microsoft/devhome/assets/27697448/bbd3a184-cfb1-4aad-b58e-2604af60748c)


## PR checklist
- [x] Closes #1956 
- [ ] Tests added/passed
- [ ] Documentation updated
