### PR TITLE
Fixing accessibility for buttons in "Welcome to DevHome" page

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -294,6 +294,7 @@
                                     DataContext="{x:Bind PageKey}"
                                     Click="Button_ClickAsync"
                                     HorizontalAlignment="Stretch"
+                                    AutomationProperties.Name="{x:Bind Button}"
                                     VerticalAlignment="Bottom">
                                     <Button.Content>
                                         <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
## Summary of the pull request
There was no accessible names for the buttons in the small cards of the "Welcome to DevHome" page. This PR adds it.
## References and relevant issues

## Detailed description of the pull request / Additional comments
As for the small cards, its buttons' contents were not simple texts, so the narrator could not narrate its name when keyboard focused. This PR adds the `AutomationProperties.Name` property with the same text the button has, so the narrator can explicitly narrate it.
## Validation steps performed

## PR checklist
- [ ] Closes #2324
- [ ] Tests added/passed
- [ ] Documentation updated
