### PR TITLE
Have IThemeSelectorService notify for ActualThemeChanged

### DIFF
--- a/common/Services/IThemeSelectorService.cs
+++ b/common/Services/IThemeSelectorService.cs
@@ -9,6 +9,9 @@ namespace DevHome.Contracts.Services;
 
 public interface IThemeSelectorService
 {
+    /// <summary>
+    /// Occurs when the theme has changed, either due to user selection or the system theme changing.
+    /// </summary>
     public event EventHandler<ElementTheme> ThemeChanged;
 
     ElementTheme Theme { get; }

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -14,21 +14,16 @@ public partial class ShellViewModel : ObservableObject
 {
     private readonly ILocalSettingsService _localSettingsService;
     private readonly IAppInfoService _appInfoService;
+    private readonly IThemeSelectorService _themeSelectorService;
 
     [ObservableProperty]
     private string? _announcementText;
 
     public string Title => _appInfoService.GetAppNameLocalized();
 
-    public INavigationService NavigationService
-    {
-        get;
-    }
+    public INavigationService NavigationService { get; }
 
-    public INavigationViewService NavigationViewService
-    {
-        get;
-    }
+    public INavigationViewService NavigationViewService { get; }
 
     [ObservableProperty]
     private object? _selected;
@@ -41,13 +36,15 @@ public partial class ShellViewModel : ObservableObject
         INavigationViewService navigationViewService,
         ILocalSettingsService localSettingsService,
         IScreenReaderService screenReaderService,
-        IAppInfoService appInfoService)
+        IAppInfoService appInfoService,
+        IThemeSelectorService themeSelectorService)
     {
         NavigationService = navigationService;
         NavigationService.Navigated += OnNavigated;
         NavigationViewService = navigationViewService;
         _localSettingsService = localSettingsService;
         _appInfoService = appInfoService;
+        _themeSelectorService = themeSelectorService;
 
         screenReaderService.AnnouncementTextChanged += OnAnnouncementTextChanged;
     }
@@ -97,5 +94,10 @@ public partial class ShellViewModel : ObservableObject
 
         // Set new announcement title
         AnnouncementText = text;
+    }
+
+    internal void NotifyActualThemeChanged()
+    {
+        _themeSelectorService.SetRequestedTheme();
     }
 }

--- a/src/Views/ShellPage.xaml.cs
+++ b/src/Views/ShellPage.xaml.cs
@@ -17,10 +17,7 @@ namespace DevHome.Views;
 
 public sealed partial class ShellPage : Page
 {
-    public ShellViewModel ViewModel
-    {
-        get;
-    }
+    public ShellViewModel ViewModel { get; }
 
     public ShellPage(ShellViewModel viewModel)
     {
@@ -59,6 +56,8 @@ public sealed partial class ShellPage : Page
         // Update the title bar if the system theme changes.
         TitleBarHelper.UpdateTitleBar(App.MainWindow, ActualTheme);
         AppTitleBar.Repaint();
+
+        ViewModel.NotifyActualThemeChanged();
     }
 
     private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)

--- a/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/AdaptiveCardRenderingService.cs
@@ -16,6 +16,8 @@ namespace DevHome.Dashboard.Services;
 
 public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisposable
 {
+    public event EventHandler RendererUpdated = (_, _) => { };
+
     private readonly WindowEx _windowEx;
 
     private readonly IThemeSelectorService _themeSelectorService;
@@ -94,7 +96,7 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
         };
     }
 
-    public async Task UpdateHostConfig()
+    private async Task UpdateHostConfig()
     {
         if (_renderer != null)
         {
@@ -127,6 +129,8 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
                     Log.Logger()?.ReportError("DashboardView", $"HostConfig contents are {hostConfigContents}");
                 }
             });
+
+            RendererUpdated(this, null);
         }
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/IAdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IAdaptiveCardRenderingService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
 
@@ -10,5 +11,5 @@ public interface IAdaptiveCardRenderingService
 {
     public Task<AdaptiveCardRenderer> GetRenderer();
 
-    public Task UpdateHostConfig();
+    public event EventHandler RendererUpdated;
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -14,6 +14,8 @@
     xmlns:controls="using:DevHome.Dashboard.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
@@ -32,6 +34,15 @@
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Page.Resources>
+
+    <i:Interaction.Behaviors>
+        <ic:EventTriggerBehavior EventName="Loaded">
+            <ic:InvokeCommandAction Command="{x:Bind LoadedCommand}" />
+        </ic:EventTriggerBehavior>
+        <ic:EventTriggerBehavior EventName="Unloaded">
+            <ic:InvokeCommandAction Command="{x:Bind UnloadedCommand}" />
+        </ic:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <Grid.RowDefinitions>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -66,10 +66,6 @@ public partial class DashboardView : ToolPage, IDisposable
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         _localSettingsService = Application.Current.GetService<ILocalSettingsService>();
 
-        Application.Current.GetService<IAdaptiveCardRenderingService>().RendererUpdated += HandleRendererUpdated;
-
-        Loaded += OnLoaded;
-
 #if DEBUG
         Loaded += AddResetButton;
 #endif
@@ -111,9 +107,17 @@ public partial class DashboardView : ToolPage, IDisposable
         }
     }
 
