### PR TITLE
Add PowerShell script and a helper class to deploy DevSetupAgent service to a Hyper-V VM.

### DIFF
--- a/HyperVExtension/src/HyperVExtension/Extensions/DevSetupAgentDeploymentException.cs
+++ b/HyperVExtension/src/HyperVExtension/Extensions/DevSetupAgentDeploymentException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HyperVExtension.Exceptions;
+
+public class DevSetupAgentDeploymentException : Exception
+{
+    public DevSetupAgentDeploymentException(string? message)
+        : base(message)
+    {
+    }
+
+    public DevSetupAgentDeploymentException(string? message, Exception? innerException)
+    : base(message, innerException)
+    {
+    }
+}

--- a/HyperVExtension/src/HyperVExtension/Extensions/DevSetupAgentDeploymentSessionException.cs
+++ b/HyperVExtension/src/HyperVExtension/Extensions/DevSetupAgentDeploymentSessionException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HyperVExtension.Exceptions;
+
+public class DevSetupAgentDeploymentSessionException : Exception
+{
+    public DevSetupAgentDeploymentSessionException(string? message)
+        : base(message)
+    {
+    }
+
+    public DevSetupAgentDeploymentSessionException(string? message, Exception? innerException)
+    : base(message, innerException)
+    {
+    }
+}

