### PR TITLE
Fix SDK CI warnings

### DIFF
--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/ExtensionInstanceManager.cs
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/ExtensionInstanceManager.cs
@@ -15,7 +15,7 @@ using WinRT;
 namespace Microsoft.Windows.DevHome.SDK;
 
 [ComVisible(true)]
-internal class ExtensionInstanceManager<T> : IClassFactory
+internal sealed class ExtensionInstanceManager<T> : IClassFactory
     where T : IExtension
 {
 #pragma warning disable SA1310 // Field names should not contain underscore

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/ExtensionInstanceManager.cs
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/ExtensionInstanceManager.cs
@@ -1,15 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel.Background;
-using Windows.Foundation;
-using Windows.Storage;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using Windows.Win32.Security;
 using WinRT;
 
 namespace Microsoft.Windows.DevHome.SDK;
@@ -40,8 +34,8 @@ internal sealed class ExtensionInstanceManager<T> : IClassFactory
 
     public ExtensionInstanceManager(Func<T> createExtension, bool restrictToMicrosoftExtensionHosts)
     {
-        this._createExtension = createExtension;
-        this._restrictToMicrosoftExtensionHosts = restrictToMicrosoftExtensionHosts;
+        _createExtension = createExtension;
+        _restrictToMicrosoftExtensionHosts = restrictToMicrosoftExtensionHosts;
     }
 
     public void CreateInstance(

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/ExtensionServer.cs
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/ExtensionServer.cs
@@ -43,7 +43,9 @@ public sealed class ExtensionServer : IDisposable
         }
     }
 
+#pragma warning disable CA1822 // Mark members as static
     public void Run()
+#pragma warning restore CA1822 // Mark members as static
     {
         // TODO : We need to handle lifetime management of the server.
         // For details around ref counting and locking of out-of-proc COM servers, see
@@ -65,7 +67,7 @@ public sealed class ExtensionServer : IDisposable
         Trace.Unindent();
     }
 
-    private class Ole32
+    private sealed class Ole32
     {
 #pragma warning disable SA1310 // Field names should not contain underscore
         // https://docs.microsoft.com/windows/win32/api/wtypesbase/ne-wtypesbase-clsctx

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
   </ItemGroup>
     
   <ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
When the CI build runs on any pull request, there are a few warnings that show up under the changed files. This fixes them by sealing two classes and specifically ignoring the suggestion to make `Run()` static.

Additionally, match the WindowsAppSDK version in SDK.Lib project to the one in SDK project, as well as removing some unused `using`s and unnecessary `this.`s.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
