### PR TITLE
Use more accessible colors in widgets

### DIFF
--- a/settings/DevHome.Settings/Assets/DarkHostConfig.json
+++ b/settings/DevHome.Settings/Assets/DarkHostConfig.json
@@ -45,8 +45,8 @@
           "subtle": "#880063B1"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#FF5555",
+          "subtle": "#DDFF5555"
         },
         "good": {
           "default": "#54a254",
@@ -71,8 +71,8 @@
           "subtle": "#882E89FC"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#FF5555",
+          "subtle": "#DDFF5555"
         },
         "good": {
           "default": "#54a254",

--- a/settings/DevHome.Settings/Assets/LightHostConfig.json
+++ b/settings/DevHome.Settings/Assets/LightHostConfig.json
@@ -45,8 +45,8 @@
           "subtle": "#880063B1"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#C00000",
+          "subtle": "#DDC00000"
         },
         "good": {
           "default": "#54a254",
@@ -71,8 +71,8 @@
           "subtle": "#882E89FC"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#C00000",
+          "subtle": "#DDC00000"
         },
         "good": {
           "default": "#54a254",

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigDark.json
@@ -58,8 +58,8 @@
           "subtle": "#880063B1"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#FF5555",
+          "subtle": "#DDFF5555"
         },
         "good": {
           "default": "#54a254",
@@ -84,8 +84,8 @@
           "subtle": "#882E89FC"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#FF5555",
+          "subtle": "#DDFF5555"
         },
         "good": {
           "default": "#54a254",

--- a/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
+++ b/tools/Dashboard/DevHome.Dashboard/Assets/HostConfigLight.json
@@ -58,8 +58,8 @@
           "subtle": "#880063B1"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#C00000",
+          "subtle": "#DDC00000"
         },
         "good": {
           "default": "#54a254",
@@ -84,8 +84,8 @@
           "subtle": "#882E89FC"
         },
         "attention": {
-          "default": "#FF0000",
-          "subtle": "#DDFF0000"
+          "default": "#C00000",
+          "subtle": "#DDC00000"
         },
         "good": {
           "default": "#54a254",

--- a/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
@@ -82,6 +82,17 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
         // A different host config is used to render widgets (adaptive cards) in light and dark themes.
         await UpdateHostConfig();
 
+        // Due to a bug in the Adaptive Card renderer (https://github.com/microsoft/AdaptiveCards/issues/8840)
+        // positive and destructive buttons render with square corners. Override with XAML styles.
+        var positiveStyle = Application.Current.Resources["AccentButtonStyle"] as Style;
+        var destructiveStyle = Application.Current.Resources["DefaultButtonStyle"] as Style;
+
+        _renderer.OverrideStyles = new ResourceDictionary
+        {
+            { "Adaptive.Action.Positive", positiveStyle },
+            { "Adaptive.Action.Destructive", destructiveStyle },
+        };
+
         // Remove margins from selectAction.
         _renderer.AddSelectActionMargin = false;
     }


### PR DESCRIPTION
## Summary of the pull request
Two bugs are fixed:
* Due to a [bug in AdaptiveCards](https://github.com/microsoft/AdaptiveCards/issues/8840), Positive and Destructive buttons are rendered with incorrect styling. It seems to be Windows 10 styling with square corners. Override the styling of Positive buttons to be Xaml's accent buttons, and make destructive buttons normal for now. We may choose an accessible foreground color in the future to match default behavior, which is to make the foreground color the "attention" color from the AC's HostConfig
* Choose an accessible color for "attention" text as it is used today.

![image](https://github.com/microsoft/devhome/assets/47155823/f9d18867-fd82-4df0-ba17-7fcab1890f26)

## References and relevant issues
[48295223](https://dev.azure.com/microsoft/OS/_workitems/edit/48295223), [48295257](https://dev.azure.com/microsoft/OS/_workitems/edit/48295257)

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2324
- [ ] Tests added/passed
- [ ] Documentation updated
