### PR TITLE
Removing graph from small sized widgets and other tweaks

### DIFF
--- a/extensions/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
+++ b/extensions/CoreWidgetProvider/Widgets/Templates/SystemCPUUsageTemplate.json
@@ -23,6 +23,7 @@
           "url": "${cpuGraphUrl}",
           "height": "${chartHeight}",
           "width": "${chartWidth}",
+          "$when": "${$host.widgetSize != \"small\"}",
           "horizontalAlignment": "center"
         },
         {
@@ -64,25 +65,31 @@
           ]
         },
         {
-          "type": "TextBlock",
-          "isSubtle": true,
-          "text": "%CPUUsage_Widget_Template/Processes%",
-          "wrap": true
-        },
-        {
-          "type": "TextBlock",
-          "size": "medium",
-          "text": "${cpuProc1}"
-        },
-        {
-          "type": "TextBlock",
-          "size": "medium",
-          "text": "${cpuProc2}"
-        },
-        {
-          "type": "TextBlock",
-          "size": "medium",
-          "text": "${cpuProc3}"
+          "type": "Container",
+          "$when": "${$host.widgetSize != \"small\"}",
+          "items": [
+            {
+              "type": "TextBlock",
+              "isSubtle": true,
+              "text": "%CPUUsage_Widget_Template/Processes%",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "size": "medium",
+              "text": "${cpuProc1}"
+            },
+            {
+              "type": "TextBlock",
+              "size": "medium",
+              "text": "${cpuProc2}"
+            },
+            {
+              "type": "TextBlock",
+              "size": "medium",
+              "text": "${cpuProc3}"
+            }
+          ]
         }
       ]
     }

--- a/extensions/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
+++ b/extensions/CoreWidgetProvider/Widgets/Templates/SystemGPUUsageTemplate.json
@@ -23,6 +23,7 @@
           "url": "${gpuGraphUrl}",
           "height": "${chartHeight}",
           "width": "${chartWidth}",
+          "$when": "${$host.widgetSize != \"small\"}",
           "horizontalAlignment": "center"
         },
         {

--- a/extensions/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
+++ b/extensions/CoreWidgetProvider/Widgets/Templates/SystemMemoryTemplate.json
@@ -23,6 +23,7 @@
           "url": "${memGraphUrl}",
           "height": "${chartHeight}",
           "width": "${chartWidth}",
+          "$when": "${$host.widgetSize != \"small\"}",
           "horizontalAlignment": "center"
         },
         {
@@ -40,7 +41,7 @@
                 {
                   "text": "${usedMem}",
                   "type": "TextBlock",
-                  "size": "large",
+                  "size": "${if($host.widgetSize == \"small\", \"medium\", \"large\")}",
                   "weight": "bolder"
                 }
               ]
@@ -58,7 +59,7 @@
                 {
                   "text": "${allMem}",
                   "type": "TextBlock",
-                  "size": "large",
+                  "size": "${if($host.widgetSize == \"small\", \"medium\", \"large\")}",
                   "weight": "bolder",
                   "horizontalAlignment": "right"
                 }
@@ -107,6 +108,7 @@
         },
         {
           "type": "ColumnSet",
+          "$when": "${$host.widgetSize == \"large\"}",
           "columns": [
             {
               "type": "Column",
@@ -146,6 +148,7 @@
         },
         {
           "type": "ColumnSet",
+          "$when": "${$host.widgetSize != \"small\"}",
           "columns": [
             {
               "type": "Column",

--- a/extensions/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
+++ b/extensions/CoreWidgetProvider/Widgets/Templates/SystemNetworkUsageTemplate.json
@@ -23,6 +23,7 @@
           "url": "${netGraphUrl}",
           "height": "${chartHeight}",
           "width": "${chartWidth}",
+          "$when": "${$host.widgetSize != \"small\"}",
           "horizontalAlignment": "center"
         },
         {


### PR DESCRIPTION
## Summary of the pull request
 When in small size, the widgets have very limited space to show meaningful information. The graph ends up occupying most of the space and make it impossible to see the actual data without scrolling. This change disables the graph from when the widgets are in small size and also adds some small changes to better use the space available.
## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/49359135/
## Detailed description of the pull request / Additional comments
On every core widget, the small size now does not show the generated graph. 

For the CPU widget, the small size also does not show the list of most expensive proccess.
![image](https://github.com/microsoft/devhome/assets/13912953/f77e62f3-4c57-4a6b-bcaa-8d462fae11d5)

For the Memory widget, the paged memory will only be shown on the large size and the percentage of memory used only on medium and large size. Also, it uses an smaller font size when the widget size is small to avoid scrolling.
![image](https://github.com/microsoft/devhome/assets/13912953/d754016f-762c-4a6e-bc7b-d1ece5fdf10f)
![image](https://github.com/microsoft/devhome/assets/13912953/eebbd7a3-a59f-48f6-9e44-d8e581c4b13b)

The GPU and Network widgets are still the same on all sizes, with further design changes needed as it still have the scroll enabled.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
