### PR TITLE
Support mouse and forward navigation

### DIFF
--- a/common/Services/INavigationService.cs
+++ b/common/Services/INavigationService.cs
@@ -34,4 +34,6 @@ public interface INavigationService
     bool NavigateTo(string pageKey, object? parameter = null, bool clearNavigation = false);
 
     bool GoBack();
+
+    bool GoForward();
 }

--- a/src/Services/NavigationService.cs
+++ b/src/Services/NavigationService.cs
@@ -55,6 +55,9 @@ public class NavigationService : INavigationService
     [MemberNotNullWhen(true, nameof(Frame), nameof(_frame))]
     public bool CanGoBack => Frame != null && Frame.CanGoBack;
 
+    [MemberNotNullWhen(true, nameof(Frame), nameof(_frame))]
+    public bool CanGoForward => Frame != null && Frame.CanGoForward;
+
     public NavigationService(IPageService pageService)
     {
         _pageService = pageService;
@@ -82,6 +85,23 @@ public class NavigationService : INavigationService
         {
             var vmBeforeNavigation = _frame.GetPageViewModel();
             _frame.GoBack();
+            if (vmBeforeNavigation is INavigationAware navigationAware)
+            {
+                navigationAware.OnNavigatedFrom();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool GoForward()
+    {
+        if (CanGoForward)
+        {
+            var vmBeforeNavigation = _frame.GetPageViewModel();
+            _frame.GoForward();
             if (vmBeforeNavigation is INavigationAware navigationAware)
             {
                 navigationAware.OnNavigatedFrom();


### PR DESCRIPTION
## Summary of the pull request
- Adds the ability to forward navigate between pages 
- Configures pointer navigation support (i.e. mouse forward and back buttons).

## References and relevant issues
Addresses #1083, specifically targeting mouse navigation but the fix should apply more broadly to other custom keys.

Similar to #551, this addresses inconsistencies in the invocation of navigation (keyboard accelerator, forward vs. back, mouse, etc.), but does not do anything to address the gap between navigation at the application level (existing navigation service implementation) vs. nested navigation in individual tools, e.g. SetupFlow. 

## Detailed description of the pull request / Additional comments
Specifically added a keyboard accelerator handler for forward, the existing implementation assumed all accelerator invocations are for back navigation.

PointerPressed is used to identify navigation via XButton1/2 as per https://learn.microsoft.com/en-us/windows/apps/design/basics/navigation-history-and-backwards-navigation#handle-mouse-navigation-buttons, using the page UIElement rather than the defunct CoreWindow in the sample.

## Validation steps performed
- Navigate manually from Dashboard to each top level page, pressing the back and forward buttons periodically to ensure navigation correctly goes back along the navigation stack.
- Ensure navigation to the Settings page correctly follows navigating to and from sub-pages.
- Ensure invocations work correctly regardless of pointer positioning, e.g. hovering over the NavigationFrame itself vs. the NavigationViewControl/hamburger menu area.

## PR checklist
- [ ] Closes #1083
- [ ] Tests passed
