### PR TITLE
Opt ExtensionSettingsPage into new header behavior

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
@@ -9,7 +9,6 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Common.Views;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 
@@ -67,19 +66,10 @@ public partial class ExtensionSettingsViewModel : ObservableObject
         await Task.CompletedTask;
     }
 
-    public void FillBreadcrumbBar(string lastCrumbName)
+    private void FillBreadcrumbBar(string lastCrumbName)
     {
         var stringResource = new StringResource("DevHome.Settings.pri", "DevHome.Settings/Resources");
         Breadcrumbs.Add(new(stringResource.GetLocalized("Settings_Extensions_Header"), typeof(ExtensionLibraryViewModel).FullName!));
         Breadcrumbs.Add(new Breadcrumb(lastCrumbName, typeof(ExtensionSettingsViewModel).FullName!));
-    }
-
-    public void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
-    {
-        if (args.Index < Breadcrumbs.Count - 1)
-        {
-            var crumb = (Breadcrumb)args.Item;
-            crumb.NavigateTo();
-        }
     }
 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -5,16 +5,13 @@
     x:Class="DevHome.ExtensionLibrary.Views.ExtensionLibraryView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:viewmodels="using:DevHome.ExtensionLibrary.ViewModels"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:commonviews="using:DevHome.Common.Views"
-    mc:Ignorable="d">
+    xmlns:commonviews="using:DevHome.Common.Views">
     <i:Interaction.Behaviors>
         <ic:EventTriggerBehavior EventName="Loaded">
             <ic:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand}" />

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
@@ -5,27 +5,15 @@
     x:Class="DevHome.ExtensionLibrary.Views.ExtensionSettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:views="using:DevHome.Common.Views"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Never">
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <BreadcrumbBar
-            MaxWidth="{ThemeResource MaxPageContentWidth}"
-            Padding="{ThemeResource ContentPageMargin}"
-            x:Name="BreadcrumbBar"
-            Margin="0,0,0,16"
-            ItemClicked="BreadcrumbBar_ItemClicked"
-            ItemsSource="{x:Bind ViewModel.Breadcrumbs}" />
-
-        <ScrollViewer Grid.Row="1" VerticalAlignment="Top">
+        <ScrollViewer VerticalAlignment="Top">
             <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <views:ExtensionAdaptiveCardPanel x:Name="SettingsContent">
                     <i:Interaction.Behaviors>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml.cs
@@ -10,19 +10,11 @@ namespace DevHome.ExtensionLibrary.Views;
 
 public sealed partial class ExtensionSettingsPage : Page
 {
-    public ExtensionSettingsViewModel ViewModel
-    {
-        get;
-    }
+    public ExtensionSettingsViewModel ViewModel { get; }
 
     public ExtensionSettingsPage()
     {
         ViewModel = Application.Current.GetService<ExtensionSettingsViewModel>();
         this.InitializeComponent();
-    }
-
-    private void BreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
-    {
-        ViewModel.BreadcrumbBar_ItemClicked(sender, args);
     }
 }


### PR DESCRIPTION
## Summary of the pull request
The ExtensionSettingsPage was left out of #2453. Opt the page into the new header behavior.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated locally, everything should look and behave the same.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
