### PR TITLE
Enable experimentation

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.369" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20230706-x2201" />
+    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240212-x1651" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.8" />
     <PackageReference Include="System.Management.Automation" Version="7.2.8" />

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.100.369" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240212-x1651" />
+    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240228-x2028" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.8" />
     <PackageReference Include="System.Management.Automation" Version="7.2.8" />

--- a/common/Models/ExperimentalFeature.cs
+++ b/common/Models/ExperimentalFeature.cs
@@ -68,6 +68,8 @@ public partial class ExperimentalFeature : ObservableObject
 
         await LocalSettingsService!.SaveSettingAsync($"ExperimentalFeature_{Id}", IsEnabled);
 
+        await LocalSettingsService!.SaveSettingAsync($"IsSeeker", true);
+
         TelemetryFactory.Get<ITelemetry>().Log("ExperimentalFeature_Toggled_Event", LogLevel.Critical, new ExperimentalFeatureEvent(Id, IsEnabled));
     }
 }

--- a/common/Models/ExperimentalFeature.cs
+++ b/common/Models/ExperimentalFeature.cs
@@ -68,6 +68,6 @@ public partial class ExperimentalFeature : ObservableObject
 
         await LocalSettingsService!.SaveSettingAsync($"ExperimentalFeature_{Id}", IsEnabled);
 
-        TelemetryFactory.Get<ITelemetry>().Log("RepoTool_SearchForExtensions_Event", LogLevel.Critical, new ExperimentalFeatureEvent(Id, IsEnabled));
+        TelemetryFactory.Get<ITelemetry>().Log("ExperimentalFeature_Toggled_Event", LogLevel.Critical, new ExperimentalFeatureEvent(Id, IsEnabled));
     }
 }

--- a/common/Services/IExperimentationService.cs
+++ b/common/Services/IExperimentationService.cs
@@ -2,15 +2,20 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using DevHome.Common.Models;
 
 namespace DevHome.Common.Services;
 
 public interface IExperimentationService
 {
-    bool IsFeatureEnabled(string key);
-
     List<ExperimentalFeature> ExperimentalFeatures { get; }
 
+    bool IsFeatureEnabled(string key);
+
     void AddExperimentalFeature(ExperimentalFeature experimentalFeature);
+
+    bool IsExperimentationEnabled { get; set; }
+
+    bool IsExperimentEnabled(string key);
 }

