### PR TITLE
Adding "open new window" icon to "Create Dev Drive" button (#1334)

### DIFF
--- a/src/Models/WhatsNewCard.cs
+++ b/src/Models/WhatsNewCard.cs
@@ -60,6 +60,11 @@ public class WhatsNewCard
         get; set;
     }
 
+    public bool? ShouldShowIcon
+    {
+        get; set;
+    }
+
     public bool? IsBig
     {
         get; set;

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -307,7 +307,8 @@
                                             <!-- The open new window icon -->
                                             <FontIcon 
                                                 Glyph="&#xE8A7;" 
-                                                Visibility="{x:Bind ShouldShowIcon}" />
+                                                Visibility="{x:Bind ShouldShowIcon}" 
+                                                FontSize="13"/>
                                         </StackPanel>
                                     </Button.Content>
                                 </Button>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -308,7 +308,7 @@
                                             <FontIcon 
                                                 Glyph="&#xE8A7;" 
                                                 Visibility="{x:Bind ShouldShowIcon}" 
-                                                FontSize="13"/>
+                                                FontSize="12"/>
                                         </StackPanel>
                                     </Button.Content>
                                 </Button>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -294,15 +294,23 @@
                                     </StackPanel>
                                 </ScrollViewer>
 
-                                <Button 
+                                <Button
                                     Grid.Row="2"
                                     Margin="15 0 15 10"
                                     DataContext="{x:Bind PageKey}"
                                     Click="Button_ClickAsync"
                                     HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Bottom"
-                                    Content="{x:Bind Button}" />
-
+                                    VerticalAlignment="Bottom">
+                                    <Button.Content>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{x:Bind Button}" Margin="0 0 5 0" />
+                                            <!-- The open new window icon -->
+                                            <FontIcon 
+                                                Glyph="&#xE8A7;" 
+                                                Visibility="{x:Bind ShouldShowIcon}" />
+                                        </StackPanel>
+                                    </Button.Content>
+                                </Button>
                             </Grid>
                         </DataTemplate>
                     </muxc:ItemsRepeater.ItemTemplate>

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -60,6 +60,10 @@ public sealed partial class WhatsNewPage : Page
                     card.ShouldShowLink = false;
                 }
             }
+            else
+            {
+                card.ShouldShowIcon = false;
+            }
 
             ViewModel.AddCard(card);
         }


### PR DESCRIPTION
## Summary of the pull request
A request was made to clarify that clicking the "Create Dev Drive" button in the "Introducing Dev Home" page view takes you outside the app. @cinnamon-msft  suggested that the same icon used in the "Machine Configuration" page should be added to convey this idea.

## References and relevant issues
#1334 

## Detailed description of the pull request / Additional comments
In WhatsNewPage.xaml, some refactoring of the button element occurs. Child elements are added in order to accommodate both text and icon inside the button.

Additionally, I added a boolean property to the WhatsNewCard.cs called ShouldShowIcon which is used to toggle the Visibility property of the icon since currently the "Create Dev Drive" button is the only button we want the icon showing for. 

In WhatsNewPage.xaml.cs, logic was added to set ShouldShowIcon to false except for the "Create Dev Drive" button.

## Validation steps performed
Manually verified UI renders as expected
![image](https://github.com/microsoft/devhome/assets/27697448/35b2404b-9b64-491d-895a-75713229b382)

## PR checklist
- [x] Closes #1334 
- [ ] Tests added/passed
- [ ] Documentation updated
