### PR TITLE
Show error if there was an error creating a widget

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -182,4 +182,12 @@
     <value>Selected</value>
     <comment>State of selected size for automatiom purposes</comment>
   </data>
+  <data name="CouldNotCreateWidgetError" xml:space="preserve">
+    <value>Dev Home encountered an error. The widget could not be created.</value>
+    <comment>Error that pops up in a message dialog when the user tries to pin a widget but the widget could not be created.</comment>
+  </data>
+  <data name="CloseButtonText" xml:space="preserve">
+    <value>Close</value>
+    <comment>Text for a button to close a content dialog.</comment>
+  </data>
 </root>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -24,6 +24,7 @@ using Microsoft.UI.Xaml.Navigation;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Windows.System;
+using WinUIEx;
 using Log = DevHome.Dashboard.Helpers.Log;
 
 namespace DevHome.Dashboard.Views;
@@ -383,6 +384,15 @@ public partial class DashboardView : ToolPage
             catch (Exception ex)
             {
                 Log.Logger()?.ReportWarn("AddWidgetDialog", $"Creating widget failed: ", ex);
+                var mainWindow = Application.Current.GetService<WindowEx>();
+                var resourceLoader =
+                    new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader(
+                        "DevHome.Dashboard.pri",
+                        "DevHome.Dashboard/Resources");
+                await mainWindow.ShowErrorMessageDialogAsync(
+                    title: string.Empty,
+                    content: resourceLoader.GetString("CouldNotCreateWidgetError"),
+                    buttonText: resourceLoader.GetString("CloseButtonText"));
             }
         }
     }


### PR DESCRIPTION
## Summary of the pull request
If the user tries to add a widget but creating the widget fails, show an error instead of failing silently.

![image](https://github.com/microsoft/devhome/assets/47155823/cf12c6c9-f336-4c65-a0db-331a3c8757d3)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
