### PR TITLE
Fix RidGraph use with .NET 8

### DIFF
--- a/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -12,7 +12,7 @@
     <Nullable>enable</Nullable>
     <CsWinRTEnabled>false</CsWinRTEnabled>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfileFullPath>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,6 +39,9 @@
   </ItemGroup>
   <!-- Needed for reverting back to pre-.NET 8 method of Host using the RID graph to determine assets  -->
   <!-- https://learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/8.0/rid-asset-list -->
+  <PropertyGroup>
+    <UseRidGraph>true</UseRidGraph>
+  </PropertyGroup>
   <ItemGroup>
 	  <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
   </ItemGroup>

--- a/SampleExtension/SampleExtension.csproj
+++ b/SampleExtension/SampleExtension.csproj
@@ -5,7 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SampleExtension</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>false</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <CsWinRTEnabled>false</CsWinRTEnabled>

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.Common</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <DevHomeSDKVersion Condition="$(DevHomeSDKVersion) == ''">$(DevHomeSDKVersion)</DevHomeSDKVersion>

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x86;x64;arm64;AnyCPU</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x86;x64;arm64;AnyCPU</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/logging/DevHome.Logging.csproj
+++ b/logging/DevHome.Logging.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
     <RootNamespace>DevHome.Logging</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/settings/DevHome.Settings.UITest/DevHome.Dashboard.UITest.csproj
+++ b/settings/DevHome.Settings.UITest/DevHome.Dashboard.UITest.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <RootNamespace>Dashboard.UITest</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWinUI>true</UseWinUI>

--- a/settings/DevHome.Settings.UnitTest/DevHome.SetupFlow.UnitTest.csproj
+++ b/settings/DevHome.Settings.UnitTest/DevHome.SetupFlow.UnitTest.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <RootNamespace>Dashboard.Test</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/settings/DevHome.Settings/DevHome.Settings.csproj
+++ b/settings/DevHome.Settings/DevHome.Settings.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.Settings</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -9,7 +9,7 @@
         <ApplicationIcon>Assets/DevHome.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <Platforms>x86;x64;arm64</Platforms>
-        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
         <PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/src/Properties/PublishProfiles/win10-arm64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>

--- a/src/Properties/PublishProfiles/win10-x64.pubxml
+++ b/src/Properties/PublishProfiles/win10-x64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>

--- a/src/Properties/PublishProfiles/win10-x86.pubxml
+++ b/src/Properties/PublishProfiles/win10-x86.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>

--- a/telemetry/DevHome.Telemetry/DevHome.Telemetry.csproj
+++ b/telemetry/DevHome.Telemetry/DevHome.Telemetry.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>DevHome.Telemetry</RootNamespace>
         <Platforms>x86;x64;arm64</Platforms>
-        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
         <UseWinUI>true</UseWinUI>
     </PropertyGroup>
 </Project>

--- a/test/DevHome.Test.csproj
+++ b/test/DevHome.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.Test</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.Dashboard.UnitTest.csproj
+++ b/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.Dashboard.UnitTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Dashboard.Test</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.Dashboard</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <CsWinRTIncludes>Microsoft.Windows.Widgets.Hosts</CsWinRTIncludes>
   </PropertyGroup>

--- a/tools/Experiments/src/DevHome.Experiments.csproj
+++ b/tools/Experiments/src/DevHome.Experiments.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.Experiments</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.ExtensionLibrary</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>

--- a/tools/SampleTool/src/SampleTool.csproj
+++ b/tools/SampleTool/src/SampleTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>SampleTool</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/SampleTool/unittest/SampleTool.UnitTest.csproj
+++ b/tools/SampleTool/unittest/SampleTool.UnitTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>SampleTool.Test</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.SetupFlow.Common</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <ApplicationIcon>$(SolutionDir)\src\Assets\DevHome.ico</ApplicationIcon>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfileFullPath>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/SetupFlow/DevHome.SetupFlow.UnitTest/DevHome.SetupFlow.UnitTest.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.UnitTest/DevHome.SetupFlow.UnitTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.SetupFlow.UnitTest</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.SetupFlow</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
 

--- a/uitest/DevHome.UITest.csproj
+++ b/uitest/DevHome.UITest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>DevHome.UITest</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWinUI>true</UseWinUI>


### PR DESCRIPTION
## Summary of the pull request
There are two parts to this change:
1. Add <UseRidGraph>
  <PropertyGroup>
    <UseRidGraph>true</UseRidGraph>
  </PropertyGroup>
  <ItemGroup>
    <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
  </ItemGroup>
UseRidGraph is for buildtime while RuntimeHostConfigurationOption is for runtime.  Both of these are needed.

2. Switch runtime identifiers back to "win10" versions.  The above RidGraph workaround doesn't mean "work with packages still using old win10 runtime identifiers".  It actually means "use the old runtime identifier system instead of the new one".

After all dependencies have moved to the new .NET 8 runtime identifiers, we can remove the workarounds (#1) and change back to the new "win" runtime identifiers (#2)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
