### PR TITLE
Remove overlay on widgets when hovering over

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -91,6 +91,14 @@
                             <!-- Default margin is "0,0,4,4". Override since margins are set on the WidgetBoard instead. -->
                             <Setter Property="Margin" Value="0,0,0,0"/>
                             <Setter Property="AutomationProperties.AutomationId" Value="WidgetItem"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="GridViewItem">
+                                        <!-- Removes overlay over entire widget on hover -->
+                                        <ListViewItemPresenter PointerOverBackground="{ThemeResource ListViewItemBackground}"/>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
                         </Style>
                     </GridView.ItemContainerStyle>
                 </GridView>


### PR DESCRIPTION
## Summary of the pull request
Sets the PointerOverBackground to ListViewItemBackground, so the background does not change on hover.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated locally.

## PR checklist
- [ ] Closes #1464
- [ ] Tests added/passed
- [ ] Documentation updated
