### PR TITLE
Introducing Windows Customization

### DIFF
--- a/DevHome.sln
+++ b/DevHome.sln
@@ -125,6 +125,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevSetupAgent.Test", "Hyper
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HyperVExtension.HostGuestCommunication", "HyperVExtension\src\HyperVExtension.HostGuestCommunication\HyperVExtension.HostGuestCommunication.csproj", "{D759CD66-494C-4A00-8075-8B65A9891349}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Customization", "Customization", "{623998FD-B0A6-4980-95D5-A5072301CA10}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevHome.Customization", "tools\Customization\DevHome.Customization\DevHome.Customization.csproj", "{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -769,6 +773,22 @@ Global
 		{D759CD66-494C-4A00-8075-8B65A9891349}.Release|x64.Build.0 = Release|x64
 		{D759CD66-494C-4A00-8075-8B65A9891349}.Release|x86.ActiveCfg = Release|x86
 		{D759CD66-494C-4A00-8075-8B65A9891349}.Release|x86.Build.0 = Release|x86
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|Any CPU.Build.0 = Debug|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|arm64.ActiveCfg = Debug|arm64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|arm64.Build.0 = Debug|arm64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|x64.ActiveCfg = Debug|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|x64.Build.0 = Debug|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|x86.ActiveCfg = Debug|x86
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Debug|x86.Build.0 = Debug|x86
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|Any CPU.ActiveCfg = Release|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|Any CPU.Build.0 = Release|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|arm64.ActiveCfg = Release|arm64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|arm64.Build.0 = Release|arm64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|x64.ActiveCfg = Release|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|x64.Build.0 = Release|x64
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|x86.ActiveCfg = Release|x86
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -816,6 +836,8 @@ Global
 		{F4095FD3-6A3F-490B-966D-E63059612EE6} = {3E3791DF-070D-4ADE-96E8-93D6FBD53953}
 		{0E05A442-BDC7-43D4-A000-F8C986826716} = {3E3791DF-070D-4ADE-96E8-93D6FBD53953}
 		{D759CD66-494C-4A00-8075-8B65A9891349} = {81AACED5-CFB5-47A6-AFD6-4625AADCFFA3}
+		{623998FD-B0A6-4980-95D5-A5072301CA10} = {A972EC5B-FC61-4964-A6FF-F9633EB75DFD}
+		{AF527EA4-6A24-4BD6-BC6E-A5863DC3489C} = {623998FD-B0A6-4980-95D5-A5072301CA10}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {030B5641-B206-46BB-BF71-36FF009088FA}

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.200.427" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240304-x1959" />
+    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240311-x1907" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.8" />
     <PackageReference Include="System.Management.Automation" Version="7.2.8" />

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,6 +71,7 @@ Dev Home currently has the following tools:
 - [Dashboard](./tools.md#dashboard-tool)
 - [Setup flow](./tools.md#setup-flow-tool)
 - Extensions
+- [Windows customization](../tools/Customization/DevHome.Customization/Customization.md)
 
 ## Extensions
 

--- a/nuget.config
+++ b/nuget.config
@@ -9,7 +9,6 @@
     <clear />
     <add key="DevHomeDependencies" value="https://pkgs.dev.azure.com/ms/DevHome/_packaging/DevHomeDependencies/nuget/v3/index.json" />
     <add key="SDKLocalSource" value=".\extensionsdk\_build" />
-    <add key="DevHomeHelpersLocalSource" value="$\..\..\ProjectGrace-Private\PackLocation\" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/nuget.config
+++ b/nuget.config
@@ -9,6 +9,7 @@
     <clear />
     <add key="DevHomeDependencies" value="https://pkgs.dev.azure.com/ms/DevHome/_packaging/DevHomeDependencies/nuget/v3/index.json" />
     <add key="SDKLocalSource" value=".\extensionsdk\_build" />
+    <add key="DevHomeHelpersLocalSource" value="$\..\..\ProjectGrace-Private\PackLocation\" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -9,6 +9,7 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
+using DevHome.Customization.Extensions;
 using DevHome.Dashboard.Extensions;
 using DevHome.ExtensionLibrary.Extensions;
 using DevHome.Helpers;
@@ -141,6 +142,9 @@ public partial class App : Application, IApp
 
             // Environments
             services.AddEnvironments(context);
+
+            // Windows customization
+            services.AddWindowsCustomization(context);
         }).
         Build();
 

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -85,6 +85,7 @@
     <ProjectReference Include="..\tools\ExtensionLibrary\DevHome.ExtensionLibrary\DevHome.ExtensionLibrary.csproj" />
     <ProjectReference Include="..\HyperVExtension\src\HyperVExtensionServer\HyperVExtensionServer.csproj" />
     <ProjectReference Include="..\tools\Environments\DevHome.Environments\DevHome.Environments.csproj" />
+    <ProjectReference Include="..\tools\Customization\DevHome.Customization\DevHome.Customization.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -61,7 +61,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240304-x1959" />
+    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240311-x1907" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -40,6 +40,13 @@
             "viewModelFullName": "DevHome.QuietBackgroundProcesses.UI.ViewModels.QuietBackgroundProcessesViewModel",
             "icon": "f5b0",
             "experimentalFeatureIdentity": "QuietBackgroundProcessesExperiment"
+          },
+          {
+            "identity": "DevHome.Customization",
+            "assembly": "DevHome.Customization",
+            "viewFullName": "DevHome.Customization.Views.MainPage",
+            "viewModelFullName": "DevHome.Customization.ViewModels.MainPageViewModel",
+            "icon": "e9f5"
           }
         ]
       }

