### PR TITLE
[Hyper-V extension] Use OOP WinGet object. Update or install Desktop App Installer package during Hyper-V Configure workflow if needed.

### DIFF
--- a/HyperVExtension/src/DevSetupAgent/Requests/RequestFactory.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/RequestFactory.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.ServiceModel.Channels;
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using Windows.Storage;
 
 namespace HyperVExtension.DevSetupAgent;
 

--- a/HyperVExtension/src/DevSetupEngine/ApplyConfigurationProgressWatcher.cs
+++ b/HyperVExtension/src/DevSetupEngine/ApplyConfigurationProgressWatcher.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using HyperVExtension.DevSetupEngine.ConfigurationResultTypes;
-using Microsoft.CodeAnalysis.Emit;
 using Windows.Foundation;
 
 using DevSetupEngineTypes = Microsoft.Windows.DevHome.DevSetupEngine;
@@ -23,6 +22,14 @@ internal sealed class ApplyConfigurationProgressWatcher
     public ApplyConfigurationProgressWatcher(IProgress<DevSetupEngineTypes.IConfigurationSetChangeData> progress)
     {
         _progress = progress;
+    }
+
+    public void Report(ConfigurationSetChangeData configurationSetChangeData)
+    {
+        if (_progress != null)
+        {
+            _progress.Report(configurationSetChangeData);
+        }
     }
 
     internal void Watcher(IAsyncOperationWithProgress<WinGet.ApplyConfigurationSetResult, WinGet.ConfigurationSetChangeData> operation, WinGet.ConfigurationSetChangeData data)

