### PR TITLE
Add error messages for DSC configuration in summary page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Configuration/ConfigurationFileHelper.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Configuration/ConfigurationFileHelper.cs
@@ -85,7 +85,7 @@ public class ConfigurationFileHelper
             _configSet = openResult.Set;
             if (_configSet == null)
             {
-                throw new OpenConfigurationSetException(openResult.ResultCode, openResult.Field);
+                throw new OpenConfigurationSetException(openResult.ResultCode, openResult.Field, openResult.Value);
             }
 
             // Set input file path in the configuration set to inform the

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Exceptions/OpenConfigurationSetException.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Exceptions/OpenConfigurationSetException.cs
@@ -6,15 +6,8 @@ using Microsoft.Management.Configuration;
 
 namespace DevHome.SetupFlow.Common.Exceptions;
 
-public class OpenConfigurationSetException : Exception
+public class OpenConfigurationSetException : WinGetConfigurationException
 {
-    // Open configuration error codes:
-    // Reference: https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerSharedLib/Public/AppInstallerErrors.h
-    public const int WingetConfigErrorInvalidConfigurationFile = unchecked((int)0x8A15C001);
-    public const int WingetConfigErrorInvalidYaml = unchecked((int)0x8A15C002);
-    public const int WingetConfigErrorInvalidField = unchecked((int)0x8A15C003);
-    public const int WingetConfigErrorUnknownConfigurationFileVersion = unchecked((int)0x8A15C004);
-
     /// <summary>
     /// Gets the <see cref="OpenConfigurationSetResult.ResultCode"/>
     /// </summary>
@@ -24,16 +17,25 @@ public class OpenConfigurationSetException : Exception
     }
 
     /// <summary>
-    /// Gets the <see cref="OpenConfigurationSetResult.Field"/>
+    /// Gets the field that is missing/invalid, if appropriate for the specific ResultCode.
     /// </summary>
     public string Field
     {
         get;
     }
 
