### PR TITLE
Change how Adaptive Cards render action margins

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -35,10 +35,10 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.8" />
     <PackageReference Include="System.Management.Automation" Version="7.2.8" />
     <PackageReference Include="WinUIEx" Version="1.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="1.0.0" />
     <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="1.0.2" />
-    <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -36,8 +36,8 @@
     <PackageReference Include="System.Management.Automation" Version="7.2.8" />
     <PackageReference Include="WinUIEx" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="1.0.0" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="1.0.2" />
+    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.0-beta" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.0.0-beta" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.5.0" />
   </ItemGroup>
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
@@ -80,6 +80,9 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
 
         // A different host config is used to render widgets (adaptive cards) in light and dark themes.
         await UpdateHostConfig();
+
+        // Remove margins from selectAction.
+        _renderer.AddSelectActionMargin = false;
     }
 
     public async Task UpdateHostConfig()


### PR DESCRIPTION
## Summary of the pull request

With the WinUI 3 adaptive card renderer version 2.0.0-beta, we have the ability to turn off the margins on Action margins, which makes GitHub widgets look much better.

![image](https://github.com/microsoft/devhome/assets/47155823/16017cb9-3896-4847-a83b-51eb2e61b231)

New AC dlls also have ControlFlowGuard.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1466
- [ ] Tests added/passed
- [ ] Documentation updated
