### PR TITLE
Experimental Feature: Quiet Background Processes UI and WinRT server

### DIFF
--- a/DevHome.sln
+++ b/DevHome.sln
@@ -73,6 +73,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ExtensionLibrary", "Extensi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevHome.Experiments", "tools\Experiments\src\DevHome.Experiments.csproj", "{2F9AD5AF-EF3B-496A-8566-9E9539E3DF43}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "QuietBackgroundProcesses", "QuietBackgroundProcesses", "{D04CD3A1-0B45-4CB3-925F-204F5F6AE2D8}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DevHome.QuietBackgroundProcesses.ElevatedServer", "tools\QuietBackgroundProcesses\DevHome.QuietBackgroundProcesses.ElevatedServer\DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj", "{75945141-03AC-4C40-A586-16D463A0AC1B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevHome.QuietBackgroundProcesses.ElevatedServer.Projection", "tools\QuietBackgroundProcesses\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj", "{092AC740-DA01-4872-8E93-B9557DAD6BE5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -413,6 +419,38 @@ Global
 		{2F9AD5AF-EF3B-496A-8566-9E9539E3DF43}.Release|x64.Build.0 = Release|x64
 		{2F9AD5AF-EF3B-496A-8566-9E9539E3DF43}.Release|x86.ActiveCfg = Release|x86
 		{2F9AD5AF-EF3B-496A-8566-9E9539E3DF43}.Release|x86.Build.0 = Release|x86
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|Any CPU.Build.0 = Debug|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|arm64.ActiveCfg = Debug|ARM64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|arm64.Build.0 = Debug|ARM64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|x64.ActiveCfg = Debug|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|x64.Build.0 = Debug|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|x86.ActiveCfg = Debug|Win32
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Debug|x86.Build.0 = Debug|Win32
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|Any CPU.ActiveCfg = Release|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|Any CPU.Build.0 = Release|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|arm64.ActiveCfg = Release|ARM64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|arm64.Build.0 = Release|ARM64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|x64.ActiveCfg = Release|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|x64.Build.0 = Release|x64
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|x86.ActiveCfg = Release|Win32
+		{75945141-03AC-4C40-A586-16D463A0AC1B}.Release|x86.Build.0 = Release|Win32
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|arm64.Build.0 = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|x64.Build.0 = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Debug|x86.Build.0 = Debug|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|arm64.ActiveCfg = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|arm64.Build.0 = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|x64.ActiveCfg = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|x64.Build.0 = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|x86.ActiveCfg = Release|Any CPU
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -434,6 +472,9 @@ Global
 		{69F8B7DF-F52B-4B74-9A16-AB3241BB8912} = {F6EAB7D3-8F0A-4455-8969-2EF4A67314A0}
 		{F6EAB7D3-8F0A-4455-8969-2EF4A67314A0} = {A972EC5B-FC61-4964-A6FF-F9633EB75DFD}
 		{2F9AD5AF-EF3B-496A-8566-9E9539E3DF43} = {A972EC5B-FC61-4964-A6FF-F9633EB75DFD}
+		{D04CD3A1-0B45-4CB3-925F-204F5F6AE2D8} = {A972EC5B-FC61-4964-A6FF-F9633EB75DFD}
+		{75945141-03AC-4C40-A586-16D463A0AC1B} = {D04CD3A1-0B45-4CB3-925F-204F5F6AE2D8}
+		{092AC740-DA01-4872-8E93-B9557DAD6BE5} = {D04CD3A1-0B45-4CB3-925F-204F5F6AE2D8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {030B5641-B206-46BB-BF71-36FF009088FA}

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -538,4 +538,10 @@
     <value>Learn more</value>
     <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>
+  <data name="QuietBackgroundProcessesExperiment_Description" xml:space="preserve">
+    <value>Silence and track background processes that may hinder device performance</value>
+  </data>
+  <data name="QuietBackgroundProcessesExperiment_Name" xml:space="preserve">
+    <value>Quiet background processes experiment</value>
+  </data>
 </root>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -43,24 +43,27 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Internal.Windows.DevHome.Win32" Version="1.0.20240126-x1507" />
         <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
         <PackageReference Include="WinUIEx" Version="1.8.0" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" GeneratePathProperty="true">
             <ExcludeAssets>contentFiles</ExcludeAssets>
         </PackageReference>
     </ItemGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\common\DevHome.Common.csproj" />
         <ProjectReference Include="..\CoreWidgetProvider\CoreWidgetProvider.csproj" />
         <ProjectReference Include="..\settings\DevHome.Settings\DevHome.Settings.csproj" />
         <ProjectReference Include="..\tools\Dashboard\DevHome.Dashboard\DevHome.Dashboard.csproj" />
         <ProjectReference Include="..\tools\Experiments\src\DevHome.Experiments.csproj" />
+        <ProjectReference Include="..\tools\QuietBackgroundProcesses\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj" />
+        <ProjectReference Include="..\tools\QuietBackgroundProcesses\DevHome.QuietBackgroundProcesses.ElevatedServer\DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj" />
         <ProjectReference Include="..\tools\SetupFlow\DevHome.SetupFlow\DevHome.SetupFlow.csproj" />
         <ProjectReference Include="..\tools\ExtensionLibrary\DevHome.ExtensionLibrary\DevHome.ExtensionLibrary.csproj" />
     </ItemGroup>
@@ -86,6 +89,12 @@
     <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
         <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
     </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="$(DevHomeInternal_Win32RuntimePath)Microsoft.Internal.Windows.DevHome.Win32.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
 
     <PropertyGroup>
         <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
@@ -120,6 +129,9 @@
             </AdditionalPackageFile>
             <AdditionalPackageFile Include="$(TargetDir)\Modules\**\*.*">
               <PackagePath>$(ModulePath)Modules</PackagePath>
+            </AdditionalPackageFile>
+            <AdditionalPackageFile Include="$(TargetDir)\DevHome.QuietBackgroundProcesses.ElevatedServer.exe">
+              <PackagePath>.\</PackagePath>
             </AdditionalPackageFile>
         </ItemGroup>
 

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -25,7 +25,7 @@
             "viewModelFullName": "DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel",
             "icon": "ea86"
           }