--- a/src/Services/PageService.cs
+++ b/src/Services/PageService.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Contracts;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
+using DevHome.Customization.Extensions;
 using DevHome.ExtensionLibrary.Extensions;
 using DevHome.Settings.Extensions;
 using DevHome.ViewModels;
@@ -46,6 +47,7 @@ public class PageService : IPageService
 
         this.ConfigureExtensionLibraryPages();
         this.ConfigureSettingsPages();
+        this.ConfigureCustomizationPages();
 
         // Configure Experimental Feature pages
         ExperimentalFeature.LocalSettingsService = localSettingsService;

--- a/src/Styles/TextBlock.xaml
+++ b/src/Styles/TextBlock.xaml
@@ -26,10 +26,19 @@
 
     <!--  Style (inc. the correct spacing) of a section header  -->
     <Style x:Key="SettingsSectionHeaderTextBlockStyle"
-               BasedOn="{StaticResource BodyStrongTextBlockStyle}"
-               TargetType="TextBlock">
+        BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+        TargetType="TextBlock">
         <Style.Setters>
             <Setter Property="Margin" Value="1,28,0,4" />
+        </Style.Setters>
+    </Style>
+
+    <Style
+        x:Key="SettingsSectionCaptionTextBlockStyle"
+        BasedOn="{StaticResource CaptionTextBlockStyle}"
+        TargetType="TextBlock">
+        <Style.Setters>
+            <Setter Property="Margin" Value="1,0,0,8" />
         </Style.Setters>
     </Style>
 

--- a/tools/Customization/DevHome.Customization/Customization.md
+++ b/tools/Customization/DevHome.Customization/Customization.md
@@ -1,0 +1,36 @@
+# Windows Customization
+
+This directory contains the Windows Customization features for the DevHome project.
+
+## Overview
+
+The `DevHome.Customization` directory includes various features and settings that allow users to customize their Windows experience.
+
+
+## Contributions
+
+Windows Customization follows an MVVM (Model-View-ViewModel) architecture. The landing page, MainPage, is backed by a primary view, MainPageView. This serves as the first-level page for the overall Windows Customization feature set in DevHome, providing users with the ability to configure Windows settings to enhance their developer experience. The goal of this architecture is to ensure adaptability of the user interface.
+
+MainPage hosts links to other pages via SettingsCard controls. These pages contain logically grouped settings and features that can be configured by the user. Each grouping is designed as portable controls, such as a UserControl. This design allows them to be hosted on the main page, included in a future "All Settings" page, and be part of a future filtered search results page.
+
+New feature additions to should expect to implement the following:
+
+1. **View**: Generally a StackPanel that contains all the user interface for the new feature or setting(s). This View should generally be implemented as a UserControl that can be hosted in any number of Pages.
+    - e.g. [DeveloperFileExplorerView](Views\DeveloperFileExplorerView.xaml)
+
+1. **ViewModel**: Generally the implementation of data binding and commands needed to support the View, including notifications to trigger changes in the View's UI.
+    - e.g. [DeveloperFileExplorerViewModel](ViewModels\DeveloperFileExplorerViewModel.cs)
+
+1. **Page**: Optionally include a page that hosts the View as a navigation target from the [MainPage](Views\MainPage.xaml). This may not be needed if the settings are minimal and can be hosted on the [MainPageView](Views\MainPageView.xaml) (e.g., as a SettingsExpander).
+    - e.g. [DeveloperFileExplorerPage](Views\DeveloperFileExplorerPage.xaml)
+
+1. **Model**: Any implementation details for the setting or feature, i.e. the data model and any business or validation logic.
+    - e.g. [DeveloperFileExplorerSettings](Models\DeveloperFileExplorerSettings.cs)
+
+1. **Service entries**: Pages, ViewModels, and any other services participating in dependency injection should be placed in AddWindowsCustomization in [ServiceExtensions.cs](Extensions\ServiceExtensions.cs)
+
+1. **Strings**: Localized strings should leverage [Resources.resw](Strings\en-us\Resources.resw)
+
+1. **Telemetry Events**: Any user interaction that results in a settings change should use [SettingChangedEvent](TelemetryEvents\SettingChangedEvent.cs)
+
+> **Note**: Private APIs (including registry keys or values that are not documented) cannot be referenced in the Windows Customization project. For public contributions that involve a private API, please file an issue on GitHub to discuss options.