-    public OpenConfigurationSetException(Exception resultCode, string field)
+    /// <summary>
+    /// Gets the value of the field, if appropriate for the specific ResultCode.
+    /// </summary>
+    public string Value
+    {
+        get;
+    }
+
+    public OpenConfigurationSetException(Exception resultCode, string field, string value)
     {
         ResultCode = resultCode;
         Field = field;
+        Value = value;
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Exceptions/WinGetConfigurationException.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Exceptions/WinGetConfigurationException.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+
+namespace DevHome.SetupFlow.Common.Exceptions;
+
+public class WinGetConfigurationException : Exception
+{
+    // WinGet Configuration error codes:
+    // https://github.com/microsoft/winget-cli/blob/master/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Exceptions/ErrorCodes.cs
+    public const int WingetConfigErrorInvalidConfigurationFile = unchecked((int)0x8A15C001);
+    public const int WingetConfigErrorInvalidYaml = unchecked((int)0x8A15C002);
+    public const int WingetConfigErrorInvalidFieldType = unchecked((int)0x8A15C003);
+    public const int WingetConfigErrorUnknownConfigurationFileVersion = unchecked((int)0x8A15C004);
+    public const int WingetConfigErrorSetApplyFailed = unchecked((int)0x8A15C005);
+    public const int WingetConfigErrorDuplicateIdentifier = unchecked((int)0x8A15C006);
+    public const int WingetConfigErrorMissingDependency = unchecked((int)0x8A15C007);
+    public const int WingetConfigErrorDependencyUnsatisfied = unchecked((int)0x8A15C008);
+    public const int WingetConfigErrorAssertionFailed = unchecked((int)0x8A15C009);
+    public const int WingetConfigErrorManuallySkipped = unchecked((int)0x8A15C00A);
+    public const int WingetConfigErrorWarningNotAccepted = unchecked((int)0x8A15C00B);
+    public const int WingetConfigErrorSetDependencyCycle = unchecked((int)0x8A15C00C);
+    public const int WingetConfigErrorInvalidFieldValue = unchecked((int)0x8A15C00D);
+    public const int WingetConfigErrorMissingField = unchecked((int)0x8A15C00E);
+
+    // WinGet Configuration unit error codes:
+    public const int WinGetConfigUnitNotFound = unchecked((int)0x8A15C101);
+    public const int WinGetConfigUnitNotFoundRepository = unchecked((int)0x8A15C102);
+    public const int WinGetConfigUnitMultipleMatches = unchecked((int)0x8A15C103);
+    public const int WinGetConfigUnitInvokeGet = unchecked((int)0x8A15C104);
+    public const int WinGetConfigUnitInvokeTest = unchecked((int)0x8A15C105);
+    public const int WinGetConfigUnitInvokeSet = unchecked((int)0x8A15C106);
+    public const int WinGetConfigUnitModuleConflict = unchecked((int)0x8A15C107);
+    public const int WinGetConfigUnitImportModule = unchecked((int)0x8A15C108);
+    public const int WinGetConfigUnitInvokeInvalidResult = unchecked((int)0x8A15C109);
+    public const int WinGetConfigUnitSettingConfigRoot = unchecked((int)0x8A15C110);
+    public const int WinGetConfigUnitImportModuleAdmin = unchecked((int)0x8A15C111);
+}

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Helpers/ElevatedConfigureUnitTaskResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Helpers/ElevatedConfigureUnitTaskResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors
 // Licensed under the MIT license.
 
+using Microsoft.Management.Configuration;
+
 namespace DevHome.SetupFlow.ElevatedComponent.Helpers;
 
 /// <summary>
@@ -19,4 +21,8 @@ public sealed class ElevatedConfigureUnitTaskResult
     public bool IsSkipped { get; set; }
 
     public int HResult { get; set; }
+
+    public int ResultSource { get; set; }
+
+    public string? Details { get; set; }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
@@ -43,6 +43,7 @@ public sealed class ElevatedConfigurationTask
                         Intent = unitResult.Unit.Intent.ToString(),
                         IsSkipped = unitResult.State == ConfigurationUnitState.Skipped,
                         HResult = unitResult.ResultInformation?.ResultCode?.HResult ?? HRESULT.S_OK,
+                        ResultSource = (int)(unitResult.ResultInformation?.ResultSource ?? ConfigurationUnitResultSource.None),
                     };
                 }).ToList();
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
@@ -20,7 +20,7 @@ public class ConfigurationUnitResult
         IsSkipped = result.State == ConfigurationUnitState.Skipped;
         HResult = result.ResultInformation?.ResultCode?.HResult ?? HRESULT.S_OK;
         ResultSource = result.ResultInformation?.ResultSource ?? ConfigurationUnitResultSource.None;
-        Details = result.ResultInformation.Details;
+        Details = result.ResultInformation?.Details;
     }
 
     public ConfigurationUnitResult(ElevatedConfigureUnitTaskResult result)

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigurationUnitResult.cs
@@ -19,6 +19,8 @@ public class ConfigurationUnitResult
         Intent = result.Unit.Intent.ToString();
         IsSkipped = result.State == ConfigurationUnitState.Skipped;
         HResult = result.ResultInformation?.ResultCode?.HResult ?? HRESULT.S_OK;
+        ResultSource = result.ResultInformation?.ResultSource ?? ConfigurationUnitResultSource.None;
+        Details = result.ResultInformation.Details;
     }
 
     public ConfigurationUnitResult(ElevatedConfigureUnitTaskResult result)
@@ -29,6 +31,8 @@ public class ConfigurationUnitResult
         Intent = result.Intent;
         IsSkipped = result.IsSkipped;
         HResult = result.HResult;
+        ResultSource = (ConfigurationUnitResultSource)result.ResultSource;
+        Details = result.Details;
     }
 
     public string UnitName { get; }
@@ -42,4 +46,8 @@ public class ConfigurationUnitResult
     public bool IsSkipped { get; }
 
     public int HResult { get; }
+
+    public ConfigurationUnitResultSource ResultSource { get; }
+
+    public string Details { get; }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -24,11 +24,6 @@ public static class StringResourceKey
     public static readonly string ConfigurationFileApplySuccess = nameof(ConfigurationFileApplySuccess);
     public static readonly string ConfigurationFileApplySuccessReboot = nameof(ConfigurationFileApplySuccessReboot);
     public static readonly string ConfigurationFileApplying = nameof(ConfigurationFileApplying);
