### PR TITLE
Create DataTemplate for BreadcrumbBar headers and create a Behavior for interaction with them

### DIFF
--- a/common/Behaviors/BreadcrumbNavigationBehavior.cs
+++ b/common/Behaviors/BreadcrumbNavigationBehavior.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using DevHome.Common.Helpers;
 using DevHome.Common.Models;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Xaml.Interactivity;
@@ -25,5 +26,10 @@ public class BreadcrumbNavigationBehavior : Behavior<BreadcrumbBar>
     {
         var crumb = args.Item as Breadcrumb;
         crumb?.NavigateTo();
+
+        if (crumb == null)
+        {
+            Log.Logger()?.ReportError("BreadcrumbNavigationBehavior", "BreadcrumbBarItemClickedEventArgs.Item is not a Breadcrumb");
+        }
     }
 }

--- a/common/Behaviors/BreadcrumbNavigationBehavior.cs
+++ b/common/Behaviors/BreadcrumbNavigationBehavior.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Models;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Xaml.Interactivity;
+
+namespace DevHome.Common.Behaviors;
+
+public class BreadcrumbNavigationBehavior : Behavior<BreadcrumbBar>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.ItemClicked += OnClick;
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        AssociatedObject.ItemClicked -= OnClick;
+    }
+
+    private void OnClick(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+    {
+        var crumb = args.Item as Breadcrumb;
+        crumb?.NavigateTo();
+    }
+}

--- a/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
@@ -31,16 +31,6 @@ public partial class AboutViewModel : ObservableObject
         };
     }
 
-    [RelayCommand]
-    public void BreadcrumbBarItemClicked(BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
-    }
-
     private static string GetVersionDescription()
     {
         var appInfoService = Application.Current.GetService<IAppInfoService>();

--- a/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
@@ -5,13 +5,11 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Contracts.Services;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Settings.ViewModels;
 
@@ -36,15 +34,5 @@ public partial class AccountsViewModel : ObservableObject
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),
             new(stringResource.GetLocalized("Settings_Accounts_Header"), typeof(AccountsViewModel).FullName!),
         };
-    }
-
-    [RelayCommand]
-    public void BreadcrumbBarItemClicked(BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 }

--- a/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
@@ -5,10 +5,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Settings.ViewModels;
 
@@ -28,15 +26,5 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),
             new(stringResource.GetLocalized("Settings_ExperimentalFeatures_Header"), typeof(ExperimentalFeaturesViewModel).FullName!),
         };
-    }
-
-    [RelayCommand]
-    public void BreadcrumbBarItemClicked(BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 }

--- a/settings/DevHome.Settings/ViewModels/FeedbackViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/FeedbackViewModel.cs
@@ -10,7 +10,6 @@ using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Settings.ViewModels;
 
@@ -38,16 +37,6 @@ public partial class FeedbackViewModel : ObservableObject
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),
             new(stringResource.GetLocalized("Settings_Feedback_Header"), typeof(FeedbackViewModel).FullName!),
         };
-    }
-
-    [RelayCommand]
-    public void BreadcrumbBarItemClicked(BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 
     [RelayCommand]

--- a/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
@@ -9,7 +9,6 @@ using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Settings.ViewModels;
 
@@ -33,16 +32,6 @@ public partial class PreferencesViewModel : ObservableObject
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),
             new(stringResource.GetLocalized("Settings_Preferences_Header"), typeof(PreferencesViewModel).FullName!),
         };
-    }
-
-    [RelayCommand]
-    public void BreadcrumbBarItemClicked(BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 
     [RelayCommand]

--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -3,13 +3,11 @@
 
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Settings.Models;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Settings.ViewModels;
 
@@ -42,16 +40,6 @@ public partial class SettingsViewModel : ObservableObject
         {
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),
         };
