### PR TITLE
Fix Dashboard crash when no widgets pinned

### DIFF
--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoConfigEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoConfigEvent.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using DevHome.Telemetry;

--- a/common/TelemetryEvents/SetupFlow/RepoTool/RepoInfoModificationEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/RepoTool/RepoInfoModificationEvent.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -124,8 +124,9 @@ public partial class WidgetViewModel : ObservableObject
                 return;
             }
 
-            Log.Logger()?.ReportDebug("WidgetViewModel", $"cardTemplate = {cardTemplate}");
-            Log.Logger()?.ReportDebug("WidgetViewModel", $"cardData = {cardData}");
+            // Uncomment for extra debugging output
+            // Log.Logger()?.ReportDebug("WidgetViewModel", $"cardTemplate = {cardTemplate}");
+            // Log.Logger()?.ReportDebug("WidgetViewModel", $"cardData = {cardData}");
 
             // Use the data to fill in the template.
             AdaptiveCardParseResult card;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -162,10 +162,11 @@ public partial class DashboardView : ToolPage
             // If it's the first time the Dashboard has been displayed and we have no other widgets pinned to a
             // different version of Dev Home, pin some default widgets.
             await PinDefaultWidgetsAsync();
-            return;
         }
-
-        await RestorePinnedWidgetsAsync(hostWidgets);
+        else if (hostWidgets != null)
+        {
+            await RestorePinnedWidgetsAsync(hostWidgets);
+        }
     }
 
     private async Task<Widget[]> GetPreviouslyPinnedWidgets()

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -126,6 +126,7 @@ public partial class DashboardView : ToolPage
             await ViewModel.WidgetIconService.CacheAllWidgetIconsAsync();
 
             var isFirstDashboardRun = !(await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstDashboardRun));
+            Log.Logger()?.ReportInfo("DashboardView", $"Is first dashboard run = {isFirstDashboardRun}");
             if (isFirstDashboardRun)
             {
                 await Application.Current.GetService<ILocalSettingsService>().SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstDashboardRun, true);
@@ -161,6 +162,7 @@ public partial class DashboardView : ToolPage
         {
             // If it's the first time the Dashboard has been displayed and we have no other widgets pinned to a
             // different version of Dev Home, pin some default widgets.
+            Log.Logger()?.ReportInfo("DashboardView", $"Pin default widgets");
             await PinDefaultWidgetsAsync();
         }
         else if (hostWidgets != null)
@@ -292,6 +294,7 @@ public partial class DashboardView : ToolPage
             var id = widgetDefinition.Id;
             if (WidgetHelpers.DefaultWidgetDefinitionIds.Contains(id))
             {
+                Log.Logger()?.ReportInfo("DashboardView", $"Found default widget {id}");
                 await PinDefaultWidgetAsync(widgetDefinition);
             }
         }
@@ -304,7 +307,9 @@ public partial class DashboardView : ToolPage
             // Create widget
             var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
             var size = WidgetHelpers.GetDefaultWidgetSize(defaultWidgetDefinition.GetWidgetCapabilities());
-            var newWidget = await Task.Run(async () => await widgetHost?.CreateWidgetAsync(defaultWidgetDefinition.Id, size));
+            var id = defaultWidgetDefinition.Id;
+            var newWidget = await Task.Run(async () => await widgetHost?.CreateWidgetAsync(id, size));
+            Log.Logger()?.ReportInfo("DashboardView", $"Created default widget {id}");
 
             // Set custom state on new widget.
             var position = PinnedWidgets.Count;
@@ -314,6 +319,7 @@ public partial class DashboardView : ToolPage
 
             // Put new widget on the Dashboard.
             await InsertWidgetInPinnedWidgetsAsync(newWidget, size, position);
+            Log.Logger()?.ReportInfo("DashboardView", $"Inserted default widget {id} at position {position}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary of the pull request
#2233 introduced a crash when the Dashboard is started with no widgets already pinned.

Comment out noisy widget content debug logging, too verbose even for regular debug.
Add more logging surrounding pinning default widgets.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
