### PR TITLE
Multiple build/pipeline fixes

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,6 +1,6 @@
 Param(
     [string]$Platform = "x64",
-    [string]$Configuration = "Debug",
+    [string]$Configuration = "debug",
     [string]$VersionOfSDK,
     [string]$SDKNugetSource,
     [string]$Version,
@@ -53,8 +53,12 @@ if ($IsAzurePipelineBuild) {
   Copy-Item (Join-Path $env:Build_RootDirectory "build\nuget.config.internal") -Destination (Join-Path $env:Build_RootDirectory "nuget.config")
 }
 
+$ErrorActionPreference = "Stop"
+
 if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "sdk")) {
-  extensionsdk\BuildSDKHelper.ps1 -VersionOfSDK $env:sdk_version -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassWarning
+  foreach ($configuration in $env:Build_Configuration.Split(",")) {
+    extensionsdk\BuildSDKHelper.ps1 -Configuration $configuration -VersionOfSDK $env:sdk_version -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassWarning
+  }
 }
 
 $msbuildPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
@@ -63,8 +67,6 @@ if ($IsAzurePipelineBuild) {
 } else {
   $nugetPath = (Join-Path $env:Build_RootDirectory "build\NugetWrapper.cmd")
 }
-
-$ErrorActionPreference = "Stop"
 
 # Install NuGet Cred Provider
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -313,6 +313,12 @@ extends:
             templateContext:
               outputs:
               - output: pipelineArtifact
+                displayName: 'Publish Artifact: Binaries'
+                artifactName: Binaries_${{ platform }}_${{ configuration }}
+                targetPath: $(Build.SourcesDirectory)\BuildOutput
+                sbomPackageName: devhome.binaries
+                sbomPackageVersion: $(MSIXVersion)
+              - output: pipelineArtifact
                 displayName: 'Publish Artifact: LocOutput'
                 condition: and(eq(variables['EnableLocalization'], 'true'), eq(variables['UpdateLocalization'], 'true'))
                 artifactName: LocOutput_${{ platform }}_${{ configuration }}
@@ -617,5 +623,5 @@ extends:
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish vpack\app artifact with vpack manifest'
-            targetPath: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
+            targetPath: $(XES_VPACKMANIFESTDIRECTORY)
             artifactName: vpackManifest

--- a/extensionsdk/BuildSDKHelper.ps1
+++ b/extensionsdk/BuildSDKHelper.ps1
@@ -1,5 +1,5 @@
 Param(
-  [string]$Configuration = "Debug",
+  [string]$Configuration = "release",
   [string]$VersionOfSDK,
   [bool]$IsAzurePipelineBuild = $false,
   [switch]$BypassWarning = $false,
@@ -74,7 +74,17 @@ Try {
   Exit 1
 }
 
-& $nugetPath pack (Join-Path $PSScriptRoot "nuget\Microsoft.Windows.DevHome.SDK.nuspec") -Version $VersionOfSDK -OutputDirectory "$PSScriptRoot\_build"
+foreach ($config in $Configuration.Split(",")) {
+  if ($config -eq "release")
+  {
+    & $nugetPath pack (Join-Path $PSScriptRoot "nuget\Microsoft.Windows.DevHome.SDK.nuspec") -Version $VersionOfSDK -OutputDirectory "$PSScriptRoot\_build"
+  } else {
+Write-Host @"
+WARNING: You are currently building as '$config' configuration.
+DevHomeSDK nuget creation only supports 'release' configuration right now.
+"@ -ForegroundColor YELLOW
+  }
+}
 
 if ($IsAzurePipelineBuild) {
   Write-Host "##vso[task.setvariable variable=VersionOfSDK;]$VersionOfSDK"

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -8,6 +8,7 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <DebugType>pdbonly</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
@@ -107,7 +107,7 @@
            supported according to the CRT maintainer. Dynamic linking against the CRT makes the binaries a bit smaller
            than they would otherwise be if the CRT, runtime, and STL were all statically linked in. -->
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries);libucrtd.lib</IgnoreSpecificDefaultLibraries>
-      <AdditionalOptions>%(AdditionalOptions) /defaultlib:ucrtd.lib</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /defaultlib:ucrtd.lib /profile /opt:ref /opt:icf</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -121,7 +121,7 @@
            supported according to the CRT maintainer. Dynamic linking against the CRT makes the binaries a bit smaller
            than they would otherwise be if the CRT, runtime, and STL were all statically linked in. -->
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries);libucrt.lib</IgnoreSpecificDefaultLibraries>
-      <AdditionalOptions>%(AdditionalOptions) /defaultlib:ucrt.lib</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /defaultlib:ucrt.lib /profile /opt:ref /opt:icf</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -171,7 +171,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
-      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj /Zi</AdditionalOptions>
       <PreprocessorDefinitions>_WINRT_DLL;WIN32_LEAN_AND_MEAN;WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <ControlFlowGuard>Guard</ControlFlowGuard>


### PR DESCRIPTION
## Summary of the pull request
1. Enable the SDK binaries to be built as debug.  This doesn't generate a debug version of the nuget yet as that requires a larger change to swap nuget.config files.
2. Make the SDK Vulcan ready to unblock APIScan.
3. Publish the binaries to Azure Artifacts so that BinSkim will find them.
4. Update targetPath for SBOM generation.  It fails on file paths and needs to target the parent directory instead.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
