### PR TITLE
Moved the About row to the bottom in Settings Page

### DIFF
--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -54,9 +54,9 @@ public partial class SettingsViewModel : ObservableObject
             new Setting("Preferences", string.Empty, stringResource.GetLocalized("Settings_Preferences_Header"), stringResource.GetLocalized("Settings_Preferences_Description"), "\ue713", false, false),
             new Setting("Accounts", string.Empty, stringResource.GetLocalized("Settings_Accounts_Header"), stringResource.GetLocalized("Settings_Accounts_Description"), "\ue77b", false, false),
             new Setting("Extensions", string.Empty, stringResource.GetLocalized("Settings_Extensions_Header"), stringResource.GetLocalized("Settings_Extensions_Description"), "\ued35", false, false),
-            new Setting("About", string.Empty, stringResource.GetLocalized("Settings_About_Header"), stringResource.GetLocalized("Settings_About_Description"), "\ue946", false, false),
             new Setting("Feedback", string.Empty, stringResource.GetLocalized("Settings_Feedback_Header"), stringResource.GetLocalized("Settings_Feedback_Description"), "\ued15", false, false),
             new Setting("ExperimentalFeatures", string.Empty, stringResource.GetLocalized("Settings_ExperimentalFeatures_Header"), stringResource.GetLocalized("Settings_ExperimentalFeatures_Description"), "\ue74c", false, false),
+            new Setting("About", string.Empty, stringResource.GetLocalized("Settings_About_Header"), stringResource.GetLocalized("Settings_About_Description"), "\ue946", false, false),
         };
 
         foreach (var setting in settings)


### PR DESCRIPTION
## Summary of the pull request

This PR will take care of moving the `About` section to the bottom of the Settings Page in DevHome(Pre).

## References and relevant issues

Feature Requested in #2063

## Validation steps performed

Attaching a screenshot of the test:

<img width="670" alt="image" src="https://github.com/microsoft/devhome/assets/140355188/84465daf-d03b-482f-b0d5-39199343c578">


## PR checklist
- [ ] Closes #2063 
- [ ] Tests added/passed
- [ ] Documentation updated
