### PR TITLE
Move Extensions page to NavigationView footer

### DIFF
--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -19,13 +19,6 @@
             "icon": "f156"
           },
           {
-            "identity": "DevHome.ExtensionLibrary",
-            "assembly": "DevHome.ExtensionLibrary",
-            "viewFullName": "DevHome.ExtensionLibrary.Views.ExtensionLibraryView",
-            "viewModelFullName": "DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel",
-            "icon": "ea86"
-          },
-          {
             "experimentalFeatureIdentity": "EnvironmentsManagementPage",
             "identity": "DevHome.Environments",
             "assembly": "DevHome.Environments",

--- a/src/Services/PageService.cs
+++ b/src/Services/PageService.cs
@@ -41,9 +41,8 @@ public class PageService : IPageService
             }
         }
 
-        // Configure other pages
+        // Configure footer pages
         Configure<WhatsNewViewModel, WhatsNewPage>();
-
         this.ConfigureExtensionLibraryPages();
         this.ConfigureSettingsPages();
 

--- a/src/Views/ShellPage.xaml
+++ b/src/Views/ShellPage.xaml
@@ -62,9 +62,16 @@
                 <NavigationViewItem x:Uid="Shell_IGNORE" helpers:NavigationHelper.NavigateTo="DevHome.Settings.ViewModels.SettingsViewModel" Visibility="Collapsed"/>
             </NavigationView.MenuItems>
             <NavigationView.FooterMenuItems>
-                <NavigationViewItem x:Uid="WhatsNew" helpers:NavigationHelper.NavigateTo="DevHome.ViewModels.WhatsNewViewModel">
+                <NavigationViewItem x:Uid="WhatsNew"
+                                    helpers:NavigationHelper.NavigateTo="DevHome.ViewModels.WhatsNewViewModel">
                     <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE789;"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem x:Uid="ms-resource:///DevHome.ExtensionLibrary/Resources/NavigationPane"
+                                    helpers:NavigationHelper.NavigateTo="DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel">
+                    <NavigationViewItem.Icon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEA86;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.FooterMenuItems>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/PageExtensions.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Extensions/PageExtensions.cs
@@ -11,6 +11,7 @@ public static class PageExtensions
 {
     public static void ConfigureExtensionLibraryPages(this IPageService pageService)
     {
+        pageService.Configure<ExtensionLibraryViewModel, ExtensionLibraryView>();
         pageService.Configure<ExtensionSettingsViewModel, ExtensionSettingsPage>();
     }
 }


### PR DESCRIPTION
## Summary of the pull request
* Remove ExtensionLibrary from NavConfig.json since it no longer should show up in the top
* Add it to the footer in ShellPage
* Since it no longer gets added to the page service automatically by being in NavConfig, add ExtensionLibraryViewModel to the page service with the other page in that project.

## Validation steps performed
Locally validated.

## PR checklist
- [ ] Closes #2391
- [ ] Tests added/passed
- [ ] Documentation updated
