### PR TITLE
Fix scroll regions across Dev Home

### DIFF
--- a/common/Environments/Styles/HorizontalCardStyles.xaml
+++ b/common/Environments/Styles/HorizontalCardStyles.xaml
@@ -15,6 +15,7 @@
         <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
         <Setter Property="Padding" Value="10 0 10 10" />
+        <Setter Property="Margin" Value="0 0 0 10" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     </Style>
@@ -33,7 +34,6 @@
         BasedOn="{StaticResource DefaultListViewItemStyle}">
         <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
-        <Setter Property="Margin" Value="0 0 0 10"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>
@@ -42,7 +42,9 @@
         x:Key="HorizontalCardListViewItemContainerForManagementPageStyle"
         TargetType="ListViewItem"
         BasedOn="{StaticResource DefaultListViewItemStyle}">
-        <Setter Property="Margin" Value="0 0 0 10"/>
+        <Setter Property="MaxWidth" Value="{ThemeResource MaxPageContentWidth}"/>
+        <!-- Default Padding is "16,0,12,0". Override since we want to take up the full width. -->
+        <Setter Property="Padding" Value="0,0,0,0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>
@@ -50,7 +52,6 @@
     <Style
         x:Key="EnvironmentScrollViewerStyle"
         TargetType="ScrollViewer">
-        <Setter Property="Margin" Value="0,22,0,0" />
         <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
     </Style>
 

--- a/common/Environments/Templates/EnvironmentsTemplates.xaml
+++ b/common/Environments/Templates/EnvironmentsTemplates.xaml
@@ -4,7 +4,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
-    xmlns:models="using:DevHome.Common.Environments.Models"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters">
     <!-- 
         Sample Template for a Dev Environment cards. 

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -26,11 +26,8 @@
         </DataTemplate>
     </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
-
-        <ScrollViewer VerticalAlignment="Top">
+    <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
+        <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <ctControls:SettingsExpander x:Uid="Settings_About_Card" IsExpanded="True">
                 <ctControls:SettingsExpander.HeaderIcon>
                     <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/DevHome.ico" />
@@ -57,6 +54,6 @@
                         ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}" />
                 </ctControls:SettingsExpander.Items>
             </ctControls:SettingsExpander>
-        </ScrollViewer>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -51,10 +51,8 @@
         </DataTemplate>
     </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
-        <ScrollViewer VerticalAlignment="Top">
+    <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
+        <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <StackPanel>
                 <ctControls:SettingsCard x:Uid="Settings_Accounts_AddAccount">
                     <ctControls:SettingsCard.HeaderIcon>
@@ -84,6 +82,6 @@
                                HorizontalAlignment="Stretch" VerticalAlignment="Center">
                 </ItemsRepeater>
             </StackPanel>
-        </ScrollViewer>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/settings/DevHome.Settings/Views/ExperimentalFeaturesPage.xaml
+++ b/settings/DevHome.Settings/Views/ExperimentalFeaturesPage.xaml
@@ -32,10 +32,8 @@
         </DataTemplate>
     </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
-        <ScrollViewer VerticalAlignment="Top">
+    <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
+        <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <StackPanel>
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.ExperimentalFeatures}">
                     <ItemsRepeater.ItemTemplate>
@@ -60,6 +58,6 @@
                     x:Uid="Settings_ExperimentalFeatures_NoExperimentalFeatures"
                     Visibility="{x:Bind ViewModel.ExperimentalFeatures.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}" />
             </StackPanel>
-        </ScrollViewer>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -29,11 +29,9 @@
         </DataTemplate>
     </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
-        <ScrollViewer VerticalAlignment="Top">
-            <StackPanel>
+    <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
+        <Grid>
+            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}" BorderBrush="Yellow" BorderThickness="1">
                 <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                     <Grid>
                         <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -167,6 +165,6 @@
                     </ctControls:SettingsCard>
                 </StackPanel>
             </StackPanel>
-        </ScrollViewer>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -2,12 +2,12 @@
     x:Class="DevHome.Settings.Views.PreferencesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:i="using:Microsoft.Xaml.Interactivity" 
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:xaml="using:Microsoft.UI.Xaml"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
     Loaded="Page_Loaded">
 
@@ -27,12 +27,10 @@
         </DataTemplate>
     </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
-
-        <ScrollViewer VerticalAlignment="Top">
-            <ctControls:SettingsCard x:Uid="Settings_Theme">
+    <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <ctControls:SettingsCard x:Uid="Settings_Theme"
+                                     MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <ctControls:SettingsCard.HeaderIcon>
                     <FontIcon Glyph="&#xE790;" />
                 </ctControls:SettingsCard.HeaderIcon>
@@ -48,6 +46,6 @@
                     </i:Interaction.Behaviors>
                 </ComboBox>
             </ctControls:SettingsCard>
-        </ScrollViewer>
-    </Grid>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -28,10 +28,8 @@
         </DataTemplate>
     </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
-        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+    <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
+        <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.SettingsList, Mode=OneWay}">
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="viewmodels:SettingViewModel">
@@ -44,6 +42,6 @@
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>
-        </ScrollViewer>
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/Styles/Thickness.xaml
+++ b/src/Styles/Thickness.xaml
@@ -28,6 +28,8 @@
     <Thickness x:Key="NavigationViewHeaderMargin">0,0,0,22</Thickness>
 
     <Thickness x:Key="ContentPageMargin">40,0,40,0</Thickness>
+    <!-- HeaderMargin combines ContentPageMargin with NavigationViewHeaderMargin-->
+    <Thickness x:Key="HeaderMargin">40,0,40,22</Thickness>
 
     <Thickness x:Key="MenuBarContentMargin">36,24,36,0</Thickness>
 

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -9,7 +9,6 @@
     xmlns:models="using:DevHome.Models"
     xmlns:behaviors="using:DevHome.Common.Behaviors" 
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     Loaded="OnLoaded"
     SizeChanged="OnSizeChanged"
