### PR TITLE
Cache widget icons on demand

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
@@ -11,13 +11,9 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetIconService
 {
-    public Task CacheAllWidgetIconsAsync();
-
-    public Task AddIconsToCacheAsync(WidgetDefinition widgetDef);
-
     public void RemoveIconsFromCache(string definitionId);
 
-    public Task<BitmapImage> GetWidgetIconForThemeAsync(WidgetDefinition widgetDefinition, ElementTheme theme);
+    public Task<BitmapImage> GetIconFromCache(WidgetDefinition widgetDefinition, ElementTheme theme);
 
     public Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
@@ -13,7 +13,7 @@ public interface IWidgetIconService
 {
     public void RemoveIconsFromCache(string definitionId);
 
-    public Task<BitmapImage> GetIconFromCache(WidgetDefinition widgetDefinition, ElementTheme theme);
+    public Task<BitmapImage> GetIconFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme theme);
 
     public Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
@@ -12,5 +12,5 @@ public interface IWidgetScreenshotService
 {
     public void RemoveScreenshotsFromCache(string definitionId);
 
-    public Task<BitmapImage> GetScreenshotFromCache(WidgetDefinition widgetDefinition, ElementTheme actualTheme);
+    public Task<BitmapImage> GetScreenshotFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme actualTheme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
@@ -10,5 +10,7 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetScreenshotService
 {
+    public void RemoveScreenshotsFromCache(string definitionId);
+
     public Task<BitmapImage> GetScreenshotFromCache(WidgetDefinition widgetDefinition, ElementTheme actualTheme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -37,7 +37,7 @@ public class WidgetIconService : IWidgetIconService
         _widgetDarkIconCache.Remove(definitionId);
     }
 
-    public async Task<BitmapImage> GetIconFromCache(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public async Task<BitmapImage> GetIconFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
         var widgetDefinitionId = widgetDefinition.Id;
         BitmapImage bitmapImage;
@@ -74,7 +74,7 @@ public class WidgetIconService : IWidgetIconService
 
     public async Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
     {
-        var image = await GetIconFromCache(widgetDefinition, theme);
+        var image = await GetIconFromCacheAsync(widgetDefinition, theme);
 
         var brush = new ImageBrush
         {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -20,21 +20,21 @@ public class WidgetIconService : IWidgetIconService
 
     private readonly WindowEx _windowEx;
 
-    private readonly Dictionary<string, BitmapImage> _widgetLightIconCache;
-    private readonly Dictionary<string, BitmapImage> _widgetDarkIconCache;
+    private readonly ConcurrentDictionary<string, BitmapImage> _widgetLightIconCache;
+    private readonly ConcurrentDictionary<string, BitmapImage> _widgetDarkIconCache;
 
     public WidgetIconService(WindowEx windowEx)
     {
         _windowEx = windowEx;
 
-        _widgetLightIconCache = new Dictionary<string, BitmapImage>();
-        _widgetDarkIconCache = new Dictionary<string, BitmapImage>();
+        _widgetLightIconCache = new ConcurrentDictionary<string, BitmapImage>();
+        _widgetDarkIconCache = new ConcurrentDictionary<string, BitmapImage>();
     }
 
     public void RemoveIconsFromCache(string definitionId)
     {
-        _widgetLightIconCache.Remove(definitionId);
-        _widgetDarkIconCache.Remove(definitionId);
+        _widgetLightIconCache.TryRemove(definitionId, out _);
+        _widgetDarkIconCache.TryRemove(definitionId, out _);
     }
 
     public async Task<BitmapImage> GetIconFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme theme)

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
@@ -28,6 +28,12 @@ public class WidgetScreenshotService : IWidgetScreenshotService
         _widgetDarkScreenshotCache = new Dictionary<string, BitmapImage>();
     }
 
+    public void RemoveScreenshotsFromCache(string definitionId)
+    {
+        _widgetLightScreenshotCache.Remove(definitionId);
+        _widgetDarkScreenshotCache.Remove(definitionId);
+    }
+
     public async Task<BitmapImage> GetScreenshotFromCache(WidgetDefinition widgetDefinition, ElementTheme actualTheme)
     {
         var widgetDefinitionId = widgetDefinition.Id;
@@ -61,12 +67,6 @@ public class WidgetScreenshotService : IWidgetScreenshotService
         }
 
         return bitmapImage;
-    }
-
-    public void RemoveScreenshotsFromCache(string definitionId)
-    {
-        _widgetLightScreenshotCache.Remove(definitionId);
-        _widgetDarkScreenshotCache.Remove(definitionId);
     }
 
     private async Task<BitmapImage> WidgetScreenshotToBitmapImageAsync(IRandomAccessStreamReference iconStreamRef)

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,21 +18,21 @@ public class WidgetScreenshotService : IWidgetScreenshotService
 {
     private readonly WindowEx _windowEx;
 
-    private readonly Dictionary<string, BitmapImage> _widgetLightScreenshotCache;
-    private readonly Dictionary<string, BitmapImage> _widgetDarkScreenshotCache;
+    private readonly ConcurrentDictionary<string, BitmapImage> _widgetLightScreenshotCache;
+    private readonly ConcurrentDictionary<string, BitmapImage> _widgetDarkScreenshotCache;
 
     public WidgetScreenshotService(WindowEx windowEx)
     {
         _windowEx = windowEx;
 
-        _widgetLightScreenshotCache = new Dictionary<string, BitmapImage>();
-        _widgetDarkScreenshotCache = new Dictionary<string, BitmapImage>();
+        _widgetLightScreenshotCache = new ConcurrentDictionary<string, BitmapImage>();
+        _widgetDarkScreenshotCache = new ConcurrentDictionary<string, BitmapImage>();
     }
 
     public void RemoveScreenshotsFromCache(string definitionId)
     {
-        _widgetLightScreenshotCache.Remove(definitionId);
-        _widgetDarkScreenshotCache.Remove(definitionId);
+        _widgetLightScreenshotCache.Remove(definitionId, out _);
+        _widgetDarkScreenshotCache.Remove(definitionId, out _);
     }
 
     public async Task<BitmapImage> GetScreenshotFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme actualTheme)

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
@@ -34,7 +34,7 @@ public class WidgetScreenshotService : IWidgetScreenshotService
         _widgetDarkScreenshotCache.Remove(definitionId);
     }
 
-    public async Task<BitmapImage> GetScreenshotFromCache(WidgetDefinition widgetDefinition, ElementTheme actualTheme)
+    public async Task<BitmapImage> GetScreenshotFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme actualTheme)
     {
         var widgetDefinitionId = widgetDefinition.Id;
         BitmapImage bitmapImage;

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
@@ -41,7 +41,7 @@ public partial class AddWidgetViewModel : ObservableObject
     public async Task SetWidgetDefinition(WidgetDefinition selectedWidgetDefinition)
     {
         _selectedWidgetDefinition = selectedWidgetDefinition;
-        var bitmap = await _widgetScreenshotService.GetScreenshotFromCache(selectedWidgetDefinition, _themeSelectorService.GetActualTheme());
+        var bitmap = await _widgetScreenshotService.GetScreenshotFromCacheAsync(selectedWidgetDefinition, _themeSelectorService.GetActualTheme());
 
         WidgetDisplayTitle = selectedWidgetDefinition.DisplayTitle;
         WidgetProviderDisplayTitle = selectedWidgetDefinition.ProviderDefinition.DisplayName;
@@ -68,7 +68,7 @@ public partial class AddWidgetViewModel : ObservableObject
         {
             // Update the preview image for the selected widget.
             var theme = _themeSelectorService.GetActualTheme();
-            var bitmap = await _widgetScreenshotService.GetScreenshotFromCache(_selectedWidgetDefinition, theme);
+            var bitmap = await _widgetScreenshotService.GetScreenshotFromCacheAsync(_selectedWidgetDefinition, theme);
             WidgetScreenshot = new ImageBrush
             {
                 ImageSource = bitmap,

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -13,6 +13,8 @@ public partial class DashboardViewModel : ObservableObject
 
     public IWidgetIconService WidgetIconService { get; }
 
+    public IWidgetScreenshotService WidgetScreenshotService { get; }
+
     [ObservableProperty]
     private bool _isLoading;
 
@@ -21,10 +23,12 @@ public partial class DashboardViewModel : ObservableObject
 
     public DashboardViewModel(
         IWidgetHostingService widgetHostingService,
-        IWidgetIconService widgetIconService)
+        IWidgetIconService widgetIconService,
+        IWidgetScreenshotService widgetScreenshotService)
     {
-        WidgetIconService = widgetIconService;
         WidgetHostingService = widgetHostingService;
+        WidgetIconService = widgetIconService;
+        WidgetScreenshotService = widgetScreenshotService;
     }
 
     public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -130,7 +130,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private async Task<StackPanel> BuildWidgetNavItem(WidgetDefinition widgetDefinition)
     {
-        var image = await _widgetIconService.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
+        var image = await _widgetIconService.GetIconFromCache(widgetDefinition, ActualTheme);
         return BuildNavItem(image, widgetDefinition.DisplayTitle);
     }
 
@@ -243,7 +243,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
             {
                 if (widgetItem.Tag is WidgetDefinition widgetDefinition)
                 {
-                    var image = await _widgetIconService.GetWidgetIconForThemeAsync(widgetDefinition, ActualTheme);
+                    var image = await _widgetIconService.GetIconFromCache(widgetDefinition, ActualTheme);
                     widgetItem.Content = BuildNavItem(image, widgetDefinition.DisplayTitle);
                 }
             }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -130,7 +130,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private async Task<StackPanel> BuildWidgetNavItem(WidgetDefinition widgetDefinition)
     {
-        var image = await _widgetIconService.GetIconFromCache(widgetDefinition, ActualTheme);
+        var image = await _widgetIconService.GetIconFromCacheAsync(widgetDefinition, ActualTheme);
         return BuildNavItem(image, widgetDefinition.DisplayTitle);
     }
 
@@ -243,7 +243,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
             {
                 if (widgetItem.Tag is WidgetDefinition widgetDefinition)
                 {
-                    var image = await _widgetIconService.GetIconFromCache(widgetDefinition, ActualTheme);
+                    var image = await _widgetIconService.GetIconFromCacheAsync(widgetDefinition, ActualTheme);
                     widgetItem.Content = BuildNavItem(image, widgetDefinition.DisplayTitle);
                 }
             }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -113,7 +113,6 @@ public partial class DashboardView : ToolPage, IDisposable
     [RelayCommand]
     private async Task OnLoadedAsync()
     {
-        Application.Current.GetService<IAdaptiveCardRenderingService>().RendererUpdated += HandleRendererUpdated;
         await InitializeDashboard();
     }
 
@@ -133,9 +132,6 @@ public partial class DashboardView : ToolPage, IDisposable
             ViewModel.HasWidgetService = true;
             if (await SubscribeToWidgetCatalogEventsAsync())
             {
-                // Cache the widget icons before we display the widgets, since we include the icons in the widgets.
-                await ViewModel.WidgetIconService.CacheAllWidgetIconsAsync();
-
                 var isFirstDashboardRun = !(await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstDashboardRun));
                 _log.Information($"Is first dashboard run = {isFirstDashboardRun}");
                 if (isFirstDashboardRun)
@@ -167,6 +163,7 @@ public partial class DashboardView : ToolPage, IDisposable
             }
         }
 
+        Application.Current.GetService<IAdaptiveCardRenderingService>().RendererUpdated += HandleRendererUpdated;
         LoadingWidgetsProgressRing.Visibility = Visibility.Collapsed;
         ViewModel.IsLoading = false;
     }
@@ -453,17 +450,14 @@ public partial class DashboardView : ToolPage, IDisposable
         });
     }
 