--- a/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
+++ b/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(SolutionDir)ToolingVersions.props" />
+  <PropertyGroup>
+    <RootNamespace>DevHome.Customization</RootNamespace>
+    <Platforms>x86;x64;arm64</Platforms>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
+    <ProjectReference Include="..\..\..\logging\DevHome.Logging.csproj" />
+    <ProjectReference Include="..\..\..\settings\DevHome.Settings\DevHome.Settings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="NativeMethods.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Views\DeveloperFileExplorerPage.xaml" />
+    <None Remove="Views\DeveloperFileExplorerView.xaml" />
+    <None Remove="Views\MainPage.xaml" />
+    <None Remove="Views\MainPageView.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Views\DeveloperFileExplorerPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+    <Page Update="Views\DeveloperFileExplorerView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+    <Page Update="Views\MainPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+    <Page Update="Views\MainPageView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
+++ b/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
-    <ProjectReference Include="..\..\..\settings\DevHome.Settings\DevHome.Settings.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
+++ b/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
-    <ProjectReference Include="..\..\..\logging\DevHome.Logging.csproj" />
     <ProjectReference Include="..\..\..\settings\DevHome.Settings\DevHome.Settings.csproj" />
   </ItemGroup>
 

--- a/tools/Customization/DevHome.Customization/Extensions/PageExtensions.cs
+++ b/tools/Customization/DevHome.Customization/Extensions/PageExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Services;
+using DevHome.Customization.ViewModels;
+using DevHome.Customization.Views;
+
+namespace DevHome.Customization.Extensions;
+
+public static class PageExtensions
+{
+    public static void ConfigureCustomizationPages(this IPageService pageService)
+    {
+        pageService.Configure<DeveloperFileExplorerViewModel, DeveloperFileExplorerPage>();
+    }
+}

--- a/tools/Customization/DevHome.Customization/Extensions/ServiceExtensions.cs
+++ b/tools/Customization/DevHome.Customization/Extensions/ServiceExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Customization.ViewModels;
+using DevHome.Customization.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DevHome.Customization.Extensions;
+
+public static class ServiceExtensions
+{
+    public static IServiceCollection AddWindowsCustomization(this IServiceCollection services, HostBuilderContext context)
+    {
+        services.AddSingleton<MainPageViewModel>();
+        services.AddTransient<MainPage>();
+
+        services.AddSingleton<DeveloperFileExplorerViewModel>();
+        services.AddTransient<DeveloperFileExplorerPage>();
+
+        return services;
+    }
+}

--- a/tools/Customization/DevHome.Customization/Models/DeveloperFileExplorerSettings.cs
+++ b/tools/Customization/DevHome.Customization/Models/DeveloperFileExplorerSettings.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Windows.Win32;
+using Windows.Win32.UI.Shell;
+
+namespace DevHome.Customization.Models;
+
+internal static class DeveloperFileExplorerSettings
+{
+    public static bool ShowFileExtensionsEnabled()
+    {
+        return GetShellSettings(SSF_MASK.SSF_SHOWEXTENSIONS);
+    }
+
+    public static void SetShowFileExtensionsEnabled(bool value)
+    {
+        SetShellSettings(SSF_MASK.SSF_SHOWEXTENSIONS, value);
+    }
+
+    public static bool ShowHiddenAndSystemFilesEnabled()
+    {
+        return GetShellSettings(SSF_MASK.SSF_SHOWALLOBJECTS);
+    }
+
+    public static void SetShowHiddenAndSystemFilesEnabled(bool value)
+    {
+        SetShellSettings(SSF_MASK.SSF_SHOWALLOBJECTS, value);
+    }
+
+    public static bool ShowFullPathInTitleBarEnabled()
+    {
+        return GetCabineteState(CabinetStateFlags.FullPathTitle);
+    }
+
+    public static void SetShowFullPathInTitleBarEnabled(bool value)
+    {
+        SetCabinetState(CabinetStateFlags.FullPathTitle, value);
+    }
+
+    private static bool GetShellSettings(SSF_MASK mask)
+    {
+        unsafe
+        {
+            var state = default(SHELLSTATEA);
+            PInvoke.SHGetSetSettings(&state, mask, false);
+            return (state._bitfield1 & (int)mask) != 0;
+        }
+    }
+
+    private static void SetShellSettings(SSF_MASK mask, bool value)
+    {
+        unsafe
+        {
+            var state = default(SHELLSTATEA);
+            PInvoke.SHGetSetSettings(&state, mask, false);
+            if (value)
+            {
+                state._bitfield1 |= (int)mask;
+            }
+            else
+            {
+                state._bitfield1 &= ~(int)mask;
+            }
+
+            PInvoke.SHGetSetSettings(&state, mask, true);
+        }
+    }
+
+    [Flags]
+    private enum CabinetStateFlags
+    {
+        FullPathTitle = 0x00000001,
+    }
+
+    private static bool GetCabineteState(CabinetStateFlags flags)
+    {
+        unsafe
+        {
+            var state = default(CABINETSTATE);
+            PInvoke.ReadCabinetState(&state, sizeof(CABINETSTATE));
+            return (state._bitfield & (int)flags) != 0;
+        }
+    }
+
+    private static void SetCabinetState(CabinetStateFlags flags, bool value)
+    {
+        unsafe
+        {
+            var state = default(CABINETSTATE);
+            PInvoke.ReadCabinetState(&state, sizeof(CABINETSTATE));
+            if (value)
+            {
+                state._bitfield |= (int)flags;
+            }
+            else
+            {
+                state._bitfield &= ~(int)flags;
+            }
+
+            PInvoke.WriteCabinetState(&state);
+        }
+    }
+}

