### PR TITLE
Show installed extension without reboot

### DIFF
--- a/src/Services/ExtensionService.cs
+++ b/src/Services/ExtensionService.cs
@@ -114,7 +114,7 @@ public class ExtensionService : IExtensionService, IDisposable
             if (package.Id.FullName == extension.Package.Id.FullName)
             {
                 var (devHomeProvider, classId) = await GetDevHomeExtensionPropertiesAsync(extension);
-                return devHomeProvider != null && classId.Count == 0;
+                return devHomeProvider != null && classId.Count != 0;
             }
         }
 


### PR DESCRIPTION
## Summary of the pull request
Extensions should show up immediately after installation without requiring reboot.  This fixes a recent bug that inverted the required check.

## References and relevant issues
https://github.com/microsoft/devhome/issues/2367

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2367 
- [ ] Tests added/passed
- [ ] Documentation updated
