### PR TITLE
Bring back GPU and Network widget buttons

### DIFF
--- a/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -78,12 +78,37 @@
           "size": "medium"
         },
         {
-          "type": "ActionSet",
-          "actions": [
+          "type": "ColumnSet",
+          "spacing": "Medium",
+          "columns": [
             {
-              "type": "Action.Execute",
-              "title": "%GPUUsage_Widget_Template/Next_GPU%",
-              "verb": "NextItem"
+              "type": "Column",
+              "width": "stretch"
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Container",
+                  "items": [
+                    {
+                      "type": "ActionSet",
+                      "actions": [
+                        {
+                          "type": "Action.Execute",
+                          "title": "%GPUUsage_Widget_Template/Next_GPU%",
+                          "verb": "NextItem"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch"
             }
           ]
         }

--- a/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -76,13 +76,16 @@
           "text": "${gpuName}",
           "type": "TextBlock",
           "size": "medium"
-        }
-      ],
-      "actions": [
+        },
         {
-          "type": "Action.Execute",
-          "title": "%GPUUsage_Widget_Template/Next_GPU%",
-          "verb": "NextItem"
+          "type": "ActionSet",
+          "actions": [
+            {
+              "type": "Action.Execute",
+              "title": "%GPUUsage_Widget_Template/Next_GPU%",
+              "verb": "NextItem"
+            }
+          ]
         }
       ]
     }

--- a/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -78,13 +78,16 @@
           "text": "${networkName}",
           "type": "TextBlock",
           "size": "medium"
-        }
-      ],
-      "actions": [
+        },
         {
-          "type": "Action.Execute",
-          "title": "%NetworkUsage_Widget_Template/Next_Network%",
-          "verb": "NextItem"
+          "type": "ActionSet",
+          "actions": [
+            {
+              "type": "Action.Execute",
+              "title": "%NetworkUsage_Widget_Template/Next_Network%",
+              "verb": "NextItem"
+            }
+          ]
         }
       ]
     }

--- a/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -80,12 +80,37 @@
           "size": "medium"
         },
         {
-          "type": "ActionSet",
-          "actions": [
+          "type": "ColumnSet",
+          "spacing": "Medium",
+          "columns": [
             {
-              "type": "Action.Execute",
-              "title": "%NetworkUsage_Widget_Template/Next_Network%",
-              "verb": "NextItem"
+              "type": "Column",
+              "width": "stretch"
+            },
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "type": "Container",
+                  "items": [
+                    {
+                      "type": "ActionSet",
+                      "actions": [
+                        {
+                          "type": "Action.Execute",
+                          "title": "%NetworkUsage_Widget_Template/Next_Network%",
+                          "verb": "NextItem"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch"
             }
           ]
         }

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -63,6 +63,8 @@
                 <Activation>
                   <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
                 </Activation>
+                <SupportedInterfaces>
+                </SupportedInterfaces>
               </DevHomeProvider>
             </uap3:Properties>
           </uap3:AppExtension>


### PR DESCRIPTION
## Summary of the pull request
0.1001 introduced a regression where the widget template json wasn't quite right, so the buttons weren't showing up. This change fixes the json to bring the buttons back. It also centers the buttons to match the design specs.

![image](https://github.com/microsoft/devhome/assets/47155823/82188285-3d1d-40a5-bffa-91dc2063a130)

Also, putting back SupportedInterfaces since the code assumes it exists.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2207
- [ ] Tests added/passed
- [ ] Documentation updated
