### PR TITLE
Use WinAppSDK Resource loader for all localized strings

### DIFF
--- a/HyperVExtension/src/HyperVExtension.Common/Services/StringResource.cs
+++ b/HyperVExtension/src/HyperVExtension.Common/Services/StringResource.cs
@@ -15,9 +15,9 @@ public class StringResource : IStringResource
         _resourceLoader = new ResourceLoader("HyperVExtension/Resources");
     }
 
-    public StringResource(string name)
+    public StringResource(string name, string path)
     {
-        _resourceLoader = new ResourceLoader(name);
+        _resourceLoader = new ResourceLoader(name, path);
     }
 
     /// <summary> Gets the localized string of a resource key.</summary>

--- a/HyperVExtension/src/HyperVExtension.Common/Services/StringResource.cs
+++ b/HyperVExtension/src/HyperVExtension.Common/Services/StringResource.cs
@@ -12,7 +12,7 @@ public class StringResource : IStringResource
 
     public StringResource()
     {
-        _resourceLoader = new ResourceLoader("HyperVExtension/Resources");
+        _resourceLoader = new ResourceLoader("HyperVExtension.pri", "HyperVExtension/Resources");
     }
 
     public StringResource(string name, string path)

--- a/HyperVExtension/src/HyperVExtension.Common/Services/StringResource.cs
+++ b/HyperVExtension/src/HyperVExtension.Common/Services/StringResource.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
-using Windows.ApplicationModel.Resources;
+using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace HyperVExtension.Common;
 

