### PR TITLE
Make KnownPageKeys available for navigation

### DIFF
--- a/common/Models/Breadcrumb.cs
+++ b/common/Models/Breadcrumb.cs
@@ -5,7 +5,7 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using Microsoft.UI.Xaml;
 
-namespace DevHome.Settings.Models;
+namespace DevHome.Common.Models;
 
 public class Breadcrumb
 {

--- a/common/Services/INavigationService.cs
+++ b/common/Services/INavigationService.cs
@@ -37,3 +37,14 @@ public interface INavigationService
 
     bool GoForward();
 }
+
+// Expose known page keys so that a project doesn't need to include a ProjectReference to another project
+// just to navigate to another page.
+public static class KnownPageKeys
+{
+    public static readonly string Dashboard = "DevHome.Dashboard.ViewModels.DashboardViewModel";
+    public static readonly string Extensions = "DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel";
+    public static readonly string WhatsNew = "DevHome.ViewModels.WhatsNewViewModel";
+    public static readonly string Settings = "DevHome.Settings.ViewModels.SettingsViewModel";
+    public static readonly string Feedback = "DevHome.Settings.ViewModels.FeedbackViewModel";
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,6 @@ graph TD;
     DevHome.SetupFlow.Common-->DevHome.SetupFlow.ElevatedServer;
     DevHome.SetupFlow.ElevatedComponent-->DevHome.SetupFlow.ElevatedServer;
     DevHome.SetupFlow.ElevatedComponent.Projection-->DevHome.SetupFlow;
-    DevHome.Dashboard-->DevHome.SetupFlow;
-    DevHome.Settings-->DevHome.SetupFlow;
     CoreWidgetProvider-->DevHome;
     DevHome.Dashboard-->DevHome;
     DevHome.Experiments-->DevHome;

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -65,6 +65,15 @@ In order to allow navigation to your tool, your page and ViewModel must be regis
 
 In order to do so, you must create an extension method for the PageService inside your tool. See examples in [Settings](../settings/DevHome.Settings/Extensions/PageExtensions.cs) or [Extensions](../tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/PageExtensions.cs). Then, call your extension from the [PageService](../src/Services/PageService.cs).
 
+#### Navigating away from your tool
+
+If you want a user action (such as clicking a link) to navigate away from your tool and your project does not otherwise rely on the destination project, do not create a PackageReference to the destination project from yours. Instead, add the destination page to `INavigationService.KnownPageKeys` and use it for navigation, like in this example:
+```cs
+navigationService.NavigateTo(KnownPageKeys.<DestinationPage>);
+```
+
+This keeps the dependency tree simple, and prevents circular references when two projects want to navigate to each other.
+
 ## Existing tools
 
 [Dashboard](./tools/Dashboard.md)

--- a/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
@@ -5,8 +5,8 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 

--- a/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
@@ -8,8 +8,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Contracts.Services;
 using DevHome.Common.Extensions;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 

--- a/settings/DevHome.Settings/ViewModels/FeedbackViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/FeedbackViewModel.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 

--- a/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
@@ -5,9 +5,9 @@ using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 

--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -66,7 +66,7 @@ public sealed partial class AccountsPage : Page
     private void FindExtensions()
     {
         var navigationService = Application.Current.GetService<INavigationService>();
-        navigationService.NavigateTo("DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel");
+        navigationService.NavigateTo(KnownPageKeys.Extensions);
     }
 
     private async void AddDeveloperId_Click(object sender, RoutedEventArgs e)

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
-    <ProjectReference Include="..\..\..\settings\DevHome.Settings\DevHome.Settings.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -12,7 +12,6 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.ExtensionLibrary.Helpers;
-using DevHome.Settings.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.ApplicationModel;
@@ -208,6 +207,6 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     public void SendFeedbackClick()
     {
         var navigationService = Application.Current.GetService<INavigationService>();
-        _ = navigationService.NavigateTo(typeof(FeedbackViewModel).FullName!);
+        _ = navigationService.NavigateTo(KnownPageKeys.Feedback);
     }
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
@@ -6,10 +6,10 @@ using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Common.Views;
 using DevHome.Logging;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -26,8 +26,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
-    <ProjectReference Include="..\..\..\settings\DevHome.Settings\DevHome.Settings.csproj" />
-    <ProjectReference Include="..\..\Dashboard\DevHome.Dashboard\DevHome.Dashboard.csproj" />
     <ProjectReference Include="..\DevHome.SetupFlow.Common\DevHome.SetupFlow.Common.csproj" />
     <ProjectReference Include="..\DevHome.SetupFlow.ElevatedComponent.Projection\DevHome.SetupFlow.ElevatedComponent.Projection.csproj">
       <Aliases>Projection</Aliases>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -13,8 +13,6 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.Contracts.Services;
-using DevHome.Dashboard.ViewModels;
-using DevHome.Settings.ViewModels;
 using DevHome.SetupFlow.Common.Helpers;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
@@ -151,7 +149,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     public void GoToDashboard()
     {
         TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("Dashboard"), Orchestrator.ActivityId);
-        _host.GetService<INavigationService>().NavigateTo(typeof(DashboardViewModel).FullName);
+        _host.GetService<INavigationService>().NavigateTo(KnownPageKeys.Dashboard);
         _setupFlowViewModel.TerminateCurrentFlow("Summary_GoToDashboard");
     }
 
@@ -159,7 +157,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
     public void GoToDevHomeSettings()
     {
         TelemetryFactory.Get<ITelemetry>().Log("Summary_NavigateTo_Event", LogLevel.Critical, new NavigateFromSummaryEvent("DevHomeSettings"), Orchestrator.ActivityId);
-        _host.GetService<INavigationService>().NavigateTo(typeof(SettingsViewModel).FullName);
+        _host.GetService<INavigationService>().NavigateTo(KnownPageKeys.Settings);
         _setupFlowViewModel.TerminateCurrentFlow("Summary_GoToSettings");
     }
 


### PR DESCRIPTION
## Summary of the pull request
Currently, if a project wants to navigate to a page in another project, the first project needs a PackageReference to the second. This makes the dependency diagram complicated, as well as causing issues with circular dependencies and spread-out magic strings to avoid those circular dependencies. Simplify this by creating a list of KnownPageKeys, which allow any project to navigate to another project.

Also move `Breadcrumb` out of Settings and into Common, since it's used in multiple places.

Diagram before:
![image](https://github.com/microsoft/devhome/assets/47155823/fd1079dc-f4c5-469f-84a2-ba394e3eb419)

Diagram after:
![image](https://github.com/microsoft/devhome/assets/47155823/9c09d893-8725-43c0-8687-6c77c1c822ce)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [x] Documentation updated
