### PR TITLE
Add telemetry event for widget interaction

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/TelemetryEvents/ReportWidgetInteractionEvent.cs
+++ b/tools/Dashboard/DevHome.Dashboard/TelemetryEvents/ReportWidgetInteractionEvent.cs
@@ -11,7 +11,7 @@ using Microsoft.Diagnostics.Telemetry.Internal;
 namespace DevHome.Dashboard.TelemetryEvents;
 
 [EventData]
-public class ReportPinnedWidgetEvent : EventBase
+public class ReportWidgetInteractionEvent : EventBase
 {
     public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
 
@@ -21,11 +21,14 @@ public class ReportPinnedWidgetEvent : EventBase
 
     public string WidgetDefinitionId { get; }
 
-    public ReportPinnedWidgetEvent(string widgetProviderDefinitionId, string widgetDefinitionId)
+    public string ActionType { get; }
+
+    public ReportWidgetInteractionEvent(string widgetProviderDefinitionId, string widgetDefinitionId, string actionType)
     {
         DeploymentIdentifier = Deployment.Identifier;
         WidgetProviderDefinitionId = widgetProviderDefinitionId;
         WidgetDefinitionId = widgetDefinitionId;
+        ActionType = actionType;
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -10,6 +10,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Renderers;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
+using DevHome.Dashboard.TelemetryEvents;
+using DevHome.Telemetry;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -287,7 +289,7 @@ public partial class WidgetViewModel : ObservableObject
 
     private async void HandleAdaptiveAction(RenderedAdaptiveCard sender, AdaptiveActionEventArgs args)
     {
-        Log.Logger()?.ReportInfo("WidgetViewModel", $"HandleInvokedAction {nameof(args.Action)} for widget {Widget.Id}");
+        Log.Logger()?.ReportInfo("WidgetViewModel", $"HandleInvokedAction {args.Action.ActionTypeString} for widget {Widget.Id}");
         if (args.Action is AdaptiveOpenUrlAction openUrlAction)
         {
             Log.Logger()?.ReportInfo("WidgetViewModel", $"Url = {openUrlAction.Url}");
@@ -313,6 +315,11 @@ public partial class WidgetViewModel : ObservableObject
             Log.Logger()?.ReportInfo("WidgetViewModel", $"Verb = {executeAction.Verb}, Data = {dataToSend}");
             await Widget.NotifyActionInvokedAsync(executeAction.Verb, dataToSend);
         }
+
+        TelemetryFactory.Get<ITelemetry>().Log(
+            "Dashboard_ReportWidgetInteraction",
+            LogLevel.Critical,
+            new ReportWidgetInteractionEvent(WidgetDefinition.ProviderDefinition.Id, WidgetDefinition.Id, args.Action.ActionTypeString));
 
         // TODO: Handle other ActionTypes
         // https://github.com/microsoft/devhome/issues/644


### PR DESCRIPTION
## Summary of the pull request

Each time the user interacts with a widget, send a telemetry event. Valid interactions are AdaptiveExecuteAction and AdaptiveOpenUrlAction. This means things like clicking on the background (which does nothing) or keystrokes do NOT send events.

Also, fix log to actually log the type of action, rather than just the name "Action".

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