-    public static readonly string ConfigurationFieldInvalid = nameof(ConfigurationFieldInvalid);
-    public static readonly string ConfigurationFileInvalid = nameof(ConfigurationFileInvalid);
-    public static readonly string ConfigurationFileOpenUnknownError = nameof(ConfigurationFileOpenUnknownError);
-    public static readonly string ConfigurationFileVersionUnknown = nameof(ConfigurationFileVersionUnknown);
-    public static readonly string ConfigurationFileTypeNotSupported = nameof(ConfigurationFileTypeNotSupported);
     public static readonly string ConfigurationUnitFailed = nameof(ConfigurationUnitFailed);
     public static readonly string ConfigurationUnitSkipped = nameof(ConfigurationUnitSkipped);
     public static readonly string ConfigurationUnitSuccess = nameof(ConfigurationUnitSuccess);
@@ -176,4 +171,33 @@ public static class StringResourceKey
     public static readonly string InstallPackageErrorNoApplicableInstallers = nameof(InstallPackageErrorNoApplicableInstallers);
     public static readonly string InstallPackageErrorUnknownErrorWithErrorCode = nameof(InstallPackageErrorUnknownErrorWithErrorCode);
     public static readonly string InstallPackageErrorUnknownErrorWithErrorCodeAndExitCode = nameof(InstallPackageErrorUnknownErrorWithErrorCodeAndExitCode);
+
+    // WinGet Configuration
+    public static readonly string ConfigurationFieldInvalidType = nameof(ConfigurationFieldInvalidType);
+    public static readonly string ConfigurationFieldInvalidValue = nameof(ConfigurationFieldInvalidValue);
+    public static readonly string ConfigurationFieldMissing = nameof(ConfigurationFieldMissing);
+    public static readonly string ConfigurationFileInvalid = nameof(ConfigurationFileInvalid);
+    public static readonly string ConfigurationFileOpenUnknownError = nameof(ConfigurationFileOpenUnknownError);
+    public static readonly string ConfigurationFileVersionUnknown = nameof(ConfigurationFileVersionUnknown);
+    public static readonly string ConfigurationUnitHasDuplicateIdentifier = nameof(ConfigurationUnitHasDuplicateIdentifier);
+    public static readonly string ConfigurationUnitHasMissingDependency = nameof(ConfigurationUnitHasMissingDependency);
+    public static readonly string ConfigurationUnitAssertHadNegativeResult = nameof(ConfigurationUnitAssertHadNegativeResult);
+    public static readonly string ConfigurationUnitNotFoundInModule = nameof(ConfigurationUnitNotFoundInModule);
+    public static readonly string ConfigurationUnitNotFound = nameof(ConfigurationUnitNotFound);
+    public static readonly string ConfigurationUnitMultipleMatches = nameof(ConfigurationUnitMultipleMatches);
+    public static readonly string ConfigurationUnitFailedDuringGet = nameof(ConfigurationUnitFailedDuringGet);
+    public static readonly string ConfigurationUnitFailedDuringTest = nameof(ConfigurationUnitFailedDuringTest);
+    public static readonly string ConfigurationUnitFailedDuringSet = nameof(ConfigurationUnitFailedDuringSet);
+    public static readonly string ConfigurationUnitModuleConflict = nameof(ConfigurationUnitModuleConflict);
+    public static readonly string ConfigurationUnitModuleImportFailed = nameof(ConfigurationUnitModuleImportFailed);
+    public static readonly string ConfigurationUnitReturnedInvalidResult = nameof(ConfigurationUnitReturnedInvalidResult);
+    public static readonly string ConfigurationUnitManuallySkipped = nameof(ConfigurationUnitManuallySkipped);
+    public static readonly string ConfigurationUnitNotRunDueToDependency = nameof(ConfigurationUnitNotRunDueToDependency);
+    public static readonly string WinGetConfigUnitSettingConfigRoot = nameof(WinGetConfigUnitSettingConfigRoot);
+    public static readonly string WinGetConfigUnitImportModuleAdmin = nameof(WinGetConfigUnitImportModuleAdmin);
+    public static readonly string ConfigurationUnitFailedConfigSet = nameof(ConfigurationUnitFailedConfigSet);
+    public static readonly string ConfigurationUnitFailedInternal = nameof(ConfigurationUnitFailedInternal);
+    public static readonly string ConfigurationUnitFailedPrecondition = nameof(ConfigurationUnitFailedPrecondition);
+    public static readonly string ConfigurationUnitFailedSystemState = nameof(ConfigurationUnitFailedSystemState);
+    public static readonly string ConfigurationUnitFailedUnitProcessing = nameof(ConfigurationUnitFailedUnitProcessing);
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -200,4 +200,5 @@ public static class StringResourceKey
     public static readonly string ConfigurationUnitFailedPrecondition = nameof(ConfigurationUnitFailedPrecondition);
     public static readonly string ConfigurationUnitFailedSystemState = nameof(ConfigurationUnitFailedSystemState);
     public static readonly string ConfigurationUnitFailedUnitProcessing = nameof(ConfigurationUnitFailedUnitProcessing);
