### PR TITLE
Update First Run install process

### DIFF
--- a/src/Services/ActivationService.cs
+++ b/src/Services/ActivationService.cs
@@ -38,13 +38,10 @@ public class ActivationService : IActivationService
             // Execute tasks before activation.
             await InitializeAsync();
 
-            // We can skip the initialization page if it's not our first run and we're on Windows 11.
-            // If we're on Windows 10, we need to go to the initialization page to install the WidgetService if we don't have it already.
-            var skipInitialization = await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstRun)
-                && RuntimeHelper.IsOnWindows11;
-
             // Set the MainWindow Content.
-            App.MainWindow.Content = skipInitialization
+            // We can skip the initialization page if it's not our first run.
+            // If it is the first run, we may have to install an extension or the widget service.
+            App.MainWindow.Content = await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstRun)
                 ? Application.Current.GetService<ShellPage>()
                 : Application.Current.GetService<InitializationPage>();
 

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -3,6 +3,7 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
 using DevHome.Contracts.Services;
 using DevHome.Dashboard.Services;
 using DevHome.Logging;
@@ -17,34 +18,56 @@ public class InitializationViewModel : ObservableObject
     private readonly IThemeSelectorService _themeSelector;
     private readonly IWidgetHostingService _widgetHostingService;
     private readonly IAppInstallManagerService _appInstallManagerService;
+    private readonly IPackageDeploymentService _packageDeploymentService;
 
 #if CANARY_BUILD
     private const string GitHubExtensionStorePackageId = "9N806ZKPW85R";
+    private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension.Canary_8wekyb3d8bbwe";
 #elif STABLE_BUILD
     private const string GitHubExtensionStorePackageId = "9NZCC27PR6N6";
+    private const string GitHubExtensionPackageFamilyName = "Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe";
 #else
     private const string GitHubExtensionStorePackageId = "";
+    private const string GitHubExtensionPackageFamilyName = "";
 #endif
 
