### PR TITLE
Added Schedule to the environments launch button

### DIFF
--- a/common/Environments/Models/ComputeSystem.cs
+++ b/common/Environments/Models/ComputeSystem.cs
@@ -183,6 +183,20 @@ public class ComputeSystem
         }
     }
 
+    public async Task<ComputeSystemOperationResult> ScheduleAsync(string options)
+    {
+        try
+        {
+            // placeholder until ComputerSystem.ScheduleAsync is implemented in the sdk
+            return await _computeSystem.ShutDownAsync(options);
+        }
+        catch (Exception ex)
+        {
+            Log.Logger()?.ReportError(_componentName, $"ScheduleAsync for: {this} failed due to exception", ex);
+            return new ComputeSystemOperationResult(ex, errorString, ex.Message);
+        }
+    }
+
     public async Task<ComputeSystemOperationResult> CreateSnapshotAsync(string options)
     {
         try

--- a/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
@@ -58,6 +58,12 @@ public class DataExtractor
             operations.Add(new OperationsViewModel("Stop", "\uE71A", computeSystem.TerminateAsync));
         }
 
+        // if (supportedOperations.HasFlag(ComputeSystemOperations.Schedule))
+        // {
+        //    operations.Add(new OperationsViewModel("Schedule", "\uEC92", computeSystem.ScheduleAsync));
+        // }
+        operations.Add(new OperationsViewModel("Schedule", "\uEC92", computeSystem.ScheduleAsync));
+
         if (supportedOperations.HasFlag(ComputeSystemOperations.CreateSnapshot))
         {
             operations.Add(new OperationsViewModel("Checkpoint", "\uE7C1", computeSystem.CreateSnapshotAsync));

--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -137,5 +196,9 @@
   <data name="SortSelectionComboBox.PlaceholderText" xml:space="preserve">
     <value>None</value>
     <comment>Text for the default selection of the sort drop down</comment>
+  </data>
+  <data name="ScheduleButtonContextMenuItem" xml:space="preserve">
+    <value>Schedule</value>
+    <comment>Text for Schedule button in the context menu that will open a bunch of task schedulers for the virtual machine</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request

Implements Scheduling tasks for environments. Such tasks include Turnoff, shutdown etc etc.

At present, only the UI change has been implemented. At present the button just fires the shutdown command until either myself or someone else implements the scheduling code.

![image](https://github.com/microsoft/devhome/assets/32421608/80dfb0dc-a364-4bdd-ab15-14805de70864)

## References and relevant issues
https://github.com/microsoft/devhome/issues/2463
## Detailed description of the pull request / Additional comments

- Only UI change
- Need to figure out how to add Scheduling as the IComputeSystem interface in the DevHome SDK does not contain ScheduleAsync
## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
