### PR TITLE
Remove widget action margins after theme change

### DIFF
--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -152,6 +152,9 @@ public sealed partial class AccountsPage : Page
             if (!string.IsNullOrEmpty(hostConfigContents))
             {
                 renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
+
+                // Remove margins from selectAction.
+                renderer.AddSelectActionMargin = false;
             }
             else
             {

--- a/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
@@ -92,9 +92,6 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
             { "Adaptive.Action.Positive", positiveStyle },
             { "Adaptive.Action.Destructive", destructiveStyle },
         };
-
-        // Remove margins from selectAction.
-        _renderer.AddSelectActionMargin = false;
     }
 
     public async Task UpdateHostConfig()
@@ -121,6 +118,9 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
                 if (!string.IsNullOrEmpty(hostConfigContents))
                 {
                     _renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
+
+                    // Remove margins from selectAction.
+                    _renderer.AddSelectActionMargin = false;
                 }
                 else
                 {

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
@@ -514,6 +514,9 @@ public class ConfigureTargetTask : ISetupTask
                 if (AdaptiveCardHostConfigs.TryGetValue(elementTheme, out var hostConfigContents))
                 {
                     Renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
+
+                    // Remove margins from selectAction.
+                    Renderer.AddSelectActionMargin = false;
                 }
                 else
                 {

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -211,6 +211,9 @@ internal sealed class RepositoryProvider
             if (!string.IsNullOrEmpty(hostConfigContents))
             {
                 renderer.HostConfig = AdaptiveHostConfig.FromJsonString(hostConfigContents).HostConfig;
+
+                // Remove margins from selectAction.
+                renderer.AddSelectActionMargin = false;
             }
             else
             {


### PR DESCRIPTION
## Summary of the pull request
Even though #2243 removed margins from actions in Adaptive Cards, the margins were coming back after a theme change, since we were overwriting the HostConfig. The fix is to set the margins every time we update the host config. Also removes margins from other places in Dev Home.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2369
- [ ] Tests added/passed
- [ ] Documentation updated