+    public static readonly string ConfigurationUnitNotRunDueToFailedAssert = nameof(ConfigurationUnitNotRunDueToFailedAssert);
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -221,14 +221,6 @@
     <value>View {0}</value>
     <comment>{Locked="{0}"}Title for the page showing the contents of a configuration file. {0} is replaced by the configuration file name.</comment>
   </data>
-  <data name="ConfigurationUnitFailed" xml:space="preserve">
-    <value>Failed: {0}</value>
-    <comment>{Locked="{0}"}Error message displayed when applying a configuration unit fails. {0} is replaced by an error code.</comment>
-  </data>
-  <data name="ConfigurationUnitSkipped" xml:space="preserve">
-    <value>Skipped: {0}</value>
-    <comment>{Locked="{0}"}Warning message displayed when applying a configuration unit is skipped. {0} is replaced by an error code.</comment>
-  </data>
   <data name="ConfigurationUnitSuccess" xml:space="preserve">
     <value>Configuration successfully applied</value>
     <comment>Message displayed when applying a configuration unit succeeds.</comment>
@@ -1262,5 +1254,95 @@
   <data name="RepoToolAddAnotherAccount" xml:space="preserve">
     <value>Add another account</value>
     <comment>Menu flyout item content to add another account</comment>
+  </data>
+  <data name="ConfigurationFieldInvalidType" xml:space="preserve">
+    <value>The field '{0}' in the configuration file is the wrong type.</value>
+    <comment>{Locked="{0}"} An error in reading a configuration file. {0} is a placeholder replaced by the field name from the file.</comment>
+  </data>
+  <data name="ConfigurationUnitAssertHadNegativeResult" xml:space="preserve">
+    <value>The system is not in the desired state asserted by the configuration.</value>
+  </data>
+  <data name="ConfigurationUnitFailed" xml:space="preserve">
+    <value>This configuration unit failed for an unknown reason: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationUnitFailedConfigSet" xml:space="preserve">
+    <value>The configuration unit failed due to the configuration: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationUnitFailedDuringGet" xml:space="preserve">
+    <value>The configuration unit failed while attempting to get the current system state.</value>
+  </data>
+  <data name="ConfigurationUnitFailedDuringSet" xml:space="preserve">
+    <value>The configuration unit failed while attempting to apply the desired state.</value>
+  </data>
+  <data name="ConfigurationUnitFailedDuringTest" xml:space="preserve">
+    <value>The configuration unit failed while attempting to test the current system state.</value>
+  </data>
+  <data name="ConfigurationUnitFailedInternal" xml:space="preserve">
+    <value>The configuration unit failed due to an internal error: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationUnitFailedPrecondition" xml:space="preserve">
+    <value>The configuration unit failed due to a precondition not being valid: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationUnitFailedSystemState" xml:space="preserve">
+    <value>The configuration unit failed due to the system state: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationUnitFailedUnitProcessing" xml:space="preserve">
+    <value>The configuration unit failed while attempting to run: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationUnitHasDuplicateIdentifier" xml:space="preserve">
+    <value>The configuration contains the identifier `{0}` multiple times.</value>
+    <comment>{Locked="{0}"} {0} is a placeholder that is replaced by the identifier string from the user input file.</comment>
+  </data>
+  <data name="ConfigurationUnitHasMissingDependency" xml:space="preserve">
+    <value>The dependency `{0}` was not found within the configuration.</value>
+    <comment>{Locked="{0}"} {0} is a placeholder that is replaced by the identifier string from the user input file.</comment>
+  </data>
+  <data name="ConfigurationUnitManuallySkipped" xml:space="preserve">
+    <value>This configuration unit was manually skipped.</value>
+  </data>
+  <data name="ConfigurationUnitModuleConflict" xml:space="preserve">
+    <value>The module for the configuration unit is available in multiple locations with the same version.</value>
+  </data>
+  <data name="ConfigurationUnitModuleImportFailed" xml:space="preserve">
+    <value>Loading the module for the configuration unit failed.</value>
+  </data>
+  <data name="ConfigurationUnitMultipleMatches" xml:space="preserve">
+    <value>Multiple matches were found for the configuration unit; specify the module to select the correct one.</value>
+  </data>
+  <data name="ConfigurationUnitNotFound" xml:space="preserve">
+    <value>The configuration unit could not be found.</value>
+  </data>
+  <data name="ConfigurationUnitNotFoundInModule" xml:space="preserve">
+    <value>The configuration unit was not in the module as expected.</value>
+  </data>
+  <data name="ConfigurationUnitNotRunDueToDependency" xml:space="preserve">
+    <value>This configuration unit was not run because a dependency failed or was not run.</value>
+  </data>
+  <data name="ConfigurationUnitReturnedInvalidResult" xml:space="preserve">
+    <value>The configuration unit returned an unexpected result during execution.</value>
+  </data>
+  <data name="ConfigurationUnitSkipped" xml:space="preserve">
+    <value>This configuration unit was not run for an unknown reason: {0}</value>
+    <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
+  </data>
+  <data name="ConfigurationFieldInvalidValue" xml:space="preserve">
+    <value>The field '{0}' has an invalid value: {1}</value>
+    <comment>{Locked="{0}","{1}"} An error in reading a configuration file. {0} is a placeholder replaced by the field name from the file. {1} is a placeholder for the invalid value.</comment>
+  </data>
+  <data name="ConfigurationFieldMissing" xml:space="preserve">
+    <value>The field '{0}' is missing or empty.</value>
+    <comment>{Locked="{0}"} An error in reading a configuration file. {0} is a placeholder replaced by the expected field name from the file.</comment>
+  </data>
+  <data name="WinGetConfigUnitImportModuleAdmin" xml:space="preserve">
+    <value>Loading the module for the configuration unit failed because it requires administrator privileges to run.</value>
+  </data>
+  <data name="WinGetConfigUnitSettingConfigRoot" xml:space="preserve">
+    <value>A unit contains a setting that requires the config root.</value>
   </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1345,4 +1345,7 @@
   <data name="WinGetConfigUnitSettingConfigRoot" xml:space="preserve">
     <value>A unit contains a setting that requires the config root.</value>
   </data>
