### PR TITLE
ChoiceSets in Adaptive Cards do not have accessible Names if they don't have a Label

### DIFF
--- a/common/Renderers/AccessibleChoiceSet.cs
+++ b/common/Renderers/AccessibleChoiceSet.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using AdaptiveCards.ObjectModel.WinUI3;
+using AdaptiveCards.Rendering.WinUI3;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Common.Renderers;
+
+public class AccessibleChoiceSet : IAdaptiveElementRenderer
+{
+    public UIElement Render(IAdaptiveCardElement element, AdaptiveRenderContext context, AdaptiveRenderArgs renderArgs)
+    {
+        var renderer = new AdaptiveChoiceSetInputRenderer();
+
+        if (element is AdaptiveChoiceSetInput choiceSet)
+        {
+            // Label property corresponds to the Header dependency property on the ComboBox.
+            var header = choiceSet.Label;
+            var placeholderText = choiceSet.Placeholder;
+
+            // If there is no Header, there will not be an accessible Name.
+            // Use the Placeholder text as the accessible Name if possible.
+            if (string.IsNullOrEmpty(header) && !string.IsNullOrEmpty(placeholderText))
+            {
+                var result = renderer.Render(choiceSet, context, renderArgs);
+                if (result is StackPanel stackPanel)
+                {
+                    var comboBox = stackPanel.Children.First() as ComboBox;
+                    if (comboBox != null)
+                    {
+                        AutomationProperties.SetName(comboBox, placeholderText);
+                        return stackPanel;
+                    }
+                }
+            }
+        }
+
+        return renderer.Render(element, context, renderArgs);
+    }
+}

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -156,6 +156,7 @@ public sealed partial class AccountsPage : Page
 
         // Add custom Adaptive Card renderer for LoginUI as done for Widgets.
         renderer.ElementRenderers.Set(LabelGroup.CustomTypeString, new LabelGroupRenderer());
+        renderer.ElementRenderers.Set("Input.ChoiceSet", new AccessibleChoiceSet());
 
         var hostConfigContents = string.Empty;
         var hostConfigFileName = (ActualTheme == ElementTheme.Light) ? "LightHostConfig.json" : "DarkHostConfig.json";

--- a/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
@@ -77,6 +77,7 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
     {
         // Add custom Adaptive Card renderer.
         _renderer.ElementRenderers.Set(LabelGroup.CustomTypeString, new LabelGroupRenderer());
+        _renderer.ElementRenderers.Set("Input.ChoiceSet", new AccessibleChoiceSet());
 
         // A different host config is used to render widgets (adaptive cards) in light and dark themes.
         await UpdateHostConfig();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -183,6 +183,7 @@ internal sealed class RepositoryProvider
 
         // Add custom Adaptive Card renderer for LoginUI as done for Widgets.
         renderer.ElementRenderers.Set(LabelGroup.CustomTypeString, new LabelGroupRenderer());
+        renderer.ElementRenderers.Set("Input.ChoiceSet", new AccessibleChoiceSet());
 
         var hostConfigContents = string.Empty;
         var hostConfigFileName = (elementTheme == ElementTheme.Light) ? "LightHostConfig.json" : "DarkHostConfig.json";


### PR DESCRIPTION
## Summary of the pull request

If a `Label` (Header) is not specified on a `ChoiceSet` (ComboBox), the resulting ComboBox will not have an accessible name. Creates a custom renderer to render ChoiceSets as `AccessibleChoiceSet`s. If there is no Label, the renderer uses the Placeholder text as the name, if it is available. If not, it renders the ChoiceSet as normal.

This workaround is necessary unless Adaptive Cards changes the renderer, see https://github.com/microsoft/AdaptiveCards/issues/8837.

## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/48294659
https://dev.azure.com/microsoft/OS/_workitems/edit/48181033

## Validation steps performed
Tested with ChoiceSets in GitHub and Azure extension widgets.

## PR checklist
- [x] Closes #2324