--- a/tools/Customization/DevHome.Customization/NativeMethods.txt
+++ b/tools/Customization/DevHome.Customization/NativeMethods.txt
@@ -1,0 +1,3 @@
+﻿SHGetSetSettings
+ReadCabinetState
+WriteCabinetState

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -1,0 +1,192 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DeveloperFileExplorerCard.Description" xml:space="preserve">
+    <value>Adjust these settings for a more developer-friendly experience using File Explorer</value>
+    <comment>The description for the Developer File Explorer settings card</comment>
+  </data>
+  <data name="DeveloperFileExplorerCard.Header" xml:space="preserve">
+    <value>Developer File Explorer</value>
+    <comment>The header for the Developer File Explorer settings card</comment>
+  </data>
+  <data name="DeveloperFileExplorer_Header" xml:space="preserve">
+    <value>Developer File Explorer</value>
+    <comment>Header for Developer File Explorer page in the breadcrumb bar</comment>
+  </data>
+  <data name="EndTaskOnTaskBar.Description" xml:space="preserve">
+    <value>Enable end task in taskbar by right click</value>
+    <comment>The description for the end task on task bar settings card</comment>
+  </data>
+  <data name="EndTaskOnTaskBar.Header" xml:space="preserve">
+    <value>End Task</value>
+    <comment>The header for the end task on task bar settings card</comment>
+  </data>
+  <data name="MoreWindowsSettingsSectionDescription.Text" xml:space="preserve">
+    <value>Additional settings below can be configured in the system settings app</value>
+    <comment>Description and context for a group of Windows settings in the system settings app</comment>
+  </data>
+  <data name="MoreWindowsSettingsSectionHeader.Text" xml:space="preserve">
+    <value>More Windows settings</value>
+    <comment>Section header for a group of Windows settings in the system settings app</comment>
+  </data>
+  <data name="NavigationPane.Content" xml:space="preserve">
+    <value>Windows customization</value>
+    <comment>Navigation pane content</comment>
+  </data>
+  <data name="SettingsAutoSuggestBox.PlaceholderText" xml:space="preserve">
+    <value>Search</value>
+    <comment>The placholder text for the settings auto suggest box</comment>
+  </data>
+  <data name="ShowEmptyDrivesCard.Header" xml:space="preserve">
+    <value>Show empty drives</value>
+    <comment>The header for the show empty drives settings card</comment>
+  </data>
+  <data name="ShowFileExtensionsCard.Header" xml:space="preserve">
+    <value>Show file extensions</value>
+    <comment>The header for the show file extensions setting.</comment>
+  </data>
+  <data name="ShowFilesAfterExtractCard.Header" xml:space="preserve">
+    <value>Show files after extraction is complete</value>
+    <comment>The header for show files after extraction is complete setting</comment>
+  </data>
+  <data name="ShowFullPathInTitleBarCard.Header" xml:space="preserve">
+    <value>Show full path in title bar</value>
+    <comment>The header for the show full path in title bar settings card</comment>
+  </data>
+  <data name="ShowHiddenAndSystemFilesCard.Header" xml:space="preserve">
+    <value>Show hidden and system files</value>
+    <comment>The header for the show hidden and system files setting.</comment>
+  </data>
+  <data name="MainPage_Header" xml:space="preserve">
+    <value>Windows customization</value>
+    <comment>Header for main Windows customization page in the breadcrumb bar</comment>
+  </data>
+  <data name="WindowsDeveloperCard.ActionIconToolTip" xml:space="preserve">
+    <value>Open the Windows Settings app</value>
+    <comment>The action tool tip for the Windows developer settings card</comment>
+  </data>
+  <data name="WindowsDeveloperCard.Description" xml:space="preserve">
+    <value>Windows Settings intended for development use only</value>
+    <comment>The description for the Windows developer settings card</comment>
+  </data>
+  <data name="WindowsDeveloperCard.Header" xml:space="preserve">
+    <value>Windows developer settings</value>
+    <comment>The header for the Windows developer settings card</comment>
+  </data>
+</root>

