### PR TITLE
Deactivate widgets when Dashboard isn't displayed

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -323,4 +323,9 @@ public partial class WidgetViewModel : ObservableObject
         Log.Logger()?.ReportDebug("WidgetViewModel", $"HandleWidgetUpdated for widget {sender.Id}");
         await RenderWidgetFrameworkElementAsync();
     }
+
+    public void UnsubscribeFromWidgetUpdates()
+    {
+        Widget.WidgetUpdated -= HandleWidgetUpdated;
+    }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -18,6 +18,7 @@ using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Windows.System;
@@ -508,6 +509,17 @@ public partial class DashboardView : ToolPage
         }
 
         Log.Logger()?.ReportDebug("DashboardView", $"Drop ended");
+    }
+
+    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+    {
+        Log.Logger()?.ReportDebug("DashboardView", $"Leaving Dashboard, deactivating widgets.");
+
+        // Deactivate widgets if we're not on the Dashboard.
+        foreach (var widget in PinnedWidgets)
+        {
+            widget.UnsubscribeFromWidgetUpdates();
+        }
     }
 
 #if DEBUG


### PR DESCRIPTION
## Summary of the pull request
After the user leaves the dashboard, the widgets are still there. By unsubscribing from the WidgetUpdated event, the widget manager "deactivates" the widget by telling it not to update until it is activated again. In our case, when we next navigate to the Dashboard we re-activate them when rebuilding the PinnedWidgets list.

## References and relevant issues
#716

## Detailed description of the pull request / Additional comments
OnNavigatingFrom is used rather than [OnNavigatedFrom](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.page.onnavigatedfrom?view=windows-app-sdk-1.4): "In addition to being invoked when navigating between pages, the OnNavigatedFrom method is invoked when [Frame.GetNavigationState](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.frame.getnavigationstate?view=windows-app-sdk-1.4#microsoft-ui-xaml-controls-frame-getnavigationstate) is called. To avoid any issues, you should use [OnNavigatingFrom](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.page.onnavigatingfrom?view=windows-app-sdk-1.4#microsoft-ui-xaml-controls-page-onnavigatingfrom(microsoft-ui-xaml-navigation-navigatingcanceleventargs)) or the [Unloaded](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.frameworkelement.unloaded?view=windows-app-sdk-1.4#microsoft-ui-xaml-frameworkelement-unloaded) event, which are only called on actual navigation, to unregister event handlers and do other cleanup."

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
