### PR TITLE
Pin default widgets

### DIFF
--- a/common/Helpers/WellKnownSettingsKeys.cs
+++ b/common/Helpers/WellKnownSettingsKeys.cs
@@ -6,4 +6,6 @@ namespace DevHome.Common.Helpers;
 public class WellKnownSettingsKeys
 {
     public const string IsNotFirstRun = "IsNotFirstRun";
+
+    public const string IsNotFirstDashboardRun = "IsNotFirstDashboardRun";
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -20,6 +20,23 @@ internal sealed class WidgetHelpers
     public const string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
     public const string WidgetServicePackageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
 
+    public static readonly string[] DefaultWidgetDefinitionIds =
+    {
+    #if CANARY_BUILD
+        "Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_CPUUsage",
+        "Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_GPUUsage",
+        "Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_NetworkUsage",
+    #elif STABLE_BUILD
+        "Microsoft.Windows.DevHome_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_CPUUsage",
+        "Microsoft.Windows.DevHome_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_GPUUsage",
+        "Microsoft.Windows.DevHome_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_NetworkUsage",
+    #else
+        "Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_CPUUsage",
+        "Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_GPUUsage",
+        "Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe!App!!CoreWidgetProvider!!System_NetworkUsage",
+    #endif
+    };
+
     public const string DevHomeHostName = "DevHome";
 
     private const double WidgetPxHeightSmall = 146;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -160,7 +160,7 @@ public partial class DashboardView : ToolPage
         {
             // If it's the first time the Dashboard has been displayed and we have no other widgets pinned to a
             // different version of Dev Home, pin some default widgets.
-            await PinDefaultWidgets();
+            await PinDefaultWidgetsAsync();
             return;
         }
 
@@ -274,7 +274,7 @@ public partial class DashboardView : ToolPage
         await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
     }
 
-    private async Task PinDefaultWidgets()
+    private async Task PinDefaultWidgetsAsync()
     {
         var catalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
 
@@ -290,12 +290,12 @@ public partial class DashboardView : ToolPage
             var id = widgetDefinition.Id;
             if (WidgetHelpers.DefaultWidgetDefinitionIds.Contains(id))
             {
-                await PinDefaultWidget(widgetDefinition);
+                await PinDefaultWidgetAsync(widgetDefinition);
             }
         }
     }
 
-    private async Task PinDefaultWidget(WidgetDefinition defaultWidgetDefinition)
+    private async Task PinDefaultWidgetAsync(WidgetDefinition defaultWidgetDefinition)
     {
         try
         {


### PR DESCRIPTION
## Summary of the pull request
On the very first time Dev Home is run, automatically pin three of the core widgets the PM team has picked.

## References and relevant issues

## Detailed description of the pull request / Additional comments
For first run, the different build channels of Dev Home are considered separately (ie. you could have and use Preview, but then if you install and run Dev for the first time, it will be considered the first run). Also, uninstalling and reinstalling will result in a "first run" (and always has).

Since from the widget service's point of view, all channels of Dev Home are considered the same app, the same widgets are considered pinned in (for example) Preview and Dev. If Dev Home is run for the first time but widgets have already been pinned in another channel by the user, the default widgets will not be pinned so as to not override the existing widgets. This is the improvement over the first version of this feature that was checked in and reverted.

## Validation steps performed

## PR checklist
- [ ] Closes #575
- [ ] Tests added/passed
- [ ] Documentation updated
