### PR TITLE
Update bot rules for no recent activity

### DIFF
--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -7,44 +7,6 @@ disabled: false
 where: 
 configuration:
   resourceManagementConfiguration:
-    scheduledSearches:
-    #
-    # close issue after no author feedback for no recent activity
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 3
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: Needs-Author-Feedback
-      - hasLabel:
-          label: No-Recent-Activity
-      - noActivitySince:
-          days: 3
-      actions:
-      - closeIssue
-    #
-    # add no-recent-activity label 4 days after requesting author feedback
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 3
-      filters:
-      - isIssue
-      - isOpen
-      - hasLabel:
-          label: Needs-Author-Feedback
-      - noActivitySince:
-          days: 4
-      - isNotLabeledWith:
-          label: No-Recent-Activity
-      actions:
-      - addLabel:
-          label: No-Recent-Activity
-      - addReply:
-          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
     eventResponderTasks:
     #
     # /feedbackHub

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -7,6 +7,44 @@ disabled: false
 where: 
 configuration:
   resourceManagementConfiguration:
+    scheduledSearches:
+    #
+    # close issue after no author feedback for no recent activity
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 3
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - hasLabel:
+          label: No-Recent-Activity
+      - noActivitySince:
+          days: 3
+      actions:
+      - closeIssue
+    #
+    # add no-recent-activity label 4 days after requesting author feedback
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 3
+      filters:
+      - isIssue
+      - isOpen
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - noActivitySince:
+          days: 4
+      - isNotLabeledWith:
+          label: No-Recent-Activity
+      actions:
+      - addLabel:
+          label: No-Recent-Activity
+      - addReply:
+          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
     eventResponderTasks:
     #
     # /feedbackHub

--- a/.github/policies/scheduledSearch.closeNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.closeNoRecentActivity.yml
@@ -13,7 +13,6 @@ configuration:
           * Issue is Open
           * Issue has the label Needs-Author-Feedback
           * Issue has the label Status-No recent activity
-          * Issue does not have the label Issue-Feature
           * Has not had activity in the last 5 days
           Then -
           * Close the Issue
@@ -27,8 +26,6 @@ configuration:
           label: Needs-Author-Feedback
       - hasLabel:
           label: Status-No recent activity
-      - isNotLabeledWith:
-          label: Issue-Feature
       - noActivitySince:
           days: 5
       actions:

--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -13,7 +13,6 @@ configuration:
           * Issue is Open
           * Issue has the label Needs-Author-Feedback
           * Issue does not have the label Status-No recent activity
-          * Issue does not have the label Issue-Feature
           * Has not had activity in the last 5 days
           Then -
           * Mark the issue as Status-No recent activity
@@ -29,8 +28,6 @@ configuration:
           days: 5
       - isNotLabeledWith:
           label: Status-No recent activity
-      - isNotLabeledWith:
-          label: Issue-Feature
       actions:
       - addLabel:
           label: Status-No recent activity


### PR DESCRIPTION
## Summary of the pull request
Noticed that the "needs-author-feedback" label doesn't trigger on features, which is keeping issues open

Removed the "issue-feature" requirements from the bot rules

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
