### PR TITLE
Add null checks to reinforce extension service

### DIFF
--- a/src/Services/ExtensionService.cs
+++ b/src/Services/ExtensionService.cs
@@ -111,7 +111,7 @@ public class ExtensionService : IExtensionService, IDisposable
         var extensions = await AppExtensionCatalog.Open("com.microsoft.devhome").FindAllAsync();
         foreach (var extension in extensions)
         {
-            if (package.Id.FullName == extension.Package.Id.FullName)
+            if (package.Id?.FullName == extension.Package?.Id?.FullName)
             {
                 var (devHomeProvider, classId) = await GetDevHomeExtensionPropertiesAsync(extension);
                 return devHomeProvider != null && classId.Count != 0;
@@ -125,6 +125,11 @@ public class ExtensionService : IExtensionService, IDisposable
     {
         var classIds = new List<string>();
         var properties = await extension.GetExtensionPropertiesAsync();
+
+        if (properties is null)
+        {
+            return (null, classIds);
+        }
 
         var devHomeProvider = GetSubPropertySet(properties, "DevHomeProvider");
         if (devHomeProvider is null)


### PR DESCRIPTION
## Summary of the pull request
Saw a failure to display all extensions when one extension had package manager corruption.  Can't repro anymore, but from visual inspection one of these could be the culprit.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
