### PR TITLE
Wrapping text on bug report dialog so it is always visible

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -43,9 +43,9 @@
                                     </Expander.Header>
                                     <Expander.Content>
                                         <StackPanel>
-                                            <TextBlock x:Name="CpuID"/>
-                                            <TextBlock x:Name="PhysicalMemory"/>
-                                            <TextBlock x:Name="ProcessorArchitecture"/>
+                                            <TextBlock x:Name="CpuID" TextWrapping="Wrap"/>
+                                            <TextBlock x:Name="PhysicalMemory" TextWrapping="Wrap"/>
+                                            <TextBlock x:Name="ProcessorArchitecture" TextWrapping="Wrap"/>
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>
@@ -55,8 +55,8 @@
                                     </Expander.Header>
                                     <Expander.Content>
                                         <StackPanel>
-                                            <TextBlock x:Name="ReportBugIncludeExtensionsList" />
-                                            <TextBlock x:Name="WidgetServiceInfo"/>
+                                            <TextBlock x:Name="ReportBugIncludeExtensionsList" TextWrapping="Wrap"/>
+                                            <TextBlock x:Name="WidgetServiceInfo" TextWrapping="Wrap"/>
                                         </StackPanel>
                                     </Expander.Content>
                                 </Expander>


### PR DESCRIPTION
## Summary of the pull request
On bigger font sizes, most of the text of the text blocks with information about the system gets clipped out. This changes wraps the text so it is always entirely visible to the user when creating the bug report.
<img width="359" alt="image" src="https://github.com/microsoft/devhome/assets/13912953/ef77f97f-730a-4f3d-89bf-d84bb14894aa">

## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/48137956
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