-    private async void OnLoaded(object sender, RoutedEventArgs e)
+    [RelayCommand]
+    private async Task OnLoadedAsync()
     {
+        Application.Current.GetService<IAdaptiveCardRenderingService>().RendererUpdated += HandleRendererUpdated;
         await InitializeDashboard();
+    }
+
+    [RelayCommand]
+    private void OnUnloaded()
+    {
+        Application.Current.GetService<IAdaptiveCardRenderingService>().RendererUpdated -= HandleRendererUpdated;
     }
 
     private async Task InitializeDashboard()

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -66,7 +66,7 @@ public partial class DashboardView : ToolPage, IDisposable
         _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         _localSettingsService = Application.Current.GetService<ILocalSettingsService>();
 
-        ActualThemeChanged += OnActualThemeChanged;
+        Application.Current.GetService<IAdaptiveCardRenderingService>().RendererUpdated += HandleRendererUpdated;
 
         Loaded += OnLoaded;
 
@@ -102,11 +102,8 @@ public partial class DashboardView : ToolPage, IDisposable
         return true;
     }
 
-    private async void OnActualThemeChanged(FrameworkElement sender, object args)
+    private async void HandleRendererUpdated(object sender, object args)
     {
-        // A different host config is used to render widgets (adaptive cards) in light and dark themes.
-        await Application.Current.GetService<IAdaptiveCardRenderingService>().UpdateHostConfig();
-
         // Re-render the widgets with the new theme and renderer.
         foreach (var widget in PinnedWidgets)
         {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/RepoConfigViewModel.cs
@@ -118,19 +118,12 @@ public partial class RepoConfigViewModel : SetupPageViewModelBase
             : stringResource.GetLocalized(StringResourceKey.SetupShellRepoConfigTargetMachine);
     }
 
-    private void OnThemeChanged(object sender, ElementTheme e)
+    private void OnThemeChanged(object sender, ElementTheme newRequestedTheme)
     {
-        var themeToSwitchTo = e;
-
-        if (themeToSwitchTo == ElementTheme.Default)
-        {
-            themeToSwitchTo = _themeSelectorService.GetActualTheme();
-        }
-
         // Because the logos aren't glyphs DevHome has to change the logos manually to match the theme.
         foreach (var cloneInformation in RepoReviewItems)
         {
-            cloneInformation.SetIcon(themeToSwitchTo);
+            cloneInformation.SetIcon(_themeSelectorService.GetActualTheme());
         }
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -39,15 +39,6 @@ public sealed partial class RepoConfigView : UserControl
 
     public void OnActualThemeChanged(FrameworkElement sender, object args)
     {
-        if (ViewModel != null)
-        {
-            // Because the logos aren't glyphs DevHome has to change the logos manually to match the theme.
-            foreach (var cloneInformation in ViewModel.RepoReviewItems)
-            {
-                cloneInformation.SetIcon(sender.ActualTheme);
-            }
-        }
-
         if (_addRepoDialog != null)
         {
             _addRepoDialog.RequestedTheme = sender.ActualTheme;


### PR DESCRIPTION
## Summary of the pull request
The `ThemeSelectorService` is limited to only notifying about changes in the theme selected within DH (Default, Dark, Light). If the theme changes due to system theme being changed, `ThemeSelectorService`(`TSS`) does not notify (theme is still "Default"). The drawback of this is that parts of DH have to subscribe to `ActualThemeChanged` as well as `TSS.ThemeChanged`. At best this results in duplicated code or awkward passing of the theme from View to ViewModel, and at worst is forgotten.

Instead, listen for `ActualThemeChanged` in the ShellView and have it tell the `ThemeSelectorService` to raise the `ThemeChanged` event. This means other parts of DH only have to listen to one event, as it will notify of either type of theme change.

In **RepoConfig**, the ViewModel can now handle settings the Icon for both types of events and that part can be removed from the View (View still subscribes to ActualThemeChanged for other reasons).

In **Dashboard**, the `AdaptiveCardRenderingService` can handle all theme changes, instead of it listening to `TSS.ThemeChanged` and Dashboard notifying it of `ActualThemeChanged`. Adds **`RendererChanged`** event to AdaptiveCardRenderingService that Dashboard (or future users) can listen for and react to if the Renderer was updated by theming (in this case, re-rendering widgets).

These changes will be useful in a future change to make the AdaptiveCardRenderingService more accessible to other parts of DH.

## Validation steps performed
Validated by changing theme in DH and via system Settings and seeing responses in Dashboard and RepoConfig flow.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
