### PR TITLE
Default header width should match page width

### DIFF
--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -25,7 +25,7 @@
     <Thickness x:Key="NavigationViewContentGridBorderThickness">1,1,0,0</Thickness>
     <CornerRadius x:Key="NavigationViewContentGridCornerRadius">8,0,0,0</CornerRadius>
     <Thickness x:Key="NavigationViewContentMargin">0,8,0,0</Thickness>
-    <Thickness x:Key="NavigationViewHeaderMargin">40,0,0,0</Thickness>
+    <Thickness x:Key="NavigationViewHeaderMargin">0,0,0,0</Thickness>
 
     <Thickness x:Key="ContentPageMargin">40,0,40,0</Thickness>
 

--- a/src/Views/ShellPage.xaml
+++ b/src/Views/ShellPage.xaml
@@ -70,7 +70,7 @@
             </NavigationView.FooterMenuItems>
             <NavigationView.HeaderTemplate>
                 <DataTemplate>
-                    <Grid>
+                    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                         <TextBlock
                             Text="{Binding}"
                             Style="{ThemeResource SubtitleTextBlockStyle}" />
@@ -82,7 +82,7 @@
                     DefaultHeader="{x:Bind ((ContentControl)ViewModel.Selected).Content, Mode=OneWay}">
                     <behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
                         <DataTemplate>
-                            <Grid>
+                            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                                 <TextBlock
                                     Text="{Binding}"
                                     Style="{ThemeResource SubtitleTextBlockStyle}" />


### PR DESCRIPTION
## Summary of the pull request
The default header template supplied by Template Studio did not have Dev Home's max page width styling, which resulted in the header being farther to the left than the rest of the page at wide window widths. This change aligns the header with the rest of the page.
Margin is included so Default Headers match the headers that are really part of the "Content" provided by other pages (Dashboard, Machine Config, Settings).

![image](https://github.com/microsoft/devhome/assets/47155823/657a07be-0787-442e-968b-2d81085d021a)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #1686
- [ ] Tests added/passed
- [ ] Documentation updated