--- a/tools/Customization/DevHome.Customization/TelemetryEvents/SettingChangedEvent.cs
+++ b/tools/Customization/DevHome.Customization/TelemetryEvents/SettingChangedEvent.cs
@@ -37,6 +37,6 @@ public class SettingChangedEvent : EventBase
 
     public static void Log(string settingName, string value)
     {
-        TelemetryFactory.Get<ITelemetry>().Log("Customization_SettingChanged_Event", LogLevel.Critical, new SettingChangedEvent(settingName, value));
+        TelemetryFactory.Get<ITelemetry>().Log("Customization_SettingChanged_Event", LogLevel.Measure, new SettingChangedEvent(settingName, value));
     }
 }

--- a/tools/Customization/DevHome.Customization/TelemetryEvents/SettingChangedEvent.cs
+++ b/tools/Customization/DevHome.Customization/TelemetryEvents/SettingChangedEvent.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Customization.TelemetryEvents;
+
+[EventData]
+public class SettingChangedEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public string Id
+    {
+        get;
+    }
+
+    public string Value
+    {
+        get;
+    }
+
+    public SettingChangedEvent(string id, string value)
+    {
+        Id = id;
+        Value = value;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+
+    public static void Log(string settingName, string value)
+    {
+        TelemetryFactory.Get<ITelemetry>().Log("Customization_SettingChanged_Event", LogLevel.Critical, new SettingChangedEvent(settingName, value));
+    }
+}

--- a/tools/Customization/DevHome.Customization/ViewModels/DeveloperFileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DeveloperFileExplorerViewModel.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using DevHome.Customization.Models;
+using DevHome.Customization.TelemetryEvents;
+using Microsoft.Internal.Windows.DevHome.Helpers;
+
+namespace DevHome.Customization.ViewModels;
+
+public partial class DeveloperFileExplorerViewModel : ObservableObject
+{
+    private readonly ShellSettings _shellSettings;
+
+    public DeveloperFileExplorerViewModel()
+    {
+        _shellSettings = new ShellSettings();
+    }
+
+    public bool ShowFileExtensions
+    {
+        get => DeveloperFileExplorerSettings.ShowFileExtensionsEnabled();
+        set
+        {
+            SettingChangedEvent.Log("ShowFileExtensions", value.ToString());
+            DeveloperFileExplorerSettings.SetShowFileExtensionsEnabled(value);
+        }
+    }
+
+    public bool ShowHiddenAndSystemFiles
+    {
+        get => DeveloperFileExplorerSettings.ShowHiddenAndSystemFilesEnabled();
+        set
+        {
+            SettingChangedEvent.Log("ShowHiddenAndSystemFiles", value.ToString());
+            DeveloperFileExplorerSettings.SetShowHiddenAndSystemFilesEnabled(value);
+        }
+    }
+
+    public bool ShowFullPathInTitleBar
+    {
+        get => DeveloperFileExplorerSettings.ShowFullPathInTitleBarEnabled();
+        set
+        {
+            SettingChangedEvent.Log("ShowFullPathInTitleBar", value.ToString());
+            DeveloperFileExplorerSettings.SetShowFullPathInTitleBarEnabled(value);
+        }
+    }
+
+    public bool ShowEmptyDrives
+    {
+        get => _shellSettings.ShowEmptyDrivesEnabled();
+        set
+        {
+            SettingChangedEvent.Log("ShowEmptyDrives", value.ToString());
+            _shellSettings.SetShowEmptyDrivesEnabled(value);
+        }
+    }
+
+    public bool ShowFilesAfterExtraction
+    {
+        get => _shellSettings.ShowFilesAfterExtractionEnabled();
+        set
+        {
+            SettingChangedEvent.Log("ShowFilesAfterExtraction", value.ToString());
+            _shellSettings.SetShowFilesAfterExtractionEnabled(value);
+        }
+    }
+
+    public bool EndTaskOnTaskBarEnabled
+    {
+        get => _shellSettings.EndTaskOnTaskBarEnabled();
+        set
+        {
+            SettingChangedEvent.Log("EndTaskOnTaskBarEnabled", value.ToString());
+            _shellSettings.SetEndTaskOnTaskBarEnabled(value);
+        }
+    }
+}

