### PR TITLE
Make CPU and Memory widgets single instance, better handle these widgets

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -139,7 +139,7 @@
                       <LightMode />
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="System_Memory" DisplayName="ms-resource:WidgetDisplayNameMemory" Description="ms-resource:WidgetDescriptionMemory" AllowMultiple="true" IsCustomizable="false">
+                  <Definition Id="System_Memory" DisplayName="ms-resource:WidgetDisplayNameMemory" Description="ms-resource:WidgetDescriptionMemory" AllowMultiple="false" IsCustomizable="false">
                     <Capabilities>
                       <Capability>
                         <Size Name="small" />
@@ -229,7 +229,7 @@
                       <LightMode />
                     </ThemeResources>
                   </Definition>
-                  <Definition Id="System_CPUUsage" DisplayName="ms-resource:WidgetDisplayNameCPU" Description="ms-resource:WidgetDescriptionCPU" AllowMultiple="true" IsCustomizable="false">
+                  <Definition Id="System_CPUUsage" DisplayName="ms-resource:WidgetDisplayNameCPU" Description="ms-resource:WidgetDescriptionCPU" AllowMultiple="false" IsCustomizable="false">
                     <Capabilities>
                       <Capability>
                         <Size Name="small" />

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -254,7 +254,7 @@ public partial class DashboardView : ToolPage, IDisposable
                 // Ensure only one copy of a widget is pinned if that widget's definition only allows for one instance.
                 var widgetDefinitionId = widget.DefinitionId;
                 var widgetDefinition = await Task.Run(() => catalog?.GetWidgetDefinition(widgetDefinitionId));
-                if (widgetDefinition.AllowMultiple == false)
+                if (widgetDefinition?.AllowMultiple == false)
                 {
                     if (pinnedSingleInstanceWidgets.Contains(widgetDefinitionId))
                     {
@@ -499,7 +499,7 @@ public partial class DashboardView : ToolPage, IDisposable
         var updatedDefinitionId = args.Definition.Id;
         _log.Information($"WidgetCatalog_WidgetDefinitionUpdated {updatedDefinitionId}");
 
-        var foundCount = 0;
+        var matchingWidgetsFound = 0;
 
         foreach (var widgetToUpdate in PinnedWidgets.Where(x => x.Widget.DefinitionId == updatedDefinitionId).ToList())
         {
@@ -509,7 +509,7 @@ public partial class DashboardView : ToolPage, IDisposable
             var newDef = args.Definition;
 
             // If we're no longer allowed to have multiple instances of this widget, delete all but the first.
-            if (foundCount++ > 1 && newDef.AllowMultiple == false && oldDef.AllowMultiple == true)
+            if (++matchingWidgetsFound > 1 && newDef.AllowMultiple == false && oldDef.AllowMultiple == true)
             {
                 _dispatcher.TryEnqueue(async () =>
                 {


### PR DESCRIPTION
## Summary of the pull request
* It only makes sense to have one CPU or Memory widget pinned to a single host, so set AllowMultiple="false" for these two widgets
* Better handle these widgets:
  * If the widget definition changes while Dev Home is running, delete all but the first pinned widget (due to a bug in the widget service, this probably won't happen, and will show up as a delete/add instead of update)
  * If the widget definition changes while Dev Home wasn't running, detect any multiples of a disallowed type and delete all but the first.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2514
- [ ] Tests added/passed
- [ ] Documentation updated
