### PR TITLE
Fix additional scroll regions

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -31,7 +31,7 @@
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid>
-            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}" BorderBrush="Yellow" BorderThickness="1">
+            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <ContentDialog x:Name="reportBugDialog" x:Uid="Settings_Feedback_ReportBug_Dialog" HorizontalAlignment="Center" DefaultButton="Primary">
                     <Grid>
                         <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -133,7 +133,7 @@
 
         <!-- Search and sort -->
         <StackPanel Grid.Row="1" Orientation="Horizontal"
-                    MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="0,0,0,22">
+                    MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource HeaderMargin}">
             <!-- Search field -->
             <AutoSuggestBox x:Uid="SearchTextBox" x:Name="SearchTextBox" MinWidth="350" MinHeight="35" QueryIcon="Find">
                 <i:Interaction.Behaviors>
@@ -161,7 +161,7 @@
 
         <!-- Per VM/Compute System card -->
         <ScrollViewer Grid.Row="2" Style="{StaticResource EnvironmentScrollViewerStyle}">
-            <StackPanel>
+            <StackPanel Margin="{ThemeResource ContentPageMargin}">
                 <ListView
                     MaxWidth="{ThemeResource MaxPageContentWidth}"
                     ItemsSource="{x:Bind ViewModel.ComputeSystemsView}" SelectionMode="None"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
@@ -5,14 +5,11 @@
     x:Class="DevHome.ExtensionLibrary.Views.ExtensionSettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:views="using:DevHome.Common.Views"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
-    mc:Ignorable="d">
+    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -28,9 +25,8 @@
             ItemClicked="BreadcrumbBar_ItemClicked"
             ItemsSource="{x:Bind ViewModel.Breadcrumbs}" />
 
-        <ScrollViewer Grid.Row="1" VerticalAlignment="Top"
-                      MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-            <StackPanel>
+        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <views:ExtensionAdaptiveCardPanel x:Name="SettingsContent">
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="Loaded">

--- a/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Controls/SetupShell.xaml
@@ -21,7 +21,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Spacing="6" Visibility="{x:Bind HeaderVisibility, Mode=OneWay}"
-                    MaxWidth="{ThemeResource MaxPageContentWidth}">
+                    MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <!-- Title -->
             <TextBlock
                 Style="{ThemeResource SubtitleTextBlockStyle}"
@@ -99,7 +99,8 @@
                             Content="{x:Bind SetupShellContent, Mode=OneWay}" >
                 <ContentControl.Template>
                     <ControlTemplate TargetType="ContentControl">
-                        <ContentPresenter Content="{TemplateBinding Content}" MaxWidth="{ThemeResource MaxPageContentWidth}" />
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}"/>
                     </ControlTemplate>
                 </ContentControl.Template>
             </ContentControl>


### PR DESCRIPTION
## Summary of the pull request
Fix a couple things missed in #2423:
- Fix scroll regions for `ExtensionSettingsPage`
- Fix margins in SetupFlow's `SetupShell` and Environments's `LandingPage` so that the header and content isn't taking up the whole MaxWidth

And
- Removed a temporary debugging border that accidentally got left in

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #566
- [ ] Tests added/passed
- [ ] Documentation updated
