### PR TITLE
Allow environments visibility to be controlled by experimentation keys in feature branch

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -538,4 +538,20 @@
     <value>Learn more</value>
     <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>
+  <data name="EnvironmentsManagementPage_Description" xml:space="preserve">
+    <value>Manage your local and cloud development virtual machines from Dev Home</value>
+    <comment>Text within a display card that explains what users can do with the Environments management feature. Users can choose to toggle this on/off to add or remove the feature.</comment>
+  </data>
+  <data name="EnvironmentsManagementPage_Name" xml:space="preserve">
+    <value>Environments Management</value>
+    <comment>Title text for the Environments management feature.</comment>
+  </data>
+  <data name="EnvironmentsSetupTargetFlow_Description" xml:space="preserve">
+    <value>Configure your local and cloud development virtual machines from Dev Home</value>
+    <comment>Text within a display card that explains what users can do with the Environments configuration feature. Users can choose to toggle this on/off to add or remove the feature.</comment>
+  </data>
+  <data name="EnvironmentsSetupTargetFlow_Name" xml:space="preserve">
+    <value>Environments Configuration</value>
+    <comment>Title text for the Environments configuration feature.</comment>
+  </data>
 </root>

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -26,6 +26,7 @@
             "icon": "ea86"
           },
           {
+            "experimentalFeatureIdentity": "EnvironmentsManagementPage",
             "identity": "DevHome.Environments",
             "assembly": "DevHome.Environments",
             "viewFullName": "DevHome.Environments.Views.LandingPage",
@@ -36,5 +37,48 @@
       }
     ]
   },
-  "experimentalFeatures": []
+  "experimentalFeatures": [
+    {
+      "identity": "EnvironmentsManagementPage",
+      "enabledByDefault": false,
+      "buildTypeOverrides": [
+        {
+          "buildType": "dev",
+          "enabledByDefault": true,
+          "visible": true
+        },
+        {
+          "buildType": "canary",
+          "enabledByDefault": false,
+          "visible": false
+        },
+        {
+          "buildType": "release",
+          "enabledByDefault": false,
+          "visible": false
+        }
+      ]
+    },
+    {
+      "identity": "EnvironmentsSetupTargetFlow",
+      "enabledByDefault": false,
+      "buildTypeOverrides": [
+        {
+          "buildType": "dev",
+          "enabledByDefault": true,
+          "visible": true
+        },
+        {
+          "buildType": "canary",
+          "enabledByDefault": false,
+          "visible": false
+        },
+        {
+          "buildType": "release",
+          "enabledByDefault": false,
+          "visible": false
+        }
+      ]
+    }
+  ]
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.SetupFlow.Common.Helpers;
@@ -28,9 +29,12 @@ namespace DevHome.SetupFlow.ViewModels;
 /// </summary>
 public partial class MainPageViewModel : SetupPageViewModelBase
 {
+    private const string EnvironmentsSetupFlowFeatureName = "EnvironmentsSetupTargetFlow";
+
     private readonly IHost _host;
     private readonly IWindowsPackageManager _wpm;
     private readonly IDesiredStateConfiguration _dsc;
+    private readonly IExperimentationService _experimentationService;
 
     public MainPageBannerViewModel BannerViewModel { get; }
 
@@ -46,6 +50,8 @@ public partial class MainPageViewModel : SetupPageViewModelBase
     [ObservableProperty]
     private bool _showAppInstallerUpdateNotification;
 
+    public bool ShouldShowSetupTargetItem => _experimentationService.IsFeatureEnabled(EnvironmentsSetupFlowFeatureName);
+
     /// <summary>
     /// Event raised when the user elects to start the setup flow.
     /// The orchestrator for the whole flow subscribes to this event to handle
@@ -59,12 +65,14 @@ public partial class MainPageViewModel : SetupPageViewModelBase
         IWindowsPackageManager wpm,
         IDesiredStateConfiguration dsc,
         IHost host,
-        MainPageBannerViewModel bannerViewModel)
+        MainPageBannerViewModel bannerViewModel,
+        IExperimentationService experimentationService)
         : base(stringResource, orchestrator)
     {
         _host = host;
         _wpm = wpm;
         _dsc = dsc;
+        _experimentationService = experimentationService;
 
         IsNavigationBarVisible = false;
         IsStepPage = false;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -114,8 +114,11 @@
                                     IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem,Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
                             </ToolTipService.ToolTip>
                         </Grid>
+                        
                         <!--  settings card for setup target flow.  -->
-                        <Grid Background="Transparent">
+                        <Grid 
+                            Background="Transparent"
+                            Visibility="{x:Bind ViewModel.ShouldShowSetupTargetItem}">
                             <ctControls:SettingsCard
                                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow_For_target"
                                 ActionIcon="{x:Null}"


### PR DESCRIPTION
## Summary of the pull request
This PR allows the visibility of the Dev Environments UX pieces in Dev Home like the environments tool page and the "Setup Target" Flow option in the machine configuration's main page to be controlled via experimentation keys.

Initially these will only be toggled on by default in Dev Builds. Canary and Preview builds will be toggled off by default.

There are 2 experimentation keys added:

1. EnvironmentsManagementPage - for environments tool page
2. EnvironmentsSetupTargetFlow - for Setup target flow option in machine configuration


See video:

https://github.com/microsoft/devhome/assets/105318831/c103637f-40b2-42de-81ea-f884d7dbfb4f



When the Setup target option in the machine configuration page **is not** clicked prior to turning off the `EnvironmentsSetupTargetFlow` key. The next time the user enters the machine configuration page the option will not appear. (this is our desired behavior). 
## References and relevant issues

## Detailed description of the pull request / Additional comments
_Explanation of edge case when the Setup target option in the machine configuration page **is** clicked prior to turning off the `EnvironmentsSetupTargetFlow` key._

Due to the machine configuration page using a singleton [SetupFlowViewModel](https://github.com/microsoft/devhome/blob/eb5273b1166e12eab6a825af391674458b026210/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs#L21) to keep which ever flow the user selects in the main page available in the view until, either the Dev Home app closes or the user clicks the cancel button in the UI. The flow stays in the view despite the key being toggled off.

Once the user clicks the cancel button in the UI or closes Dev Home, the next time the user enters into the main page, the "Setup target" option will not appear, as the experimentation key will be re-evaluated when re-creating the main page.

We'd need to update the machine configuration behavior and add events to the IExperimentationService interface to allow for us to dynamically close out UI related to an experimentation key in the future if need be. For now, I believe what we have is enough, as if the user was already in the setup target flow, then turns off the `EnvironmentsSetupTargetFlow` key, they just need to click the cancel button or close dev home for the "Setup target" option to not appear the next time they enter the machine configuration page.

_Video showing the edge case (In it I show the behavior for when the user doesn't click the setup target button and turns off the key. Then I show what happens after they click the setup target button and then turn off the experimentation key):_

https://github.com/microsoft/devhome/assets/105318831/f8f8bc43-28bd-4288-b269-8f5ffa848ec7



## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
