### PR TITLE
Update build scripts to build DevSetupAgent in Azure official build.

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -61,14 +61,17 @@ if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "sdk")) {
   }
 }
 
-if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "DevSetupAgent")) {
-  foreach ($platform in $env:Build_Platform.Split(",")) {
-    foreach ($configuration in $env:Build_Configuration.Split(",")) {
+if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "DevSetupAgent") -Or ($BuildStep -ieq "fullMsix")) {
+  foreach ($configuration in $env:Build_Configuration.Split(",")) {
+    # We use x86 DevSetupAgent for x64 and x86 Dev Home build. Only need to build it once if we are building multiple platforms. 
+    $builtX86 = $false
+    foreach ($platform in $env:Build_Platform.Split(",")) {
       if ($Platform -ieq "arm64") {
         HyperVExtension\BuildDevSetupAgentHelper.ps1 -Platform $Platform -Configuration $configuration -VersionOfSDK $env:sdk_version -SDKNugetSource $SDKNugetSource -AzureBuildingBranch $AzureBuildingBranch -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassWarning
       }
-      else {
+      elseif (-not $builtX86) {
         HyperVExtension\BuildDevSetupAgentHelper.ps1 -Platform "x86" -Configuration $configuration -VersionOfSDK $env:sdk_version -SDKNugetSource $SDKNugetSource -AzureBuildingBranch $AzureBuildingBranch -IsAzurePipelineBuild $IsAzurePipelineBuild -BypassWarning
+        $builtX86 = $true
       }
     }
   }
@@ -92,7 +95,7 @@ if (-not([string]::IsNullOrWhiteSpace($SDKNugetSource))) {
 . build\Scripts\CertSignAndInstall.ps1
 
 Try {
-  if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "msix")) {
+  if (($BuildStep -ieq "all") -Or ($BuildStep -ieq "msix") -Or ($BuildStep -ieq "fullMsix")) {
     $buildRing = "Dev"
     $newPackageName = $null
     $newPackageDisplayName = $null

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -208,7 +208,7 @@ extends:
               retryCountOnTaskFailure: 2
               inputs:
                 filePath: 'Build.ps1'
-                arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion) -BuildStep "msix" -AzureBuildingBranch "$(BuildingBranch)" -IsAzurePipelineBuild
+                arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion) -BuildStep "fullMsix" -AzureBuildingBranch "$(BuildingBranch)" -IsAzurePipelineBuild
 
             - task: EsrpCodeSigning@2
               inputs:


### PR DESCRIPTION
## Summary of the pull request
Modify Build.ps1 and azure-pipelines.yml to build DevSetupAgent in official build:
- Added new "fullMsix" build step to Build.ps1 that combines "DevSetupAgent" and "msix" build steps.
- Modified azure-pipelines.yml to use "fullMsix" build step instead of currently used "msix".


## Validation steps performed
Built locally. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