--- a/HyperVExtension/src/HyperVExtension/Helpers/DevSetupAgentDeploymentHelper.cs
+++ b/HyperVExtension/src/HyperVExtension/Helpers/DevSetupAgentDeploymentHelper.cs
@@ -1,0 +1,306 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+using System.Security;
+using HyperVExtension.Exceptions;
+using HyperVExtension.Services;
+
+namespace HyperVExtension.Helpers;
+
+/// <summary>
+/// A helper class to deploy DevSetupAgent service to a VM using PowerShell Direct service.
+/// </summary>
+public class DevSetupAgentDeploymentHelper
+{
+    // Architectures returned by Win32_Processor.Architecture (Win32_Processor WMI class)
+    private enum ProcessorArchitecture : ushort
+    {
+        X86 = 0,
+        MIPS = 1,
+        Alpha = 2,
+        PowerPC = 3,
+        ARM = 5,
+        IA64 = 6,
+        X64 = 9,
+        ARM64 = 12,
+    }
+
+    private readonly IPowerShellService _powerShellService;
+    private readonly string _vmId;
+
+    public DevSetupAgentDeploymentHelper(IPowerShellService powerShellService, string vmId)
+    {
+        _powerShellService = powerShellService;
+        _vmId = vmId;
+    }
+
+    public void DeployDevSetupAgent(string userName, SecureString password)
+    {
+        var credential = new PSCredential(userName, password);
+        var session = GetSessionObject(credential);
+        var architecture = GetVMArchitechture(session);
+        var sourcePath = GetSourcePath(architecture);
+
+        var deployDevSetupAgentStatement = new StatementBuilder()
+                .AddScript(_script, false)
+                .AddCommand("DeployDevSetupAgent")
+                .AddParameter("VMId", _vmId)
+                .AddParameter("Session", session)
+                .AddParameter("Path", sourcePath)
+                .Build();
+
+        // TODO: Subscribe for PowerShell events to get the progress of the deployment like:
+        ////  ps.Streams.Information.DataAdded += (sender, e) =>
+        ////  ps.Streams.Error.DataAdded += (sender, e) =>
+        ////  ps.Streams.Verbose.DataAdded += (sender, e) =>
+        ////  ps.Streams.Warning.DataAdded += (sender, e) =>
+        ////  ps.Streams.Progress.DataAdded += (sender, e) =>
+        var result = _powerShellService.Execute(deployDevSetupAgentStatement, PipeType.DontClearBetweenStatements);
+        if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
+        {
+            throw new DevSetupAgentDeploymentException(
+                $"Unable to deploy DevSetupAgent service to VM with Id: {_vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+        }
+    }
+
+    public virtual string GetSourcePath(ushort architecture)
+    {
+        if (architecture == (ushort)ProcessorArchitecture.X64)
+        {
+            // TODO: Adjust path once we have the actual DevSetupAgent package.
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "DevSetupAgent_x64.zip");
+        }
+        else
+        {
+            throw new DevSetupAgentDeploymentException(
+                $"Unable to deploy DevSetupAgent service to VM with Id: {_vmId} due to unsupported architecture: {architecture}");
+        }
+    }
+
+    public PSObject GetSessionObject(PSCredential credential)
+    {
+        var newSessionCommand = new StatementBuilder()
+            .AddCommand("New-PSSession")
+            .AddParameter("VMId", _vmId)
+            .AddParameter("Credential", credential)
+            .Build();
+
+        var result = _powerShellService.Execute(newSessionCommand, PipeType.None);
+        if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
+        {
+            throw new DevSetupAgentDeploymentSessionException(
+                $"Unable to create remote session for VM with Id: {_vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+        }
+
+        return result!.PsObjects.FirstOrDefault()!;
+    }
+
+    private ushort GetVMArchitechture(PSObject session)
+    {
+        var getVMArchitechtureCommand = new StatementBuilder()
+                       .AddCommand("Invoke-Command")
+                       .AddParameter("Session", session)
+                       .AddParameter("ScriptBlock", ScriptBlock.Create("(Get-CIMInstance -Class win32_processor).Architecture"))
+                       .Build();
+
+        var result = _powerShellService!.Execute(getVMArchitechtureCommand, PipeType.None);
+        if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
+        {
+            throw new DevSetupAgentDeploymentException(
+                               $"Unable to get VM architecture for VM with Id: {_vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+        }
+
+        var psObject = result.PsObjects.FirstOrDefault();
+        if (psObject == null)
+        {
+            throw new DevSetupAgentDeploymentException(
+                               $"Unable to get VM architecture for VM with Id: {_vmId} due to PowerShell error: No result returned");
+        }
+
+        return (ushort)psObject.BaseObject;
+    }
+
+    private readonly string _script = @"
+function DeployDevSetupAgent
+{
+    Param(
+        [Guid] $VMId,
+        [System.Management.Automation.Runspaces.PSSession] $Session,
+        [string] $Path
+    )
+
+        $ErrorActionPreference = ""Stop""
+        $activity = ""Installing DevSetupAgent to VM $VMId""
+
+        # Validate input. Only .cab and .zip files are supported
+        # If $Path is a directory, it will be copied to the VM and installed as is
+        $isDirectory = $false
+        $isCab = $false
+        $inputFileName = $null
+        if (Test-Path -Path $Path -PathType 'Container')
+        {
+            $isDirectory = $true
+        }
+        elseif (Test-Path -Path $Path -PathType 'Leaf')
+        {
+            if ($Path -match '\.(cab)$')
+            {
+                $isCab = $true
+            }
+            elseif (-not $Path -match '\.(zip)$')
+            {
+                throw ""Only .cab and .zip files are supported""
+            }
+            $inputFileName = Split-Path -Path $Path -Leaf
+        }
+        else
+        {
+            throw ""$Path does not exist""
+        }
+
+
+        $DevSetupAgentConst = ""DevSetupAgent""
+        $DevSetupEngineConst = ""DevSetupEngine""
+        $session = $Session
+
+        $guestTempDirectory = Invoke-Command -Session $session -ScriptBlock { $env:temp }
+        
+        [string] $guid = [System.Guid]::NewGuid()
+        $guestUnpackDirectory = Join-Path -Path $guestTempDirectory -ChildPath $guid
+        $guestDevSetupAgentTempDirectory = Join-Path -Path $guestUnpackDirectory -ChildPath $DevSetupAgentConst
+
+        Write-Host ""Creating VM temporary folder $guestUnpackDirectory""
+        Write-Progress -Activity $activity -Status ""Creating VM temporary folder $guestUnpackDirectory"" -PercentComplete 10
+        Invoke-Command -Session $session -ScriptBlock { New-Item -Path ""$using:guestUnpackDirectory"" -ItemType ""directory"" }
+
+        if ($isDirectory)
+        {
+            $destinationPath = $guestDevSetupAgentTempDirectory
+        }
+        else
+        {
+            $destinationPath = $guestUnpackDirectory
+        }
+
+        Write-Host ""Copying $Path to VM $destinationPath""
+        Write-Progress -Activity $activity -Status ""Copying DevSetupAgent to VM $destinationPath"" -PercentComplete 15
+        Copy-Item -ToSession $session -Recurse -Path $Path -Destination $destinationPath
+
+
+        Invoke-Command -Session $session -ScriptBlock {
+            $ErrorActionPreference = ""Stop""
+
+            try
+            {
+                $guestDevSetupAgentPath = Join-Path -Path $Env:Programfiles -ChildPath $using:DevSetupAgentConst
+
+                # Stop and remove previous version of DevSetupAgent service if it exists
+                $service = Get-Service -Name $using:DevSetupAgentConst -ErrorAction SilentlyContinue
+                if ($service -ne $null)
+                {
+                    $serviceWMI = Get-WmiObject -Class Win32_Service -Filter ""Name='$using:DevSetupAgentConst'""
+                    $existingServicePath = $serviceWMI.Properties[""PathName""].Value
+                    if ($existingServicePath)
+                    {
+                        $guestDevSetupAgentPath = Split-Path $existingServicePath -Parent
+                    }
+                    
+                    try
+                    {
+                        Write-Host ""Stopping DevSetupAgent service""
+                        Write-Progress -Activity $using:activity -Status ""Stopping DevSetupAgent service $destinationPath"" -PercentComplete 30
+                        $service.Stop()
+                    }
+                    catch
+                    {
+                        Write-Host ""Ignoring error: $PSItem""
+                    }
+
+                    Remove-Variable -Name service -ErrorAction SilentlyContinue
+
+                    # Remove-Service is only available in PowerShell 6.0 and later. Windows doesn't come with it preinstalled.
+                    Write-Host ""Removing DevSetupAgent service""
+                    Write-Progress -Activity $using:activity -Status ""Removing DevSetupAgent service"" -PercentComplete 35
+                    $serviceWMI = Get-WmiObject -Class Win32_Service -Filter ""Name='$using:DevSetupAgentConst'""
+                    $serviceWMI.Delete()
+                    Remove-Variable -Name serviceWMI -ErrorAction SilentlyContinue
+                }
+
+                # Stop previous version of DevSetupEngine CON server if it exists
+                $devSetupEngineProcess = Get-Process -Name ""$using:DevSetupEngineConst"" -ErrorAction SilentlyContinue
+                if ($devSetupEngineProcess -ne $null)
+                {
+                    Write-Host ""Stopping $using:DevSetupEngineConst process""
+                    Write-Progress -Activity $using:activity -Status ""Stopping $using:DevSetupEngineConst process"" -PercentComplete 40
+                    Stop-Process -Force -Name ""$using:DevSetupEngineConst""
+                }
+            
+                # Remove previous version of DevSetupAgent service files
+                if (Test-Path -Path $guestDevSetupAgentPath)
+                {
+                    Write-Host ""Deleting old DevSetupAgent service files""
+                    Write-Progress -Activity $using:activity -Status ""Deleting old DevSetupAgent service files"" -PercentComplete 45
+                    Remove-Item -Recurse -Force -Path $guestDevSetupAgentPath
+                }
+
+                if ($using:isDirectory)
+                {
+                    Write-Host ""Copying DevSetupAgent to $guestDevSetupAgentPath""
+                    Write-Progress -Activity $using:activity -Status ""Deleting old DevSetupAgent service files"" -PercentComplete 50
+                    Copy-Item -Recurse -Path $using:guestDevSetupAgentTempDirectory -Destination $guestDevSetupAgentPath
+                }
+                elseif ($using:isCab)
+                {
+                    $cabPath = Join-Path -Path $using:guestUnpackDirectory -ChildPath $using:inputFileName
+                    Write-Host ""Unpacking $cabPath to $guestDevSetupAgentPath""
+                    Write-Progress -Activity $using:activity -Status ""Unpacking $cabPath to $guestDevSetupAgentPath"" -PercentComplete 60
+                    $expandOutput=&""$Env:SystemRoot\System32\expand.exe"" $cabPath /F:* $Env:Programfiles
+                    if ($LastExitCode -ne 0)
+                    {
+                        throw ""Error unpacking $cabPath`:`n$LastExitCode`n$($expandOutput|Out-String)""
+                    }
+                }
+                else
+                {
+                    $zipPath = Join-Path -Path $using:guestUnpackDirectory -ChildPath $using:inputFileName
+                    Write-Host ""Unpacking $using:inputFileName to $guestDevSetupAgentPath""
+                    Write-Progress -Activity $using:activity -Status ""Unpacking $using:inputFileName to $guestDevSetupAgentPath"" -PercentComplete 60
+                    Expand-Archive -Path $zipPath -Destination $guestDevSetupAgentPath
+                }
+
+                # Register DevSetupAgent service				
+                $servicePath = Join-Path -Path $guestDevSetupAgentPath -ChildPath ""$using:DevSetupAgentConst.exe""
+                Write-Host ""Registering DevSetupAgent service ($servicePath)""
+                Write-Progress -Activity $using:activity -Status ""Registering DevSetupAgent service ($servicePath)"" -PercentComplete 85
+                New-Service -Name $using:DevSetupAgentConst -BinaryPathName $servicePath -StartupType Automatic
+
+                # Register DevSetupEngine
+                $enginePath = Join-Path -Path $guestDevSetupAgentPath -ChildPath ""$using:DevSetupEngineConst.exe""
+                Write-Host ""Registering DevSetupEngine ($enginePath)""
+                Write-Progress -Activity $using:activity -Status ""Registering DevSetupEngine ($enginePath)"" -PercentComplete 88
+                &$enginePath ""-RegisterComServer""
+                if ($LastExitCode -ne 0)
+                {
+                    throw ""Error registering $enginePath`: $LastExitCode""
+                }
+
+                Write-Host ""Starting DevSetupAgent service""
+                Write-Progress -Activity $using:activity -Status ""Starting DevSetupAgent service"" -PercentComplete 92
+                Start-Service $using:DevSetupAgentConst
+            }
+            catch
+            {
+                Write-Host ""Error on guest OS: $PSItem""
+            }
+            finally
+            {
+                Write-Host ""Removing temporary directory $using:guestUnpackDirectory""
+                Remove-Item -Recurse -Force -Path $using:guestUnpackDirectory -ErrorAction SilentlyContinue 
+            }
+        }
+
+        Remove-PSSession $session
+}
+";
+}

--- a/HyperVExtension/src/HyperVExtension/Helpers/StatementBuilder.cs
+++ b/HyperVExtension/src/HyperVExtension/Helpers/StatementBuilder.cs
@@ -38,9 +38,9 @@ public class StatementBuilder
 
     /// <summary>  Adds a new PowerShell commandline statement with only a single script inside.</summary>
     /// <returns>The StatementBuilder object that is being used to contain the commandline statements</returns>
-    public StatementBuilder AddScript(string script)
+    public StatementBuilder AddScript(string script, bool useLocalScope)
     {
-        var statement = new PowerShellCommandlineStatement() { Script = script, };
+        var statement = new PowerShellCommandlineStatement() { Script = script, UseLocalScope = useLocalScope };
         _powerShellCommandLineStatements.Add(statement);
         return this;
     }

--- a/HyperVExtension/src/HyperVExtension/Models/IPowerShellSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/IPowerShellSession.cs
@@ -26,7 +26,7 @@ public interface IPowerShellSession
 
     /// <summary> Adds a script to the PowerShell session. </summary>
     /// <param name="script">A string representing a script that can be run by PowerShell.</param>
-    public void AddScript(string script);
+    public void AddScript(string script, bool useLocalScope);
 
     /// <summary> Invokes the PowerShell statements. </summary>
     /// <returns>A collection of PowerShell Objects returned by PowerShell.</returns>

--- a/HyperVExtension/src/HyperVExtension/Models/PowerShellCommandlineStatement.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/PowerShellCommandlineStatement.cs
@@ -32,6 +32,11 @@ public class PowerShellCommandlineStatement
     /// </remarks>
     public string Script { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to use local scope for the PowerShell script.
+    /// </summary>
+    public bool UseLocalScope { get; set; } = true;
+
     /// <summary> Returns a clone of the PowerShellCommandlineStatement object.</summary>
     public PowerShellCommandlineStatement Clone()
     {
@@ -40,6 +45,7 @@ public class PowerShellCommandlineStatement
             Command = Command,
             Parameters = Parameters,
             Script = Script,
+            UseLocalScope = UseLocalScope,
         };
     }
 
@@ -49,6 +55,7 @@ public class PowerShellCommandlineStatement
         builder.AppendLine(CultureInfo.InvariantCulture, $"Command: {Command}");
         builder.AppendLine(CultureInfo.InvariantCulture, $"Parameters: {CreateParameterString()}");
         builder.AppendLine(CultureInfo.InvariantCulture, $"Script: {Script}");
+        builder.AppendLine(CultureInfo.InvariantCulture, $"UseLocalScope: {UseLocalScope}");
 
         return builder.ToString();
     }

--- a/HyperVExtension/src/HyperVExtension/Models/PowerShellSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/PowerShellSession.cs
@@ -37,9 +37,9 @@ public class PowerShellSession : IPowerShellSession, IDisposable
     }
 
     /// <inheritdoc cref="IPowerShellSession.AddScript(string)"/>
-    public void AddScript(string script)
+    public void AddScript(string script, bool useLocalScope)
     {
-        _powerShellSession.AddScript(script, true);
+        _powerShellSession.AddScript(script, useLocalScope);
     }
 
     /// <inheritdoc cref="IPowerShellSession.Invoke"/>

--- a/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
@@ -401,7 +401,7 @@ public class HyperVManager : IHyperVManager, IDisposable
         {
             // Build command line statement to connect to the VM.
             var commandLineStatements = new StatementBuilder()
-                .AddScript($"{HyperVStrings.VmConnectScript} {vmId}")
+                .AddScript($"{HyperVStrings.VmConnectScript} {vmId}", true)
                 .Build();
 
             var result = _powerShellService.Execute(commandLineStatements, PipeType.PipeOutput);

--- a/HyperVExtension/src/HyperVExtension/Services/IPowerShellService.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/IPowerShellService.cs
@@ -10,6 +10,7 @@ public enum PipeType
 {
     None,
     PipeOutput,
+    DontClearBetweenStatements,
 }
 
 /// <summary> Interface that handles PowerShell command line statements. </summary>

--- a/HyperVExtension/src/HyperVExtension/Services/PowerShellService.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/PowerShellService.cs
@@ -81,7 +81,7 @@ public class PowerShellService : IPowerShellService, IDisposable
             return BuildPipelineAndExecuteStatements(commandLineStatements);
         }
 
-        return ExecuteIndividualStatements(commandLineStatements);
+        return ExecuteIndividualStatements(commandLineStatements, pipeType);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public class PowerShellService : IPowerShellService, IDisposable
     /// previous statement is not used as input for the next statement.
     /// </summary>
     /// <param name="commandLineStatements"> A list of statements that houses a PowerShell command and its parameters or a script.</param>
-    private Collection<PSObject> ExecuteIndividualStatements(IEnumerable<PowerShellCommandlineStatement> commandLineStatements)
+    private Collection<PSObject> ExecuteIndividualStatements(IEnumerable<PowerShellCommandlineStatement> commandLineStatements, PipeType pipeType)
     {
         Collection<PSObject> result = new();
 
@@ -119,7 +119,10 @@ public class PowerShellService : IPowerShellService, IDisposable
             }
 
             // Clear the PowerShell commands and streams to ensure that the previous command is not run again.
-            _powerShellSession.ClearSession();
+            if (pipeType != PipeType.DontClearBetweenStatements)
+            {
+                _powerShellSession.ClearSession();
+            }
         }
 
         return result;
@@ -140,12 +143,12 @@ public class PowerShellService : IPowerShellService, IDisposable
 
         if (isCommandEmptyOrNull && isScriptEmptyOrNull)
         {
-            throw new ArgumentException("Both the Command and Script properites were empty or null.");
+            throw new ArgumentException("Both the Command and Script properties were empty or null.");
         }
 
         if (isCommandUsedWithScript)
         {
-            throw new ArgumentException("Command and Script properites were used in the same statement. This is not allowed.");
+            throw new ArgumentException("Command and Script properties were used in the same statement. This is not allowed.");
         }
 
         // Add the command if its available.
@@ -163,7 +166,7 @@ public class PowerShellService : IPowerShellService, IDisposable
         // Add a script if its available and command is non-empty.
         if (isCommandEmptyOrNull && !isScriptEmptyOrNull)
         {
-            _powerShellSession.AddScript(statement.Script);
+            _powerShellSession.AddScript(statement.Script, statement.UseLocalScope);
         }
     }
 

--- a/HyperVExtension/test/HyperVExtension/HyperVExtension.UnitTest.csproj
+++ b/HyperVExtension/test/HyperVExtension/HyperVExtension.UnitTest.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/PowerShellServiceTest.cs
+++ b/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/PowerShellServiceTest.cs
@@ -93,7 +93,8 @@ public class PowerShellServiceTest : HyperVExtensionTestsBase
         var commandLineStatements = new StatementBuilder()
             .AddScript(
                 "[cultureinfo]::CurrentUICulture = 'en-US';" +
-                " 1 / 0")
+                " 1 / 0",
+                true)
             .Build();
 
         // Act

--- a/HyperVExtension/test/HyperVExtension/Mocks/PowerShellSessionMock.cs
+++ b/HyperVExtension/test/HyperVExtension/Mocks/PowerShellSessionMock.cs
@@ -24,8 +24,8 @@ public class PowerShellSessionMock : IPowerShellSession
     {
     }
 
-    /// <inheritdoc cref="IPowerShellSession.AddScript(string)"/>
-    public void AddScript(string script)
+    /// <inheritdoc cref="IPowerShellSession.AddScript(string, bool)"/>
+    public void AddScript(string script, bool useLocalScope)
     {
     }
 


### PR DESCRIPTION
Add PowerShell script and a helper class to deploy DevSetupAgent service to a Hyper-V VM.

## Summary of the pull request

- Add DevSetupAgentDeploymentHelper helper class to handle deployment of DevSetupAgent to a Hyper-V VM.
Provided Hyper-V admin credentials and a path to DevSetupAgent (folder with binaries or a .zip file) it will 
1. Connect to the target Hyper-V device.
2. Copy file to the device
3. Remove old DevSetupAgent service if it exists
4. Copy DevSetupAgent  binaries to $env:ProgramFiles\DevSetupAgent (or to the location of the old dervice)
5. Register DevSetupEngine COM server
6. Register DevSetupAgent Windows service
7. Start DevSetupAgent service.

- Add an integration test that can call DevSetupAgentDeploymentHelper with user's credential and path to DevSetupAgent to deploy it on a VM (requires to have a VM created and modify code to enter user's password at the moment).

- Small changes to existing PowerShell helpers to custom PS function work (add useLocalScope parameter).

## Validation steps performed
Ran new test, verified that binaries were deployed on the target VM.
Manual debugging of C# and PS code.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
