### PR TITLE
Multi account support in repo tool

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.UnitTest/AddRepoDialogTests.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.UnitTest/AddRepoDialogTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 using DevHome.Common.Extensions;
+using DevHome.SetupFlow.Models;
+using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
+using Microsoft.UI.Xaml;
 
 namespace DevHome.SetupFlow.UnitTest;
 
@@ -20,5 +23,29 @@ public class AddRepoDialogTests : BaseSetupFlowTest
 
         addRepoViewModel.RepoProviderSelectedCommand.Execute("ThisIsATest");
         Assert.IsTrue(addRepoViewModel.ShouldEnablePrimaryButton);
+    }
+
+    [TestMethod]
+    public void SwitchToUrlScreenTest()
+    {
+        var addRepoViewModel = new AddRepoViewModel(TestHost.GetService<ISetupFlowStringResource>(), new List<CloningInformation>(), TestHost, Guid.NewGuid(), string.Empty, null);
+        addRepoViewModel.ChangeToUrlPage();
+        Assert.AreEqual(Visibility.Visible, addRepoViewModel.ShowUrlPage);
+        Assert.AreEqual(Visibility.Collapsed, addRepoViewModel.ShowAccountPage);
+        Assert.AreEqual(Visibility.Collapsed, addRepoViewModel.ShowRepoPage);
+        Assert.IsTrue(addRepoViewModel.IsUrlAccountButtonChecked);
+        Assert.IsFalse(addRepoViewModel.IsAccountToggleButtonChecked);
+        Assert.IsFalse(addRepoViewModel.ShouldShowLoginUi);
+    }
+
+    [TestMethod]
+    public void SwitchToRepoScreenTest()
+    {
+        var addRepoViewModel = new AddRepoViewModel(TestHost.GetService<ISetupFlowStringResource>(), new List<CloningInformation>(), TestHost, Guid.NewGuid(), string.Empty, null);
+        addRepoViewModel.ChangeToUrlPage();
+        Assert.AreEqual(Visibility.Collapsed, addRepoViewModel.ShowUrlPage);
+        Assert.AreEqual(Visibility.Collapsed, addRepoViewModel.ShowAccountPage);
+        Assert.AreEqual(Visibility.Visible, addRepoViewModel.ShowRepoPage);
+        Assert.IsFalse(addRepoViewModel.ShouldShowLoginUi);
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -139,6 +139,7 @@ public static class StringResourceKey
     public static readonly string ClonePathNotFullyQualifiedMessage = nameof(ClonePathNotFullyQualifiedMessage);
     public static readonly string ClonePathNotFolder = nameof(ClonePathNotFolder);
     public static readonly string ClonePathDriveDoesNotExist = nameof(ClonePathDriveDoesNotExist);
+    public static readonly string RepoToolAddAnotherAccount = nameof(RepoToolAddAnotherAccount);
 
     // Url Validation
     public static readonly string UrlValidationBadUrl = nameof(UrlValidationBadUrl);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1255,4 +1255,8 @@
     <value>Next</value>
     <comment>Button to go to next screen</comment>
   </data>
+  <data name="RepoToolAddAnotherAccount" xml:space="preserve">
+    <value>Add another account</value>
+    <comment>Menu flyout item content to add another account</comment>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -55,7 +55,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// </summary>
     /// <remarks>
     /// This is only to help reference back to the view's code-behind.  Please do not change anything inside
-    /// the dialog from this class.
+    /// this class.
     /// </remarks>
     private readonly AddRepoDialog _addRepoDialog;
 
@@ -223,7 +223,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// the flag _isFiltering is used to prevent modifications to EverythingToClone.
     /// Once filtering is done SelectRange is called on each item in EverythingToClone to re-select them.
     /// </summary>
-    /// <param name="text">The text to use with .StartsWith</param>
+    /// <param name="text">The text to use with .Contains</param>
     public void FilterRepositories(string text)
     {
         IEnumerable<IRepository> filteredRepositories;
@@ -234,7 +234,7 @@ public partial class AddRepoViewModel : ObservableObject
         else
         {
             filteredRepositories = _repositoriesForAccount
-                .Where(x => x.DisplayName.StartsWith(text, StringComparison.OrdinalIgnoreCase));
+                .Where(x => x.DisplayName.Contains(text, StringComparison.OrdinalIgnoreCase));
         }
 
         _isFiltering = true;
@@ -328,6 +328,9 @@ public partial class AddRepoViewModel : ObservableObject
         IsCancelling = true;
     }
 
+    /// <summary>
+    /// The accounts the user is logged into is stored here.
+    /// </summary>
     [ObservableProperty]
     private MenuFlyout _accountsToShow;
 
@@ -345,6 +348,7 @@ public partial class AddRepoViewModel : ObservableObject
 
     private MenuFlyout ConstructFlyout()
     {
+        AccountsToShow = new MenuFlyout();
         var newMenu = new MenuFlyout();
         foreach (var account in Accounts)
         {
@@ -429,8 +433,6 @@ public partial class AddRepoViewModel : ObservableObject
         _activityId = activityId;
         FolderPickerViewModel = new FolderPickerViewModel(stringResource);
         FolderPickerViewModel.CloneLocation = defaultClonePath;
-
-        AccountsToShow = new MenuFlyout();
     }
 
     /// <summary>
@@ -601,6 +603,11 @@ public partial class AddRepoViewModel : ObservableObject
             TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAccount_Event", LogLevel.Critical, new RepoDialogGetAccountEvent(repositoryProviderName, alreadyLoggedIn: true), _activityId);
         }
 
+        // At least with the github extension, LoginId is the account name and does not include
+        // @github.com.  I could try parsing the host of the URL and append that to the login id.
+        // But, if other extensions included the @something.com to the loginid, the solution mentioned above
+        // would produce [username]@[something.com]@[something.com].  Not good.
+        // To avoid this, just store the login id.
         Accounts = new ObservableCollection<string>(loggedInAccounts.Select(x => x.LoginId));
         AccountsToShow = ConstructFlyout();
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -93,7 +93,7 @@
                         <ColumnDefinition Width="auto"/>
                         <ColumnDefinition Width="3*"/>
                     </Grid.ColumnDefinitions>
-                    <ComboBox x:Name="AccountsComboBox" IsEnabled="{x:Bind AddRepoViewModel.IsAccountComboBoxEnabled, Mode=OneWay}" AutomationProperties.Name="ms-resource:///DevHome.SetupFlow/Resources/RepoTool_AccountComboBox_Description" Grid.Column="0" SelectionChanged="AccountsComboBox_SelectionChanged" ItemsSource="{x:Bind AddRepoViewModel.Accounts, Mode=OneWay}" />
+                    <SplitButton x:Name="AccountSplitButton" Grid.Row="0" Height="40" Content="{x:Bind AddRepoViewModel.SelectedAccount, Mode=OneWay}" Flyout="{x:Bind AddRepoViewModel.AccountsToShow, Mode=OneWay}"/>
                     <TextBox x:Name="FilterTextBox" Grid.Column="1" TextChanged="FilterTextBox_TextChanged" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoTool_FilterTextBox" />
                 </Grid>
                 <Grid Visibility="{x:Bind AddRepoViewModel.IsFetchingRepos, Mode=OneWay}" Height="300" Width="300">
@@ -128,7 +128,7 @@
             </StackPanel>
             <TextBlock x:Name="ErrorTextBlock" Style="{ThemeResource BodyStrongTextBlockStyle}" Visibility="{x:Bind AddRepoViewModel.ShowErrorTextBox, Mode=OneWay}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Repo_ToolClonePathError"/>
             <!-- Repo page and URL page both have clonepath + dev drive check box-->
-            <Grid Visibility="{x:Bind FolderPickerViewModel.ShouldShowFolderPicker, Mode=OneWay}">
+            <Grid Visibility="{x:Bind AddRepoViewModel.FolderPickerViewModel.ShouldShowFolderPicker, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="5*"/>
                     <ColumnDefinition Width="auto"/>
@@ -141,28 +141,28 @@
                         x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClonePathForTextBlock" />
                     <TextBox
                         TextChanged="CloneLocation_TextChanged"
-                        Text="{x:Bind FolderPickerViewModel.CloneLocationAlias, Mode=TwoWay}"
+                        Text="{x:Bind AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias, Mode=TwoWay}"
                         IsEnabled="False"
-                        Visibility="{x:Bind FolderPickerViewModel.InDevDriveScenario, Mode=OneWay}"
+                        Visibility="{x:Bind AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario, Mode=OneWay}"
                         x:Name="DevDriveCloneLocationAliasTextBox" />
                 </StackPanel>
                 <TextBox x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClonePath"
                      TextChanged="CloneLocation_TextChanged" Grid.Column="0" 
-                     Text="{x:Bind FolderPickerViewModel.CloneLocation, Mode=TwoWay}"
-                     IsEnabled="{x:Bind FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay}"
-                     Visibility="{x:Bind FolderPickerViewModel.InDevDriveScenario, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"/>
+                     Text="{x:Bind AddRepoViewModel.FolderPickerViewModel.CloneLocation, Mode=TwoWay}"
+                     IsEnabled="{x:Bind AddRepoViewModel.FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay}"
+                     Visibility="{x:Bind AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"/>
                 <Grid Grid.Column="1">
                     <!-- Workaround to show a tooltip on a disabled button.
                          https://github.com/microsoft/microsoft-ui-xaml/issues/2262 -->
                     <TextBlock>
                     <ToolTipService.ToolTip>
-                        <ToolTip x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClearCheckboxToBrowse" Visibility="{x:Bind FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"/>
+                        <ToolTip x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClearCheckboxToBrowse" Visibility="{x:Bind AddRepoViewModel.FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"/>
                     </ToolTipService.ToolTip>
                     </TextBlock>
-                    <Button IsEnabled="{x:Bind FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClonePath_Button" Click="ChooseCloneLocationButton_Click" Margin="5, 27, 0, 0"/>
+                    <Button IsEnabled="{x:Bind AddRepoViewModel.FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClonePath_Button" Click="ChooseCloneLocationButton_Click" Margin="5, 27, 0, 0"/>
                 </Grid>
             </Grid>
-            <TextBlock Text="{x:Bind FolderPickerViewModel.FolderPickerErrorMessage, Mode=OneWay}" Visibility="{x:Bind FolderPickerViewModel.ShowFolderPickerError, Mode=OneWay}"/>
+            <TextBlock Text="{x:Bind AddRepoViewModel.FolderPickerViewModel.FolderPickerErrorMessage, Mode=OneWay}" Visibility="{x:Bind AddRepoViewModel.FolderPickerViewModel.ShowFolderPickerError, Mode=OneWay}"/>
             <Grid
                     Visibility="{x:Bind EditDevDriveViewModel.ShowDevDriveInformation, Mode=OneWay}" 
                     Margin="0 10 0 10"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -90,15 +90,19 @@
             <StackPanel x:Name="ShowRepositoriesStackPanel" Visibility="{x:Bind AddRepoViewModel.ShowRepoPage, Mode=OneWay}" Orientation="Vertical" HorizontalAlignment="Stretch" Spacing="10">
                 <Grid ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto"/>
-                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="1.5*"/>
                     </Grid.ColumnDefinitions>
-                    <SplitButton x:Name="AccountSplitButton" Grid.Row="0" Height="40" Content="{x:Bind AddRepoViewModel.SelectedAccount, Mode=OneWay}" Flyout="{x:Bind AddRepoViewModel.AccountsToShow, Mode=OneWay}"/>
+                    <SplitButton x:Name="AccountSplitButton" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Grid.Row="0" Content="{x:Bind AddRepoViewModel.SelectedAccount, Mode=OneWay}" Flyout="{x:Bind AddRepoViewModel.AccountsToShow, Mode=OneWay}"/>
                     <TextBox x:Name="FilterTextBox" Grid.Column="1" TextChanged="FilterTextBox_TextChanged" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoTool_FilterTextBox" />
                 </Grid>
                 <Grid Visibility="{x:Bind AddRepoViewModel.IsFetchingRepos, Mode=OneWay}" Height="300" Width="300">
                     <ProgressRing/>
                 </Grid>
+                <!-- Removing the SelectionChanged event into a command has far reaching changes because the item that was selected can't be passed
+                into the command.  I tried converting this to use a command on SelectionChanged and pass SelectedItems into the command.
+                I ran into issues because the viewmodel expects one repository at a time.  Not a list.
+                Another issue is .SelectRange() needs to be called to "select" repos when the dialog is opened more than once. -->
                 <ListView x:Name="RepositoriesListView" Visibility="{x:Bind AddRepoViewModel.IsFetchingRepos, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" SelectionMode="Multiple" Height="300" HorizontalAlignment="Stretch" SelectionChanged="RepositoriesListView_SelectionChanged" ItemsSource="{x:Bind AddRepoViewModel.Repositories, Mode=OneWay}" Margin="0, 12, 0, 12">
                     <ListView.Header>
                         <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepositoriesList" Margin="0, 0, 0, 8"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -244,6 +244,15 @@ public partial class AddRepoDialog : ContentDialog
     }
 
     /// <summary>
+    /// Gets the frame used for logging in a user.  This can go away when the frame is moved to the view model.
+    /// </summary>
+    /// <returns>The frame used to log users in.</returns>
+    public Frame GetLoginUiContent()
+    {
+        return LoginUIContent;
+    }
+
+    /// <summary>
     /// The primary button has different behavior based on the screen the user is currently in.
     /// </summary>
     private async void AddRepoContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -24,6 +24,10 @@ namespace DevHome.SetupFlow.Views;
 /// <summary>
 /// Dialog to allow users to select repositories they want to clone.
 /// </summary>
+/// <remarks>
+/// AddRepoViewModel stores a reference to this class for the purpos of slowly migreating code from here
+/// to the view model.  The refrence the view model has will be removed once the code migration is complete.
+/// </remarks>
 public partial class AddRepoDialog : ContentDialog
 {
     private readonly IHost _host;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -24,10 +24,8 @@ namespace DevHome.SetupFlow.Views;
 /// <summary>
 /// Dialog to allow users to select repositories they want to clone.
 /// </summary>
-internal partial class AddRepoDialog : ContentDialog
+public partial class AddRepoDialog : ContentDialog
 {
-    private readonly string _defaultClonePath;
-
     private readonly IHost _host;
 
     private readonly List<CloningInformation> _previouslySelectedRepos = new ();
@@ -49,14 +47,6 @@ internal partial class AddRepoDialog : ContentDialog
     }
 
     /// <summary>
-    /// Gets or sets the view model to handle the folder picker.
-    /// </summary>
-    public FolderPickerViewModel FolderPickerViewModel
-    {
-        get; set;
-    }
-
-    /// <summary>
     /// Hold the clone location in case the user decides not to add a dev drive.
     /// </summary>
     private string _oldCloneLocation;
@@ -70,18 +60,17 @@ internal partial class AddRepoDialog : ContentDialog
     {
         this.InitializeComponent();
         _previouslySelectedRepos = previouslySelectedRepos;
-        AddRepoViewModel = new AddRepoViewModel(stringResource, previouslySelectedRepos, host, activityId);
-        EditDevDriveViewModel = new EditDevDriveViewModel(devDriveManager);
-        FolderPickerViewModel = new FolderPickerViewModel(stringResource);
 
         var userFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        _defaultClonePath = Path.Join(userFolder, "source", "repos");
-        FolderPickerViewModel.CloneLocation = _defaultClonePath;
+        var defaultClonePath = Path.Join(userFolder, "source", "repos");
+
+        AddRepoViewModel = new AddRepoViewModel(stringResource, previouslySelectedRepos, host, activityId, defaultClonePath, this);
+        EditDevDriveViewModel = new EditDevDriveViewModel(devDriveManager);
 
         EditDevDriveViewModel.DevDriveClonePathUpdated += (_, updatedDevDriveRootPath) =>
         {
-            FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
-            FolderPickerViewModel.CloneLocation = updatedDevDriveRootPath;
+            AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
+            AddRepoViewModel.FolderPickerViewModel.CloneLocation = updatedDevDriveRootPath;
         };
 
         // Changing view to account so the selection changed event for Segment correctly shows URL.
@@ -142,7 +131,7 @@ internal partial class AddRepoDialog : ContentDialog
             if (EditDevDriveViewModel.DevDrive != null &&
                 EditDevDriveViewModel.DevDrive.State == DevDriveState.ExistsOnSystem)
             {
-                FolderPickerViewModel.InDevDriveScenario = true;
+                AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario = true;
                 EditDevDriveViewModel.ClonePathUpdated();
             }
         });
@@ -151,7 +140,7 @@ internal partial class AddRepoDialog : ContentDialog
     private void ChangeToAccountPage()
     {
         AddRepoViewModel.ChangeToAccountPage();
-        FolderPickerViewModel.CloseFolderPicker();
+        AddRepoViewModel.FolderPickerViewModel.CloseFolderPicker();
         EditDevDriveViewModel.HideDevDriveUI();
 
         // If DevHome has 1 provider installed and the provider has 1 logged in account
@@ -170,7 +159,7 @@ internal partial class AddRepoDialog : ContentDialog
     {
         RepositoryProviderComboBox.SelectedIndex = -1;
         AddRepoViewModel.ChangeToUrlPage();
-        FolderPickerViewModel.ShowFolderPicker();
+        AddRepoViewModel.FolderPickerViewModel.ShowFolderPicker();
         EditDevDriveViewModel.ShowDevDriveUIIfEnabled();
         ToggleCloneButton();
     }
@@ -180,7 +169,7 @@ internal partial class AddRepoDialog : ContentDialog
     /// </summary>
     private async void ChooseCloneLocationButton_Click(object sender, RoutedEventArgs e)
     {
-        await FolderPickerViewModel.ChooseCloneLocation();
+        await AddRepoViewModel.FolderPickerViewModel.ChooseCloneLocation();
         ToggleCloneButton();
     }
 
@@ -199,35 +188,12 @@ internal partial class AddRepoDialog : ContentDialog
             }
 
             // In cases where location is empty don't update the cloneLocation. Only update when there are actual values.
-            FolderPickerViewModel.CloneLocation = string.IsNullOrEmpty(location) ? FolderPickerViewModel.CloneLocation : location;
+            AddRepoViewModel.FolderPickerViewModel.CloneLocation = string.IsNullOrEmpty(location) ? AddRepoViewModel.FolderPickerViewModel.CloneLocation : location;
         }
 
-        FolderPickerViewModel.ValidateCloneLocation();
+        AddRepoViewModel.FolderPickerViewModel.ValidateCloneLocation();
 
         ToggleCloneButton();
-    }
-
-    /// <summary>
-    /// Removes all shows repositories from the list view and replaces them with a new set of repositories from a
-    /// different account.
-    /// </summary>
-    /// <remarks>
-    /// Fired when a user changes their account on a provider.
-    /// </remarks>
-    private async void AccountsComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        // This gets fired when events are removed from the account combo box.
-        // When the provider combo box is changed all accounts are removed from the account combo box
-        // and new accounts are added. This method fires twice.
-        // Once to remove all accounts and once to add all logged in accounts.
-        // GetRepositories sets the repositories list view.
-        if (e.AddedItems.Count > 0)
-        {
-            var loginId = (string)AccountsComboBox.SelectedValue;
-            var providerName = (string)RepositoryProviderComboBox.SelectedValue;
-            await AddRepoViewModel.GetRepositoriesAsync(providerName, loginId);
-            SelectRepositories(AddRepoViewModel.SetRepositories(providerName, loginId));
-        }
     }
 
     /// <summary>
