### PR TITLE
Only add ExperimentalFeature to ExperimentalFeaturesViewModel if it's visible to the current build

### DIFF
--- a/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
@@ -21,7 +21,7 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
 
     public ExperimentalFeaturesViewModel(IExperimentationService experimentationService)
     {
-        ExperimentalFeatures = experimentationService!.ExperimentalFeatures.Where(x => x.IsEnabled).OrderBy(x => x.Id).ToList();
+        ExperimentalFeatures = experimentationService!.ExperimentalFeatures.Where(x => x.IsVisible).OrderBy(x => x.Id).ToList();
 
         var stringResource = new StringResource("DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>

--- a/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
@@ -21,7 +21,7 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
 
     public ExperimentalFeaturesViewModel(IExperimentationService experimentationService)
     {
-        ExperimentalFeatures = experimentationService!.ExperimentalFeatures.OrderBy(x => x.Id).ToList();
+        ExperimentalFeatures = experimentationService!.ExperimentalFeatures.Where(x => x.IsEnabled).OrderBy(x => x.Id).ToList();
 
         var stringResource = new StringResource("DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>

--- a/src/Services/PageService.cs
+++ b/src/Services/PageService.cs
@@ -67,10 +67,7 @@ public class PageService : IPageService
                 }
             }
 
-            if (isVisible)
-            {
-                experimentationService.AddExperimentalFeature(new ExperimentalFeature(experimentalFeature.Identity, enabledByDefault, isVisible));
-            }
+            experimentationService.AddExperimentalFeature(new ExperimentalFeature(experimentalFeature.Identity, enabledByDefault, isVisible));
         }
     }
 

--- a/src/Services/PageService.cs
+++ b/src/Services/PageService.cs
@@ -67,7 +67,10 @@ public class PageService : IPageService
                 }
             }
 
-            experimentationService.AddExperimentalFeature(new ExperimentalFeature(experimentalFeature.Identity, enabledByDefault, isVisible));
+            if (isVisible)
+            {
+                experimentationService.AddExperimentalFeature(new ExperimentalFeature(experimentalFeature.Identity, enabledByDefault, isVisible));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
If we add the feature when it's not visible it prevents the message (that there are no experimental features) from being shown on the Experimental Features Settings page. If it's not visible, the ExperimentalFeaturesViewModel doesn't need to know about it, so don't add it.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2368
- [ ] Tests added/passed
- [ ] Documentation updated
