### PR TITLE
Enable DevHome SDK debug binaries

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -54,7 +54,7 @@ if ($IsAzurePipelineBuild) {
 }
 
 if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "sdk")) {
-  extensionsdk\BuildSDKHelper.ps1 -VersionOfSDK $env:sdk_version -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassError
+  extensionsdk\BuildSDKHelper.ps1 -VersionOfSDK $env:sdk_version -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassWarning
 }
 
 $msbuildPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe

--- a/Build.ps1
+++ b/Build.ps1
@@ -54,7 +54,7 @@ if ($IsAzurePipelineBuild) {
 }
 
 if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "sdk")) {
-  extensionsdk\Build.ps1 -VersionOfSDK $env:sdk_version -IsAzurePipelineBuild $IsAzurePipelineBuild
+  extensionsdk\BuildSDKHelper.ps1 -VersionOfSDK $env:sdk_version -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassError
 }
 
 $msbuildPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe

--- a/extensionsdk/Build.cmd
+++ b/extensionsdk/Build.cmd
@@ -1,5 +1,0 @@
-@echo off
-
-powershell -ExecutionPolicy Unrestricted -NoLogo -NoProfile -File %~dp0\Build.ps1 %*
-
-exit /b %ERRORLEVEL%

--- a/extensionsdk/BuildSDKHelper.cmd
+++ b/extensionsdk/BuildSDKHelper.cmd
@@ -1,0 +1,5 @@
+@echo off
+
+powershell -ExecutionPolicy Unrestricted -NoLogo -NoProfile -File %~dp0\BuildSDKHelper.ps1 %*
+
+exit /b %ERRORLEVEL%

--- a/extensionsdk/BuildSDKHelper.ps1
+++ b/extensionsdk/BuildSDKHelper.ps1
@@ -2,7 +2,7 @@ Param(
   [string]$Configuration = "Debug",
   [string]$VersionOfSDK,
   [bool]$IsAzurePipelineBuild = $false,
-  [switch]$BypassError = $false,
+  [switch]$BypassWarning = $false,
   [switch]$Help = $false
 )
 
@@ -32,11 +32,11 @@ Options:
   Exit
 }
 
-if (-not $BypassError) {
+if (-not $BypassWarning) {
   Write-Host @"
 This script is not meant to be run directly.  To build the sdk, please run the following from the root directory:
 build -BuildStep "sdk"
-"@
+"@ -ForegroundColor RED
   Exit
 }
 

--- a/extensionsdk/BuildSDKHelper.ps1
+++ b/extensionsdk/BuildSDKHelper.ps1
@@ -1,7 +1,8 @@
 Param(
-  [string]$Configuration = "Release",
+  [string]$Configuration = "Debug",
   [string]$VersionOfSDK,
   [bool]$IsAzurePipelineBuild = $false,
+  [switch]$BypassError = $false,
   [switch]$Help = $false
 )
 
@@ -27,6 +28,14 @@ Options:
 
   -Help
       Display this usage message.
+"@
+  Exit
+}
+
+if (-not $BypassError) {
+  Write-Host @"
+This script is not meant to be run directly.  To build the sdk, please run the following from the root directory:
+build -BuildStep "sdk"
 "@
   Exit
 }

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
@@ -186,6 +186,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
## Summary of the pull request
Enable debug version of SDK binaries to be built for local testing.  This still does not enable a debug version of the nuget package.  That will come later.
 
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
