### PR TITLE
Extensions page expanders behavior is set to closed by default

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -69,7 +69,7 @@
                                                    Description="{x:Bind GeneratePackageDetails(Version,Publisher , InstalledDate), Mode=OneWay}"
                                                    Margin="{ThemeResource SettingsCardMargin}"
                                                    ItemsSource="{x:Bind InstalledExtensionsList}"
-                                                   IsExpanded="True">
+                                                   IsExpanded="False">
                                 <ctControls:SettingsExpander.HeaderIcon>
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
                                 </ctControls:SettingsExpander.HeaderIcon>


### PR DESCRIPTION
## Summary of the pull request
The pull request makes changes to the [ExtensionLibraryView.xaml](https://github.com/microsoft/devhome/compare/main...eddyfadeev:devhome:main#diff-e7af13187cc17795ad43f3ce0085cd01838278fe6d8c12118e28e973cbb0fc55) for the expanders to be closed by default, as was proposed by [cinnamon-msft](https://github.com/cinnamon-msft) [Issue #2106](https://github.com/microsoft/devhome/issues/2106)

## References and relevant issues
Closes #2106 

## Detailed description of the pull request / Additional comments
Expanders' behavior is set to be closed by default, so the people with a lot of extensions will have not to scroll and visually parse which extension they're looking for.