@@ -34,10 +33,14 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <ScrollViewer HorizontalScrollMode="Disabled" VerticalScrollMode="Auto" MaxWidth="{ThemeResource MaxPageBackgroundWidth}">
-        <RelativePanel>
+    <ScrollViewer HorizontalScrollMode="Disabled" VerticalScrollMode="Auto">
+        <RelativePanel MaxWidth="{ThemeResource MaxPageBackgroundWidth}">
             <Grid>
-                <Image Source="{ThemeResource Background}" MinWidth="{ThemeResource MaxPageBackgroundWidth}" VerticalAlignment="Top" HorizontalAlignment="Center" Stretch="UniformToFill" />
+                <Image Source="{ThemeResource Background}"
+                       MinWidth="{ThemeResource MaxPageBackgroundWidth}"
+                       VerticalAlignment="Top"
+                       HorizontalAlignment="Center"
+                       Stretch="UniformToFill" />
             </Grid>
             <Grid x:Name="ContentArea" Padding="35 0 35 30" HorizontalAlignment="Center">
                 <Grid.RowDefinitions>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -44,16 +44,17 @@
         </ic:EventTriggerBehavior>
     </i:Interaction.Behaviors>
 
-    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <!-- Header - Title and Add Widget button -->
-        <Grid Grid.Row="0" Margin="0,0,0,22">
+        <Grid Grid.Row="0"
+              MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left"/>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,22">
                 <Button x:Name="AddWidgetButton"
                         x:Uid="AddWidget"
                         HorizontalAlignment="Right"
@@ -63,7 +64,7 @@
         </Grid>
 
         <ScrollViewer VerticalScrollBarVisibility="Auto" Grid.Row="1">
-            <StackPanel>
+            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <!-- Top Banner - Default/First run experience - shown until user dismissed -->
                 <commonviews:Banner x:Name="DashboardBanner"
                     TextWidth="450"

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -2,8 +2,6 @@
     x:Class="DevHome.Environments.Views.LandingPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:vm="using:DevHome.Environments.ViewModels"
@@ -13,18 +11,16 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
-    mc:Ignorable="d"
     Loaded="OnLoaded">
 
     <pg:ToolPage.Resources>
         <ResourceDictionary Source="ms-appx:///DevHome.Common/Environments/Templates/EnvironmentsTemplates.xaml" />
     </pg:ToolPage.Resources>
 
-    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
-            <RowDefinition Height="37" />
+            <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -38,10 +34,10 @@
                         Command="{x:Bind LaunchActionCommand}" 
                         x:Uid="ms-resource:///DevHome.Environments/Resources/LaunchButton"
                         Style="{StaticResource CardBodySplitButtonStyle}">
-                        <SplitButton.Flyout>
-                            <customControls:CardFlyout ItemsViewModels="{x:Bind LaunchOperations}"/>
-                        </SplitButton.Flyout>
-                    </SplitButton>
+                    <SplitButton.Flyout>
+                        <customControls:CardFlyout ItemsViewModels="{x:Bind LaunchOperations}"/>
+                    </SplitButton.Flyout>
+                </SplitButton>
             </DataTemplate>
 
             <!-- Three Dot Button template -->
@@ -96,22 +92,23 @@
                 </Grid>
             </DataTemplate>
 
-        <!-- Shimmer template from SetupFlow/SetupTargetView.xaml -->
-        <DataTemplate x:Key="ComputeSystemLoadingTemplate">
-            <ListView
-                SelectionMode="None"
-                ItemTemplate="{StaticResource HorizontalCardRootShimmerTemplate}"
-                ItemContainerStyle="{StaticResource HorizontalCardListViewItemContainerForManagementPageStyle}">
-                <x:String>Empty value for list since it doesn't need to use any bindings.</x:String>
-                <x:String>Empty value for list since it doesn't need to use any bindings.</x:String>
-            </ListView>
-        </DataTemplate>
+            <!-- Shimmer template from SetupFlow/SetupTargetView.xaml -->
+            <DataTemplate x:Key="ComputeSystemLoadingTemplate">
+                <ListView
+                    SelectionMode="None"
+                    ItemTemplate="{StaticResource HorizontalCardRootShimmerTemplate}"
+                    ItemContainerStyle="{StaticResource HorizontalCardListViewItemContainerForManagementPageStyle}">
+                    <x:String>Empty value for list since it doesn't need to use any bindings.</x:String>
+                    <x:String>Empty value for list since it doesn't need to use any bindings.</x:String>
+                </ListView>
+            </DataTemplate>
 
         </Grid.Resources>
         <!-- Templates end here -->
 
-
-        <Grid Grid.Row="0" Margin="0,0,0,22" x:Name="SyncButtonGrid">
+        <!-- Header -->
+        <Grid Grid.Row="0" x:Name="SyncButtonGrid"
+              MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource HeaderMargin}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
@@ -121,8 +118,8 @@
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0" x:Uid="Titlebar" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left" x:Name="Titlebar"/>
             <!-- Top right 'Sync' button -->
-<!-- ToDo: Revisit after confirming glyphs to be used -->
-            <Button Grid.Column="4" HorizontalAlignment="Right" Padding="45 5 30 5" Command="{x:Bind ViewModel.SyncButtonCommand}" Margin="0 0 13 0">
+            <!-- ToDo: Revisit after confirming glyphs to be used -->
+            <Button Grid.Column="4" HorizontalAlignment="Right" Padding="45 5 30 5" Command="{x:Bind ViewModel.SyncButtonCommand}">
                 <StackPanel Orientation="Horizontal">
                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;" FontSize="11">
                         <FontIcon.RenderTransform>
@@ -134,9 +131,11 @@
             </Button>
         </Grid>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal">
+        <!-- Search and sort -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal"
+                    MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="0,0,0,22">
             <!-- Search field -->
-            <AutoSuggestBox x:Uid="SearchTextBox" x:Name="SearchTextBox" MinWidth="350" Height="35" Margin="17 0 0 0" QueryIcon="Find">
+            <AutoSuggestBox x:Uid="SearchTextBox" x:Name="SearchTextBox" MinWidth="350" MinHeight="35" QueryIcon="Find">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="TextChanged">
                         <ic:InvokeCommandAction