+  <data name="ConfigurationUnitNotRunDueToFailedAssert" xml:space="preserve">
+    <value>This configuration unit was not run because an assert failed or was false.</value>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
@@ -141,13 +141,20 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
 
     private string GetErrorMessage(OpenConfigurationSetException exception)
     {
-        return exception.ResultCode?.HResult switch
+        switch (exception.ResultCode.HResult)
         {
-            OpenConfigurationSetException.WingetConfigErrorInvalidField =>
-                StringResource.GetLocalized(StringResourceKey.ConfigurationFieldInvalid, exception.Field),
-            OpenConfigurationSetException.WingetConfigErrorUnknownConfigurationFileVersion =>
-                StringResource.GetLocalized(StringResourceKey.ConfigurationFileVersionUnknown, exception.Field),
-            _ => StringResource.GetLocalized(StringResourceKey.ConfigurationFileInvalid),
-        };
+            case WinGetConfigurationException.WingetConfigErrorInvalidFieldType:
+                return StringResource.GetLocalized(StringResourceKey.ConfigurationFieldInvalidType, exception.Field);
+            case WinGetConfigurationException.WingetConfigErrorInvalidFieldValue:
+                return StringResource.GetLocalized(StringResourceKey.ConfigurationFieldInvalidValue, exception.Field, exception.Value);
+            case WinGetConfigurationException.WingetConfigErrorMissingField:
+                return StringResource.GetLocalized(StringResourceKey.ConfigurationFieldMissing, exception.Field);
+            case WinGetConfigurationException.WingetConfigErrorUnknownConfigurationFileVersion:
+                return StringResource.GetLocalized(StringResourceKey.ConfigurationFileVersionUnknown, exception.Value);
+            case WinGetConfigurationException.WingetConfigErrorInvalidConfigurationFile:
+            case WinGetConfigurationException.WingetConfigErrorInvalidYaml:
+            default:
+                return StringResource.GetLocalized(StringResourceKey.ConfigurationFileInvalid);
+        }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationUnitResultViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationUnitResultViewModel.cs
@@ -42,9 +42,14 @@ public class ConfigurationUnitResultViewModel
 
     private string GetApplyResult()
     {
-        if (IsSkipped || IsError)
+        if (IsSkipped)
         {
-            return GetUnitMessage();
+            return GetUnitSkipMessage();
+        }
+
+        if (IsError)
+        {
+            return GetUnitErrorMessage();
         }
 
         return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSuccess);
