### PR TITLE
Fix ExtensionLibrary's Uninstall MenuFlyoutItem layout

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -83,7 +83,6 @@
                                         <MenuFlyout>
                                             <MenuFlyoutItem
                                                 x:Uid="UninstallItem"
-                                                HorizontalAlignment="Center"
                                                 Command="{x:Bind UninstallButtonCommand}">
                                             </MenuFlyoutItem>
                                         </MenuFlyout>


### PR DESCRIPTION
## Summary of the pull request
The HorizontalAlignment of the MenuFlyoutItem was "Center", making the margins a little wonky when the item was being hovered over. Instead, the HorizonalAlignment should be "Stretch". Since Stretch is the default, we can remove the property altogether.

New look with even margins:
![image](https://github.com/microsoft/devhome/assets/47155823/26c8469c-a725-4177-8afc-1c1b6b9b2244)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2393
- [ ] Tests added/passed
- [ ] Documentation updated