@@ -147,7 +146,7 @@
             </AutoSuggestBox>
             <!-- Sort field -->
             <TextBlock x:Uid="SortByTextBlock" VerticalAlignment="Center" Margin="50 0 10 0"/>
-            <ComboBox x:Uid="SortSelectionComboBox" x:Name="SortSelectionComboBox" Margin="0 3 0 0" Height="35">
+            <ComboBox x:Uid="SortSelectionComboBox" x:Name="SortSelectionComboBox" Margin="0 3 0 0" MinHeight="35">
                 <ComboBoxItem x:Uid="SortByName"/>
                 <ComboBoxItem x:Uid="SortByAltName"/>
                 <i:Interaction.Behaviors>
@@ -163,7 +162,8 @@
         <!-- Per VM/Compute System card -->
         <ScrollViewer Grid.Row="2" Style="{StaticResource EnvironmentScrollViewerStyle}">
             <StackPanel>
-                <ListView 
+                <ListView
+                    MaxWidth="{ThemeResource MaxPageContentWidth}"
                     ItemsSource="{x:Bind ViewModel.ComputeSystemsView}" SelectionMode="None"
                     ItemContainerStyle="{StaticResource HorizontalCardListViewItemContainerForManagementPageStyle}">
                     <ListView.ItemsPanel>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -38,9 +38,9 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <Grid>
         <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <StackPanel>
+            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <commonviews:Banner x:Uid="ExtensionsBanner"
                                     TextWidth="350"
                                     Visibility="{x:Bind BannerViewModel.ShowExtensionsBanner,Mode=OneWay}"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
@@ -14,21 +14,22 @@
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     mc:Ignorable="d">
 
-    <Grid
-        MaxWidth="{ThemeResource MaxPageContentWidth}"
-        Margin="{ThemeResource ContentPageMargin}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <BreadcrumbBar
+            MaxWidth="{ThemeResource MaxPageContentWidth}"
+            Padding="{ThemeResource ContentPageMargin}"
             x:Name="BreadcrumbBar"
             Margin="0,0,0,16"
             ItemClicked="BreadcrumbBar_ItemClicked"
             ItemsSource="{x:Bind ViewModel.Breadcrumbs}" />
 
-        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top"
+                      MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <StackPanel>
                 <views:ExtensionAdaptiveCardPanel x:Name="SettingsContent">
                     <i:Interaction.Behaviors>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -20,7 +20,8 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Spacing="6" Visibility="{x:Bind HeaderVisibility, Mode=OneWay}">
+        <StackPanel Spacing="6" Visibility="{x:Bind HeaderVisibility, Mode=OneWay}"
+                    MaxWidth="{ThemeResource MaxPageContentWidth}">
             <!-- Title -->
             <TextBlock
                 Style="{ThemeResource SubtitleTextBlockStyle}"
@@ -91,10 +92,17 @@
         </StackPanel>
 
         <!-- Content -->
-        <ContentControl Grid.Row="3" Grid.ColumnSpan="2"
-                        IsTabStop="False"
-                        HorizontalContentAlignment="Stretch"
-                        VerticalContentAlignment="Stretch"
-                        Content="{x:Bind SetupShellContent, Mode=OneWay}" />
+        <ScrollViewer Grid.Row="3" Grid.ColumnSpan="2">
+            <ContentControl IsTabStop="False"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
+                            Content="{x:Bind SetupShellContent, Mode=OneWay}" >
+                <ContentControl.Template>
+                    <ControlTemplate TargetType="ContentControl">
+                        <ContentPresenter Content="{TemplateBinding Content}" MaxWidth="{ThemeResource MaxPageContentWidth}" />
+                    </ControlTemplate>
+                </ContentControl.Template>
+            </ContentControl>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using DevHome.SetupFlow.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Markup;
 
 namespace DevHome.SetupFlow.Controls;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
@@ -31,7 +31,7 @@
     </i:Interaction.Behaviors>
 
     <!-- Page split layout -->
-    <Grid ColumnSpacing="10">
+    <Grid ColumnSpacing="10" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="*" MaxWidth="318"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -52,7 +52,7 @@
     </UserControl.Resources>
 
     <!-- Page split layout -->
-    <Grid RowSpacing="10">
+    <Grid RowSpacing="10" MaxWidth="{ThemeResource MaxPageContentWidth}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*"/>
             <ColumnDefinition Width="*" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -75,7 +75,7 @@
 
         <!-- Main content -->
         <controls:SetupShell Grid.Row="1" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <Grid>
                 <StackPanel>
                     <commonviews:Banner
                         TextWidth="345"
@@ -217,7 +217,7 @@
                         </ctControls:SettingsCard>
                     </StackPanel>
                 </StackPanel>
-            </ScrollViewer>
+            </Grid>
         </controls:SetupShell>
     </Grid>
 </UserControl>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -32,7 +32,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <setupControls:SetupShell 
+    <setupControls:SetupShell
             Description="{x:Bind ViewModel.PageSubTitle, Mode=OneWay}"
             Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}"
             Foreground="{ThemeResource TextFillColorSecondary}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -4,9 +4,7 @@
 <pg:ToolPage
     x:Class="DevHome.SetupFlow.Views.SetupFlowPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:pg="using:DevHome.Common"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
@@ -15,14 +13,12 @@
     xmlns:views="using:DevHome.SetupFlow.Views"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
-    mc:Ignorable="d">
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
     <Page.Resources>
         <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
     </Page.Resources>
 
-    <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
@@ -83,6 +79,7 @@
 
         <controls:SetupFlowNavigation
             Grid.Row="1"
+            MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}"
             Visibility="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.IsNavigationBarVisible, Mode=OneWay}">
             <i:Interaction.Behaviors>
                 <setupFlowBehaviors:SetupFlowNavigationBehavior>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetView.xaml
@@ -231,8 +231,8 @@
             </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
-    
-    <ScrollViewer >
+
+    <ScrollViewer MaxWidth="{ThemeResource MaxPageContentWidth}">
         <StackPanel Spacing="10">
             <!--- Show the "Setup a Target header on the page. -->
             <setupControls:SetupShell 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -51,215 +51,216 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <ScrollViewer 
