### PR TITLE
Rename logfile extension

### DIFF
--- a/logging/listeners/LogFileListenerOptions.cs
+++ b/logging/listeners/LogFileListenerOptions.cs
@@ -5,7 +5,7 @@ namespace DevHome.Logging;
 
 public partial class Options
 {
-    private const string LogFileNameDefault = "PG.log";
+    private const string LogFileNameDefault = "DevHome.dhlog";
     private const string LogFileFolderNameDefault = "{now}";
 
     public string LogFileName { get; set; } = LogFileNameDefault;

--- a/logging/logger/ComponentLogger.cs
+++ b/logging/logger/ComponentLogger.cs
@@ -57,7 +57,7 @@ public class ComponentLogger : IDisposable
         return new Options
         {
             LogFileFolderRoot = ApplicationData.Current.TemporaryFolder.Path,
-            LogFileName = _componentName + "_{now}.log",
+            LogFileName = _componentName + "_{now}.dhlog",
             LogFileFolderName = _folderName,
             DebugListenerEnabled = true,
 #if DEBUG


### PR DESCRIPTION
## Summary of the pull request
Renames logfile extension for tooling as in https://github.com/microsoft/DevHomeAzureExtension/pull/127

## References and relevant issues

## Detailed description of the pull request / Additional comments
Renames ".log" to ".dhlog"
Also renames "PG" in the test log to "DevHome".

## Validation steps performed
Verified logfile names are correctly changed to the new extension.
 
## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