-          /*,
+          ,
           {
             "identity": "DevHome.TestExperiment",
             "assembly": "DevHome.Experiments",
@@ -33,13 +33,20 @@
             "viewModelFullName": "DevHome.Experiments.ViewModels.TestExperimentViewModel",
             "icon": "f0f7",
             "experimentId": "ExperimentalFeature_1"
+          },
+          {
+            "identity": "DevHome.QuietBackgroundProcessesTestExperiment",
+            "assembly": "DevHome.Experiments",
+            "viewFullName": "DevHome.Experiments.Views.QuietBackgroundProcessesPage",
+            "viewModelFullName": "DevHome.Experiments.ViewModels.QuietBackgroundProcessesViewModel",
+            "icon": "f5b0",
+            "experimentId": "QuietBackgroundProcessesExperiment"
           }
-          */
         ]
       }
     ]
   },
-  "experiments": [ /*
-  "ExperimentalFeature_1"
-  */ ]
+  "experiments": [
+  "QuietBackgroundProcessesExperiment"
+  ]
 }

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" IgnorableNamespaces="uap uap3 rescap genTemplate desktop6">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" IgnorableNamespaces="uap uap3 uap5 rescap genTemplate desktop6">
   <Extensions>
     <Extension Category="windows.activatableClass.proxyStub">
       <ProxyStub ClassId="00000355-0000-0000-C000-000000000046">
@@ -7,6 +7,13 @@
         <Interface Name="Microsoft.Windows.Widgets.Providers.IWidgetProvider" InterfaceId="5C5774CC-72A0-452D-B9ED-075C0DD25EED" />
         <Interface Name="Microsoft.Windows.Widgets.Providers.IWidgetProvider2" InterfaceId="38C3A963-DD93-479D-9276-04BF84EE1816" />
       </ProxyStub>
+    </Extension>
+    <Extension Category="windows.activatableClass.outOfProcessServer">
+      <OutOfProcessServer ServerName="DevHome.QuietBackgroundProcesses.ElevatedServer" uap5:IdentityType="activateAsActivator">
+        <Path>DevHome.QuietBackgroundProcesses.ElevatedServer.exe</Path>
+        <Instancing>singleInstance</Instancing>
+        <ActivatableClass ActivatableClassId="DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager" />
+      </OutOfProcessServer>
     </Extension>
   </Extensions>
   <Identity Name="Microsoft.Windows.DevHome.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />

--- a/test/DevHome.Test.csproj
+++ b/test/DevHome.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(SolutionDir)ToolingVersions.props"/>
+  <Import Project="$(SolutionDir)ToolingVersions.props" />
   <PropertyGroup>
     <RootNamespace>DevHome.Test</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>

--- a/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.Dashboard.UnitTest.csproj
+++ b/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.Dashboard.UnitTest.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(SolutionDir)ToolingVersions.props"/>
+  <Import Project="$(SolutionDir)ToolingVersions.props" />
   <PropertyGroup>
     <RootNamespace>Dashboard.Test</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>

--- a/tools/Experiments/src/DevHome.Experiments.csproj
+++ b/tools/Experiments/src/DevHome.Experiments.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(SolutionDir)ToolingVersions.props"/>
+  <Import Project="$(SolutionDir)ToolingVersions.props" />
   <PropertyGroup>
     <RootNamespace>DevHome.Experiments</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
@@ -7,14 +7,23 @@
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Views\QuietBackgroundProcessesPage.xaml" />
     <None Remove="Views\TestExperimentPage.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
+    <ProjectReference Include="..\..\QuietBackgroundProcesses\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj" />
+    <ProjectReference Include="..\..\QuietBackgroundProcesses\DevHome.QuietBackgroundProcesses.ElevatedServer\DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <Page Update="Views\QuietBackgroundProcessesPage.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
     <Page Update="Views\TestExperimentPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/tools/Experiments/src/Strings/en-us/Resources.resw