-    private void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args)
-        => _log.Information($"WidgetCatalog_WidgetProviderDefinitionAdded {args.ProviderDefinition.Id}");
+    private void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args) =>
+        _log.Information("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionAdded {args.ProviderDefinition.Id}");
 
-    private void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args)
-        => _log.Information($"WidgetCatalog_WidgetProviderDefinitionDeleted {args.ProviderDefinitionId}");
+    private void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args) =>
+        _log.Information("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionDeleted {args.ProviderDefinitionId}");
 
-    private async void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args)
-    {
-        _log.Information($"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-        await ViewModel.WidgetIconService.AddIconsToCacheAsync(args.Definition);
-    }
+    private void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args) =>
+        _log.Information("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
     {
@@ -534,6 +528,7 @@ public partial class DashboardView : ToolPage, IDisposable
         });
 
         ViewModel.WidgetIconService.RemoveIconsFromCache(definitionId);
+        ViewModel.WidgetScreenshotService.RemoveScreenshotsFromCache(definitionId);
     }
 
     // If a widget is removed from the list, update the saved positions of the following widgets.


### PR DESCRIPTION
## Summary of the pull request
Caching all widget icons on first Dashboard launch was time consuming and unnecessary. Instead, we should only cache when something (the WidgetControl, AddWidgetDialog) asks for it. This is already how the WidgetScreenshotService does it, so here we update WidgetIconService to match.

This should make the Dashboard load a small amount faster on Dev Home launch.

As a small addition, if a widget is uninstalled while Dev Home is running, remove that widget's screenshots from the cache. The removal code was already there but not being used.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
