### PR TITLE
Install DevHomeGitHubExtension on first launch

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20230706-x2201" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.8" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.8" />
     <PackageReference Include="WinUIEx" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="1.0.0" />

--- a/common/Services/AppInstallManagerService.cs
+++ b/common/Services/AppInstallManagerService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using DevHome.Common.Helpers;
 using Windows.ApplicationModel.Store.Preview.InstallControl;
 using Windows.Foundation;
 
@@ -15,6 +16,8 @@ namespace DevHome.Services;
 public class AppInstallManagerService : IAppInstallManagerService
 {
     private readonly AppInstallManager _appInstallManager;
+
+    private static readonly TimeSpan StoreInstallTimeout = new (0, 0, 60);
 
     public event TypedEventHandler<AppInstallManager, AppInstallManagerItemEventArgs> ItemCompleted
     {
@@ -67,5 +70,73 @@ public class AppInstallManagerService : IAppInstallManagerService
 
         // Check if update is available
         return appInstallItem != null;
+    }
+
+    public async Task<bool> TryInstallPackageAsync(string packageId)
+    {
+        try
+        {
+            var installTask = InstallPackageAsync(packageId);
+
+            // Wait for a maximum of StoreInstallTimeout (60 seconds).
+            var completedTask = await Task.WhenAny(installTask, Task.Delay(StoreInstallTimeout));
+
+            if (completedTask.Exception != null)
+            {
+                throw completedTask.Exception;
+            }
+
+            if (completedTask != installTask)
+            {
+                throw new TimeoutException("Store Install task did not finish in time.");
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Logger()?.ReportError("Package installation Failed", ex);
+        }
+
+        return false;
+    }
+
+    private async Task InstallPackageAsync(string packageId)
+    {
+        await Task.Run(() =>
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            AppInstallItem installItem;
+            try
+            {
+                Log.Logger()?.ReportInfo("WidgetHostingService", $"Starting {packageId} install");
+                installItem = _appInstallManager.StartAppInstallAsync(packageId, null, true, false).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Log.Logger()?.ReportInfo("WidgetHostingService", $"{packageId} install failure");
+                tcs.SetException(ex);
+                return tcs.Task;
+            }
+
+            installItem.Completed += (sender, args) =>
+            {
+                tcs.SetResult(true);
+            };
+
+            installItem.StatusChanged += (sender, args) =>
+            {
+                if (installItem.GetCurrentStatus().InstallState == AppInstallState.Canceled
+                    || installItem.GetCurrentStatus().InstallState == AppInstallState.Error)
+                {
+                    tcs.TrySetException(new System.Management.Automation.JobFailedException(installItem.GetCurrentStatus().ErrorCode.ToString()));
+                }
+                else if (installItem.GetCurrentStatus().InstallState == AppInstallState.Completed)
+                {
+                    tcs.SetResult(true);
+                }
+            };
+            return tcs.Task;
+        });
     }
 }

--- a/common/Services/IAppInstallManagerService.cs
+++ b/common/Services/IAppInstallManagerService.cs
@@ -31,4 +31,11 @@ public interface IAppInstallManagerService
     /// <returns>True if an app update was triggered, false otherwise</returns>
     /// <exception cref="COMException">Throws exception if operation failed (e.g. product id was not found)</exception>
     public Task<bool> StartAppUpdateAsync(string productId);
+
+    /// <summary>
+    /// Install a package from the store.
+    /// </summary>
+    /// <param name="packageId">Target package id</param>
+    /// <returns>True if package was installed, false otherwise</returns>
+    public Task<bool> TryInstallPackageAsync(string packageId);
 }

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -6,6 +6,7 @@ using DevHome.Common.Extensions;
 using DevHome.Contracts.Services;
 using DevHome.Dashboard.Services;
 using DevHome.Logging;
+using DevHome.Services;
 using DevHome.Views;
 using Microsoft.UI.Xaml;
 
@@ -15,11 +16,21 @@ public class InitializationViewModel : ObservableObject
 {
     private readonly IThemeSelectorService _themeSelector;
     private readonly IWidgetHostingService _widgetHostingService;
+    private readonly IAppInstallManagerService _appInstallManagerService;
 
-    public InitializationViewModel(IThemeSelectorService themeSelector, IWidgetHostingService widgetHostingService)
+#if CANARY_BUILD
+    private const string GitHubExtensionStorePackageId = "9N806ZKPW85R";
+#elif STABLE_BUILD
+    private const string GitHubExtensionStorePackageId = "9NZCC27PR6N6";
+#else
+    private const string GitHubExtensionStorePackageId = "";
+#endif
+
+    public InitializationViewModel(IThemeSelectorService themeSelector, IWidgetHostingService widgetHostingService, IAppInstallManagerService appInstallManagerService)
     {
         _themeSelector = themeSelector;
         _widgetHostingService = widgetHostingService;
+        _appInstallManagerService = appInstallManagerService;
     }
 
     public async void OnPageLoaded()
@@ -31,6 +42,23 @@ public class InitializationViewModel : ObservableObject
         catch (Exception ex)
         {
             GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Installing WidgetService failed: ", ex);
+        }
+
+        if (string.IsNullOrEmpty(GitHubExtensionStorePackageId))
+        {
+            GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Skipping installing DevHomeGitHubExtension.");
+        }
+        else
+        {
+            try
+            {
+                GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Installing DevHomeGitHubExtension...");
+                await _appInstallManagerService.TryInstallPackageAsync(GitHubExtensionStorePackageId);
+            }
+            catch (Exception ex)
+            {
+                GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Installing DevHomeGitHubExtension failed: ", ex);
+            }
         }
 
         App.MainWindow.Content = Application.Current.GetService<ShellPage>();

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.230907" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-    <PackageReference Include="System.Management.Automation" Version="7.2.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
Install the Dev Home GitHub Extension on first Dev Home launch after install. It won't be re-installed on subsequent launches. Preview Dev Home installs the Preview extension, Canary DH installs the Canary extension, and Dev DH installs nothing.

## References and relevant issues

## Detailed description of the pull request / Additional comments
Store installation logic moves from Dashboard's WidgetHostingService to a more generalized TryInstallPackageAsync in the AppInstallManagerService.

## Validation steps performed

## PR checklist
- [ ] Closes #2102 
- [ ] Tests added/passed
- [ ] Documentation updated
