### PR TITLE
Environments Fix- incorrect label for Storage

### DIFF
--- a/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -527,7 +527,7 @@ public class HyperVVirtualMachine : IComputeSystem
                 {
                     ComputeSystemProperty.Create(ComputeSystemPropertyKind.CpuCount, ProcessorCount),
                     ComputeSystemProperty.Create(ComputeSystemPropertyKind.AssignedMemorySizeInBytes, MemoryAssigned),
-                    ComputeSystemProperty.Create(ComputeSystemPropertyKind.AssignedMemorySizeInBytes, totalDiskSize),
+                    ComputeSystemProperty.Create(ComputeSystemPropertyKind.StorageSizeInBytes, totalDiskSize),
                     ComputeSystemProperty.Create(ComputeSystemPropertyKind.UptimeIn100ns, Uptime),
                     ComputeSystemProperty.CreateCustom(ParentCheckpointName, _stringResource.GetLocalized(_currentCheckpointKey), null),
                 };


### PR DESCRIPTION
## Summary of the pull request
Fixes displaying Ram label instead of Storage for totalDiskSize

## References and relevant issues

Fixes: #2434


## Before
![image](https://github.com/microsoft/devhome/assets/32421608/866d567d-7a8b-4ba3-8c98-23b0adbdcdd8)

## After

![image](https://github.com/microsoft/devhome/assets/32421608/01acd525-f1e0-4498-aa58-9ec07aeb3288)