+    <ScrollViewer
         VerticalScrollMode="Enabled" 
         VerticalScrollBarVisibility="Auto"
         Padding="0,0,10,0">
-        <Grid RowSpacing="5" >
-            <Grid.RowDefinitions>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+        <StackPanel>
+            <Grid RowSpacing="5" MaxWidth="{ThemeResource MaxPageContentWidth}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
-            <!-- Display if the user has tasks need the machine to restart.-->
-            <Grid Visibility="{x:Bind ViewModel.ShowRestartNeeded}"  Background="{ThemeResource ComboBoxItemBackgroundPressed}" CornerRadius="5" Height="55" Padding="10" >
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition MinWidth="100" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Orientation="Horizontal" Grid.Column="0" Spacing="5">
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xF167;" Foreground="{ThemeResource AccentAAFillColorDefaultBrush}" />
-                    <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequired_First" Style="{ThemeResource BodyStrongTextBlockStyle}" VerticalAlignment="Center"/>
-                    <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequired_Second" VerticalAlignment="Center"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right" Spacing="5">
-                    <Button x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequiredButton" Style="{ThemeResource DefaultButtonStyle}" Width="120"/>
-                    <commonviews:CloseButton Command="{x:Bind ViewModel.RemoveRestartGridCommand}" />
-                </StackPanel>
-            </Grid>
-
-            <!-- Introduction to the summary page via configuration results-->
-            <Grid Grid.Row="1" Padding="0,20,0,40" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock
-                    Style="{ThemeResource BodyStrongTextBlockStyle}"
-                    Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
-                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Header"/>
-                <TextBlock
-                    Style="{ThemeResource SubtitleTextBlockStyle}"
-                    Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay}"
-                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_HeaderWithErrors"/>
-            </Grid>
-
-            <!-- Introduction to the summary page via non-configuration flow -->
-            <Grid Grid.Row="1" Padding="0,20,0,40" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock
-                    Style="{ThemeResource SubtitleTextBlockStyle}"
-                    Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource NegatedCollectionVisibilityConverter}}"
-                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Header"/>
-                <TextBlock
-                    Style="{ThemeResource SubtitleTextBlockStyle}"
-                    Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}"
-                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_HeaderWithErrors"/>
-            </Grid>
-
-            <Grid Grid.Row="2" ColumnSpacing="25" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1.77*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <!-- Configuration unit results -->
-                <Grid RowSpacing="20" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}" >
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <!-- Section header -->
-                    <Grid Padding="0,20,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Summary"
-                            Style="{ThemeResource BodyStrongTextBlockStyle}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Text="{x:Bind ViewModel.ConfigurationUnitStats}"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Style="{ThemeResource CaptionTextBlockStyle}" />
-                    </Grid>
-                    <ScrollViewer Grid.Row="1" VerticalScrollMode="Auto">
-                        <ItemsRepeater ItemsSource="{x:Bind ViewModel.ConfigurationUnitResults, Mode=OneWay}">
-                            <ItemsRepeater.Resources>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="FontFamily" Value="{StaticResource CascadiaMonoFontFamily}"/>
-                                    <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                    <Setter Property="LineHeight" Value="20"/>
-                                    <Setter Property="TextWrapping" Value="Wrap"/>
-                                    <Setter Property="IsTextSelectionEnabled" Value="True"/>
-                                </Style>
-                            </ItemsRepeater.Resources>
-                            <ItemsRepeater.ItemTemplate>
-                                <DataTemplate x:DataType="viewModels:ConfigurationUnitResultViewModel">
-                                    <StackPanel>
-                                        <TextBlock Text="{x:Bind Title}"/>
-                                        <StackPanel Margin="20,0,0,0">
-                                            <TextBlock Text="{x:Bind ApplyResult}">
-                                                <i:Interaction.Behaviors>
-                                                    <ic:DataTriggerBehavior Binding="{x:Bind IsError}" Value="True">
-                                                        <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorCriticalBrush}"/>
-                                                    </ic:DataTriggerBehavior>
-                                                    <ic:DataTriggerBehavior Binding="{x:Bind IsSkipped}" Value="True">
-                                                        <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorCautionBrush}"/>
-                                                    </ic:DataTriggerBehavior>
-                                                </i:Interaction.Behaviors>
-                                            </TextBlock>
-                                            <TextBlock Text="{x:Bind ErrorDescription}"
-                                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                                       Visibility="{x:Bind ErrorDescription, Converter={StaticResource StringVisibilityConverter}}"/>
-                                        </StackPanel>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ItemsRepeater.ItemTemplate>
-                        </ItemsRepeater>
-                    </ScrollViewer>
+                <!-- Display if the user has tasks need the machine to restart.-->
+                <Grid Visibility="{x:Bind ViewModel.ShowRestartNeeded}" Background="{ThemeResource ComboBoxItemBackgroundPressed}" CornerRadius="5" Height="55" Padding="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition MinWidth="100" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" Grid.Column="0" Spacing="5">
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xF167;" Foreground="{ThemeResource AccentAAFillColorDefaultBrush}" />
+                        <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequired_First" Style="{ThemeResource BodyStrongTextBlockStyle}" VerticalAlignment="Center"/>
+                        <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequired_Second" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right" Spacing="5">
+                        <Button x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_RestartRequiredButton" Style="{ThemeResource DefaultButtonStyle}" Width="120"/>
+                        <commonviews:CloseButton Command="{x:Bind ViewModel.RemoveRestartGridCommand}" />
+                    </StackPanel>
                 </Grid>
 
-                <!-- Next steps section -->
-                <ContentControl Grid.Column="1" Template="{ThemeResource LinksTemplate}" />
-            </Grid>
+                <!-- Introduction to the summary page via configuration results-->
+                <Grid Grid.Row="1" Padding="0,20,0,40" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Style="{ThemeResource BodyStrongTextBlockStyle}"
+                        Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
+                        x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Header"/>
+                    <TextBlock
+                        Style="{ThemeResource SubtitleTextBlockStyle}"
+                        Visibility="{x:Bind ViewModel.CompletedWithErrors, Mode=OneWay}"
+                        x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_HeaderWithErrors"/>
+                </Grid>
 
