### PR TITLE
Don't read empty links on What's New page

### DIFF
--- a/src/Models/WhatsNewCard.cs
+++ b/src/Models/WhatsNewCard.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using Microsoft.UI.Xaml;
+
 namespace DevHome.Models;
 
 public class WhatsNewCard
@@ -55,13 +57,22 @@ public class WhatsNewCard
         get; set;
     }
 
-    public bool? ShouldShowLink
-    {
-        get; set;
-    }
+    public bool ShouldShowLink { get; set; } = true;
 
     public bool? IsBig
     {
         get; set;
+    }
+
+    public Visibility HasLinkAndShouldShowIt(string? link, bool shouldShowLink)
+    {
+        if (link != null && shouldShowLink)
+        {
+            return Visibility.Visible;
+        }
+        else
+        {
+            return Visibility.Collapsed;
+        }
     }
 }

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -17,7 +17,7 @@
 
     <Page.Resources>
         <ResourceDictionary>
-            <converters:EmptyStringToObjectConverter x:Key="EmptyStringToBoolConverter" EmptyValue="False" NotEmptyValue="True"/>
+            <converters:EmptyStringToObjectConverter x:Key="EmptyStringToVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <x:String x:Key="Background">/Assets/WhatsNewPage/LightTheme/Background.png</x:String>
@@ -158,14 +158,12 @@
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton
-                                        Content="{x:Bind Link}"
-                                        IsTabStop="{x:Bind Link, Converter={StaticResource EmptyStringToBoolConverter}, Mode=OneWay}"
-                                        Foreground="{ThemeResource LearnMoreForeground}"
-                                        NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
-                                        Padding="0"
-                                        Margin="0"
-                                        Visibility="{x:Bind ShouldShowLink}"/>
-
+                                            Content="{x:Bind Link}"
+                                            Foreground="{ThemeResource LearnMoreForeground}"
+                                            NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
+                                            Padding="0"
+                                            Margin="0"
+                                            Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
                                     <Button 
                                         Margin="0 0 0 10"
                                         Padding="50 5 50 5"
@@ -280,16 +278,14 @@
                                                 VerticalAlignment="Top"
                                                 TextTrimming="WordEllipsis"
                                                 Text="{x:Bind Description}"/>
-
                                             <HyperlinkButton
-                                                Content="{x:Bind Link}"
-                                                IsTabStop="{x:Bind Link, Converter={StaticResource EmptyStringToBoolConverter}, Mode=OneWay}"
-                                                Foreground="{ThemeResource LearnMoreForeground}"
-                                                NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
-                                                VerticalAlignment="Top"
-                                                Padding="0"
-                                                Margin="0"
-                                                Visibility="{x:Bind ShouldShowLink}" />
+                                                    Content="{x:Bind Link}"
+                                                    Foreground="{ThemeResource LearnMoreForeground}"
+                                                    NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
+                                                    VerticalAlignment="Top"
+                                                    Padding="0"
+                                                    Margin="0"
+                                                    Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
                                         </controls:WrapPanel>
                                     </StackPanel>
                                 </ScrollViewer>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -157,12 +157,13 @@
                                         Text="{x:Bind Description}"/>
 
                                     <HyperlinkButton
-                                            Content="{x:Bind Link}"
-                                            Foreground="{ThemeResource LearnMoreForeground}"
-                                            NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
-                                            Padding="0"
-                                            Margin="0"
-                                            Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
+                                        Content="{x:Bind Link}"
+                                        Foreground="{ThemeResource LearnMoreForeground}"
+                                        NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
+                                        Padding="0"
+                                        Margin="0"
+                                        Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
+
                                     <Button 
                                         Margin="0 0 0 10"
                                         Padding="50 5 50 5"
@@ -279,13 +280,13 @@
                                                 Text="{x:Bind Description}"/>
 
                                             <HyperlinkButton
-                                                    Content="{x:Bind Link}"
-                                                    Foreground="{ThemeResource LearnMoreForeground}"
-                                                    NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
-                                                    VerticalAlignment="Top"
-                                                    Padding="0"
-                                                    Margin="0"
-                                                    Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
+                                                Content="{x:Bind Link}"
+                                                Foreground="{ThemeResource LearnMoreForeground}"
+                                                NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
+                                                VerticalAlignment="Top"
+                                                Padding="0"
+                                                Margin="0"
+                                                Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
                                         </controls:WrapPanel>
                                     </StackPanel>
                                 </ScrollViewer>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -17,7 +17,6 @@
 
     <Page.Resources>
         <ResourceDictionary>
-            <converters:EmptyStringToObjectConverter x:Key="EmptyStringToVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <x:String x:Key="Background">/Assets/WhatsNewPage/LightTheme/Background.png</x:String>
@@ -278,6 +277,7 @@
                                                 VerticalAlignment="Top"
                                                 TextTrimming="WordEllipsis"
                                                 Text="{x:Bind Description}"/>
+
                                             <HyperlinkButton
                                                     Content="{x:Bind Link}"
                                                     Foreground="{ThemeResource LearnMoreForeground}"


### PR DESCRIPTION
## Summary of the pull request

Empty links were still being read out by Narrator, because the EmptyStringToBoolConverter wasn't converting to Bool objects as expected so the links were always TabStops, even when empty. Instead of using IsTabStop, just use Visibility. Bind visibility to a combination of the link existing and ShouldShowLink. Set ShouldShowLink to default to True, since it should default to true -- we set it to false in specific instances, but otherwise if a link is there, it should be shown.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #1722
- [ ] Tests added/passed
- [ ] Documentation updated