-    public InitializationViewModel(IThemeSelectorService themeSelector, IWidgetHostingService widgetHostingService, IAppInstallManagerService appInstallManagerService)
+    public InitializationViewModel(
+        IThemeSelectorService themeSelector,
+        IWidgetHostingService widgetHostingService,
+        IAppInstallManagerService appInstallManagerService,
+        IPackageDeploymentService packageDeploymentService)
     {
         _themeSelector = themeSelector;
         _widgetHostingService = widgetHostingService;
         _appInstallManagerService = appInstallManagerService;
+        _packageDeploymentService = packageDeploymentService;
     }
 
     public async void OnPageLoaded()
     {
+        // Install the widget service if we're on Windows 10 and it's not already installed.
         try
         {
-            await _widgetHostingService.EnsureWidgetServiceAsync();
+            if (_widgetHostingService.CheckForWidgetServiceAsync())
+            {
+                GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Skipping installing WidgetService, already installed.");
+            }
+            else
+            {
+                if (_widgetHostingService.GetWidgetServiceState() == WidgetHostingService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
+                {
+                    // We're on Windows 10 and don't have the widget service, try to install it.
+                    await _widgetHostingService.TryInstallingWidgetService();
+                }
+            }
         }
         catch (Exception ex)
         {
             GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Installing WidgetService failed: ", ex);
         }
 
-        if (string.IsNullOrEmpty(GitHubExtensionStorePackageId))
+        // Install the DevHomeGitHubExtension, unless it's already installed or a dev build is running.
+        if (string.IsNullOrEmpty(GitHubExtensionStorePackageId) || HasDevHomeGitHubExtensionInstalled())
         {
             GlobalLog.Logger?.ReportInfo("InitializationViewModel", "Skipping installing DevHomeGitHubExtension.");
         }
@@ -64,5 +87,11 @@ public class InitializationViewModel : ObservableObject
         App.MainWindow.Content = Application.Current.GetService<ShellPage>();
 
         _themeSelector.SetRequestedTheme();
+    }
+
+    private bool HasDevHomeGitHubExtensionInstalled()
+    {
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(GitHubExtensionPackageFamilyName);
+        return packages.Any();
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -15,6 +15,11 @@ namespace DevHome.Dashboard.Helpers;
 
 internal sealed class WidgetHelpers
 {
+    public const string WebExperiencePackPackageId = "9MSSGKG348SP";
+    public const string WebExperiencePackageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
+    public const string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
+    public const string WidgetServicePackageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
+
     public const string DevHomeHostName = "DevHome";
 
     private const double WidgetPxHeightSmall = 146;

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -9,7 +9,9 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
-    public Task<bool> EnsureWidgetServiceAsync();
+    public bool CheckForWidgetServiceAsync();
+
+    public Task<bool> TryInstallingWidgetService();
 
     public WidgetServiceStates GetWidgetServiceState();
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -8,18 +8,15 @@ using DevHome.Common.Helpers;
 using DevHome.Common.Services;
 using DevHome.Services;
 using Microsoft.Windows.Widgets.Hosts;
-using Log = DevHome.Dashboard.Helpers.Log;
 
 namespace DevHome.Dashboard.Services;
 
 public class WidgetHostingService : IWidgetHostingService
 {
     private readonly IPackageDeploymentService _packageDeploymentService;
-
     private readonly IAppInstallManagerService _appInstallManagerService;
 
     private static readonly string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
-    private static readonly TimeSpan StoreInstallTimeout = new(0, 0, 60);
 
     private WidgetHost _widgetHost;
     private WidgetCatalog _widgetCatalog;
@@ -43,7 +40,7 @@ public class WidgetHostingService : IWidgetHostingService
         _appInstallManagerService = appInstallManagerService;
     }
 
-    public async Task<bool> EnsureWidgetServiceAsync()
+    public bool CheckForWidgetServiceAsync()
     {
         // If we're on Windows 11, check if we have the right WebExperiencePack version of the WidgetService.
         if (RuntimeHelper.IsOnWindows11)
@@ -63,31 +60,29 @@ public class WidgetHostingService : IWidgetHostingService
         }
         else
         {
-            // If we're on Windows 10, check if we have the store version installed. Check against what's really
-            // installed instead of the enum, just in case something changed between startup and now.
+            // If we're on Windows 10, check if we have the store version installed.
             if (HasValidWidgetServicePackage())
             {
                 Log.Logger()?.ReportInfo("WidgetHostingService", "On Windows 10, HasStoreWidgetServiceGoodVersion");
                 _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceGoodVersion;
                 return true;
             }
-            else if (_widgetServiceState == WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
-            {
-                // If it's not there and we already knew that, it means we tried to install during setup and it failed.
-                // Don't try again when we get to the Dashboard, it takes too long.
-                Log.Logger()?.ReportInfo("WidgetHostingService", "On Windows 10, already HasStoreWidgetServiceNoOrBadVersion");
-                return false;
-            }
             else
             {
-                // Try to install and report the outcome.
-                Log.Logger()?.ReportInfo("WidgetHostingService", "On Windows 10, TryInstallWidgetServicePackageAsync...");
-                var installedSuccessfully = await _appInstallManagerService.TryInstallPackageAsync(WidgetServiceStorePackageId);
-                _widgetServiceState = installedSuccessfully ? WidgetServiceStates.HasStoreWidgetServiceGoodVersion : WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
-                Log.Logger()?.ReportInfo("WidgetHostingService", $"On Windows 10, ...{_widgetServiceState}");
-                return installedSuccessfully;
+                Log.Logger()?.ReportInfo("WidgetHostingService", "On Windows 10, HasStoreWidgetServiceNoOrBadVersion");
+                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
+                return false;
             }
         }
+    }
+
+    public async Task<bool> TryInstallingWidgetService()
+    {
+        Log.Logger()?.ReportInfo("WidgetHostingService", "Try installing widget service...");
+        var installedSuccessfully = await _appInstallManagerService.TryInstallPackageAsync(WidgetServiceStorePackageId);
+        _widgetServiceState = installedSuccessfully ? WidgetServiceStates.HasStoreWidgetServiceGoodVersion : WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
+        Log.Logger()?.ReportInfo("WidgetHostingService", $"InstalledSuccessfully == {installedSuccessfully}, {_widgetServiceState}");
+        return installedSuccessfully;
     }
 
     private bool HasValidWebExperiencePack()

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -6,8 +6,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
+using DevHome.Dashboard.Helpers;
 using DevHome.Services;
 using Microsoft.Windows.Widgets.Hosts;
+using Log = DevHome.Dashboard.Helpers.Log;
 
 namespace DevHome.Dashboard.Services;
 
@@ -15,8 +17,6 @@ public class WidgetHostingService : IWidgetHostingService
 {
     private readonly IPackageDeploymentService _packageDeploymentService;
     private readonly IAppInstallManagerService _appInstallManagerService;
-
-    private static readonly string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
 
     private WidgetHost _widgetHost;
     private WidgetCatalog _widgetCatalog;
@@ -79,7 +79,7 @@ public class WidgetHostingService : IWidgetHostingService
     public async Task<bool> TryInstallingWidgetService()
     {
         Log.Logger()?.ReportInfo("WidgetHostingService", "Try installing widget service...");
-        var installedSuccessfully = await _appInstallManagerService.TryInstallPackageAsync(WidgetServiceStorePackageId);
+        var installedSuccessfully = await _appInstallManagerService.TryInstallPackageAsync(WidgetHelpers.WidgetServiceStorePackageId);
         _widgetServiceState = installedSuccessfully ? WidgetServiceStates.HasStoreWidgetServiceGoodVersion : WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
         Log.Logger()?.ReportInfo("WidgetHostingService", $"InstalledSuccessfully == {installedSuccessfully}, {_widgetServiceState}");
         return installedSuccessfully;
@@ -92,9 +92,8 @@ public class WidgetHostingService : IWidgetHostingService
         var version500 = new Version(500, 0);
 
         // Ensure the application is installed, and the version is high enough.
-        const string packageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
         var packages = _packageDeploymentService.FindPackagesForCurrentUser(
-            packageFamilyName,
+            WidgetHelpers.WebExperiencePackageFamilyName,
             (minSupportedVersion400, version500),
             (minSupportedVersion500, null));
         return packages.Any();
@@ -104,8 +103,7 @@ public class WidgetHostingService : IWidgetHostingService
     {
         var minSupportedVersion = new Version(1, 0, 0, 0);
 
-        const string packageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
-        var packages = _packageDeploymentService.FindPackagesForCurrentUser(packageFamilyName, (minSupportedVersion, null));
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetServicePackageFamilyName, (minSupportedVersion, null));
         return packages.Any();
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -135,7 +135,7 @@
     <comment>Message shown when there's no widget service and the user should restart Dev Home.</comment>
   </data>
   <data name="UpdateWidgetsMessage.Text" xml:space="preserve">
-    <value>You do not have the required version of the Windows Web Experience Pack to display widgets. Please ensure you have the latest version installed and then restart Dev Home.</value>
+    <value>You do not have the required dependency installed to display widgets. Please install or update the package from the Store and then restart Dev Home.</value>
     <comment>Message shown when no widgets have been added to the Dashboard</comment>
   </data>
   <data name="UpdateWidgetsMessageLink.Content" xml:space="preserve">

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -127,12 +127,8 @@ public partial class DashboardView : ToolPage
         else
         {
             var widgetServiceState = ViewModel.WidgetHostingService.GetWidgetServiceState();
-            if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
-            {
-                // Show error message that restarting Dev Home may help
-                RestartDevHomeMessageStackPanel.Visibility = Visibility.Visible;
-            }
-            else if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasWebExperienceNoOrBadVersion)
+            if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion ||
+                widgetServiceState == WidgetHostingService.WidgetServiceStates.HasWebExperienceNoOrBadVersion)
             {
                 // Show error message that updating may help
                 UpdateWidgetsMessageStackPanel.Visibility = Visibility.Visible;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -41,6 +41,9 @@ public partial class DashboardView : ToolPage
     private const string DraggedWidget = "DraggedWidget";
     private const string DraggedIndex = "DraggedIndex";
 
+    private static readonly string WebExperiencePackPackageId = "9MSSGKG348SP";
+    private static readonly string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
+
     public DashboardView()
     {
         ViewModel = Application.Current.GetService<DashboardViewModel>();
@@ -111,7 +114,7 @@ public partial class DashboardView : ToolPage
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
         ViewModel.IsLoading = true;
 
-        if (await ViewModel.WidgetHostingService.EnsureWidgetServiceAsync())
+        if (ViewModel.WidgetHostingService.CheckForWidgetServiceAsync())
         {
             ViewModel.HasWidgetService = true;
             await SubscribeToWidgetCatalogEventsAsync();
@@ -247,7 +250,14 @@ public partial class DashboardView : ToolPage
     [RelayCommand]
     public async Task GoToWidgetsInStoreAsync()
     {
-        await Launcher.LaunchUriAsync(new("ms-windows-store://pdp/?productid=9MSSGKG348SP"));
+        if (Common.Helpers.RuntimeHelper.IsOnWindows11)
+        {
+            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WebExperiencePackPackageId}"));
+        }
+        else
+        {
+            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WidgetServiceStorePackageId}"));
+        }
     }
 
     [RelayCommand]

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -41,9 +41,6 @@ public partial class DashboardView : ToolPage
     private const string DraggedWidget = "DraggedWidget";
     private const string DraggedIndex = "DraggedIndex";
 
-    private static readonly string WebExperiencePackPackageId = "9MSSGKG348SP";
-    private static readonly string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
-
     public DashboardView()
     {
         ViewModel = Application.Current.GetService<DashboardViewModel>();
@@ -248,11 +245,11 @@ public partial class DashboardView : ToolPage
     {
         if (Common.Helpers.RuntimeHelper.IsOnWindows11)
         {
-            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WebExperiencePackPackageId}"));
+            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
         }
         else
         {
-            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WidgetServiceStorePackageId}"));
+            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
         }
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -245,11 +245,11 @@ public partial class DashboardView : ToolPage
     {
         if (Common.Helpers.RuntimeHelper.IsOnWindows11)
         {
-            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
+            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
         }
         else
         {
-            await Launcher.LaunchUriAsync(new ($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
+            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
         }
     }
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -193,8 +193,6 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
     private bool IsAlreadyInstalled(string packageFamilyName)
     {
-        // PackageFullName = Microsoft.Windows.DevHome.Dev_0.0.0.0_x64__8wekyb3d8bbwe
-        // PackageFamilyName = Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe
         return InstalledPackagesList.Any(package => packageFamilyName == package.PackageFamilyName);
     }
 


### PR DESCRIPTION
## Summary of the pull request

Simplify the process for installing the widget service on Windows 10 to mimic what we already do on Windows 11.

## References and relevant issues
#2191

## Detailed description of the pull request / Additional comments

On Windows 11 (already):
1. We assume the package is there
2. On navigation to Dashboard, we ensure it's there and if not, send the user to the store

On Windows 10 (as of this change):
1. On first launch of Dev Home, install the widget service from the store
2. On navigation to Dashboard, we ensure it's there and if not, send the user to the store

This fixes the bug where we would re-install on every launch. 

## Validation steps performed

## PR checklist
- [x] Closes #2191
- [ ] Tests added/passed
- [ ] Documentation updated