-            <!-- Results/NextSteps/List of repos/List of apps -->
-            <Grid
-                Grid.Row="2"
-                Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
-                ColumnSpacing="50">
-                <Grid.ColumnDefinitions>
-                    <!-- repos cloned/apps downloaded and next steps column -->
-                    <ColumnDefinition/>
-                    <!-- Clone repos list and apps downloaded list-->
-                    <ColumnDefinition Width="1.77*"/>
-                </Grid.ColumnDefinitions>
+                <!-- Introduction to the summary page via non-configuration flow -->
+                <Grid Grid.Row="1" Padding="0,20,0,40" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Style="{ThemeResource SubtitleTextBlockStyle}"
+                        Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource NegatedCollectionVisibilityConverter}}"
+                        x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Header"/>
+                    <TextBlock
+                        Style="{ThemeResource SubtitleTextBlockStyle}"
+                        Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}"
+                        x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_HeaderWithErrors"/>
+                </Grid>
 
-                <!-- Numbers of tasks ran and next steps.-->
-                <!-- Or, if any tasks failed, failed tasks and next steps.-->
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
+                <Grid Grid.Row="2" ColumnSpacing="25" Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.77*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                    <!-- Show any failed tasks if the loading screen has any failed tasks-->
-                    <Grid Grid.Row="0" Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}"
-                        HorizontalAlignment="Stretch" 
-                        Padding="0,15,0,30"
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="50"/>
-                                <RowDefinition Height="132"/>
-                            </Grid.RowDefinitions>
+                    <!-- Configuration unit results -->
+                    <Grid RowSpacing="20" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}" >
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <!-- Section header -->
+                        <Grid Padding="0,20,0,0">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition/>
-                                <ColumnDefinition/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="auto"/>
                             </Grid.ColumnDefinitions>
-                            <!-- message with how many errors-->
-                            <Grid Grid.Row="0" Grid.Column="0">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition/>
-                                    <RowDefinition/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Text="Error logs" Grid.Row="0" Grid.Column="0" Margin="0, 5, 0, 0"/>
-                                <StackPanel Orientation="Horizontal" Spacing="5" Grid.Row="1" Grid.Column="0">
-                                    <TextBlock Text="{x:Bind ViewModel.FailedTasks.Count}" Foreground="{ThemeResource TextFillColorSecondary}"/>
-                                    <TextBlock Text="installation errors" Foreground="{ThemeResource TextFillColorSecondary}"/>
-                                </StackPanel>
-                            </Grid>
-                            <HyperlinkButton Content="View log" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{x:Bind ViewModel.ShowLogFilesCommand, Mode=OneWay}"/>
-                            <ListView Grid.Row="1" Grid.ColumnSpan="2" SelectionMode="None" ItemsSource="{x:Bind ViewModel.FailedTasks, Mode=OneWay}" ItemContainerStyle="{ThemeResource ListViewItemStretchStyle}">
-                                <ListView.ItemTemplate>
-                                    <DataTemplate x:DataType="viewModels:SummaryErrorMessageViewModel">
-                                        <Grid ColumnSpacing="5" Margin="0">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="18"/>
-                                                <ColumnDefinition/>
-                                            </Grid.ColumnDefinitions>
-                                            <ImageIcon
-                                                 Source="{x:Bind StatusSymbolIcon, Mode=OneWay}" Grid.Column="0"/>
-                                            <TextBlock Text="{x:Bind MessageToShow, Mode=OneWay}" Grid.Column="1" TextTrimming="CharacterEllipsis" Foreground="{ThemeResource SystemErrorTextColor}">
-                                                <ToolTipService.ToolTip>
-                                                    <ToolTip IsEnabled="{x:Bind IsMessageTrimmed, Mode=OneWay}" Content="{x:Bind MessageToShow}"/>
-                                                </ToolTipService.ToolTip>
-                                                <i:Interaction.Behaviors>
-                                                    <ic:EventTriggerBehavior EventName="IsTextTrimmedChanged">
-                                                        <ic:InvokeCommandAction Command="{x:Bind TextTrimmedCommand}"/>
-                                                    </ic:EventTriggerBehavior>
-                                                 </i:Interaction.Behaviors>
-                                            </TextBlock>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ListView.ItemTemplate>
-                            </ListView>
+                            <TextBlock
+                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_Summary"
+                                Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Text="{x:Bind ViewModel.ConfigurationUnitStats}"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{ThemeResource CaptionTextBlockStyle}" />
                         </Grid>
+                        <ScrollViewer Grid.Row="1" VerticalScrollMode="Auto">
+                            <ItemsRepeater ItemsSource="{x:Bind ViewModel.ConfigurationUnitResults, Mode=OneWay}">
+                                <ItemsRepeater.Resources>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="FontFamily" Value="{StaticResource CascadiaMonoFontFamily}"/>
+                                        <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                        <Setter Property="LineHeight" Value="20"/>
+                                        <Setter Property="TextWrapping" Value="Wrap"/>
+                                        <Setter Property="IsTextSelectionEnabled" Value="True"/>
+                                    </Style>
+                                </ItemsRepeater.Resources>
+                                <ItemsRepeater.ItemTemplate>
+                                    <DataTemplate x:DataType="viewModels:ConfigurationUnitResultViewModel">
+                                        <StackPanel>
+                                            <TextBlock Text="{x:Bind Title}"/>
+                                            <StackPanel Margin="20,0,0,0">
+                                                <TextBlock Text="{x:Bind ApplyResult}">
+                                                    <i:Interaction.Behaviors>
+                                                        <ic:DataTriggerBehavior Binding="{x:Bind IsError}" Value="True">
+                                                            <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorCriticalBrush}"/>
+                                                        </ic:DataTriggerBehavior>
+                                                        <ic:DataTriggerBehavior Binding="{x:Bind IsSkipped}" Value="True">
+                                                            <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorCautionBrush}"/>
+                                                        </ic:DataTriggerBehavior>
+                                                    </i:Interaction.Behaviors>
+                                                </TextBlock>
+                                                <TextBlock Text="{x:Bind ErrorDescription}"
+                                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                           Visibility="{x:Bind ErrorDescription, Converter={StaticResource StringVisibilityConverter}}"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsRepeater.ItemTemplate>
+                            </ItemsRepeater>
+                        </ScrollViewer>
                     </Grid>
