### PR TITLE
Changing TextBox to use MinHeight instead of Height to fix 200% font scaling

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -96,7 +96,7 @@
                         <ScrollViewer VerticalScrollBarVisibility="Auto">
                             <StackPanel>
                                 <TextBox x:Name="DocumentationIssueTitle" x:Uid="Settings_Feedback_DocumentationIssue_IssueTitle" AcceptsReturn="True"/>
-                                <TextBox x:Name="DocumentationIssueDescription" x:Uid="Settings_Feedback_DocumentationIssue_Description" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" Height="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
+                                <TextBox x:Name="DocumentationIssueDescription" x:Uid="Settings_Feedback_DocumentationIssue_Description" TextWrapping="Wrap" Margin="{StaticResource SmallTopMargin}" MinHeight="{StaticResource FeedbackTextBoxHeight}" AcceptsReturn="True"/>
                             </StackPanel>
                         </ScrollViewer>
                     </Grid>


### PR DESCRIPTION
## Summary of the pull request
Changing TextBox to use MinHeight instead of Height to get the placeholder text and input to not be clipped when higher font scale is selected by the user.
<img width="389" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/03ebd814-a946-4405-9a81-50ca430c41e1">

## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/48138266
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
