### PR TITLE
Add new Breadcrumb header to Windows customization

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/DeveloperFileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DeveloperFileExplorerViewModel.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using DevHome.Common.Models;
+using DevHome.Common.Services;
 using DevHome.Customization.Models;
 using DevHome.Customization.TelemetryEvents;
 using Microsoft.Internal.Windows.DevHome.Helpers;
@@ -12,9 +15,18 @@ public partial class DeveloperFileExplorerViewModel : ObservableObject
 {
     private readonly ShellSettings _shellSettings;
 
+    public ObservableCollection<Breadcrumb> Breadcrumbs { get; }
+
     public DeveloperFileExplorerViewModel()
     {
         _shellSettings = new ShellSettings();
+
+        var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
+        Breadcrumbs =
+        [
+            new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
+            new(stringResource.GetLocalized("DeveloperFileExplorer_Header"), typeof(DeveloperFileExplorerViewModel).FullName!)
+        ];
     }
 
     public bool ShowFileExtensions

--- a/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
+using DevHome.Common.Models;
 using DevHome.Common.Services;
 using Microsoft.UI.Xaml;
 using Windows.System;
@@ -16,10 +18,15 @@ public partial class MainPageViewModel : ObservableObject
 {
     private INavigationService NavigationService { get; }
 
+    public ObservableCollection<Breadcrumb> Breadcrumbs { get; }
+
     public MainPageViewModel(
         INavigationService navigationService)
     {
         NavigationService = navigationService;
+
+        var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
+        Breadcrumbs = [new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!)];
     }
 
     [RelayCommand]

--- a/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DeveloperFileExplorerPage.xaml
@@ -3,11 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:DevHome.Customization.Views"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Always"
-    mc:Ignorable="d">
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <Grid.RowDefinitions>

--- a/tools/Customization/DevHome.Customization/Views/MainPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/MainPage.xaml
@@ -6,12 +6,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pg="using:DevHome.Common"
     xmlns:views="using:DevHome.Customization.Views"
-    behaviors:NavigationViewHeaderBehavior.HeaderMode="Always"
-    mc:Ignorable="d">
+    behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
     <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary of the pull request
Windows customization was excluded from the initial breadcrumb header introduction. This converts the two existing pages to use it with the completion of #2453 

## References and relevant issues
#2453 

## Detailed description of the pull request / Additional comments

## Validation steps performed
Built and navigated the pages, no functional changes

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
