### PR TITLE
[Hyper-V extension] Add DevSetupEngine COM permissions and Dispose method to force shutdown.

### DIFF
--- a/HyperVExtension/src/DevSetupAgent/Requests/ConfigureRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/ConfigureRequest.cs
@@ -32,8 +32,8 @@ internal sealed class ConfigureRequest : RequestBase
 
     public override IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken)
     {
-        // DevSetupEngine needs to be started manually from command line in the test.
         var devSetupEnginePtr = IntPtr.Zero;
+        var devSetupEngine = default(IDevSetupEngine);
         try
         {
             var hr = PInvoke.CoCreateInstance(Guid.Parse("82E86C64-A8B9-44F9-9323-C37982F2D8BE"), null, CLSCTX.CLSCTX_LOCAL_SERVER, typeof(IDevSetupEngine).GUID, out var devSetupEngineObj);
@@ -44,7 +44,7 @@ internal sealed class ConfigureRequest : RequestBase
 
             devSetupEnginePtr = Marshal.GetIUnknownForObject(devSetupEngineObj);
 
-            var devSetupEngine = MarshalInterface<IDevSetupEngine>.FromAbi(devSetupEnginePtr);
+            devSetupEngine = MarshalInterface<IDevSetupEngine>.FromAbi(devSetupEnginePtr);
             var operation = devSetupEngine.ApplyConfigurationAsync(ConfigureData);
 
             uint progressCounter = 0;
@@ -65,6 +65,11 @@ internal sealed class ConfigureRequest : RequestBase
             if (devSetupEnginePtr != IntPtr.Zero)
             {
                 Marshal.Release(devSetupEnginePtr);
+            }
+
+            if (devSetupEngine != null)
+            {
+                devSetupEngine.Dispose();
             }
         }
     }

--- a/HyperVExtension/src/DevSetupEngineIdl/Microsoft.Windows.DevHome.DevSetupEngine.idl
+++ b/HyperVExtension/src/DevSetupEngineIdl/Microsoft.Windows.DevHome.DevSetupEngine.idl
@@ -217,5 +217,6 @@ namespace Microsoft.Windows.DevHome.DevSetupEngine
     {
         // Applies the configuration set state.
         Windows.Foundation.IAsyncOperationWithProgress<IApplyConfigurationResult, IConfigurationSetChangeData> ApplyConfigurationAsync(String content);
+        void Dispose();
     };
 }


### PR DESCRIPTION
## Summary of the pull request
- Add COM launch and access permissions to DevSetupEngine registration: limit access to System, Local Service, and SELF.
- Add Dispose method to IDevSetupEngine (internal) interface to force shutdown of DevSetupEngine after finishing "Configure" operation initiated from DevSetupAgent service.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
