### PR TITLE
[Dev Environments] Update experiments to enable environments in Canary

### DIFF
--- a/common/Services/ComputeSystemService.cs
+++ b/common/Services/ComputeSystemService.cs
@@ -12,11 +12,25 @@ using DevHome.Common.Helpers;
 using DevHome.Common.Models;
 using DevHome.Logging;
 using Microsoft.Windows.DevHome.SDK;
+using Windows.ApplicationModel;
 
 namespace DevHome.Common.Services;
 
 public class ComputeSystemService : IComputeSystemService
 {
+    private const string DevHomePreviewPackageFamilyName = "Microsoft.Windows.DevHome_8wekyb3d8bbwe";
+
+    private const string DevHomeDevPackageFamilyName = "Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe";
+
+    private const string DevHomeCanaryPackageFamilyName = "Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe";
+
+    private readonly HashSet<string> _devHomePackageFamilyName = new()
+    {
+        DevHomePreviewPackageFamilyName,
+        DevHomeDevPackageFamilyName,
+        DevHomeCanaryPackageFamilyName,
+    };
+
     private readonly IExtensionService _extensionService;
 
     private readonly IAccountsService _accountService;
@@ -35,6 +49,17 @@ public class ComputeSystemService : IComputeSystemService
         {
             try
             {
+                // Work around for issue where the Dev Home's extension service uses classIds within a package to identify the extension, but doesn't handle
+                // multiple packages with the same extension classIds. We need to filter out the Dev Home extensions that are not within the current package.
+                // E.g the Hyper-V extension is in Dev Home Dev, Canary and preview builds, each with the same class Id.
+                // So Dev Home sees this as 3 separate extensions, causing us to query the same COM server up to 3 times depending on how many of the 3 are
+                // installed.
+                if (_devHomePackageFamilyName.Contains(extension.PackageFamilyName) &&
+                    extension.PackageFamilyName != Package.Current.Id.FamilyName)
+                {
+                    continue;
+                }
+
                 var computeSystemProviders = await extension.GetListOfProvidersAsync<IComputeSystemProvider>();
                 var extensionObj = extension.GetExtensionObject();
                 var devIdList = new List<DeveloperIdWrapper>();

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -50,8 +50,8 @@
         },
         {
           "buildType": "canary",
-          "enabledByDefault": false,
-          "visible": false
+          "enabledByDefault": true,
+          "visible": true
         },
         {
           "buildType": "release",


### PR DESCRIPTION
## Summary of the pull request
This PR makes the environments feature visible in Canary builds of Dev Home. I've also added a workaround in the `ComputeSystemService` to prevent duplicate Hyper-V VMs from being retrieved by Dev Home due to issue #2451 as this will make self-hosting easier for the Hyper-V extension. But the issue still exists for other extensions like the Azure extension with DevBoxes.


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Installed Dev Home Dev, Canary and Preview and confirmed duplicate requests were not made to the Hyper-V extension's COM server when retrieving VMs.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
