### PR TITLE
Pin default widgets on first run

### DIFF
--- a/common/Helpers/WellKnownSettingsKeys.cs
+++ b/common/Helpers/WellKnownSettingsKeys.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace DevHome.Common.Helpers;
+
 public class WellKnownSettingsKeys
 {
     public const string IsNotFirstRun = "IsNotFirstRun";
+
+    public const string IsNotFirstDashboardRun = "IsNotFirstDashboardRun";
 }


### PR DESCRIPTION
## Summary of the pull request
The first time after install the user goes to the Dashboard, pin a few default widgets. Pins the Stable/Canary/Dev version that matches the Dev Home version running. Creates a new "IsNotFirstDashboardRun" WellKnownSettingsKey that is used the same way as "IsNotFirstRun". We can't re-use the first one, since it will already be true by the time we get to the Dashboard.
 
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #575
- [ ] Tests added/passed
- [ ] Documentation updated
