### PR TITLE
System.Text.Json is not behaving well with Adaptive Cards

### DIFF
--- a/common/Models/ExtensionAdaptiveCard.cs
+++ b/common/Models/ExtensionAdaptiveCard.cs
@@ -29,7 +29,12 @@ public class ExtensionAdaptiveCard : IExtensionAdaptiveCard
     public ProviderOperationResult Update(string templateJson, string dataJson, string state)
     {
         var template = new AdaptiveCardTemplate(templateJson ?? TemplateJson);
-        var adaptiveCardString = template.Expand(JsonNode.Parse(dataJson ?? DataJson));
+
+        // Need to use Newtonsoft.Json here because System.Text.Json is missing a set of wrapping brackets
+        // which causes AdaptiveCardTemplate.Expand to fail.  System.Text.Json also does not support parsing
+        // an empty string.
+        var adaptiveCardString = template.Expand(Newtonsoft.Json.JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(dataJson ?? DataJson));
+
         var parseResult = AdaptiveCard.FromJsonString(adaptiveCardString);
 
         if (parseResult.AdaptiveCard is null)


### PR DESCRIPTION
## Summary of the pull request
1. System.Text.Json's Parse() does not work with empty strings.
2. System.Text.Json's Parse() only puts one bracket around the parent object while Newtonsoft puts two brackets.

These two problems are causing issues with AdaptiveCardTemplate.Expand() which uses Newtonsoft internally.  Solution is to move back to Newtonsoft.Json for this piece.  Alternatively, we could stay with System.Text.Json here, but it would require us to manually add an extra set of brackets and have forked logic for trying to pass an empty string to AdaptiveCardTemplate.Expand().  This is much simpler and safer for now.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