--- a/common/TelemetryEvents/ExperimentationEvent.cs
+++ b/common/TelemetryEvents/ExperimentationEvent.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents;
+
+[EventData]
+public class ExperimentationEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public bool Enabled
+    {
+        get;
+    }
+
+    public ExperimentationEvent(bool enabled)
+    {
+        Enabled = enabled;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/common/TelemetryEvents/SeekerEvent.cs
+++ b/common/TelemetryEvents/SeekerEvent.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents;
+
+// A seeker is someone who has sought out experimental features or experiements
+[EventData]
+public class SeekerEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public bool IsSeeker
+    {
+        get;
+    }
+
+    public SeekerEvent(bool isSeeker)
+    {
+        IsSeeker = isSeeker;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/docs/ExperimentalFeatures.md
+++ b/docs/ExperimentalFeatures.md
@@ -52,5 +52,5 @@ In `navConfig.jsonc`, add the following in the tool's definition:
 
 ```csharp
 var experimentationService = Application.Current.GetService<IExperimentationService>();
-var isEnabled = experimentationService.IsEnabled("MyExperimentalFeature");
+var isEnabled = experimentationService.IsFeatureEnabled("MyExperimentalFeature");
 ```

--- a/nuget.config
+++ b/nuget.config
@@ -9,6 +9,7 @@
     <clear />
     <add key="DevHomeDependencies" value="https://pkgs.dev.azure.com/ms/DevHome/_packaging/DevHomeDependencies/nuget/v3/index.json" />
     <add key="SDKLocalSource" value=".\extensionsdk\_build" />
+    <add key="HelpersLocalSource" value="..\ProjectGrace-Private\PackLocation" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -541,5 +541,12 @@
   <data name="ViewLogs.Header" xml:space="preserve">
     <value>View logs</value>
     <comment>Click on this if you want to see Dev Home's logs on your machine.</comment>
+  <data name="Settings_Experimentation.Header" xml:space="preserve">
+    <value>Enable Experimentation</value>
+    <comment>Header for a card than when turned on enables experimentation</comment>
+  </data>
+  <data name="Settings_Experimentation.Description" xml:space="preserve">
+    <value>Placeholder description</value>
+    <comment>Body text description for a card that when turned on enables experimentation</comment>
   </data>
 </root>

--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Settings_Preferences_Description" xml:space="preserve">
-    <value>Theme</value>
+    <value>Themes and experimentation</value>
     <comment>Body text description for a card than when clicked takes the user to the Preferences settings page</comment>
   </data>
   <data name="Settings_Preferences_Header" xml:space="preserve">
@@ -542,11 +542,11 @@
     <value>View logs</value>
     <comment>Click on this if you want to see Dev Home's logs on your machine.</comment>
   <data name="Settings_Experimentation.Header" xml:space="preserve">
-    <value>Enable Experimentation</value>
+    <value>Experimentation</value>
     <comment>Header for a card than when turned on enables experimentation</comment>
   </data>
   <data name="Settings_Experimentation.Description" xml:space="preserve">
-    <value>Placeholder description</value>
+    <value>Turn off to opt out of experimentation</value>
     <comment>Body text description for a card that when turned on enables experimentation</comment>
   </data>
 </root>

--- a/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
@@ -4,7 +4,11 @@
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Contracts;
+using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Contracts.Services;
+using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 
 namespace DevHome.Settings.ViewModels;
@@ -12,14 +16,22 @@ namespace DevHome.Settings.ViewModels;
 public partial class PreferencesViewModel : ObservableObject
 {
     private readonly IThemeSelectorService _themeSelectorService;
+    private readonly IExperimentationService _experimentationService;
 
     [ObservableProperty]
     private ElementTheme _elementTheme;
 
-    public PreferencesViewModel(IThemeSelectorService themeSelectorService)
+    [ObservableProperty]
+    private bool _isExperimentationEnabled;
+
+    public PreferencesViewModel(IThemeSelectorService themeSelectorService, IExperimentationService experimentationService)
     {
         _themeSelectorService = themeSelectorService;
+        _experimentationService = experimentationService;
+
         _elementTheme = _themeSelectorService.Theme;
+
+        _isExperimentationEnabled = _experimentationService.IsExperimentationEnabled;
     }
 
     [RelayCommand]
@@ -27,5 +39,15 @@ public partial class PreferencesViewModel : ObservableObject
     {
         ElementTheme = elementTheme;
         await _themeSelectorService.SetThemeAsync(elementTheme);
+    }
+
+    [RelayCommand]
+    public async Task ExperimentationToggledAsync()
+    {
+        IsExperimentationEnabled = !IsExperimentationEnabled;
+
+        _experimentationService.IsExperimentationEnabled = IsExperimentationEnabled;
+
+        await Task.CompletedTask;
     }
 }

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -46,6 +46,9 @@
                     </ComboBox>
                 </ctControls:SettingsCard>
                 <ctControls:SettingsCard x:Uid="Settings_Experimentation" Margin="{ThemeResource SettingsCardMargin}">
+                    <ctControls:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xF196;" />
+                    </ctControls:SettingsCard.HeaderIcon>
                     <ToggleSwitch IsOn="{x:Bind ViewModel.IsExperimentationEnabled, Mode=OneWay}">
                         <i:Interaction.Behaviors>
                             <ic:EventTriggerBehavior EventName="Toggled">

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -28,22 +28,33 @@
             ItemsSource="{x:Bind Breadcrumbs}" />
 
         <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
-            <ctControls:SettingsCard x:Uid="Settings_Theme">
-                <ctControls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE790;" />
-                </ctControls:SettingsCard.HeaderIcon>
-                <ComboBox x:Name="ThemeSelectionComboBox">
-                    <ComboBoxItem x:Uid="Settings_Theme_Default" Tag="{x:Bind xaml:ElementTheme.Default}" />
-                    <ComboBoxItem x:Uid="Settings_Theme_Light" Tag="{x:Bind xaml:ElementTheme.Light}" />
-                    <ComboBoxItem x:Uid="Settings_Theme_Dark" Tag="{x:Bind xaml:ElementTheme.Dark}" />
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="SelectionChanged">
-                            <ic:InvokeCommandAction Command="{x:Bind ViewModel.SwitchThemeCommand}" 
-                                                    CommandParameter="{x:Bind ((ComboBoxItem)ThemeSelectionComboBox.SelectedItem).Tag, Mode=OneWay}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </ComboBox>
-            </ctControls:SettingsCard>
+            <StackPanel>
+                <ctControls:SettingsCard x:Uid="Settings_Theme">
+                    <ctControls:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE790;" />
+                    </ctControls:SettingsCard.HeaderIcon>
+                    <ComboBox x:Name="ThemeSelectionComboBox">
+                        <ComboBoxItem x:Uid="Settings_Theme_Default" Tag="{x:Bind xaml:ElementTheme.Default}" />
+                        <ComboBoxItem x:Uid="Settings_Theme_Light" Tag="{x:Bind xaml:ElementTheme.Light}" />
+                        <ComboBoxItem x:Uid="Settings_Theme_Dark" Tag="{x:Bind xaml:ElementTheme.Dark}" />
+                        <i:Interaction.Behaviors>
+                            <ic:EventTriggerBehavior EventName="SelectionChanged">
+                                <ic:InvokeCommandAction Command="{x:Bind ViewModel.SwitchThemeCommand}" 
+                                                        CommandParameter="{x:Bind ((ComboBoxItem)ThemeSelectionComboBox.SelectedItem).Tag, Mode=OneWay}" />
+                            </ic:EventTriggerBehavior>
+                        </i:Interaction.Behaviors>
+                    </ComboBox>
+                </ctControls:SettingsCard>
+                <ctControls:SettingsCard x:Uid="Settings_Experimentation" Margin="{ThemeResource SettingsCardMargin}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsExperimentationEnabled, Mode=OneWay}">
+                        <i:Interaction.Behaviors>
+                            <ic:EventTriggerBehavior EventName="Toggled">
+                                <ic:InvokeCommandAction Command="{x:Bind ViewModel.ExperimentationToggledCommand}" />
+                            </ic:EventTriggerBehavior>
+                        </i:Interaction.Behaviors>
+                    </ToggleSwitch>
+                </ctControls:SettingsCard>
+            </StackPanel>
         </ScrollViewer>
     </Grid>
 </Page>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -63,8 +63,7 @@
                 <Activation>
                   <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
                 </Activation>
-                <SupportedInterfaces>
-                </SupportedInterfaces>
+                <SupportedInterfaces></SupportedInterfaces>
               </DevHomeProvider>
             </uap3:Properties>
           </uap3:AppExtension>

--- a/src/Services/ExperimentationService.cs
+++ b/src/Services/ExperimentationService.cs
@@ -27,6 +27,9 @@ public class ExperimentationService : IExperimentationService
         {
             _isExperimentationEnabled = _localSettingsService.ReadSettingAsync<bool>("ExperimentationEnabled").Result;
         }
+
+        var isSeeker = _localSettingsService.ReadSettingAsync<bool>("IsSeeker").Result;
+        TelemetryFactory.Get<ITelemetry>().Log("Seeker_Event", LogLevel.Critical, new SeekerEvent(isSeeker));
     }
 
     public bool IsFeatureEnabled(string key)
@@ -60,6 +63,7 @@ public class ExperimentationService : IExperimentationService
                 Task.Run(() =>
                 {
                     TelemetryFactory.Get<ITelemetry>().Log("Experimentation_Toggled_Event", LogLevel.Critical, new ExperimentationEvent(_isExperimentationEnabled));
+                    _localSettingsService!.SaveSettingAsync($"IsSeeker", true);
                     return _localSettingsService!.SaveSettingAsync($"ExperimentationEnabled", _isExperimentationEnabled);
                 }).Wait();
             }

--- a/test/TestClass.cs
+++ b/test/TestClass.cs
@@ -54,4 +54,11 @@ public class TestClass
         Microsoft.Internal.Windows.DevHome.Helpers.Helpers helpers = new();
         Assert.AreEqual("This is a test", helpers.Test());
     }
+
+    [TestMethod]
+    public void TestExperimentHelpers()
+    {
+        Microsoft.Internal.Windows.DevHome.Helpers.Experimentation.Experiment experiment = new();
+        Assert.IsTrue(experiment.IsEnabled("Sample_FeatureStaging"));
+    }
 }


### PR DESCRIPTION
## Summary of the pull request
Adding the ability for experimentation in Dev Home.  This will be controlled by Windows Experimentation.

Also adding a toggle (default on), allowing the user to opt out of all experiments.  This does not affect "experimental features" which are basically "features in development".
![image](https://github.com/microsoft/devhome/assets/50181812/5331d1e8-cc60-4138-bb71-3c56b2e9ba89)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