--- a/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
@@ -14,8 +14,12 @@ namespace DevHome.Customization.ViewModels;
 
 public partial class MainPageViewModel : ObservableObject
 {
-    public MainPageViewModel()
+    private INavigationService NavigationService { get; }
+
+    public MainPageViewModel(
+        INavigationService navigationService)
     {
+        NavigationService = navigationService;
     }
 
     [RelayCommand]
@@ -27,7 +31,6 @@ public partial class MainPageViewModel : ObservableObject
     [RelayCommand]
     private void NavigateToDeveloperFileExplorerPage()
     {
-        var navigationService = Application.Current.GetService<INavigationService>();
-        navigationService.NavigateTo(typeof(DeveloperFileExplorerViewModel).FullName!);
+        NavigationService.NavigateTo(typeof(DeveloperFileExplorerViewModel).FullName!);
     }
 }

--- a/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using Microsoft.UI.Xaml;
+using Windows.System;
+
+namespace DevHome.Customization.ViewModels;
+
+public partial class MainPageViewModel : ObservableObject
+{
+    public MainPageViewModel()
+    {
+    }
+
+    [RelayCommand]
+    private async Task LaunchWindowsDeveloperSettings()
+    {
+        await Launcher.LaunchUriAsync(new("ms-settings:developers"));
+    }
+
+    [RelayCommand]
+    private void NavigateToDeveloperFileExplorerPage()
+    {
+        var navigationService = Application.Current.GetService<INavigationService>();
+        navigationService.NavigateTo(typeof(DeveloperFileExplorerViewModel).FullName!);
+    }
+}

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml
@@ -1,0 +1,29 @@
+<Page
+    x:Class="DevHome.Customization.Views.DeveloperFileExplorerPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:views="using:DevHome.Customization.Views"
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    mc:Ignorable="d">
+
+    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+            Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollView Grid.Row="2" VerticalAlignment="Top">
+            <views:DeveloperFileExplorerView />
+        </ScrollView>
+    </Grid>
+</Page>

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:DevHome.Customization.Views"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Always"
     mc:Ignorable="d">
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
@@ -15,12 +15,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-
-        <BreadcrumbBar
-            x:Name="BreadcrumbBar"
-            Margin="0,0,0,16"
-            ItemClicked="BreadcrumbBar_ItemClicked"
-            ItemsSource="{x:Bind Breadcrumbs}" />
 
         <ScrollView Grid.Row="2" VerticalAlignment="Top">
             <views:DeveloperFileExplorerView />

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using DevHome.Customization.ViewModels;
+using DevHome.Settings.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Customization.Views;
+
+public sealed partial class DeveloperFileExplorerPage : Page
+{
+    public DeveloperFileExplorerViewModel ViewModel
+    {
+        get;
+    }
+
+    public ObservableCollection<Breadcrumb> Breadcrumbs
+    {
+        get;
+    }
+
+    public DeveloperFileExplorerPage()
+    {
+        ViewModel = Application.Current.GetService<DeveloperFileExplorerViewModel>();
+        this.InitializeComponent();
+
+        var stringResource = new StringResource("DevHome.Customization/Resources");
+        Breadcrumbs = new ObservableCollection<Breadcrumb>
+        {
+            new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
+            new(stringResource.GetLocalized("DeveloperFileExplorer_Header"), typeof(DeveloperFileExplorerViewModel).FullName!),
+        };
+    }
+
+    private void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+    {
+        if (args.Index < Breadcrumbs.Count - 1)
+        {
+            var crumb = (Breadcrumb)args.Item;
+            crumb.NavigateTo();
+        }
+    }
+}

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.ObjectModel;
 using DevHome.Common.Extensions;
-using DevHome.Common.Services;
 using DevHome.Customization.ViewModels;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml.cs
@@ -18,30 +18,9 @@ public sealed partial class DeveloperFileExplorerPage : Page
         get;
     }
 