+++ b/tools/Experiments/src/Strings/en-us/Resources.resw
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -63,7 +122,28 @@
     <comment>The name is Experiments</comment>
   </data>
   <data name="NavigationPane.Content" xml:space="preserve">
-    <value>Test Experiment page</value>
-    <comment>The name of the Experiments page</comment>
+    <value>Quiet Background Processes</value>
+    <comment>The name of the Quiet Background Processes page</comment>
+  </data>
+  <data name="QuietBackgroundProcesses.Description" xml:space="preserve">
+    <value>Silence and track background processes that may hinder device performance</value>
+  </data>
+  <data name="QuietBackgroundProcesses.Header" xml:space="preserve">
+    <value>Quiet background processes</value>
+  </data>
+  <data name="QuietBackgroundProcessesExplanation.Description" xml:space="preserve">
+    <value>This feature can be activated for 2 hours.</value>
+  </data>
+  <data name="QuietBackgroundProcessesExplanation.Header" xml:space="preserve">
+    <value>Quiet background processes beta feature description</value>
+  </data>
+  <data name="QuietBackgroundProcessesExplanation_LinkToDocs.Text" xml:space="preserve">
+    <value>Link to docs</value>
+  </data>
+  <data name="QuietBackgroundProcessesExplanation_ProvideFeedback.Text" xml:space="preserve">
+    <value>Provide feedback</value>
+  </data>
+  <data name="QuietBackgroundProcessesExplanation_RelatedLinks.Text" xml:space="preserve">
+    <value>Related links</value>
   </data>
 </root>

