### PR TITLE
Add error display to core widgets.

### DIFF
--- a/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -86,6 +86,11 @@ internal class SSHWalletWidget : CoreWidget
         catch (Exception e)
         {
             Log.Logger()?.ReportError(Name, ShortId, "Error retrieving data.", e);
+            var content = new JsonObject
+            {
+                { "errorMessage", e.Message },
+            };
+            ContentData = content.ToJsonString();
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/CoreWidgetProvider/Widgets/SystemCPUUsageWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemCPUUsageWidget.cs
@@ -58,6 +58,11 @@ internal class SystemCPUUsageWidget : CoreWidget, IDisposable
         catch (Exception e)
         {
             Log.Logger()?.ReportError(Name, ShortId, "Error retrieving stats.", e);
+            var content = new JsonObject
+            {
+                { "errorMessage", e.Message },
+            };
+            ContentData = content.ToJsonString();
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/CoreWidgetProvider/Widgets/SystemGPUUsageWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemGPUUsageWidget.cs
@@ -61,6 +61,11 @@ internal class SystemGPUUsageWidget : CoreWidget, IDisposable
         catch (Exception e)
         {
             Log.Logger()?.ReportError(Name, ShortId, "Error retrieving data.", e);
+            var content = new JsonObject
+            {
+                { "errorMessage", e.Message },
+            };
+            ContentData = content.ToJsonString();
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/CoreWidgetProvider/Widgets/SystemMemoryWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemMemoryWidget.cs
@@ -78,6 +78,11 @@ internal class SystemMemoryWidget : CoreWidget, IDisposable
         catch (Exception e)
         {
             Log.Logger()?.ReportError(Name, ShortId, "Error retrieving data.", e);
+            var content = new JsonObject
+            {
+                { "errorMessage", e.Message },
+            };
+            ContentData = content.ToJsonString();
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/CoreWidgetProvider/Widgets/SystemNetworkUsageWidget.cs
+++ b/CoreWidgetProvider/Widgets/SystemNetworkUsageWidget.cs
@@ -78,6 +78,11 @@ internal class SystemNetworkUsageWidget : CoreWidget, IDisposable
         catch (Exception e)
         {
             Log.Logger()?.ReportError(Name, ShortId, "Error retrieving data.", e);
+            var content = new JsonObject
+            {
+                { "errorMessage", e.Message },
+            };
+            ContentData = content.ToJsonString();
             DataState = WidgetDataState.Failed;
             return;
         }

--- a/CoreWidgetProvider/Widgets/Templates/SSHWalletTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SSHWalletTemplate.json
@@ -3,53 +3,72 @@
   "body": [
     {
       "type": "Container",
-      "$when": "${(count(hosts) == 0)}",
+      "$when": "${errorMessage != null}",
       "items": [
         {
           "type": "TextBlock",
-          "text": "%SSH_Widget_Template/EmptyHosts%",
+          "text": "${errorMessage}",
           "wrap": true,
-          "weight": "Bolder",
-          "horizontalAlignment": "Center"
+          "size": "small"
         }
       ],
-      "spacing": "Medium",
-      "verticalContentAlignment": "Center"
+      "style": "warning"
     },
     {
-      "$data": "${hosts}",
-      "type": "ColumnSet",
-      "style": "emphasis",
-      "selectAction": {
-        "type": "Action.Execute",
-        "verb": "Connect",
-        "data": "${host}"
-      },
-      "columns": [
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
         {
-          "type": "Column",
-          "verticalContentAlignment": "Center",
-          "width": "auto",
-          "items": [
-            {
-              "type": "Image",
-              "url": "data:image/png;base64,${icon}",
-              "size": "small",
-              "horizontalAlignment": "left"
-            }
-          ]
-        },
-        {
-          "type": "Column",
-          "width": "stretch",
-          "verticalContentAlignment": "Center",
+          "type": "Container",
+          "$when": "${(count(hosts) == 0)}",
           "items": [
             {
               "type": "TextBlock",
-              "text": "${host}",
-              "size": "medium",
+              "text": "%SSH_Widget_Template/EmptyHosts%",
               "wrap": true,
-              "horizontalAlignment": "left"
+              "weight": "Bolder",
+              "horizontalAlignment": "Center"
+            }
+          ],
+          "spacing": "Medium",
+          "verticalContentAlignment": "Center"
+        },
+        {
+          "$data": "${hosts}",
+          "type": "ColumnSet",
+          "style": "emphasis",
+          "selectAction": {
+            "type": "Action.Execute",
+            "verb": "Connect",
+            "data": "${host}"
+          },
+          "columns": [
+            {
+              "type": "Column",
+              "verticalContentAlignment": "Center",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Image",
+                  "url": "data:image/png;base64,${icon}",
+                  "size": "small",
+                  "horizontalAlignment": "left"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "verticalContentAlignment": "Center",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "${host}",
+                  "size": "medium",
+                  "wrap": true,
+                  "horizontalAlignment": "left"
+                }
+              ]
             }
           ]
         }

--- a/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
@@ -2,70 +2,89 @@
   "type": "AdaptiveCard",
   "body": [
     {
-      "type": "Image",
-      "url": "${cpuGraphUrl}",
-      "height": "${chartHeight}",
-      "width": "${chartWidth}",
-      "horizontalAlignment": "center"
+      "type": "Container",
+      "$when": "${errorMessage != null}",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "size": "small"
+        }
+      ],
+      "style": "warning"
     },
     {
-      "type": "ColumnSet",
-      "columns": [
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
         {
-          "type": "Column",
-          "items": [
+          "type": "Image",
+          "url": "${cpuGraphUrl}",
+          "height": "${chartHeight}",
+          "width": "${chartWidth}",
+          "horizontalAlignment": "center"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
             {
-              "type": "TextBlock",
-              "isSubtle": true,
-              "text": "%CPUUsage_Widget_Template/CPU_Usage%"
+              "type": "Column",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "isSubtle": true,
+                  "text": "%CPUUsage_Widget_Template/CPU_Usage%"
+                },
+                {
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder",
+                  "text": "${cpuUsage}"
+                }
+              ]
             },
             {
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder",
-              "text": "${cpuUsage}"
+              "type": "Column",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right",
+                  "text": "%CPUUsage_Widget_Template/CPU_Speed%"
+                },
+                {
+                  "type": "TextBlock",
+                  "size": "large",
+                  "horizontalAlignment": "right",
+                  "text": "${cpuSpeed}"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "Column",
-          "items": [
-            {
-              "type": "TextBlock",
-              "isSubtle": true,
-              "horizontalAlignment": "right",
-              "text": "%CPUUsage_Widget_Template/CPU_Speed%"
-            },
-            {
-              "type": "TextBlock",
-              "size": "large",
-              "horizontalAlignment": "right",
-              "text": "${cpuSpeed}"
-            }
-          ]
+          "type": "TextBlock",
+          "isSubtle": true,
+          "text": "%CPUUsage_Widget_Template/Processes%",
+          "wrap": true
+        },
+        {
+          "type": "TextBlock",
+          "size": "medium",
+          "text": "${cpuProc1}"
+        },
+        {
+          "type": "TextBlock",
+          "size": "medium",
+          "text": "${cpuProc2}"
+        },
+        {
+          "type": "TextBlock",
+          "size": "medium",
+          "text": "${cpuProc3}"
         }
       ]
-    },
-    {
-      "type": "TextBlock",
-      "isSubtle": true,
-      "text": "%CPUUsage_Widget_Template/Processes%",
-      "wrap": true
-    },
-    {
-      "type": "TextBlock",
-      "size": "medium",
-      "text": "${cpuProc1}"
-    },
-    {
-      "type": "TextBlock",
-      "size": "medium",
-      "text": "${cpuProc2}"
-    },
-    {
-      "type": "TextBlock",
-      "size": "medium",
-      "text": "${cpuProc3}"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -2,70 +2,89 @@
   "type": "AdaptiveCard",
   "body": [
     {
-      "type": "Image",
-      "url": "${gpuGraphUrl}",
-      "height": "${chartHeight}",
-      "width": "${chartWidth}",
-      "horizontalAlignment": "center"
+      "type": "Container",
+      "$when": "${errorMessage != null}",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "size": "small"
+        }
+      ],
+      "style": "warning"
     },
     {
-      "type": "ColumnSet",
-      "columns": [
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
         {
-          "type": "Column",
-          "items": [
+          "type": "Image",
+          "url": "${gpuGraphUrl}",
+          "height": "${chartHeight}",
+          "width": "${chartWidth}",
+          "horizontalAlignment": "center"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
             {
-              "text": "%GPUUsage_Widget_Template/GPU_Usage%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%GPUUsage_Widget_Template/GPU_Usage%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${gpuUsage}",
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder"
+                }
+              ]
             },
             {
-              "text": "${gpuUsage}",
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%GPUUsage_Widget_Template/GPU_Temperature%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${gpuTemp}",
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder",
+                  "horizontalAlignment": "right"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "Column",
-          "items": [
-            {
-              "text": "%GPUUsage_Widget_Template/GPU_Temperature%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true,
-              "horizontalAlignment": "right"
-            },
-            {
-              "text": "${gpuTemp}",
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder",
-              "horizontalAlignment": "right"
-            }
-          ]
+          "text": "%GPUUsage_Widget_Template/GPU_Name%",
+          "type": "TextBlock",
+          "size": "small",
+          "isSubtle": true
+        },
+        {
+          "text": "${gpuName}",
+          "type": "TextBlock",
+          "size": "medium"
+        }
+      ],
+      "actions": [
+        {
+          "type": "Action.Execute",
+          "title": "%GPUUsage_Widget_Template/Next_GPU%",
+          "verb": "NextItem"
         }
       ]
-    },
-    {
-      "text": "%GPUUsage_Widget_Template/GPU_Name%",
-      "type": "TextBlock",
-      "size": "small",
-      "isSubtle": true
-    },
-    {
-      "text": "${gpuName}",
-      "type": "TextBlock",
-      "size": "medium"
-    }
-  ],
-  "actions": [
-    {
-      "type": "Action.Execute",
-      "title": "%GPUUsage_Widget_Template/Next_GPU%",
-      "verb": "NextItem"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
@@ -2,126 +2,145 @@
   "type": "AdaptiveCard",
   "body": [
     {
-      "type": "Image",
-      "url": "${memGraphUrl}",
-      "height": "${chartHeight}",
-      "width": "${chartWidth}",
-      "horizontalAlignment": "center"
-    },
-    {
-      "type": "ColumnSet",
-      "columns": [
+      "type": "Container",
+      "$when": "${errorMessage != null}",
+      "items": [
         {
-          "type": "Column",
-          "items": [
-            {
-              "text": "%Memory_Widget_Template/UsedMemory%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true
-            },
-            {
-              "text": "${usedMem}",
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder"
-            }
-          ]
-        },
-        {
-          "type": "Column",
-          "items": [
-            {
-              "text": "%Memory_Widget_Template/AllMemory%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true,
-              "horizontalAlignment": "right"
-            },
-            {
-              "text": "${allMem}",
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder",
-              "horizontalAlignment": "right"
-            }
-          ]
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "size": "small"
         }
-      ]
+      ],
+      "style": "warning"
     },
     {
-      "type": "ColumnSet",
-      "columns": [
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
         {
-          "type": "Column",
-          "items": [
+          "type": "Image",
+          "url": "${memGraphUrl}",
+          "height": "${chartHeight}",
+          "width": "${chartWidth}",
+          "horizontalAlignment": "center"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
             {
-              "text": "%Memory_Widget_Template/Committed%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Memory_Widget_Template/UsedMemory%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${usedMem}",
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder"
+                }
+              ]
             },
             {
-              "text": "${committedMem}/${committedLimitMem}",
-              "type": "TextBlock",
-              "size": "medium"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Memory_Widget_Template/AllMemory%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${allMem}",
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder",
+                  "horizontalAlignment": "right"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "Column",
-          "items": [
+          "type": "ColumnSet",
+          "columns": [
             {
-              "text": "%Memory_Widget_Template/Cached%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true,
-              "horizontalAlignment": "right"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Memory_Widget_Template/Committed%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${committedMem}/${committedLimitMem}",
+                  "type": "TextBlock",
+                  "size": "medium"
+                }
+              ]
             },
             {
-              "text": "${cachedMem}",
-              "type": "TextBlock",
-              "size": "medium",
-              "horizontalAlignment": "right"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "ColumnSet",
-      "columns": [
-        {
-          "type": "Column",
-          "items": [
-            {
-              "text": "%Memory_Widget_Template/PagedPool%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true
-            },
-            {
-              "text": "${pagedPoolMem}",
-              "type": "TextBlock",
-              "size": "medium"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Memory_Widget_Template/Cached%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${cachedMem}",
+                  "type": "TextBlock",
+                  "size": "medium",
+                  "horizontalAlignment": "right"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "Column",
-          "items": [
+          "type": "ColumnSet",
+          "columns": [
             {
-              "text": "%Memory_Widget_Template/NonPagedPool%",
-              "type": "TextBlock",
-              "size": "small",
-              "isSubtle": true,
-              "horizontalAlignment": "right"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Memory_Widget_Template/PagedPool%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${pagedPoolMem}",
+                  "type": "TextBlock",
+                  "size": "medium"
+                }
+              ]
             },
             {
-              "text": "${nonPagedPoolMem}",
-              "type": "TextBlock",
-              "size": "medium",
-              "horizontalAlignment": "right"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Memory_Widget_Template/NonPagedPool%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${nonPagedPoolMem}",
+                  "type": "TextBlock",
+                  "size": "medium",
+                  "horizontalAlignment": "right"
+                }
+              ]
             }
           ]
         }

--- a/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -2,72 +2,91 @@
   "type": "AdaptiveCard",
   "body": [
     {
-      "type": "Image",
-      "url": "${netGraphUrl}",
-      "height": "${chartHeight}",
-      "width": "${chartWidth}",
-      "horizontalAlignment": "center"
+      "type": "Container",
+      "$when": "${errorMessage != null}",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "size": "small"
+        }
+      ],
+      "style": "warning"
     },
     {
-      "type": "ColumnSet",
-      "columns": [
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
         {
-          "type": "Column",
-          "items": [
+          "type": "Image",
+          "url": "${netGraphUrl}",
+          "height": "${chartHeight}",
+          "width": "${chartWidth}",
+          "horizontalAlignment": "center"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
             {
-              "text": "%NetworkUsage_Widget_Template/Sent%",
-              "type": "TextBlock",
-              "spacing": "none",
-              "size": "small",
-              "isSubtle": true
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%NetworkUsage_Widget_Template/Sent%",
+                  "type": "TextBlock",
+                  "spacing": "none",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${netSent}",
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder"
+                }
+              ]
             },
             {
-              "text": "${netSent}",
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder"
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%NetworkUsage_Widget_Template/Received%",
+                  "type": "TextBlock",
+                  "spacing": "none",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${netReceived}",
+                  "type": "TextBlock",
+                  "size": "large",
+                  "weight": "bolder",
+                  "horizontalAlignment": "right"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "Column",
-          "items": [
-            {
-              "text": "%NetworkUsage_Widget_Template/Received%",
-              "type": "TextBlock",
-              "spacing": "none",
-              "size": "small",
-              "isSubtle": true,
-              "horizontalAlignment": "right"
-            },
-            {
-              "text": "${netReceived}",
-              "type": "TextBlock",
-              "size": "large",
-              "weight": "bolder",
-              "horizontalAlignment": "right"
-            }
-          ]
+          "text": "%NetworkUsage_Widget_Template/Network_Name%",
+          "type": "TextBlock",
+          "size": "small",
+          "isSubtle": true
+        },
+        {
+          "text": "${networkName}",
+          "type": "TextBlock",
+          "size": "medium"
+        }
+      ],
+      "actions": [
+        {
+          "type": "Action.Execute",
+          "title": "%NetworkUsage_Widget_Template/Next_Network%",
+          "verb": "NextItem"
         }
       ]
-    },
-    {
-      "text": "%NetworkUsage_Widget_Template/Network_Name%",
-      "type": "TextBlock",
-      "size": "small",
-      "isSubtle": true
-    },
-    {
-      "text": "${networkName}",
-      "type": "TextBlock",
-      "size": "medium"
-    }
-  ],
-  "actions": [
-    {
-      "type": "Action.Execute",
-      "title": "%NetworkUsage_Widget_Template/Next_Network%",
-      "verb": "NextItem"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",


### PR DESCRIPTION
## Summary of the pull request

Core widgets currently do not set ContentData to anything on error, which causes them to display an empty template with variable names with no indication of what is wrong. This change adds an error message to the main template for each of the core widgets, and populates that message with any exception errors when encountered so it is obvious to the user that something is wrong.  If there is no error message, then the templates display as normal, but if there is an error message that is displayed instead.
 
## References and relevant issues
Closes #1248

## Detailed description of the pull request / Additional comments

* Each core widget now sets an error message when an exception occurs during LoadContentData.
* Each core widget template has a container for displaying any error messages that is mutually exclusive with its normal display (if error, show error, else show normal template). 

The diff of the templates looks like a lot changed, but the actual change was adding a new container for the error message and then shifting the previous content to be in a second container mutually exclusive with the error container. Shifting it one indentation level made for a messy JSON diff.

## Validation steps performed

* Manual test by forcing failure in the LoadContentData method of each widget.
* Confirmed that the widgets look normal without failure and that they show the failure message with
* Exception: I was unable to validate the SSH widget as I had no SSH config file.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