-                <!-- Number of apps and repos cloned.  Show if not failed tasks-->
-                    <Grid Grid.Row="0" Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource NegatedCollectionVisibilityConverter}}"
-                        HorizontalAlignment="Stretch" 
-                        Padding="0,15,0,30"
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
-                        <Grid.ColumnDefinitions>
+
+                    <!-- Next steps section -->
+                    <ContentControl Grid.Column="1" Template="{ThemeResource LinksTemplate}" />
+                </Grid>
+
+                <!-- Results/NextSteps/List of repos/List of apps -->
+                <Grid
+                    Grid.Row="2"
+                    Visibility="{x:Bind ViewModel.ShowConfigurationUnitResults, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
+                    ColumnSpacing="50">
+                    <Grid.ColumnDefinitions>
+                        <!-- repos cloned/apps downloaded and next steps column -->
+                        <ColumnDefinition/>
+                        <!-- Clone repos list and apps downloaded list-->
+                        <ColumnDefinition Width="1.77*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Numbers of tasks ran and next steps.-->
+                    <!-- Or, if any tasks failed, failed tasks and next steps.-->
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <!-- Show any failed tasks if the loading screen has any failed tasks-->
+                        <Grid Grid.Row="0" Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}"
+                            HorizontalAlignment="Stretch" 
+                            Padding="0,15,0,30"
+                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
+                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="50"/>
+                                    <RowDefinition Height="132"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition/>
+                                    <ColumnDefinition/>
+                                </Grid.ColumnDefinitions>
+                                <!-- message with how many errors-->
+                                <Grid Grid.Row="0" Grid.Column="0">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition/>
+                                        <RowDefinition/>
+                                    </Grid.RowDefinitions>
+                                    <TextBlock Text="Error logs" Grid.Row="0" Grid.Column="0" Margin="0, 5, 0, 0"/>
+                                    <StackPanel Orientation="Horizontal" Spacing="5" Grid.Row="1" Grid.Column="0">
+                                        <TextBlock Text="{x:Bind ViewModel.FailedTasks.Count}" Foreground="{ThemeResource TextFillColorSecondary}"/>
+                                        <TextBlock Text="installation errors" Foreground="{ThemeResource TextFillColorSecondary}"/>
+                                    </StackPanel>
+                                </Grid>
+                                <HyperlinkButton Content="View log" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{x:Bind ViewModel.ShowLogFilesCommand, Mode=OneWay}"/>
+                                <ListView Grid.Row="1" Grid.ColumnSpan="2" SelectionMode="None" ItemsSource="{x:Bind ViewModel.FailedTasks, Mode=OneWay}" ItemContainerStyle="{ThemeResource ListViewItemStretchStyle}">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="viewModels:SummaryErrorMessageViewModel">
+                                            <Grid ColumnSpacing="5" Margin="0">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="18"/>
+                                                    <ColumnDefinition/>
+                                                </Grid.ColumnDefinitions>
+                                                <ImageIcon
+                                                     Source="{x:Bind StatusSymbolIcon, Mode=OneWay}" Grid.Column="0"/>
+                                                <TextBlock Text="{x:Bind MessageToShow, Mode=OneWay}" Grid.Column="1" TextTrimming="CharacterEllipsis" Foreground="{ThemeResource SystemErrorTextColor}">
+                                                    <ToolTipService.ToolTip>
+                                                        <ToolTip IsEnabled="{x:Bind IsMessageTrimmed, Mode=OneWay}" Content="{x:Bind MessageToShow}"/>
+                                                    </ToolTipService.ToolTip>
+                                                    <i:Interaction.Behaviors>
+                                                        <ic:EventTriggerBehavior EventName="IsTextTrimmedChanged">
+                                                            <ic:InvokeCommandAction Command="{x:Bind TextTrimmedCommand}"/>
+                                                        </ic:EventTriggerBehavior>
+                                                     </i:Interaction.Behaviors>
+                                                </TextBlock>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </Grid>
+                        </Grid>
+                        <!-- Number of apps and repos cloned. Show if not failed tasks-->
+                        <Grid Grid.Row="0" Visibility="{x:Bind ViewModel.FailedTasks, Mode=OneWay, Converter={StaticResource NegatedCollectionVisibilityConverter}}"
+                            HorizontalAlignment="Stretch" 
+                            Padding="0,15,0,30"
+                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
+                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
+                            <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource EmptyCollectionWillNotSpanColumnsConverter}}"/>
                                 <ColumnDefinition Width="{x:Bind ViewModel.RepositoriesCloned, Converter={StaticResource EmptyCollectionWillNotSpanColumnsConverter}}"/>
                             </Grid.ColumnDefinitions>
@@ -267,11 +268,11 @@
                                 <RowDefinition />
                                 <RowDefinition />
                             </Grid.RowDefinitions>
-                        <Grid
-                            Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}"
-                            Grid.Column="0"
-                            HorizontalAlignment="Center">
-                            <Grid.RowDefinitions>
+                            <Grid
+                                Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}"
+                                Grid.Column="0"
+                                HorizontalAlignment="Center">
+                                <Grid.RowDefinitions>
                                     <RowDefinition/>
                                     <RowDefinition/>
                                 </Grid.RowDefinitions>
@@ -311,138 +312,139 @@
                                 Command="{x:Bind ViewModel.GoToDashboardCommand, Mode=OneWay}" 
                                 Style="{StaticResource AccentButtonStyle}"
                                 Margin="0, 50, 0, 0"/>
+                        </Grid>
+                        <!-- Next steps section -->
+                        <ContentControl Grid.Row="1" Template="{ThemeResource LinksTemplate}" />
                     </Grid>
