### PR TITLE
Fix experimental features visibility in nav menu

### DIFF
--- a/src/Views/ShellPage.xaml.cs
+++ b/src/Views/ShellPage.xaml.cs
@@ -150,12 +150,12 @@ public sealed partial class ShellPage : Page
 
     private void UpdateNavigationMenuItems()
     {
-        var expVM = App.Current.GetService<ExperimentalFeaturesViewModel>();
+        var expService = App.Current.GetService<IExperimentationService>();
         foreach (var group in App.NavConfig.NavMenu.Groups)
         {
             foreach (var tool in group.Tools)
             {
-                var expFeature = expVM.ExperimentalFeatures.FirstOrDefault(x => x.Id == tool.ExperimentalFeatureIdentity);
+                var expFeature = expService.ExperimentalFeatures.FirstOrDefault(x => x.Id == tool.ExperimentalFeatureIdentity);
 
                 var navigationViewItemString = $@"
                     <NavigationViewItem


### PR DESCRIPTION
## Summary of the pull request
The navigation menu was looking in the wrong place for experimental features.  They were originally stored in the viewmodel, but were recently moved to the ExperimentationService.  The viewmodel still has a list of experimental features, but it only gets populated when navigating to the settings page.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2414
- [ ] Tests added/passed
- [ ] Documentation updated
