### PR TITLE
Update theme of Add Widget dialog when system theme changes

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
@@ -58,17 +58,21 @@ public partial class AddWidgetViewModel : ObservableObject
         WidgetProviderDisplayTitle = string.Empty;
         WidgetScreenshot = null;
         PinButtonVisibility = false;
+        _selectedWidgetDefinition = null;
     }
 
     [RelayCommand]
     private async Task UpdateThemeAsync()
     {
-        // Update the preview image for the selected widget.
-        var theme = _themeSelectorService.GetActualTheme();
-        var bitmap = await _widgetScreenshotService.GetScreenshotFromCache(_selectedWidgetDefinition, theme);
-        WidgetScreenshot = new ImageBrush
+        if (_selectedWidgetDefinition != null)
         {
-            ImageSource = bitmap,
-        };
+            // Update the preview image for the selected widget.
+            var theme = _themeSelectorService.GetActualTheme();
+            var bitmap = await _widgetScreenshotService.GetScreenshotFromCache(_selectedWidgetDefinition, theme);
+            WidgetScreenshot = new ImageBrush
+            {
+                ImageSource = bitmap,
+            };
+        }
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
@@ -61,7 +61,7 @@ public partial class AddWidgetViewModel : ObservableObject
     }
 
     [RelayCommand]
-    internal async Task UpdateThemeAsync()
+    private async Task UpdateThemeAsync()
     {
         // Update the preview image for the selected widget.
         var theme = _themeSelectorService.GetActualTheme();

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
@@ -63,6 +63,7 @@ public partial class AddWidgetViewModel : ObservableObject
     [RelayCommand]
     internal async Task UpdateThemeAsync()
     {
+        // Update the preview image for the selected widget.
         var theme = _themeSelectorService.GetActualTheme();
         var bitmap = await _widgetScreenshotService.GetScreenshotFromCache(_selectedWidgetDefinition, theme);
         WidgetScreenshot = new ImageBrush

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -5,17 +5,17 @@
     x:Class="DevHome.Dashboard.Views.AddWidgetDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    mc:Ignorable="d"
     Style="{StaticResource DefaultContentDialogStyle}"
     SizeChanged="ContentDialog_SizeChanged">
     <i:Interaction.Behaviors>
         <ic:EventTriggerBehavior EventName="Loaded">
             <ic:InvokeCommandAction Command="{x:Bind LoadedCommand}" />
+        </ic:EventTriggerBehavior>
+        <ic:EventTriggerBehavior EventName="ActualThemeChanged">
+            <ic:InvokeCommandAction Command="{x:Bind ViewModel.UpdateThemeCommand}" />
         </ic:EventTriggerBehavior>
     </i:Interaction.Behaviors>
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml
@@ -16,6 +16,7 @@
         </ic:EventTriggerBehavior>
         <ic:EventTriggerBehavior EventName="ActualThemeChanged">
             <ic:InvokeCommandAction Command="{x:Bind ViewModel.UpdateThemeCommand}" />
+            <ic:InvokeCommandAction Command="{x:Bind UpdateThemeCommand}" />
         </ic:EventTriggerBehavior>
     </i:Interaction.Behaviors>
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -313,6 +313,8 @@ public sealed partial class AddWidgetDialog : ContentDialog
                                     Log.Logger()?.ReportError("AddWidgetDialog", $"WidgetCatalog_WidgetDefinitionDeleted found no available widgets.");
                                 }
                             }
+
+                            return;
                         }
                     }
                 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Contracts.Services;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
@@ -32,9 +33,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
     private readonly IWidgetHostingService _hostingService;
     private readonly IWidgetIconService _widgetIconService;
 