-    public ObservableCollection<Breadcrumb> Breadcrumbs
-    {
-        get;
-    }
-
     public DeveloperFileExplorerPage()
     {
         ViewModel = Application.Current.GetService<DeveloperFileExplorerViewModel>();
         this.InitializeComponent();
-
-        var stringResource = new StringResource("DevHome.Customization/Resources");
-        Breadcrumbs = new ObservableCollection<Breadcrumb>
-        {
-            new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
-            new(stringResource.GetLocalized("DeveloperFileExplorer_Header"), typeof(DeveloperFileExplorerViewModel).FullName!),
-        };
-    }
-
-    private void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerView.xaml
@@ -1,0 +1,29 @@
+<UserControl
+    x:Class="DevHome.Customization.Views.DeveloperFileExplorerView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <StackPanel>
+        <controls:SettingsCard x:Uid="ShowFileExtensionsCard">
+            <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.ShowFileExtensions, Mode=TwoWay}" />
+        </controls:SettingsCard>
+        <controls:SettingsCard x:Uid="ShowHiddenAndSystemFilesCard">
+            <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.ShowHiddenAndSystemFiles, Mode=TwoWay}" />
+        </controls:SettingsCard>
+        <controls:SettingsCard x:Uid="ShowFullPathInTitleBarCard">
+            <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.ShowFullPathInTitleBar, Mode=TwoWay}" />
+        </controls:SettingsCard>
+        <controls:SettingsCard x:Uid="ShowFilesAfterExtractCard">
+            <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.ShowFilesAfterExtraction, Mode=TwoWay}" />
+        </controls:SettingsCard>
+        <controls:SettingsCard x:Uid="ShowEmptyDrivesCard">
+            <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.ShowEmptyDrives, Mode=TwoWay}" />
+        </controls:SettingsCard>
+        <controls:SettingsCard x:Uid="EndTaskOnTaskBar">
+            <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.EndTaskOnTaskBarEnabled, Mode=TwoWay}" />
+        </controls:SettingsCard>
+    </StackPanel>
+</UserControl>

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerView.xaml.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Extensions;
+using DevHome.Customization.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Customization.Views;
+
+public sealed partial class DeveloperFileExplorerView : UserControl
+{
+    public DeveloperFileExplorerViewModel ViewModel
+    {
+        get;
+    }
+
+    public DeveloperFileExplorerView()
+    {
+        InitializeComponent();
+
+        ViewModel = Application.Current.GetService<DeveloperFileExplorerViewModel>();
+    }
+}

--- a/tools/Customization/DevHome.Customization/Views/MainPage.cs
+++ b/tools/Customization/DevHome.Customization/Views/MainPage.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using DevHome.Common;
+using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using DevHome.Customization.ViewModels;
+using DevHome.Settings.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Customization.Views;
+
+public sealed partial class MainPage : ToolPage
+{
+    public override string ShortName => "Windows customization";
+
+    public MainPageViewModel ViewModel
+    {
+        get;
+    }
+
+    public ObservableCollection<Breadcrumb> Breadcrumbs
+    {
+        get;
+    }
+
+    public MainPage()
+    {
+        ViewModel = Application.Current.GetService<MainPageViewModel>();
+        InitializeComponent();
+
+        var stringResource = new StringResource("DevHome.Customization/Resources");
+        Breadcrumbs = new ObservableCollection<Breadcrumb>
+        {
+            new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
+        };
+    }
+
+    private void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+    {
+        if (args.Index < Breadcrumbs.Count - 1)
+        {
+            var crumb = (Breadcrumb)args.Item;
+            crumb.NavigateTo();
+        }
+    }
+}

--- a/tools/Customization/DevHome.Customization/Views/MainPage.cs
+++ b/tools/Customization/DevHome.Customization/Views/MainPage.cs
@@ -21,29 +21,9 @@ public sealed partial class MainPage : ToolPage
         get;
     }
 
-    public ObservableCollection<Breadcrumb> Breadcrumbs
-    {
-        get;
-    }
-
     public MainPage()
     {
         ViewModel = Application.Current.GetService<MainPageViewModel>();
         InitializeComponent();
-
-        var stringResource = new StringResource("DevHome.Customization/Resources");
-        Breadcrumbs = new ObservableCollection<Breadcrumb>
-        {
-            new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
-        };
-    }
-
-    private void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/MainPage.cs
+++ b/tools/Customization/DevHome.Customization/Views/MainPage.cs
@@ -1,14 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.ObjectModel;
 using DevHome.Common;
 using DevHome.Common.Extensions;
-using DevHome.Common.Services;
 using DevHome.Customization.ViewModels;
-using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Customization.Views;
 

--- a/tools/Customization/DevHome.Customization/Views/MainPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/MainPage.xaml
@@ -1,0 +1,33 @@
+<!--  Copyright (c) Microsoft Corporation..  -->
+<!--  Licensed under the MIT License.  -->
+
+<pg:ToolPage
+    x:Class="DevHome.Customization.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:pg="using:DevHome.Common"
+    xmlns:views="using:DevHome.Customization.Views"
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    mc:Ignorable="d">
+
+    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <BreadcrumbBar
+            x:Name="BreadcrumbBar"
+                Margin="0,0,0,16"
+            ItemClicked="BreadcrumbBar_ItemClicked"
+            ItemsSource="{x:Bind Breadcrumbs}" />
+
+        <ScrollView Grid.Row="1" VerticalAlignment="Top">
+            <!-- TODO: Replace with a ContentPresenter to enable swapping the root view with a search view, etc. -->
+            <views:MainPageView />
+        </ScrollView>
+    </Grid>
+</pg:ToolPage>

--- a/tools/Customization/DevHome.Customization/Views/MainPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/MainPage.xaml
@@ -10,7 +10,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
     xmlns:views="using:DevHome.Customization.Views"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Always"
     mc:Ignorable="d">
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
@@ -18,12 +18,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-
-        <BreadcrumbBar
-            x:Name="BreadcrumbBar"
-                Margin="0,0,0,16"
-            ItemClicked="BreadcrumbBar_ItemClicked"
-            ItemsSource="{x:Bind Breadcrumbs}" />
 
         <ScrollView Grid.Row="1" VerticalAlignment="Top">
             <!-- TODO: Replace with a ContentPresenter to enable swapping the root view with a search view, etc. -->

