### PR TITLE
Mark LogException Events as Critical & fix tagging

### DIFF
--- a/build/scripts/Unstub.ps1
+++ b/build/scripts/Unstub.ps1
@@ -5,13 +5,20 @@ Remove-Item "$($PSScriptRoot)\..\..\telemetry\DevHome.Telemetry\TelemetryEventSo
 $projFile = "$($PSScriptRoot)\..\..\telemetry\DevHome.Telemetry\DevHome.Telemetry.csproj"
 $projFileContent = Get-Content $projFile -Encoding UTF8 -Raw
 
+$xml = [xml]$projFileContent
+$xml.PreserveWhitespace = $true
+
+$defineConstantsNode = $xml.SelectSingleNode("//DefineConstants")
+if ($defineConstantsNode -ne $null) {
+    $defineConstantsNode.ParentNode.RemoveChild($defineConstantsNode)
+    $xml.Save($projFile)
+}
+
 if ($projFileContent.Contains('Microsoft.Telemetry.Inbox.Managed')) {
     Write-Output "Project file already contains a reference to the internal package."
     return;
 }
 
-$xml = [xml]$projFileContent
-$xml.PreserveWhitespace = $true
 $packageReferenceNode = $xml.CreateElement("PackageReference");
 $packageReferenceNode.SetAttribute("Include", "Microsoft.Telemetry.Inbox.Managed")
 $packageReferenceNode.SetAttribute("Version", "10.0.25148.1001-220626-1600.rs-fun-deploy-dev5")

--- a/common/TelemetryEvents/ExceptionEvent.cs
+++ b/common/TelemetryEvents/ExceptionEvent.cs
@@ -12,7 +12,7 @@ namespace DevHome.Common.TelemetryEvents;
 [EventData]
 public class ExceptionEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public int HResult { get; }
 

--- a/telemetry/DevHome.Telemetry/DevHome.Telemetry.csproj
+++ b/telemetry/DevHome.Telemetry/DevHome.Telemetry.csproj
@@ -5,5 +5,7 @@
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
         <UseWinUI>true</UseWinUI>
+        <!-- DefineConstants is removed in Unstub.ps1-->
+        <DefineConstants>TELEMETRYEVENTSOURCE_PUBLIC</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/telemetry/DevHome.Telemetry/Telemetry.cs
+++ b/telemetry/DevHome.Telemetry/Telemetry.cs
@@ -143,7 +143,7 @@ internal sealed class Telemetry : ITelemetry
 
         this.LogInternal(
             ExceptionThrownEventName,
-            LogLevel.Measure,
+            LogLevel.Critical,
             new
             {
                 action,

--- a/telemetry/DevHome.Telemetry/TelemetryEventSource.cs
+++ b/telemetry/DevHome.Telemetry/TelemetryEventSource.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#define TELEMETRYEVENTSOURCE_PUBLIC
-
 #if TELEMETRYEVENTSOURCE_USE_NUGET
 using Microsoft.Diagnostics.Tracing;
 #else


### PR DESCRIPTION
## Summary of the pull request
- Marks LogException events as Critical
- Updates Tagging for LogException
- Nit Change for defining TELEMETRYEVENTSOURCE_PUBLIC


## Detailed description of the pull request / Additional comments
As I'm adding in some telemetry in the extensions, I noticed that the LogException event was marked at Measure level -- since I'll be going through the approval process for Critical for a handful of other events, I thought I'd make this change here as well and take care of it all at once. 

I also changed the Privacy Tag to `ProductAndServicePerformance` as that's better aligned with the usage. See more here: https://www.osgwiki.com/wiki/PDT_Privacy_Data_Tag

While I'm at it, I made a small tweak to the definition of TELEMETRYEVENTSOURCE_PUBLIC, instead using a DefineConstants in the project file as that's the approach usually used for bringing in constants. (h/t @adrastogi)

## Validation steps performed
Keeping in draft until I get a moment to validate. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