--- a/common/Environments/Converters/CardStateToLocalizedTextConverter.cs
+++ b/common/Environments/Converters/CardStateToLocalizedTextConverter.cs
@@ -15,7 +15,7 @@ namespace DevHome.Common.Environments.Converters;
 /// </summary>
 public class CardStateToLocalizedTextConverter : IValueConverter
 {
-    private static readonly StringResource _stringResource = new("DevHome.Common/Resources");
+    private static readonly StringResource _stringResource = new("DevHome.Common.pri", "DevHome.Common/Resources");
     private const string Prefix = "ComputeSystem";
 
     public object Convert(object value, Type targetType, object parameter, string language)

--- a/common/Environments/Helpers/StringResourceHelper.cs
+++ b/common/Environments/Helpers/StringResourceHelper.cs
@@ -9,7 +9,7 @@ namespace DevHome.Common.Environments.Helpers;
 
 public static class StringResourceHelper
 {
-    private static readonly StringResource _stringResource = new("DevHome.Common/Resources");
+    private static readonly StringResource _stringResource = new("DevHome.Common.pri", "DevHome.Common/Resources");
     private const string ComputeSystemCpu = "ComputeSystemCpu";
     private const string ComputeSystemAssignedMemory = "ComputeSystemAssignedMemory";
     private const string ComputeSystemUptime = "ComputeSystemUptime";

--- a/common/Models/ExperimentalFeature.cs
+++ b/common/Models/ExperimentalFeature.cs
@@ -47,7 +47,7 @@ public partial class ExperimentalFeature : ObservableObject
     {
         get
         {
-            var stringResource = new StringResource("DevHome.Settings/Resources");
+            var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
             return stringResource.GetLocalized(Id + "_Name");
         }
     }
@@ -56,7 +56,7 @@ public partial class ExperimentalFeature : ObservableObject
     {
         get
         {
-            var stringResource = new StringResource("DevHome.Settings/Resources");
+            var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
             return stringResource.GetLocalized(Id + "_Description");
         }
     }

--- a/common/Services/StringResource.cs
+++ b/common/Services/StringResource.cs
@@ -24,9 +24,10 @@ public class StringResource : IStringResource
     /// <inheritdoc cref="ResourceLoader.ResourceLoader(string)"/>
     /// </summary>
     /// <param name="name">fsa</param>
-    public StringResource(string name)
+    /// <param name="path">path</param>
+    public StringResource(string name, string path)
     {
-        _resourceLoader = new ResourceLoader(name);
+        _resourceLoader = new ResourceLoader(name, path);
     }
 
     /// <summary>

--- a/common/Services/StringResource.cs
+++ b/common/Services/StringResource.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
-using Windows.ApplicationModel.Resources;
+using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace DevHome.Common.Services;
 

--- a/docs/common/StringResource.md
+++ b/docs/common/StringResource.md
@@ -1,0 +1,35 @@
+# Localized strings
+
+All strings shown to the user must be localized. The `StringResource` service provides an easy way to access those strings.
+
+## Usage
+
+### Creating a localized string
+
+The project you are working in should have a directory under `Strings\en-us`, containing a file called `Resources.resw`.
+If it does not, see [Writing a tool](../tools.md#writing-a-tool).
+For information about adding strings to this file, refer to 
+[Store strings in a resources file](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/mrtcore/localize-strings#store-strings-in-a-resources-file).
+Dev Home will take care of getting localized versions of these strings.
+
+### Referencing your localized string from XAML
+
+To learn how to reference your string from XAML, see 
+[Refer to a string resource identifier from XAML](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/mrtcore/localize-strings#refer-to-a-string-resource-identifier-from-xaml).
+
+### Referencing your localized string from code
+
+While it is possible to reference your strings from code using the method in the article linked to on this page, for consistency you should use the `StringResource` service.
+You can obtain a reference to the StringResource service with the following code:
+```cs
+var stringResource = new StringResource("<your_project_name>.pri", "<your_project_name>/Resources");
+```
+For example, the DevHome.Settings project woud use
+```cs
+var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
+```
+
+Then, to get a specific string, use `StringResource.GetLocalized()`.
+```cs
+var str = stringResource.GetLocalized("MyString");
+```

--- a/docs/common/StringResource.md
+++ b/docs/common/StringResource.md
@@ -9,13 +9,13 @@ All strings shown to the user must be localized. The `StringResource` service pr
 The project you are working in should have a directory under `Strings\en-us`, containing a file called `Resources.resw`.
 If it does not, see [Writing a tool](../tools.md#writing-a-tool).
 For information about adding strings to this file, refer to 
-[Store strings in a resources file](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/mrtcore/localize-strings#store-strings-in-a-resources-file).
+[Store strings in a resources file](https://learn.microsoft.com/windows/apps/windows-app-sdk/mrtcore/localize-strings#store-strings-in-a-resources-file).
 Dev Home will take care of getting localized versions of these strings.
 
 ### Referencing your localized string from XAML
 
 To learn how to reference your string from XAML, see 
-[Refer to a string resource identifier from XAML](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/mrtcore/localize-strings#refer-to-a-string-resource-identifier-from-xaml).
+[Refer to a string resource identifier from XAML](https://learn.microsoft.com/windows/apps/windows-app-sdk/mrtcore/localize-strings#refer-to-a-string-resource-identifier-from-xaml).
 
 ### Referencing your localized string from code
 
@@ -24,7 +24,7 @@ You can obtain a reference to the StringResource service with the following code
 ```cs
 var stringResource = new StringResource("<your_project_name>.pri", "<your_project_name>/Resources");
 ```
-For example, the DevHome.Settings project woud use
+For example, the DevHome.Settings project would use
 ```cs
 var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
 ```

--- a/docs/common/StringResource.md
+++ b/docs/common/StringResource.md
@@ -31,5 +31,6 @@ var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Setting
 
 Then, to get a specific string, use `StringResource.GetLocalized()`.
 ```cs
+// Here, MyString is the "Name" of the string to be localized that you specified in the Resources.resw file
 var str = stringResource.GetLocalized("MyString");
 ```

--- a/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AboutViewModel.cs
@@ -23,7 +23,7 @@ public partial class AboutViewModel : ObservableObject
     {
         _versionDescription = GetVersionDescription();
 
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>
         {
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),

--- a/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsViewModel.cs
@@ -30,7 +30,7 @@ public partial class AccountsViewModel : ObservableObject
             AccountsProviders.Add(new AccountsProviderViewModel(devIdProvider));
         });
 
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>
         {
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),

--- a/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
@@ -22,7 +22,7 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
     {
         ExperimentalFeatures = experimentationService!.ExperimentalFeatures.Where(x => x.IsVisible).OrderBy(x => x.Id).ToList();
 
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>
         {
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),

--- a/settings/DevHome.Settings/ViewModels/FeedbackViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/FeedbackViewModel.cs
@@ -32,7 +32,7 @@ public partial class FeedbackViewModel : ObservableObject
         _elementTheme = _themeSelectorService.Theme;
         _versionDescription = GetVersionDescription();
 
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>
         {
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),

--- a/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/PreferencesViewModel.cs
@@ -27,7 +27,7 @@ public partial class PreferencesViewModel : ObservableObject
         _themeSelectorService = themeSelectorService;
         _elementTheme = _themeSelectorService.Theme;
 
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs = new ObservableCollection<Breadcrumb>
         {
             new(stringResource.GetLocalized("Settings_Header"), typeof(SettingsViewModel).FullName!),

--- a/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/SettingsViewModel.cs
@@ -22,7 +22,7 @@ public partial class SettingsViewModel : ObservableObject
 
     public SettingsViewModel()
     {
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
 
         var settings = new[]
         {

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -17,7 +17,6 @@ using DevHome.Telemetry;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.DevHome.SDK;
 using Windows.Storage;
 using WinUIEx;
@@ -47,15 +46,15 @@ public sealed partial class AccountsPage : Page
         }
         else
         {
-            var resourceLoader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "DevHome.Settings/Resources");
+            var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
             var noProvidersContentDialog = new ContentDialog
             {
-                Title = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_Title"),
-                Content = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_Content"),
-                PrimaryButtonText = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText"),
+                Title = stringResource.GetLocalized("Settings_Accounts_NoProvidersContentDialog_Title"),
+                Content = stringResource.GetLocalized("Settings_Accounts_NoProvidersContentDialog_Content"),
+                PrimaryButtonText = stringResource.GetLocalized("Settings_Accounts_NoProvidersContentDialog_PrimaryButtonText"),
                 PrimaryButtonCommand = FindExtensionsCommand,
                 PrimaryButtonStyle = (Style)Application.Current.Resources["AccentButtonStyle"],
-                SecondaryButtonText = resourceLoader.GetString("Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText"),
+                SecondaryButtonText = stringResource.GetLocalized("Settings_Accounts_NoProvidersContentDialog_SecondaryButtonText"),
                 XamlRoot = XamlRoot,
             };
             await noProvidersContentDialog.ShowAsync();
@@ -166,13 +165,13 @@ public sealed partial class AccountsPage : Page
 
     private async void Logout_Click(object sender, RoutedEventArgs e)
     {
-        var resourceLoader = new ResourceLoader(ResourceLoader.GetDefaultResourceFilePath(), "DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         var confirmLogoutContentDialog = new ContentDialog
         {
-            Title = resourceLoader.GetString("Settings_Accounts_ConfirmLogoutContentDialog_Title"),
-            Content = resourceLoader.GetString("Settings_Accounts_ConfirmLogoutContentDialog_Content"),
-            PrimaryButtonText = resourceLoader.GetString("Settings_Accounts_ConfirmLogoutContentDialog_PrimaryButtonText"),
-            SecondaryButtonText = resourceLoader.GetString("Settings_Accounts_ConfirmLogoutContentDialog_SecondaryButtonText"),
+            Title = stringResource.GetLocalized("Settings_Accounts_ConfirmLogoutContentDialog_Title"),
+            Content = stringResource.GetLocalized("Settings_Accounts_ConfirmLogoutContentDialog_Content"),
+            PrimaryButtonText = stringResource.GetLocalized("Settings_Accounts_ConfirmLogoutContentDialog_PrimaryButtonText"),
+            SecondaryButtonText = stringResource.GetLocalized("Settings_Accounts_ConfirmLogoutContentDialog_SecondaryButtonText"),
             DefaultButton = ContentDialogButton.Primary,
             XamlRoot = XamlRoot,
             RequestedTheme = ActualTheme,
@@ -193,9 +192,9 @@ public sealed partial class AccountsPage : Page
             // Confirmation of removal Content Dialog
             var afterLogoutContentDialog = new ContentDialog
             {
-                Title = resourceLoader.GetString("Settings_Accounts_AfterLogoutContentDialog_Title"),
-                Content = $"{accountToRemove.LoginId} " + resourceLoader.GetString("Settings_Accounts_AfterLogoutContentDialog_Content"),
-                CloseButtonText = resourceLoader.GetString("Settings_Accounts_AfterLogoutContentDialog_PrimaryButtonText"),
+                Title = stringResource.GetLocalized("Settings_Accounts_AfterLogoutContentDialog_Title"),
+                Content = $"{accountToRemove.LoginId} " + stringResource.GetLocalized("Settings_Accounts_AfterLogoutContentDialog_Content"),
+                CloseButtonText = stringResource.GetLocalized("Settings_Accounts_AfterLogoutContentDialog_PrimaryButtonText"),
                 XamlRoot = XamlRoot,
                 RequestedTheme = ActualTheme,
             };

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -252,7 +252,7 @@ public sealed partial class FeedbackPage : Page
         var availMemKbToGb = Math.Round(memStatus.ullAvailPhys / ByteSizeGB, 2);
         var totalMemKbToGb = Math.Round(memStatus.ullTotalPhys / ByteSizeGB, 2);
 
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         return stringResource.GetLocalized("Settings_Feedback_PhysicalMemory") + ": " + totalMemKbToGb.ToString(cultures) + "GB (" + availMemKbToGb.ToString(cultures) + "GB free)";
     }
 
@@ -260,7 +260,7 @@ public sealed partial class FeedbackPage : Page
     {
         SYSTEM_INFO sysInfo;
         PInvoke.GetSystemInfo(out sysInfo);
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         return stringResource.GetLocalized("Settings_Feedback_ProcessorArchitecture") + ": " + DetermineArchitecture((int)sysInfo.Anonymous.Anonymous.wProcessorArchitecture);
     }
 
@@ -293,7 +293,7 @@ public sealed partial class FeedbackPage : Page
     {
         var extensionService = Application.Current.GetService<IExtensionService>();
         var extensions = extensionService.GetInstalledExtensionsAsync(true).Result;
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         var extensionsStr = stringResource.GetLocalized("Settings_Feedback_Extensions") + ": \n";
         foreach (var extension in extensions)
         {
@@ -305,7 +305,7 @@ public sealed partial class FeedbackPage : Page
 
     private string GetWidgetService()
     {
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         var widgetServiceString = stringResource.GetLocalized("Settings_Feedback_WidgetService") + ": \n";
         var packageDeploymentService = Application.Current.GetService<IPackageDeploymentService>();
 

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,10 +1,11 @@
 ﻿{
-    "LocalSettingsOptions": {
-      "ApplicationDataFolder": "DevHome/ApplicationData",
-      "LocalSettingsFile": "LocalSettings.json"
-    },
-    "SetupFlowOptions": {
-      "StringResourcePath": "DevHome.SetupFlow/Resources",
-      "WinGetPackageJsonDataSourcePath": "DevHome.SetupFlow/Assets/AppManagementPackages.json"
-    }
+  "LocalSettingsOptions": {
+    "ApplicationDataFolder": "DevHome/ApplicationData",
+    "LocalSettingsFile": "LocalSettings.json"
+  },
+  "SetupFlowOptions": {
+    "StringResourceName": "DevHome.SetupFlow.pri",
+    "StringResourcePath": "DevHome.SetupFlow/Resources",
+    "WinGetPackageJsonDataSourcePath": "DevHome.SetupFlow/Assets/AppManagementPackages.json"
+  }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Common.Extensions;
+using DevHome.Common.Services;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
@@ -14,13 +15,14 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Windows.ApplicationModel.Resources;
 using Microsoft.Windows.Widgets;
 
 namespace DevHome.Dashboard.Controls;
 
 public sealed partial class WidgetControl : UserControl
 {
+    private readonly StringResource _stringResource;
+
     private SelectableMenuFlyoutItem _currentSelectedSize;
 
     public WidgetViewModel WidgetSource
@@ -45,6 +47,7 @@ public sealed partial class WidgetControl : UserControl
     public WidgetControl()
     {
         this.InitializeComponent();
+        _stringResource = new StringResource("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
         ActualThemeChanged += OnActualThemeChanged;
     }
 
@@ -59,20 +62,18 @@ public sealed partial class WidgetControl : UserControl
                 var widgetControl = widgetMenuButton.Tag as WidgetControl;
                 if (widgetControl != null && widgetControl.WidgetSource is WidgetViewModel widgetViewModel)
                 {
-                    var resourceLoader = new ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
-
-                    await AddSizesToWidgetMenuAsync(widgetMenuFlyout, widgetViewModel, resourceLoader);
+                    await AddSizesToWidgetMenuAsync(widgetMenuFlyout, widgetViewModel);
                     widgetMenuFlyout.Items.Add(new MenuFlyoutSeparator());
-                    AddCustomizeToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
-                    AddRemoveToWidgetMenu(widgetMenuFlyout, widgetViewModel, resourceLoader);
+                    AddCustomizeToWidgetMenu(widgetMenuFlyout, widgetViewModel);
+                    AddRemoveToWidgetMenu(widgetMenuFlyout, widgetViewModel);
                 }
             }
         }
     }
 
-    private void AddRemoveToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
+    private void AddRemoveToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel)
     {
-        var removeWidgetText = resourceLoader.GetString("RemoveWidgetMenuText");
+        var removeWidgetText = _stringResource.GetLocalized("RemoveWidgetMenuText");
         var icon = new FontIcon()
         {
             Glyph = "\xE77A",
@@ -116,7 +117,7 @@ public sealed partial class WidgetControl : UserControl
         }
     }
 
-    private async Task AddSizesToWidgetMenuAsync(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
+    private async Task AddSizesToWidgetMenuAsync(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel)
     {
         var widgetCatalog = await Application.Current.GetService<IWidgetHostingService>().GetWidgetCatalogAsync();
         var widgetDefinition = await Task.Run(() => widgetCatalog.GetWidgetDefinition(widgetViewModel.Widget.DefinitionId));
@@ -129,7 +130,7 @@ public sealed partial class WidgetControl : UserControl
             var menuItemSmall = new SelectableMenuFlyoutItem
             {
                 Tag = WidgetSize.Small,
-                Text = resourceLoader.GetString("SmallWidgetMenuText"),
+                Text = _stringResource.GetLocalized("SmallWidgetMenuText"),
             };
             menuItemSmall.Click += OnMenuItemSizeClick;
             widgetMenuFlyout.Items.Add(menuItemSmall);
@@ -141,7 +142,7 @@ public sealed partial class WidgetControl : UserControl
             var menuItemMedium = new SelectableMenuFlyoutItem
             {
                 Tag = WidgetSize.Medium,
-                Text = resourceLoader.GetString("MediumWidgetMenuText"),
+                Text = _stringResource.GetLocalized("MediumWidgetMenuText"),
             };
             menuItemMedium.Click += OnMenuItemSizeClick;
             widgetMenuFlyout.Items.Add(menuItemMedium);
@@ -153,7 +154,7 @@ public sealed partial class WidgetControl : UserControl
             var menuItemLarge = new SelectableMenuFlyoutItem
             {
                 Tag = WidgetSize.Large,
-                Text = resourceLoader.GetString("LargeWidgetMenuText"),
+                Text = _stringResource.GetLocalized("LargeWidgetMenuText"),
             };
             menuItemLarge.Click += OnMenuItemSizeClick;
             widgetMenuFlyout.Items.Add(menuItemLarge);
@@ -202,11 +203,11 @@ public sealed partial class WidgetControl : UserControl
         peer.Select();
     }
 
-    private void AddCustomizeToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel, ResourceLoader resourceLoader)
+    private void AddCustomizeToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel)
     {
         if (widgetViewModel.IsCustomizable)
         {
-            var customizeWidgetText = resourceLoader.GetString("CustomizeWidgetMenuText");
+            var customizeWidgetText = _stringResource.GetLocalized("CustomizeWidgetMenuText");
             var icon = new FontIcon()
             {
                 Glyph = "\xE70F",

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -8,6 +8,7 @@ using AdaptiveCards.Rendering.WinUI3;
 using AdaptiveCards.Templating;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Renderers;
+using DevHome.Common.Services;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.TelemetryEvents;
@@ -249,7 +250,7 @@ public partial class WidgetViewModel : ObservableObject
 
     private Grid GetErrorCard(string error, string subError = null)
     {
-        var resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
+        var stringResource = new StringResource("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
 
         var grid = new Grid
         {
@@ -267,7 +268,7 @@ public partial class WidgetViewModel : ObservableObject
             HorizontalAlignment = HorizontalAlignment.Center,
             TextWrapping = TextWrapping.WrapWholeWords,
             FontWeight = FontWeights.Bold,
-            Text = resourceLoader.GetString(error),
+            Text = stringResource.GetLocalized(error),
         };
         sp.Children.Add(errorText);
 
@@ -277,7 +278,7 @@ public partial class WidgetViewModel : ObservableObject
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
                 TextWrapping = TextWrapping.WrapWholeWords,
-                Text = resourceLoader.GetString(subError),
+                Text = stringResource.GetLocalized(subError),
                 Margin = new Thickness(0, 12, 0, 0),
             };
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -13,6 +13,7 @@ using DevHome.Common;
 using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
+using DevHome.Common.Services;
 using DevHome.Dashboard.Controls;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
@@ -391,14 +392,11 @@ public partial class DashboardView : ToolPage, IDisposable
             {
                 Log.Logger()?.ReportWarn("AddWidgetDialog", $"Creating widget failed: ", ex);
                 var mainWindow = Application.Current.GetService<WindowEx>();
-                var resourceLoader =
-                    new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader(
-                        "DevHome.Dashboard.pri",
-                        "DevHome.Dashboard/Resources");
+                var stringResource = new StringResource("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
                 await mainWindow.ShowErrorMessageDialogAsync(
                     title: string.Empty,
-                    content: resourceLoader.GetString("CouldNotCreateWidgetError"),
-                    buttonText: resourceLoader.GetString("CloseButtonText"));
+                    content: stringResource.GetLocalized("CouldNotCreateWidgetError"),
+                    buttonText: stringResource.GetLocalized("CloseButtonText"));
             }
         }
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
@@ -67,7 +67,7 @@ public partial class ExtensionSettingsViewModel : ObservableObject
 
     public void FillBreadcrumbBar(string lastCrumbName)
     {
-        var stringResource = new StringResource("DevHome.Settings/Resources");
+        var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs.Add(new(stringResource.GetLocalized("Settings_Extensions_Header"), typeof(ExtensionLibraryViewModel).FullName!));
         Breadcrumbs.Add(new Breadcrumb(lastCrumbName, typeof(ExtensionSettingsViewModel).FullName!));
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -128,9 +128,9 @@ public partial class InstalledPackageViewModel : ObservableObject
 
     public string GeneratePackageDetails(PackageVersion version, string publisher, DateTimeOffset installedDate)
     {
-        var resourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader("DevHome.ExtensionLibrary.pri", "DevHome.ExtensionLibrary/Resources");
-        var versionLabel = resourceLoader.GetString("Version");
-        var lastUpdatedLabel = resourceLoader.GetString("LastUpdated");
+        var stringResource = new StringResource("DevHome.ExtensionLibrary.pri", "DevHome.ExtensionLibrary/Resources");
+        var versionLabel = stringResource.GetLocalized("Version");
+        var lastUpdatedLabel = stringResource.GetLocalized("LastUpdated");
 
         var versionString = $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
 

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/ViewModels/QuietBackgroundProcessesViewModel.cs
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/ViewModels/QuietBackgroundProcessesViewModel.cs
@@ -42,7 +42,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
 
     private string GetString(string id)
     {
-        var stringResource = new StringResource("DevHome.QuietBackgroundProcesses.UI/Resources");
+        var stringResource = new StringResource("DevHome.QuietBackgroundProcesses.UI.pri", "DevHome.QuietBackgroundProcesses.UI/Resources");
         return stringResource.GetLocalized(id);
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/SetupFlowOptions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/SetupFlowOptions.cs
@@ -8,6 +8,11 @@ namespace DevHome.SetupFlow.Services;
 /// </summary>
 public class SetupFlowOptions
 {
+    public string StringResourceName
+    {
+        get; set;
+    }
+
     /// <summary>
     /// Gets or sets the string resource map path for the setup flow project
     /// </summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/SetupFlowStringResource.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/SetupFlowStringResource.cs
@@ -14,7 +14,7 @@ namespace DevHome.SetupFlow.Services;
 public class SetupFlowStringResource : StringResource, ISetupFlowStringResource
 {
     public SetupFlowStringResource(IOptions<SetupFlowOptions> setupFlowOptions)
-        : base(setupFlowOptions.Value.StringResourcePath)
+        : base(setupFlowOptions.Value.StringResourceName, setupFlowOptions.Value.StringResourcePath)
     {
     }
 


### PR DESCRIPTION
## Summary of the pull request
Our code was split between using WinAppSDK's `Microsoft.Windows.ApplicationModel.Resources` and UWP's `Windows.ApplicationModel.Resources`. Use WinAppSDK's version everywhere.

This required passing in not just the resource map, but also the resource context to the ResourceLoader constructors.

Once StringResource was using the WinAppSDK version, swap the instances that used WinAppSDK directly to use StringResource for consistency.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2465
- [ ] Tests added/passed
- [ ] Documentation updated