@@ -236,7 +202,7 @@ internal partial class AddRepoDialog : ContentDialog
     /// IsCallingSelectRange is used to prevent modifying EverythingToClone when repos are being re-selected after filtering.
     /// </summary>
     /// <param name="reposToSelect">The repos to select in the UI.</param>
-    private void SelectRepositories(IEnumerable<RepoViewListItem> reposToSelect)
+    public void SelectRepositories(IEnumerable<RepoViewListItem> reposToSelect)
     {
         AddRepoViewModel.IsCallingSelectRange = true;
         var onlyRepoNames = AddRepoViewModel.Repositories.Select(x => x.RepoName).ToList();
@@ -270,7 +236,7 @@ internal partial class AddRepoDialog : ContentDialog
     /// </summary>
     private void RepositoriesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        var loginId = (string)AccountsComboBox.SelectedValue;
+        var loginId = AddRepoViewModel.SelectedAccount;
         var providerName = (string)RepositoryProviderComboBox.SelectedValue;
 
         AddRepoViewModel.AddOrRemoveRepository(providerName, loginId, e.AddedItems, e.RemovedItems);
@@ -296,7 +262,7 @@ internal partial class AddRepoDialog : ContentDialog
             // Get the number of repos already selected to clone in a previous instance.
             // Used to figure out if the repo was added after the user logged into an account.
             var numberOfReposToCloneCount = AddRepoViewModel.EverythingToClone.Count;
-            AddRepoViewModel.AddRepositoryViaUri(AddRepoViewModel.Url, FolderPickerViewModel.CloneLocation, LoginUIContent);
+            AddRepoViewModel.AddRepositoryViaUri(AddRepoViewModel.Url, AddRepoViewModel.FolderPickerViewModel.CloneLocation, LoginUIContent);
 
             // On the first run, ignore any warnings.
             // If this is set to visible and the user needs to log in they'll see an error message after the log-in
@@ -337,7 +303,7 @@ internal partial class AddRepoDialog : ContentDialog
             // and the number of repos to clone will not be changed.
             if (numberOfReposToCloneCount == AddRepoViewModel.EverythingToClone.Count)
             {
-                AddRepoViewModel.AddRepositoryViaUri(AddRepoViewModel.Url, FolderPickerViewModel.CloneLocation, LoginUIContent);
+                AddRepoViewModel.AddRepositoryViaUri(AddRepoViewModel.Url, AddRepoViewModel.FolderPickerViewModel.CloneLocation, LoginUIContent);
             }
 
             if (AddRepoViewModel.ShouldShowUrlError == Visibility.Visible)
@@ -366,9 +332,9 @@ internal partial class AddRepoDialog : ContentDialog
         if (AddRepoViewModel.Accounts.Any())
         {
             AddRepoViewModel.ChangeToRepoPage();
-            FolderPickerViewModel.ShowFolderPicker();
+            AddRepoViewModel.FolderPickerViewModel.ShowFolderPicker();
             EditDevDriveViewModel.ShowDevDriveUIIfEnabled();
-            AccountsComboBox.SelectedValue = AddRepoViewModel.Accounts.First();
+            AddRepoViewModel.SelectedAccount = AddRepoViewModel.Accounts.First();
             AddRepoViewModel.ShouldEnablePrimaryButton = false;
         }
     }
