### PR TITLE
Add shortcut to show logs in Debug builds

### DIFF
--- a/settings/DevHome.Settings/DevHome.Settings.csproj
+++ b/settings/DevHome.Settings/DevHome.Settings.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
+
   <ItemGroup>
     <Content Update="Assets\LightHostConfig.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -15,6 +16,7 @@
        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
   <ItemGroup>
     <None Remove="Views\AboutPage.xaml" />
     <None Remove="Views\AccountsPage.xaml" />
@@ -64,15 +66,16 @@
     <Page Update="Views\ExtensionSettingsPage.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
+    <Page Update="Views\ExperimentalFeaturesPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="TelemetryEvents\" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Page Update="Views\ExperimentalFeaturesPage.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -538,7 +538,7 @@
     <value>Learn more</value>
     <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>
-  <data name="ViewLogs.Text" xml:space="preserve">
+  <data name="ViewLogs.Header" xml:space="preserve">
     <value>View logs</value>
     <comment>Click on this if you want to see Dev Home's logs on your machine.</comment>
   </data>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -538,4 +538,8 @@
     <value>Learn more</value>
     <comment>Click on this link if you want to learn more and read the security policy. View is an action.</comment>
   </data>
+  <data name="ViewLogs.Text" xml:space="preserve">
+    <value>View logs</value>
+    <comment>Click on this if you want to see Dev Home's logs on your machine.</comment>
+  </data>
 </root>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -46,13 +46,9 @@
                     <ctControls:SettingsCard
                         Visibility="Collapsed"
                         x:Name="ViewLogsSettingsCard"
+                        x:Uid="ViewLogs"
                         IsClickEnabled="True"
-                        ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}"
-                        HorizontalContentAlignment="Left"
-                        VerticalContentAlignment="Center"
-                        ContentAlignment="Left">
-                        <TextBlock x:Uid="ViewLogs" />
-                    </ctControls:SettingsCard>
+                        ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}" />
                 </ctControls:SettingsExpander.Items>
             </ctControls:SettingsExpander>
         </ScrollViewer>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -42,6 +42,18 @@
                             <HyperlinkButton x:Uid="SettingsPage_PrivacyPolicyLink" Margin="{StaticResource HyperlinkButtonNegativeMargin}" />
                         </StackPanel>
                     </ctControls:SettingsCard>
+                    <ctControls:SettingsCard
+                        Visibility="Collapsed"
+                        x:Name="ViewLogsSettingsCard"
+                        IsClickEnabled="True"
+                        HorizontalContentAlignment="Left"
+                        VerticalContentAlignment="Center"
+                        ContentAlignment="Left">
+                        <ctControls:SettingsCard.ActionIcon>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8A7;"/>
+                        </ctControls:SettingsCard.ActionIcon>
+                        <TextBlock x:Uid="ViewLogs" />
+                    </ctControls:SettingsCard>
                 </ctControls:SettingsExpander.Items>
             </ctControls:SettingsExpander>
         </ScrollViewer>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
@@ -46,12 +47,10 @@
                         Visibility="Collapsed"
                         x:Name="ViewLogsSettingsCard"
                         IsClickEnabled="True"
+                        ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}"
                         HorizontalContentAlignment="Left"
                         VerticalContentAlignment="Center"
                         ContentAlignment="Left">
-                        <ctControls:SettingsCard.ActionIcon>
-                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8A7;"/>
-                        </ctControls:SettingsCard.ActionIcon>
                         <TextBlock x:Uid="ViewLogs" />
                     </ctControls:SettingsCard>
                 </ctControls:SettingsExpander.Items>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml.cs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
+using DevHome.Logging;
 using DevHome.Settings.Models;
 using DevHome.Settings.ViewModels;
 using Microsoft.UI.Xaml;
@@ -13,15 +17,9 @@ namespace DevHome.Settings.Views;
 
 public sealed partial class AboutPage : Page
 {
-    public AboutViewModel ViewModel
-    {
-        get;
-    }
+    public AboutViewModel ViewModel { get; }
 
-    public ObservableCollection<Breadcrumb> Breadcrumbs
-    {
-        get;
-    }
+    public ObservableCollection<Breadcrumb> Breadcrumbs { get; }
 
     public AboutPage()
     {
@@ -34,6 +32,10 @@ public sealed partial class AboutPage : Page
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),
             new(stringResource.GetLocalized("Settings_About_Header"), typeof(AboutViewModel).FullName!),
         };
+
+#if DEBUG
+        Loaded += ShowViewLogsButton;
+#endif
     }
 
     private void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
@@ -44,4 +46,26 @@ public sealed partial class AboutPage : Page
             crumb.NavigateTo();
         }
     }
+
+#if DEBUG
+    private void ShowViewLogsButton(object sender, RoutedEventArgs e)
+    {
+        ViewLogsSettingsCard.Visibility = Visibility.Visible;
+        ViewLogsSettingsCard.Command = OpenLogsLocationCommand;
+    }
+
+    [RelayCommand]
+    private void OpenLogsLocation()
+    {
+        var logLocation = GlobalLog.Logger?.Options.LogFileFolderRoot ?? string.Empty;
+        try
+        {
+            Process.Start("explorer.exe", $"{logLocation}");
+        }
+        catch (Exception e)
+        {
+            GlobalLog.Logger?.ReportError("AboutPage", $"Error opening log location", e);
+        }
+    }
+#endif
 }


### PR DESCRIPTION
## Summary of the pull request
Add shortcut to the Dev Home logs. Only visible in Debug builds for now.
Command is added in codebehind so the code can stay inside `#if DEBUG`

![image](https://github.com/microsoft/devhome/assets/47155823/ddb1af5a-134c-4496-9438-f0b8ea793491)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