-                    <!-- Next steps section -->
-                    <ContentControl Grid.Row="1" Template="{ThemeResource LinksTemplate}" />
+
+                    <!-- Displays the repos cloned and apps downloaded -->
+                    <StackPanel Grid.Column="1" Orientation="Vertical" x:Name="TaskGroupSections">
+                        <StackPanel.Resources>
+                            <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
+                            <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent" />
+                            <SolidColorBrush x:Key="ExpanderContentBackground" Color="Transparent" />
+                            <SolidColorBrush x:Key="ExpanderContentBorderBrush" Color="Transparent" />
+                            <Style TargetType="Expander">
+                                <Setter Property="IsExpanded" Value="True"/>
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            </Style>
+                        </StackPanel.Resources>
+
+                        <!-- Repos cloned -->
+                        <Grid Padding="0,13" Visibility="{x:Bind ViewModel.RepositoriesCloned, Converter={StaticResource CollectionVisibilityConverter}}"
+                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
+                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
+                            <Expander MaxHeight="200">
+                                <Expander.Header>
+                                    <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
+                                </Expander.Header>
+                                <ListView ItemsSource="{x:Bind ViewModel.RepositoriesCloned, Mode=OneWay}" SelectionMode="None">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="models:RepoViewListItem">
+                                            <Grid Margin="0, 10, 0, 0" ColumnSpacing="5">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="auto"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                </Grid.ColumnDefinitions>
+                                                <FontIcon Grid.Column="0" FontSize="16"  FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
+                                                <TextBlock 
+                                                    Grid.Column="1"
+                                                    Text="{x:Bind RepoName}"
+                                                    Margin="5 0 0 0"
+                                                    TextWrapping="Wrap"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </Expander>
+                        </Grid>
+
+                        <!-- Apps downloaded -->
+                        <Grid 
+                            Padding="0,12"
+                            Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}"
+                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
+                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
+                            <Expander>
+                                <Expander.Header>
+                                    <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_AppsDownlodedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12"/>
+                                </Expander.Header>
+                                <GridView ItemsSource="{x:Bind ViewModel.AppsDownloaded, Mode=OneWay}" SelectionMode="None">
+                                    <GridView.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal" />
+                                        </ItemsPanelTemplate>
+                                    </GridView.ItemsPanel>
+                                    <GridView.ItemTemplate>
+                                        <DataTemplate x:DataType="viewModels:PackageViewModel">
+                                            <controls:PackageDetailsSettingsCard Width="250" Padding="5">
+                                                <ToolTipService.ToolTip>
+                                                    <controls:PackageDetailsTooltip Package="{x:Bind}" />
+                                                </ToolTipService.ToolTip>
+                                                <controls:PackageDetailsSettingsCard.Header>
+                                                    <TextBlock Style="{ThemeResource AppManagementPackageTitleTextBlock}" Text="{x:Bind PackageTitle}" />
+                                                </controls:PackageDetailsSettingsCard.Header>
+                                                <controls:PackageDetailsSettingsCard.Description>
+                                                    <TextBlock Style="{ThemeResource AppManagementPackageDescriptionTextBlock}" Text="{x:Bind PackageFullDescription}" />
+                                                </controls:PackageDetailsSettingsCard.Description>
+                                                <controls:PackageDetailsSettingsCard.HeaderIcon>
+                                                    <ImageIcon Source="{x:Bind Icon}"/>
+                                                </controls:PackageDetailsSettingsCard.HeaderIcon>
+                                            </controls:PackageDetailsSettingsCard>
+                                        </DataTemplate>
+                                    </GridView.ItemTemplate>
+                                </GridView>
+                            </Expander>
+                        </Grid>
+
+                        <!-- Installation notes -->
+                        <Grid 
+                            Padding="0,12"
+                            Visibility="{x:Bind ViewModel.AppsDownloadedInstallationNotes, Converter={StaticResource CollectionVisibilityConverter}}"
+                            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
+                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
+                            <Expander>
+                                <Expander.Header>
+                                    <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12">Installation Notes</TextBlock>
+                                </Expander.Header>
+                                <ListView SelectionMode="None" ItemsSource="{x:Bind ViewModel.AppsDownloadedInstallationNotes}">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="viewModels:PackageViewModel">
+                                            <Grid ColumnSpacing="12" Margin="0,0,0,4" CornerRadius="8" Padding="18,20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <ImageIcon Width="24" VerticalAlignment="Top" Source="{x:Bind Icon}"/>
+                                                <StackPanel Grid.Column="1">
+                                                    <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="{x:Bind PackageTitle}"/>
+                                                    <TextBlock
+                                                        MaxLines="2"
+                                                        IsTextSelectionEnabled="True"
+                                                        TextWrapping="WrapWholeWords"
+                                                        TextTrimming="WordEllipsis"
+                                                        IsTextTrimmedChanged="InstallationNotes_IsTextTrimmedChanged"
+                                                        Tag="{Binding ElementName=ViewAllButton}"
+                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                        Text="{x:Bind InstallationNotes}"/>
+                                                    <HyperlinkButton
+                                                        Name="ViewAllButton"
+                                                        Visibility="Collapsed"
+                                                        Click="ViewAllButton_Click"
+                                                        Style="{ThemeResource TextBlockButtonStyle}"
+                                                        x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ViewAll"
+                                                        Tag="{x:Bind}"/>
+                                                </StackPanel>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </Expander>
+                        </Grid>
+                    </StackPanel>
                 </Grid>