-    }
-
-    [RelayCommand]
-    public void BreadcrumbBarItemClicked(BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 
     public void Navigate(string path)

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -4,27 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
-
-    <behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
-        <DataTemplate x:DataType="viewmodels:AboutViewModel">
-            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-                <BreadcrumbBar
-                    x:Name="BreadcrumbBar"
-                    ItemsSource="{x:Bind Breadcrumbs}">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="ItemClicked">
-                            <ic:InvokeCommandAction Command="{x:Bind BreadcrumbBarItemClickedCommand}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </BreadcrumbBar>
-            </Grid>
-        </DataTemplate>
-    </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">

--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -5,8 +5,8 @@
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
-    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -7,8 +7,8 @@
     xmlns:models="using:DevHome.Settings.Models"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
-    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <Page.Resources>
         <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Collapsed" TrueValue="Visible"/>

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -4,12 +4,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:models="using:DevHome.Settings.Models"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
 
     <Page.Resources>
         <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Collapsed" TrueValue="Visible"/>
@@ -34,22 +33,6 @@
             </ctControls:SettingsCard>
         </DataTemplate>
     </Page.Resources>
-
-    <behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
-        <DataTemplate x:DataType="viewmodels:AccountsViewModel">
-            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-                <BreadcrumbBar
-                    x:Name="BreadcrumbBar"
-                    ItemsSource="{x:Bind Breadcrumbs}">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="ItemClicked">
-                            <ic:InvokeCommandAction Command="{x:Bind BreadcrumbBarItemClickedCommand}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </BreadcrumbBar>
-            </Grid>
-        </DataTemplate>
-    </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">

--- a/settings/DevHome.Settings/Views/ExperimentalFeaturesPage.xaml
+++ b/settings/DevHome.Settings/Views/ExperimentalFeaturesPage.xaml
@@ -9,8 +9,8 @@
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:models="using:DevHome.Common.Models"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
-    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <Page.Resources>
         <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Visible" TrueValue="Collapsed" />

--- a/settings/DevHome.Settings/Views/ExperimentalFeaturesPage.xaml
+++ b/settings/DevHome.Settings/Views/ExperimentalFeaturesPage.xaml
@@ -8,29 +8,13 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:models="using:DevHome.Common.Models"
-    xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
 
     <Page.Resources>
         <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Visible" TrueValue="Collapsed" />
     </Page.Resources>
-
-    <behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
-        <DataTemplate x:DataType="viewmodels:ExperimentalFeaturesViewModel">
-            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-                <BreadcrumbBar
-                    x:Name="BreadcrumbBar"
-                    ItemsSource="{x:Bind Breadcrumbs}">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="ItemClicked">
-                            <ic:InvokeCommandAction Command="{x:Bind BreadcrumbBarItemClickedCommand}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </BreadcrumbBar>
-            </Grid>
-        </DataTemplate>
-    </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -6,28 +6,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:viewmodels="using:DevHome.Settings.ViewModels"
-    xmlns:behaviors="using:DevHome.Common.Behaviors" 
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
     Loaded="Page_Loaded">
-
-    <behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
-        <DataTemplate x:DataType="viewmodels:FeedbackViewModel">
-            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-                <BreadcrumbBar
-                    x:Name="BreadcrumbBar"
-                    ItemsSource="{x:Bind Breadcrumbs}">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="ItemClicked">
-                            <ic:InvokeCommandAction Command="{x:Bind BreadcrumbBarItemClickedCommand}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </BreadcrumbBar>
-            </Grid>
-        </DataTemplate>
-    </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid>

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml
@@ -7,8 +7,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
     behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
     Loaded="Page_Loaded">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -7,8 +7,8 @@
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:xaml="using:Microsoft.UI.Xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
     behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
     Loaded="Page_Loaded">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">

--- a/settings/DevHome.Settings/Views/PreferencesPage.xaml
+++ b/settings/DevHome.Settings/Views/PreferencesPage.xaml
@@ -6,26 +6,10 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:xaml="using:Microsoft.UI.Xaml"
-    xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
     Loaded="Page_Loaded">
-
-    <behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
-        <DataTemplate x:DataType="viewmodels:PreferencesViewModel">
-            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-                <BreadcrumbBar
-                    x:Name="BreadcrumbBar"
-                    ItemsSource="{x:Bind Breadcrumbs}">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="ItemClicked">
-                            <ic:InvokeCommandAction Command="{x:Bind BreadcrumbBarItemClickedCommand}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </BreadcrumbBar>
-            </Grid>
-        </DataTemplate>
-    </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <StackPanel>

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -6,27 +6,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
-
-    <behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
-        <DataTemplate x:DataType="viewmodels:SettingsViewModel">
-            <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-                <BreadcrumbBar
-                    x:Name="BreadcrumbBar"
-                    ItemsSource="{x:Bind Breadcrumbs}">
-                    <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="ItemClicked">
-                            <ic:InvokeCommandAction Command="{x:Bind BreadcrumbBarItemClickedCommand}" />
-                        </ic:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </BreadcrumbBar>
-            </Grid>
-        </DataTemplate>
-    </behaviors:NavigationViewHeaderBehavior.HeaderTemplate>
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">

--- a/settings/DevHome.Settings/Views/SettingsPage.xaml
+++ b/settings/DevHome.Settings/Views/SettingsPage.xaml
@@ -8,8 +8,8 @@
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:viewmodels="using:DevHome.Settings.ViewModels"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
-    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}">
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">

--- a/src/Styles/BreadcrumbBar.xaml
+++ b/src/Styles/BreadcrumbBar.xaml
@@ -1,6 +1,8 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:behaviors="using:DevHome.Common.Behaviors">
 
     <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
 
@@ -15,5 +17,17 @@
 
     <!-- Applies to all items but the last (current) item -->
     <ThemeResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+
+    <DataTemplate x:Key="BreadcrumbBarDataTemplate">
+        <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+            <BreadcrumbBar
+                    x:Name="BreadcrumbBar"
+                    ItemsSource="{Binding Breadcrumbs}">
+                <i:Interaction.Behaviors>
+                    <behaviors:BreadcrumbNavigationBehavior />
+                </i:Interaction.Behaviors>
+            </BreadcrumbBar>
+        </Grid>
+    </DataTemplate>
 
 </ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request
* Create `BreadcrumbBarDataTemplate`, a template for our BreadcrumbBar headers and use it in the Settings pages to override the Default template.
* Create a Behavior `BreadcrumbNavigationBehavior` that we can set of the BreadcrumbBar to implement the navigation action

## References and relevant issues
This is the first step towards implementing #2426.