--- a/tools/Experiments/src/ViewModels/QuietBackgroundProcessesViewModel.cs
+++ b/tools/Experiments/src/ViewModels/QuietBackgroundProcessesViewModel.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using DevHome.Common.Helpers;
+using Microsoft.UI.Xaml;
+using Windows.UI.Xaml;
+
+namespace DevHome.Experiments.ViewModels;
+public class QuietBackgroundProcessesViewModel : INotifyPropertyChanged
+{
+    private readonly TimeSpan _zero;
+    private readonly bool _isElevated;
+    private readonly bool _validOsVersion;
+
+    public QuietBackgroundProcessesViewModel()
+    {
+        _zero = new TimeSpan(0, 0, 0);
+
+        var osVersion = Environment.OSVersion;
+        _validOsVersion = osVersion.Version.Build >= 26024;
+        _validOsVersion = true;
+
+        if (!_validOsVersion)
+        {
+            TimeLeft = "This feature requires OS version 10.0.26024.0+";
+            return;
+        }
+
+        using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+        {
+            WindowsPrincipal principal = new WindowsPrincipal(identity);
+            _isElevated = principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+
+        // Resume countdown if there's an existing quiet window
+        if (GetIsActive())
+        {
+            _isToggleOn = true;
+            var timeLeftInSeconds = GetTimeRemaining();
+            StartCountdownTimer(timeLeftInSeconds);
+        }
+        else
+        {
+            if (!_isElevated)
+            {
+                TimeLeft = "This feature requires running as admin";
+            }
+        }
+    }
+
+    public bool IsToggleEnabled
+    {
+        get
+        {
+            return _isElevated && _validOsVersion;
+        }
+    }
+
+    private bool _isToggleOn;
+
+    public bool IsToggleOn
+    {
+        get => _isToggleOn;
+
+        set
+        {
+            if (_isToggleOn == value)
+            {
+                return;
+            }
+
+            _isToggleOn = value;
+
+            // Stop any existing timer
+            _dispatcherTimer?.Stop();
+
+            if (_isToggleOn)
+            {
+                try
+                {
+                    var timeLeftInSeconds = DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.Start();
+                    StartCountdownTimer(timeLeftInSeconds);
+                }
+                catch
+                {
+                    TimeLeft = "Service error";
+                }
+            }
+            else
+            {
+                try
+                {
+                    DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.Stop();
+                }
+                catch
+                {
+                    TimeLeft = "Unable to cancel session";
+                }
+            }
+
+            OnPropertyChanged(nameof(IsToggleOn));
+        }
+    }
+
+    private bool GetIsActive()
+    {
+        try
+        {
+            return DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.IsActive;
+        }
+        catch (Exception ex)
+        {
+            TimeLeft = "Session error";
+            Log.Logger()?.ReportInfo("QuietBackgroundProcesses", $"IsActive = {ex.ToString()}");
+            return false;
+        }
+    }
+
+    private int GetTimeRemaining()
+    {
+        try
+        {
+            return (int)DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.TimeLeftInSeconds;
+        }
+        catch (Exception ex)
+        {
+            TimeLeft = "Session error";
+            Log.Logger()?.ReportInfo("QuietBackgroundProcesses", $"TimeLeftInSeconds = {ex.ToString()}");
+            return 0;
+        }
+    }
+
+    private DispatcherTimer _dispatcherTimer;
+    private TimeSpan _secondsLeft;
+
+    private void StartCountdownTimer(long timeLeftInSeconds)
+    {
+        if (timeLeftInSeconds <= 0)
+        {
+            return;
+        }
+
+        _dispatcherTimer = new DispatcherTimer();
+        _dispatcherTimer.Tick += DispatcherTimer_Tick;
+        _dispatcherTimer.Interval = new TimeSpan(0, 0, 1);
+        _secondsLeft = new TimeSpan(0, 0, (int)timeLeftInSeconds);
+        _dispatcherTimer.Start();
+
+        TimeLeft = _secondsLeft.ToString();
+    }
+
+    private void DispatcherTimer_Tick(object sender, object e)
+    {
+        var sessionEnded = false;
+
+        _secondsLeft = new TimeSpan(0, 0, GetTimeRemaining());
+
+        if (_secondsLeft.CompareTo(_zero) <= 0)
+        {
+            // The window should be closed, but let's confirm with the server
+            if (GetIsActive())
+            {
+                // There has been some drift
+                _secondsLeft = new TimeSpan(0, 0, GetTimeRemaining());
+            }
+            else
+            {
+                _dispatcherTimer.Stop();
+                _secondsLeft = _zero;
+                IsToggleOn = false;
+                sessionEnded = true;
+            }
+        }
+
+        if (sessionEnded)
+        {
+            TimeLeft = "Session ended";
+        }
+        else
+        {
+            TimeLeft = _secondsLeft.ToString(); // CultureInfo.InvariantCulture
+        }
+    }
+
+    private string _timeLeft = string.Empty;
+
+    public string TimeLeft
+    {
+        get => _timeLeft;
+
+        set
+        {
+            _timeLeft = value;
+            OnPropertyChanged(nameof(TimeLeft));
+        }
+    }
+
+    // INotifyPropertyChanged members
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        var handler = PropertyChanged;
+        if (handler != null)
+        {
+            handler(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/tools/Experiments/src/Views/QuietBackgroundProcessesPage.xaml
+++ b/tools/Experiments/src/Views/QuietBackgroundProcessesPage.xaml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pg:ToolPage
+    x:Class="DevHome.Experiments.Views.QuietBackgroundProcessesPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DevHome.Experiments.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:pg="using:DevHome.Common"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    mc:Ignorable="d">
+
+    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Text="{Binding ViewModel.TimeLeft, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" FontSize="16" Foreground="LightBlue"  Margin="{StaticResource MediumLeftRightMargin}" Grid.Column="1" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                <controls:SettingsExpander x:Uid="QuietBackgroundProcesses" IsExpanded="True" Margin="{ThemeResource SettingsCardMargin}">
+
+                    <!-- Header icon -->
+                    <controls:SettingsExpander.HeaderIcon>
+                        <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/DevHome.ico" />
+                    </controls:SettingsExpander.HeaderIcon>
+
+                    <!-- Toggle switch -->
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{x:Bind ViewModel.TimeLeft, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" FontSize="16" Foreground="LightBlue"  Margin="{StaticResource MediumLeftRightMargin}" Grid.Column="1" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.IsToggleOn, Mode=TwoWay}" IsEnabled="{x:Bind ViewModel.IsToggleEnabled, Mode=OneWay}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Expander -->
+                    <controls:SettingsExpander.Items>
+                        <controls:SettingsCard x:Uid="QuietBackgroundProcessesExplanation" HorizontalContentAlignment="Left" >
+                            <!-- Analytic Summary button -->
+                            <!--
+                            <StackPanel Orientation="Vertical">
+                                <Button x:Name="analyticSummaryButton" AutomationProperties.Name="{Binding ElementName=StartButtonText, Path=Text}" IsTextScaleFactorEnabled="True" Style="{StaticResource AccentButtonStyle}">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="Analytic summary" Grid.Column="1" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                                    </Grid>
+                                </Button>
+                            </StackPanel>
+                            -->
+                        </controls:SettingsCard>
+
+                        <!-- Hyperlinks -->
+                        <!--
+                        <controls:SettingsCard ContentAlignment="Left">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock x:Uid="QuietBackgroundProcessesExplanation_RelatedLinks" Margin="0,0,12,0" VerticalAlignment="Center" />
+                                <HyperlinkButton Margin="{StaticResource HyperlinkButtonNegativeMargin}">
+                                    <TextBlock x:Uid="QuietBackgroundProcessesExplanation_ProvideFeedback" />
+                                </HyperlinkButton>
+                                <HyperlinkButton Margin="{StaticResource HyperlinkButtonNegativeMargin}">
+                                    <TextBlock x:Uid="QuietBackgroundProcessesExplanation_LinkToDocs" />
+                                </HyperlinkButton>
+                            </StackPanel>
+                        </controls:SettingsCard>
+                        -->
+                    </controls:SettingsExpander.Items>
+
+                </controls:SettingsExpander>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</pg:ToolPage>

--- a/tools/Experiments/src/Views/QuietBackgroundProcessesPage.xaml.cs
+++ b/tools/Experiments/src/Views/QuietBackgroundProcessesPage.xaml.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using System.Xml;
+using DevHome.Common;
+using DevHome.Common.Extensions;
+using DevHome.Common.Helpers;
+using DevHome.Common.Services;
+using DevHome.Experiments.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Resources;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace DevHome.Experiments.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class QuietBackgroundProcessesPage : ToolPage
+{
+    public override string ShortName => "Quiet Background Processes";
+
+    public QuietBackgroundProcessesViewModel ViewModel
+    {
+        get;
+    }
+
+    public QuietBackgroundProcessesPage()
+    {
+        ViewModel = new QuietBackgroundProcessesViewModel();
+        InitializeComponent();
+    }
+}

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(SolutionDir)ToolingVersions.props" />
+  
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <CsWinRTIncludes>DevHome.QuietBackgroundProcesses</CsWinRTIncludes>
+    <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GeneratedNugetDir>.\nuget\</GeneratedNugetDir>
+    <NuspecFile>$(GeneratedNugetDir)DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.nuspec</NuspecFile>
+    <OutputPath>$(GeneratedNugetDir)</OutputPath>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.240111.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DevHome.QuietBackgroundProcesses.ElevatedServer\DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="nuget\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.nuspec" />
+  </ItemGroup>
+
+</Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/Directory.Build.props
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/Directory.Build.props
@@ -1,0 +1,7 @@
+﻿<Project>
+  <PropertyGroup>
+    <BuildOutDir>$([MSBuild]::NormalizeDirectory('$(SolutionDir)', '_build', '$(Platform)', '$(Configuration)'))</BuildOutDir>
+    <OutDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'bin'))</OutDir>
+    <IntDir>$([MSBuild]::NormalizeDirectory('$(BuildOutDir)', '$(MSBuildProjectName)', 'obj'))</IntDir>
+  </PropertyGroup>
+</Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/Properties/QuietBackgroundProcesses.ElevatedServer.Projection.rd.xml
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/Properties/QuietBackgroundProcesses.ElevatedServer.Projection.rd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file contains Runtime Directives, specifications about types your application accesses
+    through reflection and other dynamic code patterns. Runtime Directives are used to control the
+    .NET Native optimizer and ensure that it does not remove code accessed by your library. If your
+    library does not do any reflection, then you generally do not need to edit this file. However,
+    if your library reflects over types, especially types passed to it or derived from its types,
+    then you should write Runtime Directives.
+
+    The most common use of reflection in libraries is to discover information about types passed
+    to the library. Runtime Directives have three ways to express requirements on types passed to
+    your library.
+
+    1.  Parameter, GenericParameter, TypeParameter, TypeEnumerableParameter
+        Use these directives to reflect over types passed as a parameter.
+
+    2.  SubTypes
+        Use a SubTypes directive to reflect over types derived from another type.
+
+    3.  AttributeImplies
+        Use an AttributeImplies directive to indicate that your library needs to reflect over
+        types or methods decorated with an attribute.
+
+    For more information on writing Runtime Directives for libraries, please visit
+    https://go.microsoft.com/fwlink/?LinkID=391919
+-->
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="QuietBackgroundProcesses.ElevatedServer.Projection">
+
+  	<!-- add directives for your library here -->
+
+  </Library>
+</Directives>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/nuget/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.nuspec
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/nuget/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.nuspec
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>QuietBackgroundProcesses.ElevatedServer</id>
+    <version>0.1.0-prerelease</version>
+    <authors>Microsoft</authors>
+    <description>An out-of-proc server for the QuietBackgroundProcesses feature.</description>
+    <dependencies>
+      <group targetFramework="net6.0-windows10.0.19041.0" />
+      <group targetFramework=".NETCoreApp3.0" />
+      <group targetFramework="UAP10.0" />
+      <group targetFramework=".NETFramework4.6" />
+    </dependencies>
+  </metadata>
+  <files>
+    <!-- Projection -->
+    <file src="..\..\..\..\_build\AnyCPU\Release\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection\bin\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.dll" target="lib\net6.0-windows10.0.19041.0\DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.dll" />
+
+    <!-- WinMD -->
+    <file src="..\..\DevHome.QuietBackgroundProcesses.ElevatedServer\x64\Release\Merged\DevHome.QuietBackgroundProcesses.winmd" target="lib\netcoreapp3.0\DevHome.DevHome.QuietBackgroundProcesses.winmd" />
+    <file src="..\..\DevHome.QuietBackgroundProcesses.ElevatedServer\x64\Release\Merged\DevHome.QuietBackgroundProcesses.winmd" target="lib\uap10.0\DevHome.DevHome.QuietBackgroundProcesses.winmd" />
+    <file src="..\..\DevHome.QuietBackgroundProcesses.ElevatedServer\x64\Release\Merged\DevHome.QuietBackgroundProcesses.winmd" target="lib\net46\DevHome.DevHome.QuietBackgroundProcesses.winmd" />
+    <!-- Runtime -->
+    <file src="..\..\..\..\src\bin\x64\Release\net8.0-windows10.0.22000.0\DevHome.QuietBackgroundProcesses.ElevatedServer.exe" target="runtimes\win10-x64\native\DevHome.QuietBackgroundProcesses.ElevatedServer.exe" />
+  </files>
+</package>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Win32.1.0.20240126-x1504\build\native\Microsoft.Internal.Windows.DevHome.Win32.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Win32.1.0.20240126-x1504\build\native\Microsoft.Internal.Windows.DevHome.Win32.props')" />
+  <Import Project="..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)ToolingVersions.props" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{75945141-03ac-4c40-a586-16d463a0ac1b}</ProjectGuid>
+    <ProjectName>DevHome.QuietBackgroundProcesses.ElevatedServer</ProjectName>
+    <RootNamespace>DevHome.QuietBackgroundProcesses</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <WindowsAppContainer>false</WindowsAppContainer>
+    <!-- Avoid WRL alignment warnings -->
+    <NoWarn>$(NoWarn);C4324</NoWarn>
+    <!-- Generate OutDir -->
+    <OutDir>$(SolutionDir)src\bin\$(Platform)\$(Configuration)\$(TargetFramework)\</OutDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DesktopCompatible>true</DesktopCompatible>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="PropertySheet.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <PreprocessorDefinitions>_WINRT_DLL;WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+      <ModuleDefinitionFile>QuietBackgroundProcesses_ElevatedServer.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.h">
+      <DependentUpon>DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="QuietState.h" />
+    <ClInclude Include="Timer.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.cpp">
+      <DependentUpon>DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="QuietState.cpp" />
+    <ClCompile Include="Timer.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="QuietBackgroundProcesses_ElevatedServer.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Win32.1.0.20240126-x1504\build\native\Microsoft.Internal.Windows.DevHome.Win32.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Win32.1.0.20240126-x1504\build\native\Microsoft.Internal.Windows.DevHome.Win32.props'))" />
+  </Target>
+</Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+#include <wil/resource.h>
+#include <wil/win32_helpers.h>
+#include <wil/result_macros.h>
+
+#include "Timer.h"
+#include "QuietState.h"
+#include "DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.h"
+#include "QuietBackgroundProcessesManager.g.cpp"
+
+constexpr auto QUIET_DURATION = std::chrono::hours(2);
+
+std::mutex g_mutex;
+std::unique_ptr<Timer> g_activeTimer;
+
+QuietState::unique_quietwindowclose_call g_quietState{false};
+
+namespace winrt::DevHome::QuietBackgroundProcesses::implementation
+{
+    int64_t QuietBackgroundProcessesManager::Start()
+    {
+        auto lock = std::scoped_lock(g_mutex);
+
+        // Discard the active timer
+        Timer::Discard(std::move(g_activeTimer));
+
+        // Start timer
+        g_activeTimer.reset(new Timer(QUIET_DURATION, []()
+        {
+            auto lock = std::scoped_lock(g_mutex);
+            g_quietState.reset();
+        }));
+
+        // Turn on quiet mode
+        g_quietState = QuietState::TurnOn();
+
+        // Return duration for showing countdown
+        return g_activeTimer->TimeLeftInSeconds();
+    }
+
+    void QuietBackgroundProcessesManager::Stop()
+    {
+        auto lock = std::scoped_lock(g_mutex);
+
+        // Turn off quiet mode
+        g_quietState.reset();
+
+        // Detach and destruct the current time window
+        Timer::Discard(std::move(g_activeTimer));
+    }
+
+    bool QuietBackgroundProcessesManager::IsActive()
+    {
+        auto lock = std::scoped_lock(g_mutex);
+        return (bool)g_quietState;
+    }
+
+    int64_t QuietBackgroundProcessesManager::TimeLeftInSeconds()
+    {
+        auto lock = std::scoped_lock(g_mutex);
+        if (!g_quietState || !g_activeTimer)
+        {
+            return 0;
+        }
+        return g_activeTimer->TimeLeftInSeconds();
+    }
+}

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#pragma once
+#include "QuietBackgroundProcessesManager.g.h"
+
+namespace winrt::DevHome::QuietBackgroundProcesses::implementation
+{
+    struct QuietBackgroundProcessesManager : QuietBackgroundProcessesManagerT<QuietBackgroundProcessesManager>
+    {
+        QuietBackgroundProcessesManager() = default;
+
+        static int64_t Start();
+        static void Stop();
+        static bool IsActive();
+        static int64_t TimeLeftInSeconds();
+    };
+}
+namespace winrt::DevHome::QuietBackgroundProcesses::factory_implementation
+{
+    struct QuietBackgroundProcessesManager : QuietBackgroundProcessesManagerT<QuietBackgroundProcessesManager, implementation::QuietBackgroundProcessesManager>
+    {
+    };
+}

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.idl
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.idl
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+namespace DevHome.QuietBackgroundProcesses
+{
+    [default_interface] runtimeclass QuietBackgroundProcessesManager
+    {
+        static Int64 Start();
+        static void Stop();
+        static Boolean IsActive{ get; };
+        static Int64 TimeLeftInSeconds{ get; };
+    }
+}

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/PropertySheet.props
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/PropertySheet.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <!--
+    To customize common C++/WinRT project properties: 
+    * right-click the project node
+    * expand the Common Properties item
+    * select the C++/WinRT property page
+
+    For more advanced scenarios, and complete documentation, please see:
+    https://github.com/Microsoft/cppwinrt/tree/master/nuget 
+    -->
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietBackgroundProcesses_ElevatedServer.def
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietBackgroundProcesses_ElevatedServer.def
@@ -1,0 +1,3 @@
+﻿EXPORTS
+DllCanUnloadNow = WINRT_CanUnloadNow                    PRIVATE
+DllGetActivationFactory = WINRT_GetActivationFactory    PRIVATE

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietState.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietState.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+#include <mutex>
+
+#include <QuietBackgroundProcesses.h>
+#include "QuietState.h"
+
+namespace QuietState
+{
+    std::mutex g_mutex;
+
+    void TurnOff()
+    {
+        auto lock = std::scoped_lock(g_mutex);
+        DisableQuietBackgroundProcesses();
+    }
+
+    unique_quietwindowclose_call TurnOn()
+    {
+        auto lock = std::scoped_lock(g_mutex);
+        THROW_IF_FAILED(EnableQuietBackgroundProcesses());
+        return {};
+    }
+}

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietState.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietState.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#pragma once
+
+#include <wil/resource.h>
+
+namespace QuietState
+{
+    void TurnOff();
+
+    using unique_quietwindowclose_call = wil::unique_call<decltype(&TurnOff), TurnOff>;
+    
+    unique_quietwindowclose_call TurnOn();
+}
+

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Timer.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Timer.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Timer.h"
+
+std::mutex g_discardMutex;
+std::thread g_discardThread;
+
+void Timer::WaitForAllDiscardedTimersToDestruct()
+{
+    auto lock = std::scoped_lock(g_discardMutex);
+    if (g_discardThread.joinable())
+    {
+        g_discardThread.join();
+    }
+}
+
+void Timer::Discard(std::unique_ptr<Timer> timer)
+{
+    if (!timer)
+    {
+        return;
+    }
+    timer->Cancel();
+
+    std::thread previousThread;
+    {
+        auto lock = std::scoped_lock(g_discardMutex);
+        previousThread = std::move(g_discardThread);
+    }
+
+    // Destruct time window on sepearate thread because its destructor may take time to end (the std::future member is blocking)
+    // 
+    // (Make a new discard thread and chain the existing one to it)
+    g_discardThread = std::thread([timer = std::move(timer), previousThread = std::move(previousThread)]() mutable {
+        // Delete the timer (blocking)
+        timer.reset();
+
+        // Finish previous discard thread if there was one
+        if (previousThread.joinable())
+        {
+            previousThread.join();
+        }
+    });
+}

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Timer.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Timer.h
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <optional>
+
+using CallbackFunction = void (*)();
+
+class Timer
+{
+public:
+    // Cleanup functions
+    static void Discard(std::unique_ptr<Timer> timer);
+    static void WaitForAllDiscardedTimersToDestruct();
+
+    Timer(std::chrono::seconds seconds, CallbackFunction callback)
+    {
+        m_startTime = std::chrono::steady_clock::now();
+        m_duration = seconds;
+        m_callback = std::move(callback);
+        m_timerThreadFuture = std::async(std::launch::async, &Timer::TimerThread, this);
+    }
+
+    Timer(Timer&& other) noexcept = default;
+    Timer& operator=(Timer&& other) noexcept = default;
+
+    Timer(const Timer&) = delete;
+    Timer& operator=(const Timer&) = delete;
+
+    void Cancel()
+    {
+        auto lock = std::scoped_lock(m_mutex);
+        m_cancelled = true;
+    }
+
+    int64_t TimeLeftInSeconds()
+    {
+        auto lock = std::scoped_lock(m_mutex);
+        if (m_cancelled)
+        {
+            return 0;
+        }
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - m_startTime);
+
+        auto left = m_duration.count() - elapsed.count();
+        return std::max(left, 0ll);
+    }
+
+private:
+    void TimerThread()
+    {
+        // Pause until timer expired or cancelled
+        while (true)
+        {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - this->m_startTime);
+
+            if (this->m_cancelled || elapsed >= m_duration)
+            {
+                break;
+            }
+
+            // Sleep for a short duration to avoid busy waiting
+            std::this_thread::sleep_for(std::chrono::seconds(30));
+        }
+
+        // Do the callback
+        auto lock = std::scoped_lock(m_mutex);
+        if (!this->m_cancelled)
+        {
+            this->m_callback();
+        }
+    }
+
+    std::chrono::steady_clock::time_point m_startTime{};
+    std::chrono::seconds m_duration{};
+    std::future<void> m_timerThreadFuture;
+    std::mutex m_mutex;
+    std::atomic<bool> m_cancelled{};
+    CallbackFunction m_callback;
+};

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/main.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/main.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#include <pch.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include <wrl/client.h>
+#include <wrl/wrappers/corewrappers.h>
+#include <wrl/implements.h>
+#include <wrl/module.h>
+#include <wil/result_macros.h>
+#include <wil/token_helpers.h>
+#include <wil/win32_helpers.h>
+
+#include <objbase.h>
+#include <roregistrationapi.h>
+
+#include <DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager.h>
+#include "QuietState.h"
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+using unique_hstring_array_ptr = wil::unique_any_array_ptr<HSTRING, wil::cotaskmem_deleter, wil::function_deleter<decltype(::WindowsDeleteString), ::WindowsDeleteString>>;
+
+std::mutex g_finishMutex;
+std::condition_variable g_finishCondition;
+bool g_lastInstanceOfTheModuleObjectIsReleased;
+
+bool IsTokenElevated(HANDLE token)
+{
+    auto mandatoryLabel = wil::get_token_information<TOKEN_MANDATORY_LABEL>(token);
+    LONG levelRid = static_cast<SID*>(mandatoryLabel->Label.Sid)->SubAuthority[0];
+    return levelRid == SECURITY_MANDATORY_HIGH_RID;
+}
+
+wil::unique_ro_registration_cookie RegisterWinrtClasses(_In_ PCWSTR serverName, std::function<void()> objectsReleasedCallback)
+{
+    Module<OutOfProc>::Create(objectsReleasedCallback);
+
+    // Get module classes
+    unique_hstring_array_ptr classes;
+    THROW_IF_FAILED(RoGetServerActivatableClasses(HStringReference(serverName).Get(), &classes, reinterpret_cast<DWORD*>(classes.size_address())));
+
+    // Creation callback
+    PFNGETACTIVATIONFACTORY callback = [](HSTRING name, IActivationFactory** factory) -> HRESULT {
+        RETURN_HR_IF(E_UNEXPECTED, wil::compare_string_ordinal(WindowsGetStringRawBuffer(name, nullptr), L"DevHome.QuietBackgroundProcesses.QuietBackgroundProcessesManager", true) != 0);
+
+        auto manager = winrt::make<winrt::DevHome::QuietBackgroundProcesses::factory_implementation::QuietBackgroundProcessesManager>();
+        manager.as<winrt::Windows::Foundation::IActivationFactory>();
+        *factory = static_cast<IActivationFactory*>(winrt::detach_abi(manager));
+        return S_OK;
+    };
+
+    // Register
+    wil::unique_ro_registration_cookie registrationCookie;
+    PFNGETACTIVATIONFACTORY callbacks[1] = { callback };
+    THROW_IF_FAILED(RoRegisterActivationFactories(classes.get(), callbacks, static_cast<UINT32>(classes.size()), &registrationCookie));
+    return registrationCookie;
+}
+
+//int _cdecl wmain(int argc, __in_ecount(argc) PWSTR wargv[])
+int CALLBACK wWinMain(_In_ HINSTANCE, _In_ HINSTANCE, _In_ LPWSTR wargv, _In_ int)
+try
+{
+    constexpr WCHAR serverNamePrefix[] = L"-ServerName:";
+    if (_wcsnicmp(wargv, serverNamePrefix, wcslen(serverNamePrefix)) != 0)
+    {
+        return E_UNEXPECTED;
+    }
+
+    if (!IsTokenElevated(GetCurrentProcessToken()))
+    {
+        return E_ACCESSDENIED;
+    }
+
+    // To be safe, force quiet mode off to begin the proceedings in case we leaked the machine state previously
+    QuietState::TurnOff();
+
+    PCWSTR serverName = wargv + wcslen(serverNamePrefix);
+    auto unique_rouninitialize_call = wil::RoInitialize();
+
+    // Register WinRT activatable classes
+    auto registrationCookie = RegisterWinrtClasses(serverName, [] {
+        // The last instance object of the module is released
+        {
+            auto lock = std::unique_lock<std::mutex>(g_finishMutex);
+            g_lastInstanceOfTheModuleObjectIsReleased = true;
+        }
+        g_finishCondition.notify_one();
+    });
+
+    // Wait for the module objects to be released and the timer threads to finish
+    {
+        auto lock = std::unique_lock<std::mutex>(g_finishMutex);
+
+        // Wait for both events to complete
+        g_finishCondition.wait(lock, [] {
+            return g_lastInstanceOfTheModuleObjectIsReleased && winrt::DevHome::QuietBackgroundProcesses::implementation::QuietBackgroundProcessesManager::IsActive();
+        });
+    }
+
+    // To be safe, force quiet mode off
+    QuietState::TurnOff();
+
+    return 0;
+}
+CATCH_RETURN();

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/packages.config
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Internal.Windows.DevHome.Win32" version="1.0.20240126-x1504" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
+</packages>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/pch.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/pch.cpp
@@ -1,0 +1,4 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#include "pch.h"

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/pch.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/pch.h
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors
+// Licensed under the MIT license.
+
+#pragma once
+
+#define NOMINMAX
+
+#include <unknwn.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>

--- a/tools/SampleTool/unittest/SampleTool.UnitTest.csproj
+++ b/tools/SampleTool/unittest/SampleTool.UnitTest.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>


### PR DESCRIPTION
Adding the "Enable 'Quiet Background Processes'" experimental feature to Dev Home. It's a toggle that is enabled similarly to Focus Assist mode, that expires after a period of time. When you enable it/toggle it on via the UI, Dev Home will call into the OS to enable quieting down background services (e.g. Search Indexer).

* Requires 'Admin'
* Requires OS build 26024 or higher

## Summary of the pull request

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