-
-                <!-- Displays the repos cloned and apps downloaded -->
-                <StackPanel Grid.Column="1" Orientation="Vertical" x:Name="TaskGroupSections">
-                    <StackPanel.Resources>
-                        <Thickness x:Key="ExpanderHeaderBorderThickness">0</Thickness>
-                        <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent" />
-                        <SolidColorBrush x:Key="ExpanderContentBackground" Color="Transparent" />
-                        <SolidColorBrush x:Key="ExpanderContentBorderBrush" Color="Transparent" />
-                        <Style TargetType="Expander">
-                            <Setter Property="IsExpanded" Value="True"/>
-                            <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                        </Style>
-                    </StackPanel.Resources>
-
-                    <!-- Repos cloned -->
-                    <Grid Padding="0,13" Visibility="{x:Bind ViewModel.RepositoriesCloned, Converter={StaticResource CollectionVisibilityConverter}}"
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
-                        <Expander MaxHeight="200">
-                            <Expander.Header>
-                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
-                            </Expander.Header>
-                            <ListView ItemsSource="{x:Bind ViewModel.RepositoriesCloned, Mode=OneWay}" SelectionMode="None">
-                                <ListView.ItemTemplate>
-                                    <DataTemplate x:DataType="models:RepoViewListItem">
-                                        <Grid Margin="0, 10, 0, 0" ColumnSpacing="5">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="auto"/>
-                                                <ColumnDefinition Width="*"/>
-                                            </Grid.ColumnDefinitions>
-                                            <FontIcon Grid.Column="0" FontSize="16"  FontFamily="{StaticResource DevHomeFluentIcons}" Glyph="{x:Bind IsPrivate, Mode=OneWay, Converter={StaticResource BoolToGlyphConverter}}"/>
-                                            <TextBlock 
-                                                Grid.Column="1"
-                                                Text="{x:Bind RepoName}"
-                                                Margin="5 0 0 0"
-                                                TextWrapping="Wrap"/>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ListView.ItemTemplate>
-                            </ListView>
-                        </Expander>
-                    </Grid>
-
-                    <!-- Apps downloaded -->
-                    <Grid 
-                        Padding="0,12"
-                        Visibility="{x:Bind ViewModel.AppsDownloaded, Converter={StaticResource CollectionVisibilityConverter}}"
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
-                        <Expander>
-                            <Expander.Header>
-                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_AppsDownlodedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12"/>
-                            </Expander.Header>
-                            <GridView ItemsSource="{x:Bind ViewModel.AppsDownloaded, Mode=OneWay}" SelectionMode="None">
-                                <GridView.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal" />
-                                    </ItemsPanelTemplate>
-                                </GridView.ItemsPanel>
-                                <GridView.ItemTemplate>
-                                    <DataTemplate x:DataType="viewModels:PackageViewModel">
-                                        <controls:PackageDetailsSettingsCard Width="250" Padding="5">
-                                            <ToolTipService.ToolTip>
-                                                <controls:PackageDetailsTooltip Package="{x:Bind}" />
-                                            </ToolTipService.ToolTip>
-                                            <controls:PackageDetailsSettingsCard.Header>
-                                                <TextBlock Style="{ThemeResource AppManagementPackageTitleTextBlock}" Text="{x:Bind PackageTitle}" />
-                                            </controls:PackageDetailsSettingsCard.Header>
-                                            <controls:PackageDetailsSettingsCard.Description>
-                                                <TextBlock Style="{ThemeResource AppManagementPackageDescriptionTextBlock}" Text="{x:Bind PackageFullDescription}" />
-                                            </controls:PackageDetailsSettingsCard.Description>
-                                            <controls:PackageDetailsSettingsCard.HeaderIcon>
-                                                <ImageIcon Source="{x:Bind Icon}"/>
-                                            </controls:PackageDetailsSettingsCard.HeaderIcon>
-                                        </controls:PackageDetailsSettingsCard>
-                                    </DataTemplate>
-                                </GridView.ItemTemplate>
-                            </GridView>
-                        </Expander>
-                    </Grid>
-
-                    <!-- Installation notes -->
-                    <Grid 
-                        Padding="0,12"
-                        Visibility="{x:Bind ViewModel.AppsDownloadedInstallationNotes, Converter={StaticResource CollectionVisibilityConverter}}"
-                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                        BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
-                        <Expander>
-                            <Expander.Header>
-                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Padding="0,12">Installation Notes</TextBlock>
-                            </Expander.Header>
-                            <ListView SelectionMode="None" ItemsSource="{x:Bind ViewModel.AppsDownloadedInstallationNotes}">
-                                <ListView.ItemTemplate>
-                                    <DataTemplate x:DataType="viewModels:PackageViewModel">
-                                        <Grid ColumnSpacing="12" Margin="0,0,0,4" CornerRadius="8" Padding="18,20" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="auto" />
-                                                <ColumnDefinition Width="*" />
-                                            </Grid.ColumnDefinitions>
-                                            <ImageIcon Width="24" VerticalAlignment="Top" Source="{x:Bind Icon}"/>
-                                            <StackPanel Grid.Column="1">
-                                                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="{x:Bind PackageTitle}"/>
-                                                <TextBlock
-                                                    MaxLines="2"
-                                                    IsTextSelectionEnabled="True"
-                                                    TextWrapping="WrapWholeWords"
-                                                    TextTrimming="WordEllipsis"
-                                                    IsTextTrimmedChanged="InstallationNotes_IsTextTrimmedChanged"
-                                                    Tag="{Binding ElementName=ViewAllButton}"
-                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                    Text="{x:Bind InstallationNotes}"/>
-                                                <HyperlinkButton
-                                                    Name="ViewAllButton"
-                                                    Visibility="Collapsed"
-                                                    Click="ViewAllButton_Click"
-                                                    Style="{ThemeResource TextBlockButtonStyle}"
-                                                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ViewAll"
-                                                    Tag="{x:Bind}"/>
-                                            </StackPanel>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ListView.ItemTemplate>
-                            </ListView>
-                        </Expander>
-                    </Grid>
-                </StackPanel>
             </Grid>
-        </Grid>
+        </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Summary of the pull request

Moves scrollbars on all appropriate pages to the far side of the window
![image](https://github.com/microsoft/devhome/assets/47155823/c091d421-1cfa-4b6b-a635-b6fb8c5a18bb)

I would specifically like folks with pages I'm less familiar with to check that their flows look ok with this change (checking out the branch would be great). There was quite a bit of change in the SetupFlow and Environments areas and I wan to be sure I got every sub-page. @AmelBawa-msft @dhoehna @bbonaby 

I tried to leave other code alone where I could (ie. replacing a StackPanel with an unnecessary grid so that everything inside of it wouldn't change indent in SetupFlow MainPage) but couldn't avoid it everywhere (all the indentation changes in SummaryView)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #566
- [ ] Tests added/passed
- [ ] Documentation updated
