### PR TITLE
Update FailFast Logging comments

### DIFF
--- a/common/Views/ExtensionAdaptiveCardPanel.cs
+++ b/common/Views/ExtensionAdaptiveCardPanel.cs
@@ -15,7 +15,6 @@ namespace DevHome.Common.Views;
 
 // XAML element to contain a single instance of extension UI.
 // Use this element where extension UI is expected to pop up.
-// https://github.com/microsoft/devhome/issues/610
 public class ExtensionAdaptiveCardPanel : StackPanel
 {
     public event EventHandler<FrameworkElement>? UiUpdate;

--- a/logging/logger/ComponentLogger.cs
+++ b/logging/logger/ComponentLogger.cs
@@ -69,7 +69,6 @@ public class ComponentLogger : IDisposable
             LogStdoutFilter = SeverityLevel.Info,
             LogFileFilter = SeverityLevel.Info,
 #endif
-            FailFastSeverity = FailFastSeverityLevel.Critical,
         };
     }
 

--- a/logging/logger/FailFast.cs
+++ b/logging/logger/FailFast.cs
@@ -12,9 +12,7 @@ public enum SeverityLevel
     Critical,
 }
 
-// For setting fail-fast behavior, at what level of failure will we conduct a fail-fast?
-// This is mostly intended for specifying whether any error or any critical error causes an FailFast.
-// By default we assume any critical failure is by definition something we should not continue after detecting.
+// By default, we FailFast on Critical since Critical failure is, by definition, something we should not continue after detecting.
 public enum FailFastSeverityLevel
 {
     Ignore = -1,
@@ -25,6 +23,12 @@ public enum FailFastSeverityLevel
 
 public class FailFast
 {
+    /// <summary>
+    /// Determine whether the message's severity level is at least at the FailFastSeverity threshold.
+    /// </summary>
+    /// <param name="severity">Severity of the log message.</param>
+    /// <param name="failFastSeverity">Threshold set for FailFast on logging.</param>
+    /// <returns>True if Dev Home should fail fast, false if it should not.</returns>
     public static bool IsFailFastSeverityLevel(SeverityLevel severity, FailFastSeverityLevel failFastSeverity)
     {
         return failFastSeverity switch

--- a/logging/logger/Options.cs
+++ b/logging/logger/Options.cs
@@ -5,6 +5,7 @@ namespace DevHome.Logging;
 
 public partial class Options : ICloneable
 {
+    // Logging events marked Critical will cause a FailFast.
     public FailFastSeverityLevel FailFastSeverity { get; set; } = FailFastSeverityLevel.Critical;
 
     public object Clone() => MemberwiseClone();


### PR DESCRIPTION
## Summary of the pull request
* Issue #610 is no longer valid, remove reference from code
* Issue #609 is resolved by keeping FailFast at Critical logging level.
  * Update comments
  * Remove setting FailFastSeverity in ComponentLogger.cs, since it's already set in Options.cs

## PR checklist
- [x] Closes #609
- [x] Closes #610