@@ -70,7 +75,24 @@ public class ConfigurationUnitResultViewModel
         return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSummaryFull, _unitResult.Intent, _unitResult.UnitName, _unitResult.Id, _unitResult.Description);
     }
 
-    private string GetUnitMessage()
+    private string GetUnitSkipMessage()
+    {
+        var resultCode = _unitResult.HResult;
+        switch (resultCode)
+        {
+            case WinGetConfigurationException.WingetConfigErrorManuallySkipped:
+                return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitManuallySkipped);
+            case WinGetConfigurationException.WingetConfigErrorDependencyUnsatisfied:
+                return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitNotRunDueToDependency);
+            case WinGetConfigurationException.WingetConfigErrorAssertionFailed:
+                return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitNotRunDueToFailedAssert);
+        }
+
+        var resultCodeHex = $"0x{resultCode:X}";
+        return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSkipped, resultCodeHex);
+    }
+
+    private string GetUnitErrorMessage()
     {
         var resultCode = _unitResult.HResult;
         switch (resultCode)
@@ -122,11 +144,6 @@ public class ConfigurationUnitResultViewModel
                 return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitFailedSystemState, resultCodeHex);
             case ConfigurationUnitResultSource.UnitProcessing:
                 return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitFailedUnitProcessing, resultCodeHex);
-        }
-
-        if (IsSkipped)
-        {
-            return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitSkipped, resultCodeHex);
         }
 
         return _stringResource.GetLocalized(StringResourceKey.ConfigurationUnitFailed, resultCodeHex);


### PR DESCRIPTION
## Summary of the pull request
- Copy DSC error messages over from winget repository:
  - [ErrorCodes.cs](https://github.com/microsoft/winget-cli/blob/master/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Exceptions/ErrorCodes.cs)
  - [Resources.resx](https://github.com/microsoft/winget-cli/blob/master/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Resources/Resources.resx)

## References and relevant issues


## Detailed description of the pull request / Additional comments

## Validation steps performed
<table>
<tr><th>Before</th></tr>
<tr>
<td>
<img src="https://github.com/microsoft/devhome/assets/104940545/abc64c2c-f6a0-4b6b-a78f-392a2dddbc23" Width="400" />
</td>
</tr>
<tr><th>After</th></tr>
<tr>
<td>
<img src="https://github.com/microsoft/devhome/assets/104940545/d208acc9-74f0-43c3-a55a-c89aa63d65b8" Width="800" />
</td>
</tr>
</table>


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
