### PR TITLE
Use different StyleCop suppressions between projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,8 +33,9 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference> 
-    <Compile Include="$(MSBuildThisFileDirectory)\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    </PackageReference>
+    <Compile Condition="$(MSBuildProjectName) != 'DevHomeStub'" Include="$(MSBuildThisFileDirectory)\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Condition="$(MSBuildProjectName) == 'DevHomeStub'" Include="$(MSBuildThisFileDirectory)\codeAnalysis\StubSuppressions.cs" Link="GlobalSuppressions.cs" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\codeAnalysis\StyleCop.json" Link="StyleCop.json" />
   </ItemGroup>
   <!-- Needed for reverting back to pre-.NET 8 method of Host using the RID graph to determine assets  -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,6 +44,6 @@
     <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
   <ItemGroup>
-	  <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
   </ItemGroup>
 </Project>

--- a/codeAnalysis/StubSuppressions.cs
+++ b/codeAnalysis/StubSuppressions.cs
@@ -55,3 +55,9 @@ using System.Diagnostics.CodeAnalysis;
 
 // Code quality
 [assembly: SuppressMessage("CodeQuality", "IDE0076:Invalid global 'SuppressMessageAttribute'", Justification = "Affect predefined suppressions.")]
+
+// Generated code
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.DocumentationRules",
+    "SA1636:FileHeaderCopyrightTextMustMatch",
+    Justification = "Stub files are causing analyzer error because the file header does not match the expected value.")]


### PR DESCRIPTION
## Summary of the pull request
The Stub project pulls in Directory.Build.props, but it needs a different set of StyleCop rules. Add a different file that will be used specifically by that project, while keeping it so the main file is used by all current and future projects.

## Validation steps performed
Validated in internal repo and pipelines.
