### PR TITLE
Prevent concurrent loading of catalogs

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -64,6 +64,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
     /// </summary>
     private async Task LoadCatalogsAsync()
     {
+        // Prevent concurrent loading of catalogs
         await _loadCatalogsSemaphore.WaitAsync();
         try
         {


### PR DESCRIPTION
## Summary of the pull request
- Added semaphore to prevent concurrent loading of catalogs and operating on shared resources by multiple tasks.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
