### PR TITLE
Use CloseButton on Popular applications page

### DIFF
--- a/common/Views/CloseButton.xaml
+++ b/common/Views/CloseButton.xaml
@@ -1,10 +1,7 @@
 <Button
     x:Class="DevHome.Common.Views.CloseButton"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
     x:Uid="CloseButton"
     Style="{StaticResource DefaultButtonStyle}"
     HorizontalAlignment="Right"

--- a/docs/common/CloseButton.md
+++ b/docs/common/CloseButton.md
@@ -1,0 +1,41 @@
+# Close button
+Create a close button (X button) for exiting a piece of UI.
+
+## Usage
+### Example 1: Use the CloseButton in fixed-width UI
+#### HelloWorldDialog.xaml
+```xml
+<!-- Title and Close button -->
+<Grid>
+    <TextBlock Text="Dialog Title" HorizontalAlignment="Left" />
+    <commonviews:CloseButton Command="{x:Bind CancelButtonClickCommand}" />
+</Grid>
+```
+
+#### HelloWorldDialogViewModel.cs
+```cs
+[RelayCommand]
+private void CancelButtonClick()
+{
+    HideDialogAsync();
+}
+```
+
+### Example 2: Use the CloseButton in dynamically-sized UI, preventing overlap when the width is small
+#### HelloWorldControl.xaml.cs
+```xml
+<Grid>
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="auto" />
+    </Grid.ColumnDefinitions>
+
+    <!-- Title -->
+    <TextBlock Text="Control Title" />
+
+    <!-- Close button -->
+    <common:CloseButton
+        Grid.Column="1"
+        Command="{x:Bind CancelButtonClickCommand}" />
+</Grid>
+```

--- a/docs/common/Readme.md
+++ b/docs/common/Readme.md
@@ -4,3 +4,6 @@ List of common controls that are generic, customizable and reusable from all pag
 ## Windows
 - [Window title bar](./WindowTitleBar.md)
 - [Secondary window](./SecondaryWindow.md)
+
+## Controls
+- [CloseButton](./CloseButton.md)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogListView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogListView.xaml
@@ -6,6 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="using:DevHome.SetupFlow.ViewModels"
     xmlns:views="using:DevHome.SetupFlow.Views"
+    xmlns:common="using:DevHome.Common.Views"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
@@ -33,11 +34,6 @@
             Spacing="27"
             Visibility="{x:Bind ViewModel.ViewAllCatalog, Mode=OneWay, Converter={StaticResource ViewAllConverter}}">
             <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
-
                 <!-- Full catalog path -->
                 <StackPanel Spacing="8">
                     <!-- Add negative margin to counteract the margin added by breadcrumb bar -->
@@ -57,12 +53,7 @@
                 </StackPanel>
 
                 <!-- Close button -->
-                <Button
-                    Grid.Column="1"
-                    FontSize="{ThemeResource CaptionTextBlockFontSize}"
-                    Padding="5"
-                    Command="{x:Bind ViewModel.ExitViewAllPackagesCommand}"
-                    Style="{ThemeResource AlternateCloseButtonStyle}" />
+                <common:CloseButton Command="{x:Bind ViewModel.ExitViewAllPackagesCommand}" />
             </Grid>
 
             <!-- Package list -->

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogListView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogListView.xaml
@@ -34,6 +34,11 @@
             Spacing="27"
             Visibility="{x:Bind ViewModel.ViewAllCatalog, Mode=OneWay, Converter={StaticResource ViewAllConverter}}">
             <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+
                 <!-- Full catalog path -->
                 <StackPanel Spacing="8">
                     <!-- Add negative margin to counteract the margin added by breadcrumb bar -->
@@ -53,7 +58,9 @@
                 </StackPanel>
 
                 <!-- Close button -->
-                <common:CloseButton Command="{x:Bind ViewModel.ExitViewAllPackagesCommand}" />
+                <common:CloseButton
+                    Grid.Column="1"
+                    Command="{x:Bind ViewModel.ExitViewAllPackagesCommand}" />
             </Grid>
 
             <!-- Package list -->


### PR DESCRIPTION
## Summary of the pull request
Close Button on the Popular Applications page didn't have an accessible name. Use CloseButton control instead, which does set the name.
CloseButton font size is slightly larger (14 vs 12) but matches all other CloseButtons in Dev Home.

![image](https://github.com/microsoft/devhome/assets/47155823/447abbdb-9589-4906-87c4-b5df0bc6c18b)

## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/49012933

## PR checklist
- [x] Closes #2324
- [x] Documentation updated
