### PR TITLE
Add sample WinGet Configuration for PowerToys

### DIFF
--- a/sampleConfigurations/DscResources/PowerToysConfigure/PowerToys.dsc.yaml
+++ b/sampleConfigurations/DscResources/PowerToysConfigure/PowerToys.dsc.yaml
@@ -1,0 +1,29 @@
+################################################################################
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2    #
+#                                                                              #
+# This DSC config file will install Microsoft.PowerToys, then configure, by:    #
+# Disabling the ShortcutGuide and setting it to full opacity, then enabling    #
+# Fancy Zones and setting the Fancy Zone Editor hotkey to Shift+Ctrl+Alt+F.    #
+#                                                                              #
+################################################################################
+#
+properties:
+  configurationVersion: 0.2.0
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install PowerToys
+        allowPrerelease: true
+      settings:
+        id: Microsoft.PowerToys
+        source: winget
+    - resource: PowerToysConfigure
+      directives:
+        description: Configure PowerToys
+      settings:
+        ShortcutGuide:
+          Enabled: false
+          OverlayOpacity: 1
+        FancyZones:
+          Enabled: true
+          FancyzonesEditorHotkey: "Shift+Ctrl+Alt+F"

--- a/sampleConfigurations/DscResources/PowerToysConfigure/PowerToys.dsc.yaml
+++ b/sampleConfigurations/DscResources/PowerToysConfigure/PowerToys.dsc.yaml
@@ -1,7 +1,7 @@
 ################################################################################
 # yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2    #
 #                                                                              #
-# This DSC config file will install Microsoft.PowerToys, then configure, by:    #
+# This DSC config file will install Microsoft.PowerToys, then configure, by:   #
 # Disabling the ShortcutGuide and setting it to full opacity, then enabling    #
 # Fancy Zones and setting the Fancy Zone Editor hotkey to Shift+Ctrl+Alt+F.    #
 #                                                                              #


### PR DESCRIPTION
## Summary of the pull request
This sample configuration installs PowerToys, then changes 2 settings.

## References and relevant issues
- https://github.com/microsoft/devhome/issues/2299

## Detailed description of the pull request / Additional comments
**Currently reqiures installing a specific edition of PowerToys v0.80 Preview** (If this PR has to wait until that release, it's okay.)
This installs PowerToys, then uses a DSC resource provided by the PowerToys installer to configure: disabling the shortcut keys display, and adding a hotkey for fancy zones setup. 

## Validation steps performed
Tested in VM. 

## PR checklist
- [x] Closes #2299
- [x] Tests added/passed
- [ ] Documentation updated
