### PR TITLE
Adding AutomationProperties.Name to Learn More buttons in feedback page

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -433,7 +433,7 @@
   </data>
   <data name="Settings_Feedback_ReportSecurity_Button.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Learn more</value>
-    <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
+    <comment>Click on this link if you want to learn more and read the security policy. View is an action. Narrated by the narrator.</comment>
   </data>
   <data name="Settings_Feedback_LocalizationIssue_LanguageAffected.Header" xml:space="preserve">
     <value>Language</value>
@@ -528,8 +528,10 @@
   </data>
   <data name="Settings_Feedback_BuildExtension_Button.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Learn more</value>
+    <comment>Description or instruction on building an extension. Narrated by the narrator.</comment>
   </data>
   <data name="Settings_Feedback_ReportSecurity_TextBlock.Text" xml:space="preserve">
     <value>Learn more</value>
+    <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>
 </root>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -291,7 +350,7 @@
     <value>Create an extension</value>
     <comment>Creating a new extension</comment>
   </data>
-  <data name="Settings_Feedback_BuildExtension_Button.Text" xml:space="preserve">
+  <data name="Settings_Feedback_BuildExtension_TextBlock.Text" xml:space="preserve">
     <value>Learn more</value>
     <comment>Description or instruction on building an extension</comment>
   </data>
@@ -372,7 +431,7 @@
     <value>Report a security vulnerability</value>
     <comment>Tell us about potential security concerns</comment>
   </data>
-  <data name="Settings_Feedback_ReportSecurity_Button.Text" xml:space="preserve">
+  <data name="Settings_Feedback_ReportSecurity_Button.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Learn more</value>
     <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>
@@ -466,5 +525,11 @@
   <data name="Settings_ExperimentalFeatures_NoExperimentalFeatures.Text" xml:space="preserve">
     <value>There are currently no experimental features</value>
     <comment>Message shown when there are no available experimental features</comment>
+  </data>
+  <data name="Settings_Feedback_BuildExtension_Button.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
+  <data name="Settings_Feedback_ReportSecurity_TextBlock.Text" xml:space="preserve">
+    <value>Learn more</value>
   </data>
 </root>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -140,9 +140,9 @@
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xea86;"/>
                         </ctControls:SettingsCard.HeaderIcon>
-                        <Button Click="BuildExtensionButtonClicked" MinWidth="150">
+                        <Button x:Uid="Settings_Feedback_BuildExtension_Button" Click="BuildExtensionButtonClicked" MinWidth="150">
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <TextBlock x:Uid="Settings_Feedback_BuildExtension_Button" />
+                                <TextBlock x:Uid="Settings_Feedback_BuildExtension_TextBlock" />
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" FontSize="12" />
                             </StackPanel>
                         </Button>
@@ -152,9 +152,9 @@
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                   Glyph="&#xf552;"/>
                         </ctControls:SettingsCard.HeaderIcon>
-                        <Button Click="ReportSecurityButtonClicked" MinWidth="150">
+                        <Button x:Uid="Settings_Feedback_ReportSecurity_Button" Click="ReportSecurityButtonClicked" MinWidth="150">
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <TextBlock x:Uid="Settings_Feedback_ReportSecurity_Button" />
+                                <TextBlock x:Uid="Settings_Feedback_ReportSecurity_TextBlock" />
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8A7;" FontSize="12" />
                             </StackPanel>
                         </Button>


### PR DESCRIPTION
## Summary of the pull request
This pull request fixes the accessibility bug where the narrator was not telling the content of the button it was focused in. Now, the narrator will be correctly saying "Learn more button" when navigating over these buttons.
## References and relevant issues

## Detailed description of the pull request / Additional comments
Added the `AutomationProperties.Name` property to both `Learn more` buttons who didn't have it, as their structure is more complex because of the icon inside them.
## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