@@ -389,11 +355,11 @@ internal partial class AddRepoDialog : ContentDialog
         }
         else
         {
-            FolderPickerViewModel.CloneLocationAlias = string.Empty;
-            FolderPickerViewModel.InDevDriveScenario = false;
+            AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias = string.Empty;
+            AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario = false;
             EditDevDriveViewModel.RemoveNewDevDrive();
-            FolderPickerViewModel.EnableBrowseButton();
-            FolderPickerViewModel.CloneLocation = _oldCloneLocation;
+            AddRepoViewModel.FolderPickerViewModel.EnableBrowseButton();
+            AddRepoViewModel.FolderPickerViewModel.CloneLocation = _oldCloneLocation;
         }
     }
 
@@ -411,7 +377,7 @@ internal partial class AddRepoDialog : ContentDialog
     /// </summary>
     private void ToggleCloneButton()
     {
-        var isEverythingGood = AddRepoViewModel.ValidateRepoInformation() && FolderPickerViewModel.ValidateCloneLocation();
+        var isEverythingGood = AddRepoViewModel.ValidateRepoInformation() && AddRepoViewModel.FolderPickerViewModel.ValidateCloneLocation();
         if (EditDevDriveViewModel.DevDrive != null && EditDevDriveViewModel.DevDrive.State != DevDriveState.ExistsOnSystem)
         {
             isEverythingGood &= EditDevDriveViewModel.IsDevDriveValid();
@@ -422,7 +388,7 @@ internal partial class AddRepoDialog : ContentDialog
         // Fill in EverythingToClone with the location
         if (isEverythingGood)
         {
-            AddRepoViewModel.SetCloneLocation(FolderPickerViewModel.CloneLocation);
+            AddRepoViewModel.SetCloneLocation(AddRepoViewModel.FolderPickerViewModel.CloneLocation);
         }
     }
 
@@ -471,11 +437,11 @@ internal partial class AddRepoDialog : ContentDialog
     public void UpdateDevDriveInfo()
     {
         EditDevDriveViewModel.MakeDefaultDevDrive();
-        FolderPickerViewModel.DisableBrowseButton();
-        _oldCloneLocation = FolderPickerViewModel.CloneLocation;
-        FolderPickerViewModel.CloneLocation = EditDevDriveViewModel.GetDriveDisplayName();
-        FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
-        FolderPickerViewModel.InDevDriveScenario = true;
+        AddRepoViewModel.FolderPickerViewModel.DisableBrowseButton();
+        _oldCloneLocation = AddRepoViewModel.FolderPickerViewModel.CloneLocation;
+        AddRepoViewModel.FolderPickerViewModel.CloneLocation = EditDevDriveViewModel.GetDriveDisplayName();
+        AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
+        AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario = true;
         EditDevDriveViewModel.IsDevDriveCheckboxChecked = true;
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -20,7 +20,7 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
                     <!-- The TextBlock styles and the converter are duplicated below.  However, these resources needs to exist
-                    both here and in the data context.  IF the resources from here are removed, errors happen.
+                    both here and in the data context.  If the resources from here are removed, errors happen.
                     If you can figure out why and fix the issues, feel free to do so.-->
                     <converters:BoolToObjectConverter x:Key="BoolToTextBrush" TrueValue="{ThemeResource PrimaryTextStyle}" FalseValue="{ThemeResource SecondaryTextStyle}"/>
                     <Style x:Key="DevHomeBorderStyle" TargetType="Border" >

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -19,6 +19,9 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
+                    <!-- The TextBlock styles and the converter are duplicated below.  However, these resources needs to exist
+                    both here and in the data context.  IF the resources from here are removed, errors happen.
+                    If you can figure out why and fix the issues, feel free to do so.-->
                     <converters:BoolToObjectConverter x:Key="BoolToTextBrush" TrueValue="{ThemeResource PrimaryTextStyle}" FalseValue="{ThemeResource SecondaryTextStyle}"/>
                     <Style x:Key="DevHomeBorderStyle" TargetType="Border" >
                         <Setter Property="BorderBrush">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -118,7 +118,7 @@ public sealed partial class RepoConfigView : UserControl
                 foreach (var cloneInfo in everythingToClone)
                 {
                     cloneInfo.CloneToDevDrive = true;
-                    cloneInfo.CloneLocationAlias = _addRepoDialog.FolderPickerViewModel.CloneLocationAlias;
+                    cloneInfo.CloneLocationAlias = _addRepoDialog.AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias;
                 }
 
                 // The cloning location may have changed e.g The original Drive clone path for Dev Drives was the F: drive for items


### PR DESCRIPTION
## Summary of the pull request
This PR adds multi account support to the repo tool  This includes
1. Logging into a different account
2. Selecting repos from both accounts
3. Switching between accounts.

## References and relevant issues

## Detailed description of the pull request / Additional comments

This PR has other changes that aren't related to multi-account support.
1. FolderPickerViewModel moved from AddRepoDialog.xaml.cs to AddRepoViewModel.cs.  This is part of the effort to move all code from code-behind to the view model.
2. Filtering in the repo tool now uses .contains() instead of .starts with.

## Validation steps performed
Manual tests.

## PR checklist
- [ ] Closes #xxx
- [ X] Tests added/passed
- [ ] Documentation updated


Movie!
Logging into an account via the repo tool
![LoggingInWithRepoTool](https://github.com/microsoft/devhome/assets/2517139/b1aedb1d-b33c-41ca-86b5-a61341787c3b)


Cloning repos after logging in!
![CloningAfterAddingAnAccount](https://github.com/microsoft/devhome/assets/2517139/20348f5a-8161-4a30-91f5-b2d95cb3996d)

Pictures!
The X button to cancel the login prompt.
![LoginWithXButton](https://github.com/microsoft/devhome/assets/2517139/767bb802-becf-4d39-b581-ea59330468e7)