--- a/tools/Customization/DevHome.Customization/Views/MainPageView.cs
+++ b/tools/Customization/DevHome.Customization/Views/MainPageView.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Extensions;
+using DevHome.Customization.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Customization.Views;
+
+public sealed partial class MainPageView : UserControl
+{
+    public MainPageViewModel ViewModel
+    {
+        get;
+    }
+
+    public MainPageView()
+    {
+        InitializeComponent();
+
+        ViewModel = Application.Current.GetService<MainPageViewModel>();
+    }
+}

--- a/tools/Customization/DevHome.Customization/Views/MainPageView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/MainPageView.xaml
@@ -1,0 +1,35 @@
+<UserControl
+    x:Class="DevHome.Customization.Views.MainPageView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+        <!--  Primary settings group (untitled)  -->
+        <controls:SettingsCard
+            x:Uid="DeveloperFileExplorerCard"
+            AutomationProperties.AccessibilityView="Control"
+            AutomationProperties.AutomationId="NavigateDeveloperFileExplorerCardButton"
+            Command="{x:Bind ViewModel.NavigateToDeveloperFileExplorerPageCommand}"
+            HeaderIcon="{ui:FontIcon Glyph=&#xEC50;}"
+            IsClickEnabled="True" />
+
+        <!--  More Windows settings  -->
+        <StackPanel>
+            <TextBlock x:Uid="MoreWindowsSettingsSectionHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
+            <TextBlock x:Uid="MoreWindowsSettingsSectionDescription" Style="{StaticResource SettingsSectionCaptionTextBlockStyle}" />
+            <controls:SettingsCard
+                x:Uid="WindowsDeveloperCard"
+                ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}"
+                AutomationProperties.AccessibilityView="Control"
+                AutomationProperties.AutomationId="LaunchWindowsDeveloperSettingsButton"
+                Command="{x:Bind ViewModel.LaunchWindowsDeveloperSettingsCommand}"
+                HeaderIcon="{ui:FontIcon Glyph=&#xEC7A;}"
+                IsClickEnabled="True" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <Import Project="$(SolutionDir)Directory.CppBuild.props" />
-  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
+  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -168,6 +168,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
   </Target>
 </Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/packages.config
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240304-x1959" targetFramework="native" />
+  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240311-x1907" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/DevHome.QuietBackgroundProcesses.Server.vcxproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/DevHome.QuietBackgroundProcesses.Server.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <Language>C++</Language>
   </PropertyGroup>
-  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
+  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <Import Project="$(SolutionDir)Directory.CppBuild.props" />
   <PropertyGroup Label="Globals">
@@ -170,6 +170,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240304-x1959\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240311-x1907\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
   </Target>
 </Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/packages.config
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240304-x1959" targetFramework="native" />
+  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240311-x1907" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Summary of the pull request
This commit includes the initial placeholder L1 page for 'Windows customization' which will host various settings and utilities to customize Windows to a developer's preferences.

![image](https://github.com/microsoft/devhome/assets/7259210/07fdd650-9b76-4500-8e50-4c307b958b4c)

![image](https://github.com/microsoft/devhome/assets/7259210/5ffdf7fe-4721-407c-8a9f-1d53972b4d64)

## References and relevant issues
Starts the work related to the "Advanced Settings" feature exploration #1983 

## Detailed description of the pull request / Additional comments
The MainPage acts as a root which eventually will host a ContentPresenter for displaying the active view (for example, when search is added the ContentPresent will switch the root view temporarily to the 'All settings' search view, and once we get better support to integrate into the navigation service, sub-pages could be consolidated into that content presenter as well.

To provide an example of how options can be incorporated, the Developer File Explorer page was introduced.

The pattern we’re going for here is to provide logical settings groups in the form of a UserControl, which is then wrapped by a Page. This helps in the future when implementing search because we want to host all settings controls in the same root view and filter visibility based on the search filter. Having each group as a separate control view can easily enable hosting that UI in any form we need to down the line. The sub-pages themselves are probably temporarily placeholders for a better integration with the navigation service down the line.

See tools\Customization\DevHome.Customization\Customization.md for details.

## Validation steps performed
- Verified that the Windows customization section appears on the navigation menu and can be navigated to.
- Clicking on the Windows developer settings link will navigate to the Windows Settings app "For developers" page
- Toggle each setting on "Developer File Explorer" and verify that the setting takes effect, both on and off
- 
## PR checklist
- [x] Makes progress on #1983 
- [x] Tests passed
- [x] Documentation updated