-    public AddWidgetDialog(
-        DispatcherQueue dispatcher,
-        ElementTheme theme)
+    public AddWidgetDialog(DispatcherQueue dispatcher)
     {
         ViewModel = Application.Current.GetService<AddWidgetViewModel>();
         _hostingService = Application.Current.GetService<IWidgetHostingService>();
@@ -44,9 +43,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
         _dispatcher = dispatcher;
 
-        // Strange behavior: just setting the requested theme when we new-up the dialog results in
-        // the wrong theme's resources being used. Setting RequestedTheme here fixes the problem.
-        RequestedTheme = theme;
+        RequestedTheme = Application.Current.GetService<IThemeSelectorService>().Theme;
     }
 
     [RelayCommand]

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -234,9 +234,9 @@ public sealed partial class AddWidgetDialog : ContentDialog
     private async Task UpdateThemeAsync()
     {
         // Update the icons for each available widget listed.
-        foreach (var providerItem in AddWidgetNavigationView.MenuItems.Cast<NavigationViewItem>())
+        foreach (var providerItem in AddWidgetNavigationView.MenuItems.OfType<NavigationViewItem>())
         {
-            foreach (var widgetItem in providerItem.MenuItems.Cast<NavigationViewItem>())
+            foreach (var widgetItem in providerItem.MenuItems.OfType<NavigationViewItem>())
             {
                 var widgetDefinition = widgetItem.Tag as WidgetDefinition;
                 var image = await _widgetIconService.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
@@ -291,9 +291,9 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
             // Remove the deleted WidgetDefinition from the list of available widgets.
             var menuItems = AddWidgetNavigationView.MenuItems;
-            foreach (var providerItem in menuItems.Cast<NavigationViewItem>())
+            foreach (var providerItem in menuItems.OfType<NavigationViewItem>())
             {
-                foreach (var widgetItem in providerItem.MenuItems.Cast<NavigationViewItem>())
+                foreach (var widgetItem in providerItem.MenuItems.OfType<NavigationViewItem>())
                 {
                     if (widgetItem.Tag is WidgetDefinition tagDefinition)
                     {

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -222,7 +222,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         if (selectedTag as WidgetDefinition is WidgetDefinition selectedWidgetDefinition)
         {
             _selectedWidget = selectedWidgetDefinition;
-            await ViewModel.SetWidgetDefinition(selectedWidgetDefinition, ActualTheme);
+            await ViewModel.SetWidgetDefinition(selectedWidgetDefinition);
         }
         else if (selectedTag as WidgetProviderDefinition is not null)
         {

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -232,6 +232,21 @@ public sealed partial class AddWidgetDialog : ContentDialog
     }
 
     [RelayCommand]
+    internal async Task UpdateThemeAsync()
+    {
+        // Update the icons for each available widget listed.
+        foreach (var providerItem in AddWidgetNavigationView.MenuItems.Cast<NavigationViewItem>())
+        {
+            foreach (var widgetItem in providerItem.MenuItems.Cast<NavigationViewItem>())
+            {
+                var widgetDefinition = widgetItem.Tag as WidgetDefinition;
+                var image = await _widgetIconService.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
+                widgetItem.Content = BuildNavItem(image, widgetDefinition.DisplayTitle);
+            }
+        }
+    }
+
+    [RelayCommand]
     private void PinButtonClick()
     {
         Log.Logger()?.ReportDebug("AddWidgetDialog", $"Pin selected");

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -238,9 +238,11 @@ public sealed partial class AddWidgetDialog : ContentDialog
         {
             foreach (var widgetItem in providerItem.MenuItems.OfType<NavigationViewItem>())
             {
-                var widgetDefinition = widgetItem.Tag as WidgetDefinition;
-                var image = await _widgetIconService.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
-                widgetItem.Content = BuildNavItem(image, widgetDefinition.DisplayTitle);
+                if (widgetItem.Tag is WidgetDefinition widgetDefinition)
+                {
+                    var image = await _widgetIconService.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
+                    widgetItem.Content = BuildNavItem(image, widgetDefinition.DisplayTitle);
+                }
             }
         }
     }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -18,13 +18,13 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
 using Microsoft.Windows.Widgets.Hosts;
+using WinUIEx;
 
 namespace DevHome.Dashboard.Views;
 
 public sealed partial class AddWidgetDialog : ContentDialog
 {
     private WidgetDefinition _selectedWidget;
-    private static DispatcherQueue _dispatcher;
 
     public WidgetDefinition AddedWidget { get; private set; }
 
@@ -32,8 +32,9 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private readonly IWidgetHostingService _hostingService;
     private readonly IWidgetIconService _widgetIconService;
+    private readonly WindowEx _windowEx;
 
-    public AddWidgetDialog(DispatcherQueue dispatcher)
+    public AddWidgetDialog()
     {
         ViewModel = Application.Current.GetService<AddWidgetViewModel>();
         _hostingService = Application.Current.GetService<IWidgetHostingService>();
@@ -41,7 +42,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
         this.InitializeComponent();
 
-        _dispatcher = dispatcher;
+        _windowEx = Application.Current.GetService<WindowEx>();
 
         RequestedTheme = Application.Current.GetService<IThemeSelectorService>().Theme;
     }
@@ -263,7 +264,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
     {
         var deletedDefinitionId = args.DefinitionId;
 
-        _dispatcher.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.TryEnqueue(() =>
         {
             // If we currently have the deleted widget open, un-select it.
             if (_selectedWidget is not null &&

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -10,7 +10,6 @@ using DevHome.Contracts.Services;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
@@ -232,7 +231,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
     }
 
     [RelayCommand]
-    internal async Task UpdateThemeAsync()
+    private async Task UpdateThemeAsync()
     {
         // Update the icons for each available widget listed.
         foreach (var providerItem in AddWidgetNavigationView.MenuItems.Cast<NavigationViewItem>())

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -359,11 +359,10 @@ public partial class DashboardView : ToolPage, IDisposable
     [RelayCommand]
     public async Task AddWidgetClickAsync()
     {
-        var dialog = new AddWidgetDialog(_dispatcher, ActualTheme)
+        var dialog = new AddWidgetDialog(_dispatcher)
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.
             XamlRoot = this.XamlRoot,
-            RequestedTheme = this.ActualTheme,
         };
 
         _ = await dialog.ShowAsync();

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -359,7 +359,7 @@ public partial class DashboardView : ToolPage, IDisposable
     [RelayCommand]
     public async Task AddWidgetClickAsync()
     {
-        var dialog = new AddWidgetDialog(_dispatcher)
+        var dialog = new AddWidgetDialog()
         {
             // XamlRoot must be set in the case of a ContentDialog running in a Desktop app.
             XamlRoot = this.XamlRoot,


### PR DESCRIPTION
## Summary of the pull request
If the user updated the system theme while the Add Widget dialog was open, the dialog would not update. This change fixes the problem by:
- Update the dialog itself. Before we were setting the RequestedTheme to be the ActualTheme, which meant if the RequestedTheme was Default, it would not update when the Default changed.
- Update the widget preview image by listening to ActualThemeChanged and swapping out the image.
- Update the widget icons by listening to ActualThemeChanged and swapping out the Content of the menu items.

This change has the nice side-effect of decoupling the AddWidgetView and the DashboardView, by requiring the DashboardView to pass in the dispatcherQueue or ActualTheme anymore. It will also make it easier to move more logic from the AddWidget View to ViewModel in the future if we want to.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2406
- [ ] Tests added/passed
- [ ] Documentation updated