--- a/HyperVExtension/src/DevSetupEngine/ApplyConfigurationResult.cs
+++ b/HyperVExtension/src/DevSetupEngine/ApplyConfigurationResult.cs
@@ -97,7 +97,7 @@ public class OpenConfigurationSetResult : IOpenConfigurationSetResult
 [ComDefaultInterface(typeof(IConfigurationUnit))]
 public class ConfigurationUnit : IConfigurationUnit
 {
-    public ConfigurationUnit(string type, string identifier, DevSetupEngineTypes.ConfigurationUnitState state, bool isGroup, IList<IConfigurationUnit>? units, ValueSet settings, ConfigurationUnitIntent intent)
+    public ConfigurationUnit(string type, string identifier, DevSetupEngineTypes.ConfigurationUnitState state, bool isGroup, IList<IConfigurationUnit>? units, ValueSet? settings, ConfigurationUnitIntent intent)
     {
         Type = type;
         Identifier = identifier;
@@ -193,14 +193,14 @@ public class ApplyConfigurationUnitResult : IApplyConfigurationUnitResult
 [ComDefaultInterface(typeof(IApplyConfigurationSetResult))]
 public class ApplyConfigurationSetResult : IApplyConfigurationSetResult
 {
-    public ApplyConfigurationSetResult(Exception? resultCode, IReadOnlyList<IApplyConfigurationUnitResult> unitResults)
+    public ApplyConfigurationSetResult(Exception? resultCode, IReadOnlyList<IApplyConfigurationUnitResult>? unitResults)
     {
         ResultCode = resultCode;
         UnitResults = unitResults;
     }
 
     // Results for each configuration unit in the set.
-    public IReadOnlyList<IApplyConfigurationUnitResult> UnitResults { get; }
+    public IReadOnlyList<IApplyConfigurationUnitResult>? UnitResults { get; }
 
     // The overall result from applying the configuration set.
     public Exception? ResultCode { get; }

--- a/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
+++ b/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Buffers;
+using System;
 using Microsoft.Management.Configuration;
-using Microsoft.Management.Configuration.Processor;
-using Microsoft.Management.Configuration.SetProcessorFactory;
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Store.Preview.InstallControl;
+using Windows.Foundation;
+using Windows.Media.Playback;
 using Windows.Storage.Streams;
-using WinRT;
 using DevSetupEngineTypes = Microsoft.Windows.DevHome.DevSetupEngine;
 using WinGet = Microsoft.Management.Configuration;
 
@@ -18,6 +19,8 @@ namespace HyperVExtension.DevSetupEngine;
 /// </summary>
 public class ConfigurationFileHelper
 {
+    private const string PowerShellHandlerIdentifier = "pwsh";
+
     public class ApplicationResult
     {
         public WinGet.ApplyConfigurationSetResult Result
@@ -44,34 +47,130 @@ public class ConfigurationFileHelper
     {
     }
 
+    private static async Task InstallOrUpdateAppInstallerIfNeeded(IProgress<DevSetupEngineTypes.IConfigurationSetChangeData> progress)
+    {
+        const string AppInstallerPackageName = "Microsoft.DesktopAppInstaller";
+        const string AppInstallerPackageFamilyName = "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe";
+        const string AppInstallerStoreId = "9NBLGGH4NNS1";
+
+        var doInstall = false;
+        Windows.Management.Deployment.PackageManager packageManager = new();
+        var currentInstallerPackage = packageManager.FindPackagesForUser(string.Empty, AppInstallerPackageFamilyName).FirstOrDefault();
+        if (currentInstallerPackage == null)
+        {
+            doInstall = true;
+        }
+        else
+        {
+            if (!IsAppInstallerUpdateNeeded(currentInstallerPackage))
+            {
+                return;
+            }
+        }
+
+        AppInstallManager installManager = new();
+        var progressWatcher = new ApplyConfigurationProgressWatcher(progress);
+        var configurationSetChangeData = GetConfigurationSetChangeData(AppInstallerPackageName, DevSetupEngineTypes.ConfigurationUnitState.Pending, string.Empty);
+        progressWatcher.Report(configurationSetChangeData);
+
+        AppInstallItem? installItem;
+        if (doInstall)
+        {
+            installItem = await installManager.StartAppInstallAsync(AppInstallerStoreId, null, true, false);
+        }
+        else
+        {
+            installItem = await installManager.UpdateAppByPackageFamilyNameAsync(AppInstallerPackageFamilyName);
+        }
+
+        if (installItem == null)
+        {
+            throw new PackageOperationException(PackageOperationException.ErrorCode.DevSetupErrorUpdateNotApplicable, $"Failed to search for {AppInstallerPackageName} updates");
+        }
+
+        CancellationTokenSource cancellationToken = new();
+        TypedEventHandler<AppInstallItem, object> completedHandler = (sender, args) =>
+        {
+            configurationSetChangeData = GetConfigurationSetChangeData(AppInstallerPackageName, DevSetupEngineTypes.ConfigurationUnitState.Completed);
+            progressWatcher.Report(configurationSetChangeData);
+            cancellationToken.Cancel();
+        };
+
+        TypedEventHandler<AppInstallItem, object> statusChangedHandler = (sender, args) =>
+        {
+            configurationSetChangeData = GetConfigurationSetChangeData(AppInstallerPackageName, DevSetupEngineTypes.ConfigurationUnitState.InProgress);
+            progressWatcher.Report(configurationSetChangeData);
+        };
+
+        try
+        {
+            installItem.InstallInProgressToastNotificationMode = AppInstallationToastNotificationMode.NoToast;
+            installItem.CompletedInstallToastNotificationMode = AppInstallationToastNotificationMode.NoToast;
+            installItem.Completed += completedHandler;
+            installItem.StatusChanged += statusChangedHandler;
+
+#if DEBUG
+            // In debug mode report more often and with extended description.
+            var installStatus = installItem.GetCurrentStatus();
+            cancellationToken.CancelAfter(TimeSpan.FromMinutes(15));
+            while (!installStatus.ReadyForLaunch &&
+                   !cancellationToken.IsCancellationRequested &&
+                   (installStatus.InstallState != AppInstallState.Error) &&
+                   (installStatus.InstallState != AppInstallState.Canceled))
+            {
+                installStatus = installItem.GetCurrentStatus();
+                var description = GetInstallStatusDescription(installStatus);
+                configurationSetChangeData = GetConfigurationSetChangeData(AppInstallerPackageName, DevSetupEngineTypes.ConfigurationUnitState.InProgress, description);
+                progressWatcher.Report(configurationSetChangeData);
+                await Task.Delay(5000);
+                installStatus = installItem.GetCurrentStatus();
+            }
+#else
+            try
+            {
+                await Task.Delay((int)TimeSpan.FromMinutes(15).TotalMilliseconds, cancellationToken.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected
+            }
+
+            var installStatus = installItem.GetCurrentStatus();
+            Logging.Logger()?.ReportInfo($"{AppInstallerPackageName} installation status: {installStatus}");
+            if (installStatus.InstallState != AppInstallState.Completed)
+            {
+                throw new PackageOperationException(PackageOperationException.ErrorCode.DevSetupErrorMsStoreInstallFailed, $"Failed to install {AppInstallerPackageName} updates");
+            }
+#endif
+        }
+        finally
+        {
+            installItem.Completed -= completedHandler;
+            installItem.StatusChanged -= statusChangedHandler;
+        }
+    }
+
     /// <summary>
     /// Open configuration set from the provided <paramref name="content"/>.
     /// </summary>
     /// <param name="content">DSC configuration file content</param>
-    private ConfigurationResultTypes.OpenConfigurationSetResult OpenConfigurationSet(string content)
+    private async Task<ConfigurationResultTypes.OpenConfigurationSetResult> OpenConfigurationSet(string content)
     {
         try
         {
-            var modulesPath = Path.Combine(AppContext.BaseDirectory, @"runtimes\win\lib\net8.0\Modules");
-            var externalModulesPath = Path.Combine(AppContext.BaseDirectory, "ExternalModules");
+            ConfigurationStaticFunctions config = new();
+            var factory = await config.CreateConfigurationSetProcessorFactoryAsync(PowerShellHandlerIdentifier).AsTask();
 
-            PowerShellConfigurationSetProcessorFactory pwshFactory = new PowerShellConfigurationSetProcessorFactory();
-            pwshFactory.Policy = PowerShellConfigurationProcessorPolicy.Unrestricted;
-            pwshFactory.AdditionalModulePaths = new List<string>() { modulesPath, externalModulesPath };
-            Logging.Logger()?.ReportInfo($"Additional module paths: {string.Join(", ", pwshFactory.AdditionalModulePaths)}");
-
-            _processor = new ConfigurationProcessor(pwshFactory);
-            _processor.MinimumLevel = WinGet.DiagnosticLevel.Verbose;
-            _processor.Diagnostics += (sender, args) => LogConfigurationDiagnostics(args);
-            _processor.Caller = nameof(DevSetupEngine);
+            // Create and configure the configuration processor.
+            var processor = config.CreateConfigurationProcessor(factory);
+            processor.Caller = nameof(DevSetupEngine);
+            processor.Diagnostics += (sender, args) => LogConfigurationDiagnostics(args);
+            processor.MinimumLevel = DiagnosticLevel.Verbose;
+            _processor = processor;
 
             var inputStream = StringToStream(content);
             var openResult = _processor.OpenConfigurationSet(inputStream);
-            _configSet = openResult.Set;
-            if (_configSet == null)
-            {
-                throw new OpenConfigurationSetException(openResult);
-            }
+            _configSet = openResult.Set ?? throw new OpenConfigurationSetException(openResult);
 
             return new ConfigurationResultTypes.OpenConfigurationSetResult(openResult.ResultCode, openResult.Field, openResult.Value, openResult.Line, openResult.Column);
         }
@@ -97,63 +196,81 @@ public class ConfigurationFileHelper
 
     private async Task<DevSetupEngineTypes.IApplyConfigurationSetResult> ApplyConfigurationSetAsync(IProgress<DevSetupEngineTypes.IConfigurationSetChangeData> progress)
     {
-        if (_processor == null || _configSet == null)
+        try
         {
-            throw new InvalidOperationException();
+            if (_processor == null || _configSet == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            Logging.Logger()?.ReportInfo("Starting to apply configuration set");
+            var applySetOperation = _processor.ApplySetAsync(_configSet, WinGet.ApplyConfigurationSetFlags.None);
+            var progressWatcher = new ApplyConfigurationProgressWatcher(progress);
+            applySetOperation.Progress += progressWatcher.Watcher;
+            var result = await applySetOperation;
+
+            Logging.Logger()?.ReportInfo($"Apply configuration finished. HResult: {result.ResultCode?.HResult}");
+
+            var unitResults = new List<DevSetupEngineTypes.IApplyConfigurationUnitResult>();
+            foreach (var unitResult in result.UnitResults)
+            {
+                var unit = new ConfigurationResultTypes.ConfigurationUnit(
+                    unitResult.Unit.Type,
+                    unitResult.Unit.Identifier,
+                    (DevSetupEngineTypes.ConfigurationUnitState)unitResult.Unit.State,
+                    false,
+                    null,
+                    unitResult.Unit.Settings,
+                    (DevSetupEngineTypes.ConfigurationUnitIntent)unitResult.Unit.Intent);
+
+                var resultInfo = new ConfigurationResultTypes.ConfigurationUnitResultInformation(
+                    unitResult.ResultInformation.ResultCode,
+                    unitResult.ResultInformation.Description,
+                    unitResult.ResultInformation.Details,
+                    (DevSetupEngineTypes.ConfigurationUnitResultSource)unitResult.ResultInformation.ResultSource);
+
+                var configurationUnitResult = new ConfigurationResultTypes.ApplyConfigurationUnitResult(
+                    unit,
+                    (DevSetupEngineTypes.ConfigurationUnitState)unitResult.State,
+                    unitResult.PreviouslyInDesiredState,
+                    unitResult.RebootRequired,
+                    resultInfo);
+
+                unitResults.Add(configurationUnitResult);
+            }
+
+            var applyConfigurationSetResult = new ConfigurationResultTypes.ApplyConfigurationSetResult(result.ResultCode, unitResults);
+
+            return applyConfigurationSetResult;
         }
-
-        Logging.Logger()?.ReportInfo("Starting to apply configuration set");
-        var applySetOperation = _processor.ApplySetAsync(_configSet, WinGet.ApplyConfigurationSetFlags.None);
-        var progressWatcher = new ApplyConfigurationProgressWatcher(progress);
-        applySetOperation.Progress += progressWatcher.Watcher;
-        var result = await applySetOperation;
-
-        Logging.Logger()?.ReportInfo($"Apply configuration finished. HResult: {result.ResultCode?.HResult}");
-
-        var unitResults = new List<DevSetupEngineTypes.IApplyConfigurationUnitResult>();
-        foreach (var unitResult in result.UnitResults)
+        catch (Exception ex)
         {
-            var unit = new ConfigurationResultTypes.ConfigurationUnit(
-                unitResult.Unit.Type,
-                unitResult.Unit.Identifier,
-                (DevSetupEngineTypes.ConfigurationUnitState)unitResult.Unit.State,
-                false,
-                null,
-                unitResult.Unit.Settings,
-                (DevSetupEngineTypes.ConfigurationUnitIntent)unitResult.Unit.Intent);
-
-            var resultInfo = new ConfigurationResultTypes.ConfigurationUnitResultInformation(
-                unitResult.ResultInformation.ResultCode,
-                unitResult.ResultInformation.Description,
-                unitResult.ResultInformation.Details,
-                (DevSetupEngineTypes.ConfigurationUnitResultSource)unitResult.ResultInformation.ResultSource);
-
-            var configurationUnitResult = new ConfigurationResultTypes.ApplyConfigurationUnitResult(
-                unit,
-                (DevSetupEngineTypes.ConfigurationUnitState)unitResult.State,
-                unitResult.PreviouslyInDesiredState,
-                unitResult.RebootRequired,
-                resultInfo);
-
-            unitResults.Add(configurationUnitResult);
+            return new ConfigurationResultTypes.ApplyConfigurationSetResult(ex, null);
         }
-
-        var applyConfigurationSetResult = new ConfigurationResultTypes.ApplyConfigurationSetResult(result.ResultCode, unitResults);
-
-        return applyConfigurationSetResult;
     }
 
     public async Task<DevSetupEngineTypes.IApplyConfigurationResult> ApplyConfigurationAsync(string content, IProgress<DevSetupEngineTypes.IConfigurationSetChangeData> progress)
     {
-        var openConfigurationSetResult = OpenConfigurationSet(content);
-        if (openConfigurationSetResult.ResultCode != null)
+        DevSetupEngineTypes.IOpenConfigurationSetResult? openConfigurationSetResult = default;
+        DevSetupEngineTypes.IApplyConfigurationSetResult? applyConfigurationResult = default;
+        try
         {
-            return new ConfigurationResultTypes.ApplyConfigurationResult(openConfigurationSetResult.ResultCode, string.Empty, openConfigurationSetResult, null);
+            await InstallOrUpdateAppInstallerIfNeeded(progress);
+
+            openConfigurationSetResult = await OpenConfigurationSet(content);
+            if (openConfigurationSetResult.ResultCode != null)
+            {
+                return new ConfigurationResultTypes.ApplyConfigurationResult(openConfigurationSetResult.ResultCode, string.Empty, openConfigurationSetResult, null);
+            }
+
+            var applyConfigurationSetResult = await ApplyConfigurationSetAsync(progress);
+
+            return new ConfigurationResultTypes.ApplyConfigurationResult(applyConfigurationSetResult.ResultCode, string.Empty, openConfigurationSetResult, applyConfigurationSetResult);
         }
-
-        var applyConfigurationSetResult = await ApplyConfigurationSetAsync(progress);
-
-        return new ConfigurationResultTypes.ApplyConfigurationResult(applyConfigurationSetResult.ResultCode, string.Empty, openConfigurationSetResult, applyConfigurationSetResult);
+        catch (Exception ex)
+        {
+            return new ConfigurationResultTypes.ApplyConfigurationResult(ex, ex.Message, openConfigurationSetResult, applyConfigurationResult);
+        }
     }
 
     private void LogConfigurationDiagnostics(WinGet.IDiagnosticInformation diagnosticInformation)
@@ -201,4 +318,110 @@ public class ConfigurationFileHelper
         result.Seek(0);
         return result;
     }
+
+    /// <summary>
+    /// Check if the App Installer needs to be updated.
+    /// </summary>
+    /// <param name="currentInstallerPackage">Microsoft.DesktopAppInstaller package</param>
+    /// <returns>true if current Microsoft.DesktopAppInstaller package version is less than 1.22.10661.0</returns>
+    private static bool IsAppInstallerUpdateNeeded(Package currentInstallerPackage)
+    {
+        var packageVersion = currentInstallerPackage.Id.Version;
+        const int minMajor = 1;
+        const int minMinor = 22;
+        const int minBuild = 10661;
+
+        if (packageVersion.Major > minMajor)
+        {
+            return false;
+        }
+        else if (packageVersion.Major < minMajor)
+        {
+            return true;
+        }
+
+        if (packageVersion.Minor > minMinor)
+        {
+            return false;
+        }
+        else if (packageVersion.Minor < minMinor)
+        {
+            return true;
+        }
+
+        if (packageVersion.Build > minBuild)
+        {
+            return false;
+        }
+        else if (packageVersion.Build < minBuild)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static ConfigurationResultTypes.ConfigurationSetChangeData GetConfigurationSetChangeData(string identifier, DevSetupEngineTypes.ConfigurationUnitState unitState, string description = "")
+    {
+        var resultInfo = new ConfigurationResultTypes.ConfigurationUnitResultInformation(
+                null,
+                description,
+                string.Empty,
+                DevSetupEngineTypes.ConfigurationUnitResultSource.Precondition);
+
+        var configurationUnit = new ConfigurationResultTypes.ConfigurationUnit(
+            string.Empty,
+            identifier,
+            unitState,
+            false,
+            null,
+            null,
+            DevSetupEngineTypes.ConfigurationUnitIntent.Apply);
+
+        return new ConfigurationResultTypes.ConfigurationSetChangeData(
+            DevSetupEngineTypes.ConfigurationSetChangeEventType.UnitStateChanged,
+            DevSetupEngineTypes.ConfigurationSetState.Unknown,
+            unitState,
+            resultInfo,
+            configurationUnit);
+    }
+
+#if DEBUG
+    private static string GetInstallStatusDescription(AppInstallStatus installStatus)
+    {
+        switch (installStatus.InstallState)
+        {
+            case AppInstallState.Completed:
+                return "Status: Completed";
+            case AppInstallState.ReadyToDownload:
+                return "Status: Ready To Download";
+            case AppInstallState.Starting:
+                return "Status: Starting";
+            case AppInstallState.Installing:
+                return $"Status: Installing ({installStatus.PercentComplete}%)";
+            case AppInstallState.Downloading:
+                return $"Status: Downloading ({installStatus.PercentComplete}%)";
+            case AppInstallState.AcquiringLicense:
+                return "Status: Acquiring license";
+            case AppInstallState.Pending:
+                return "Status: Pending";
+            case AppInstallState.RestoringData:
+                return "Status: Restoring Data";
+            case AppInstallState.Paused:
+                return "Status: Paused";
+            case AppInstallState.Error:
+                return "Status: Error";
+            case AppInstallState.Canceled:
+                return "Status: Canceled";
+            case AppInstallState.PausedLowBattery:
+                return "Status: Paused low battery";
+            case AppInstallState.PausedWiFiRecommended:
+                return "Status: Paused WiFi Recommended";
+            case AppInstallState.PausedWiFiRequired:
+                return "Status: Paused WiFi Required";
+            default:
+                return "Status: Unknown";
+        }
+    }
+#endif
 }

--- a/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
+++ b/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
@@ -128,7 +128,7 @@ public class ConfigurationFileHelper
 #else
             try
             {
-                await Task.Delay((int)TimeSpan.FromMinutes(15).TotalMilliseconds, cancellationToken.Token);
+                await Task.Delay(TimeSpan.FromMinutes(15), cancellationToken.Token);
             }
             catch (TaskCanceledException)
             {

--- a/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
+++ b/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Management.Configuration;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Store.Preview.InstallControl;
 using Windows.Foundation;
-using Windows.Media.Playback;
 using Windows.Storage.Streams;
 using DevSetupEngineTypes = Microsoft.Windows.DevHome.DevSetupEngine;
 using WinGet = Microsoft.Management.Configuration;

--- a/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
+++ b/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
@@ -29,14 +29,31 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
-    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration" Version="1.7.10091-preview" />
 
+    <!--
+    Microsoft.WindowsPackageManager.ComInterop nuget targets .NET Framework:
+    https://www.nuget.org/packages/Microsoft.WindowsPackageManager.ComInterop#readme-body-tab
+    To workaround this issue in this .net project:
+    - Suppress warning 1701 (Package not compatible)
+    - Do not include nuget assets
+    - Generate a property for this package so the path can be referenced
+    - Copy the WINMD to the $(TargetDir) before the build starts
+    - Feed the $(TargetDir)\WINMD path to CsWinRT in order to generate the projected classes
+    NOTE: Suppressing the warning only is not enough as this will cause CoreClrInitFailure (0x80008089) error.
+    -->
+    <PackageReference Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.7.10091-preview">
+      <NoWarn>NU1701</NoWarn>
+      <GeneratePathProperty>true</GeneratePathProperty>
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration.OutOfProc" Version="1.7.10091-preview">
+      <GeneratePathProperty>True</GeneratePathProperty>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HyperVExtension/src/DevSetupEngine/PackageOperationException.cs
+++ b/HyperVExtension/src/DevSetupEngine/PackageOperationException.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Management.Configuration;
+
+namespace HyperVExtension.DevSetupEngine;
+
+public class PackageOperationException : Exception
+{
+    public enum ErrorCode
+    {
+        DevSetupErrorUpdateNotApplicable = unchecked((int)0x8500002B),
+        DevSetupErrorMsStoreInstallFailed = unchecked((int)0x8500001E),
+    }
+
+    public PackageOperationException(ErrorCode errorCode, string message)
+        : base(message)
+    {
+        HResult = (int)errorCode;
+        Logging.Logger()?.ReportError(string.Empty, this);
+    }
+}


### PR DESCRIPTION
Replace usage of in-proc WinGet object with OOP one in Hyper-V configure workflow.
Add check for version of Microsoft.DesktopAppInstaller package installed on the target Hyper-V VM. If the version is less than 1.22.10661.0 update it to the latest in MS Store using Store APIs.

## Validation steps performed
Tested OOP WinGet and install and update of Microsoft.DesktopAppInstaller on 19041.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
