### PR TITLE
Create WidgetViewModels using a WidgetViewModelFactory

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -17,6 +17,12 @@ public static class ServiceExtensions
         services.AddTransient<DashboardBannerViewModel>();
         services.AddTransient<AddWidgetViewModel>();
 
+        // DI factory pattern for creating instances with certain parameters
+        // determined at runtime
+        services.AddSingleton<WidgetViewModelFactory>(
+            sp => (widget, widgetSize, widgetDefinition) =>
+                ActivatorUtilities.CreateInstance<WidgetViewModel>(sp, widget, widgetSize, widgetDefinition));
+
         // Services
         services.AddSingleton<IWidgetHostingService, WidgetHostingService>();
         services.AddSingleton<IWidgetIconService, WidgetIconService>();

--- a/tools/Dashboard/DevHome.Dashboard/Services/IAdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IAdaptiveCardRenderingService.cs
@@ -6,7 +6,7 @@ using AdaptiveCards.Rendering.WinUI3;
 
 namespace DevHome.Dashboard.Services;
 
-internal interface IAdaptiveCardRenderingService
+public interface IAdaptiveCardRenderingService
 {
     public Task<AdaptiveCardRenderer> GetRenderer();
 

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -7,7 +7,6 @@ using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
 using AdaptiveCards.Templating;
 using CommunityToolkit.Mvvm.ComponentModel;
-using DevHome.Common.Extensions;
 using DevHome.Common.Renderers;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
@@ -18,12 +17,25 @@ using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Windows.Data.Json;
 using Windows.System;
+using WinUIEx;
 
 namespace DevHome.Dashboard.ViewModels;
 
+/// <summary>
+/// Delegate factory for creating widget view models
+/// </summary>
+/// <param name="widget">Widget</param>
+/// <param name="widgetSize">WidgetSize</param>
+/// <param name="widgetDefinition">WidgetDefinition</param>
+/// <returns>Widget view model</returns>
+public delegate WidgetViewModel WidgetViewModelFactory(
+    Widget widget,
+    WidgetSize widgetSize,
+    WidgetDefinition widgetDefinition);
+
 public partial class WidgetViewModel : ObservableObject
 {
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
+    private readonly WindowEx _windowEx;
     private readonly IAdaptiveCardRenderingService _renderingService;
 
     private RenderedAdaptiveCard _renderedCard;
@@ -80,10 +92,11 @@ public partial class WidgetViewModel : ObservableObject
         Widget widget,
         WidgetSize widgetSize,
         WidgetDefinition widgetDefinition,
-        Microsoft.UI.Dispatching.DispatcherQueue dispatcher)
+        IAdaptiveCardRenderingService adaptiveCardRenderingService,
+        WindowEx windowEx)
     {
-        _renderingService = Application.Current.GetService<IAdaptiveCardRenderingService>();
-        _dispatcher = dispatcher;
+        _renderingService = adaptiveCardRenderingService;
+        _windowEx = windowEx;
 
         Widget = widget;
         WidgetSize = widgetSize;
@@ -154,7 +167,7 @@ public partial class WidgetViewModel : ObservableObject
             }
 
             // Render card on the UI thread.
-            _dispatcher.TryEnqueue(async () =>
+            _windowEx.DispatcherQueue.TryEnqueue(async () =>
             {
                 try
                 {
@@ -216,7 +229,7 @@ public partial class WidgetViewModel : ObservableObject
     public void ShowLoadingCard()
     {
         Log.Logger()?.ReportDebug("WidgetViewModel", "Show loading card.");
-        _dispatcher.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.TryEnqueue(() =>
         {
             WidgetFrameworkElement = new ProgressRing();
         });
@@ -225,7 +238,7 @@ public partial class WidgetViewModel : ObservableObject
     // Used to show a message instead of Adaptive Card content in a widget.
     public void ShowErrorCard(string error, string subError = null)
     {
-        _dispatcher.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.TryEnqueue(() =>
         {
             WidgetFrameworkElement = GetErrorCard(error, subError);
         });

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -28,20 +28,13 @@ public partial class DashboardView : ToolPage
 {
     public override string ShortName => "Dashboard";
 
-    public DashboardViewModel ViewModel
-    {
-        get;
-    }
+    public DashboardViewModel ViewModel { get; }
 
-    internal DashboardBannerViewModel BannerViewModel
-    {
-        get;
-    }
+    internal DashboardBannerViewModel BannerViewModel { get; }
 
-    public static ObservableCollection<WidgetViewModel> PinnedWidgets
-    {
-        get; set;
-    }
+    private readonly WidgetViewModelFactory _widgetViewModelFactory;
+
+    public static ObservableCollection<WidgetViewModel> PinnedWidgets { get; set; }
 
     private static Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
 
@@ -52,6 +45,7 @@ public partial class DashboardView : ToolPage
     {
         ViewModel = Application.Current.GetService<DashboardViewModel>();
         BannerViewModel = Application.Current.GetService<DashboardBannerViewModel>();
+        _widgetViewModelFactory = Application.Current.GetService<WidgetViewModelFactory>();
 
         this.InitializeComponent();
 
@@ -313,7 +307,7 @@ public partial class DashboardView : ToolPage
                     LogLevel.Critical,
                     new ReportPinnedWidgetEvent(widgetDefinition.ProviderDefinition.Id, widgetDefinitionId));
 
-                var wvm = new WidgetViewModel(widget, size, widgetDefinition, _dispatcher);
+                var wvm = _widgetViewModelFactory(widget, size, widgetDefinition);
                 _dispatcher.TryEnqueue(() =>
                 {
                     try


### PR DESCRIPTION
## Summary of the pull request
By creating WidgetViewModels via a factory rather than new-ing them up, they can be more easily mocked for testing.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
