### PR TITLE
Handle unspecified error when clearing catalogs

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -105,7 +105,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
     {
         // Note: Create new observable collections instead of clearing existing
         // ones to ensure that the collections are not modified while binding
-        // notification event handlers are being processed which can causes
+        // notification event handlers are being processed which can cause
         // "unspecified exception".
         PackageCatalogs = [];
         PackageCatalogShimmers = [];

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -40,13 +40,15 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
     /// <summary>
     /// Gets a list of package catalogs to display
     /// </summary>
-    public ObservableCollection<PackageCatalogViewModel> PackageCatalogs { get; } = new();
+    [ObservableProperty]
+    private ObservableCollection<PackageCatalogViewModel> _packageCatalogs;
 
     /// <summary>
     /// Gets a list of shimmer indices.
     /// This list is used to repeat the shimmer control {Count} times
     /// </summary>
-    public ObservableCollection<int> PackageCatalogShimmers { get; } = new();
+    [ObservableProperty]
+    private ObservableCollection<int> _packageCatalogShimmers;
 
     public PackageCatalogListViewModel(
         IExtensionService extensionService,
@@ -68,7 +70,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
         await _loadCatalogsSemaphore.WaitAsync();
         try
         {
-            PackageCatalogs.Clear();
+            ResetCatalogs();
             AddShimmers(_catalogDataSourceLoader.CatalogCount);
             await foreach (var dataSourceCatalogs in _catalogDataSourceLoader.LoadCatalogsAsync())
             {
@@ -94,6 +96,19 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
         {
             _loadCatalogsSemaphore.Release();
         }
+    }
+
+    /// <summary>
+    /// Reset package catalogs
+    /// </summary>
+    private void ResetCatalogs()
+    {
+        // Note: Create new observable collections instead of clearing existing
+        // ones to ensure that the collections are not modified while binding
+        // notification event handlers are being processed which can causes
+        // "unspecified exception".
+        PackageCatalogs = [];
+        PackageCatalogShimmers = [];
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary of the pull request
Create new observable collections instead of clearing existing ones to avoid an "unspecified error" which occurs when binding notification event handlers and collection manipulation are happening concurrently.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
