### PR TITLE
Fix Dashboard hang when restoring uninstalled widgets

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -242,16 +242,13 @@ public partial class DashboardView : ToolPage
             }
         }
 
+        // Merge the dictionaries for easier looping. restoredWidgetsWithoutPosition should be empty, so this should be fast.
+        var lastOrderedKey = restoredWidgetsWithPosition.Count > 0 ? restoredWidgetsWithPosition.Last().Key : -1;
+        restoredWidgetsWithoutPosition.ToList().ForEach(x => restoredWidgetsWithPosition.Add(++lastOrderedKey, x.Value));
+
         // Now that we've ordered the widgets, put them in their final collection.
         var finalPlace = 0;
         foreach (var orderedWidget in restoredWidgetsWithPosition)
-        {
-            var widget = orderedWidget.Value;
-            var size = await widget.GetSizeAsync();
-            await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace++);
-        }
-
-        foreach (var orderedWidget in restoredWidgetsWithoutPosition)
         {
             var widget = orderedWidget.Value;
             var size = await widget.GetSizeAsync();

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -246,12 +246,16 @@ public partial class DashboardView : ToolPage
         var finalPlace = 0;
         foreach (var orderedWidget in restoredWidgetsWithPosition)
         {
-            await PlaceWidget(orderedWidget, finalPlace++);
+            var widget = orderedWidget.Value;
+            var size = await widget.GetSizeAsync();
+            await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace++);
         }
 
         foreach (var orderedWidget in restoredWidgetsWithoutPosition)
         {
-            await PlaceWidget(orderedWidget, finalPlace++);
+            var widget = orderedWidget.Value;
+            var size = await widget.GetSizeAsync();
+            await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace++);
         }
 
         // Go through the newly created list of pinned widgets and update any positions that may have changed.
@@ -277,13 +281,6 @@ public partial class DashboardView : ToolPage
         var newWidgetList = await Task.Run(() => widgetHost.GetWidgets());
         length = (newWidgetList == null) ? 0 : newWidgetList.Length;
         Log.Logger()?.ReportInfo("DashboardView", $"After delete, {length} widgets for this host");
-    }
-
-    private async Task PlaceWidget(KeyValuePair<int, Widget> orderedWidget, int finalPlace)
-    {
-        var widget = orderedWidget.Value;
-        var size = await widget.GetSizeAsync();
-        await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
     }
 
     private async Task PinDefaultWidgetsAsync()
@@ -589,8 +586,8 @@ public partial class DashboardView : ToolPage
         // widgets between the starting and ending indices move up to replace the removed widget. If the widget was
         // moved from a higher index to a lower one, then the order of removal and insertion doesn't matter.
         PinnedWidgets.RemoveAt(draggedIndex);
-        var widgetPair = new KeyValuePair<int, Widget>(droppedIndex, draggedWidgetViewModel.Widget);
-        await PlaceWidget(widgetPair, droppedIndex);
+        var size = await draggedWidgetViewModel.Widget.GetSizeAsync();
+        await InsertWidgetInPinnedWidgetsAsync(draggedWidgetViewModel.Widget, size, droppedIndex);
         await WidgetHelpers.SetPositionCustomStateAsync(draggedWidgetViewModel.Widget, droppedIndex);
 
         // Update the CustomState Position of any widgets that were moved.

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -253,6 +253,15 @@ public partial class DashboardView : ToolPage
         {
             await PlaceWidget(orderedWidget, finalPlace++);
         }
+
+        // Go through the newly created list of pinned widgets and update any positions that may have changed.
+        // For example, if the provider for the widget at position 0 was deleted, the widget at position 1
+        // should be updated to have position 0, etc.
+        var updatedPlace = 0;
+        foreach (var widget in PinnedWidgets)
+        {
+            await WidgetHelpers.SetPositionCustomStateAsync(widget.Widget, updatedPlace++);
+        }
     }
 
     private async Task DeleteAbandonedWidgetAsync(Widget widget)
@@ -275,7 +284,6 @@ public partial class DashboardView : ToolPage
         var widget = orderedWidget.Value;
         var size = await widget.GetSizeAsync();
         await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace);
-        await WidgetHelpers.SetPositionCustomStateAsync(widget, finalPlace);
     }
 
     private async Task PinDefaultWidgetsAsync()
@@ -583,6 +591,7 @@ public partial class DashboardView : ToolPage
         PinnedWidgets.RemoveAt(draggedIndex);
         var widgetPair = new KeyValuePair<int, Widget>(droppedIndex, draggedWidgetViewModel.Widget);
         await PlaceWidget(widgetPair, droppedIndex);
+        await WidgetHelpers.SetPositionCustomStateAsync(draggedWidgetViewModel.Widget, droppedIndex);
 
         // Update the CustomState Position of any widgets that were moved.
         // The widget that has been dropped has already been updated, so don't do it again here.


### PR DESCRIPTION
## Summary of the pull request
`PlaceWidget` could cause a hang or crash if the widget was deleted and then we tried to update the position via `SetPositionCustomStateAsync`. This change prevents that crash by only updating state on real widgets, after they are all inserted. `PlaceWidget` also was a somewhat confusing insertion middleman, and this change removes it entirely and just uses `InsertWidgetInPinnedWidgetsAsync` instead.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #2252
- [ ] Tests added/passed
- [ ] Documentation updated
