### PR TITLE
Remove uses of Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()

### DIFF
--- a/common/Views/ExtensionAdaptiveCardPanel.cs
+++ b/common/Views/ExtensionAdaptiveCardPanel.cs
@@ -5,7 +5,6 @@ using System;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common.Models;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
@@ -30,7 +29,7 @@ public class ExtensionAdaptiveCardPanel : StackPanel
             throw new ArgumentException("The ExtensionUI element must be bound to an empty container.");
         }
 
-        var uiDispatcher = DispatcherQueue.GetForCurrentThread();
+        var uiDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         var extensionUI = new ExtensionAdaptiveCard();
 
         extensionUI.UiUpdate += (object? sender, AdaptiveCard adaptiveCard) =>

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -25,3 +25,7 @@
 ﻿appsettings
 ﻿yaml
 ﻿awaitable
+﻿Serilog
+﻿jsonc
+﻿appsettings
+﻿awaitable

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -28,7 +28,6 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 using Serilog;
-using Serilog.Extensions.Logging;
 
 namespace DevHome;
 

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
@@ -6,8 +6,6 @@ using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Utilities;
 
-using Dispatching = Microsoft.UI.Dispatching;
-
 namespace DevHome.Customization.ViewModels.DevDriveInsights;
 
 /// <summary>
@@ -15,10 +13,6 @@ namespace DevHome.Customization.ViewModels.DevDriveInsights;
 /// </summary>
 public partial class DevDriveCardViewModel : ObservableObject
 {
-    private readonly Dispatching.DispatcherQueue _dispatcher;
-
-    private readonly DevHome.Common.Services.IDevDriveManager _devDriveManager;
-
     public string DevDriveLabel { get; set; }
 
     public ulong DevDriveSize { get; set; }
@@ -37,11 +31,8 @@ public partial class DevDriveCardViewModel : ObservableObject
 
     public string DevDriveFreeSizeText { get; set; }
 
-    public DevDriveCardViewModel(IDevDrive devDrive, IDevDriveManager manager)
+    public DevDriveCardViewModel(IDevDrive devDrive)
     {
-        _dispatcher = Dispatching.DispatcherQueue.GetForCurrentThread();
-        _devDriveManager = manager;
-
         DevDriveLabel = devDrive.DriveLabel;
         var divider = (ulong)((devDrive.DriveUnitOfMeasure == ByteUnit.TB) ? 1000_000_000_000 : 1000_000_000);
         DevDriveSize = devDrive.DriveSizeInBytes / divider;

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -17,8 +17,6 @@ namespace DevHome.Customization.ViewModels;
 
 public partial class DevDriveInsightsViewModel : ObservableObject
 {
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
-
     public ObservableCollection<DevDriveCardViewModel> DevDriveCardCollection { get; private set; } = new();
 
     public ObservableCollection<DevDriveOptimizerCardViewModel> DevDriveOptimizerCardCollection { get; private set; } = new();
@@ -52,7 +50,6 @@ public partial class DevDriveInsightsViewModel : ObservableObject
     public DevDriveInsightsViewModel(IDevDriveManager devDriveManager, OptimizeDevDriveDialogViewModelFactory optimizeDevDriveDialogViewModelFactory)
     {
         _optimizeDevDriveDialogViewModelFactory = optimizeDevDriveDialogViewModelFactory;
-        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         DevDriveManagerObj = devDriveManager;
     }
 
@@ -221,7 +218,7 @@ public partial class DevDriveInsightsViewModel : ObservableObject
     {
         foreach (var existingDevDrive in ExistingDevDrives)
         {
-            DevDriveCardCollection.Add(new DevDriveCardViewModel(existingDevDrive, DevDriveManagerObj));
+            DevDriveCardCollection.Add(new DevDriveCardViewModel(existingDevDrive));
         }
 
         DevDriveLoadingCompleted = true;

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -9,10 +9,13 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
+using DevHome.Common.Extensions;
 using DevHome.Environments.Helpers;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using WinUIEx;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -24,7 +27,7 @@ public partial class ComputeSystemViewModel : ObservableObject
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemViewModel));
 
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
+    private readonly WindowEx _windowEx;
 
     public string Name => ComputeSystem.DisplayName;
 
@@ -60,9 +63,14 @@ public partial class ComputeSystemViewModel : ObservableObject
 
     public string PackageFullName { get; set; }
 
-    public ComputeSystemViewModel(IComputeSystemManager manager, IComputeSystem system, ComputeSystemProvider provider, string packageFullName)
+    public ComputeSystemViewModel(
+        IComputeSystemManager manager,
+        IComputeSystem system,
+        ComputeSystemProvider provider,
+        string packageFullName,
+        WindowEx windowEx)
     {
-        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        _windowEx = windowEx;
         _computeSystemManager = manager;
 
         ComputeSystem = new(system);
@@ -115,7 +123,7 @@ public partial class ComputeSystemViewModel : ObservableObject
 
     public void OnComputeSystemStateChanged(ComputeSystem sender, ComputeSystemState state)
     {
-        _dispatcher.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.TryEnqueue(() =>
         {
             if (sender.Id == ComputeSystem.Id)
             {

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -18,6 +18,7 @@ using Windows.ApplicationModel;
 using Windows.Data.Json;
 using Windows.Storage;
 using Windows.System;
+using WinUIEx;
 
 namespace DevHome.ExtensionLibrary.ViewModels;
 
@@ -27,8 +28,8 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
     private readonly string devHomeProductId = "9N8MHTPHNGVV";
 
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
     private readonly IExtensionService _extensionService;
+    private readonly WindowEx _windowEx;
 
     public ObservableCollection<StorePackageViewModel> StorePackagesList { get; set; }
 
@@ -37,10 +38,10 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     [ObservableProperty]
     private bool _shouldShowStoreError = false;
 
-    public ExtensionLibraryViewModel(IExtensionService extensionService)
+    public ExtensionLibraryViewModel(IExtensionService extensionService, WindowEx windowEx)
     {
-        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         _extensionService = extensionService;
+        _windowEx = windowEx;
 
         extensionService.OnExtensionsChanged -= OnExtensionsChanged;
         extensionService.OnExtensionsChanged += OnExtensionsChanged;
@@ -64,7 +65,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
     private async void OnExtensionsChanged(object? sender, EventArgs e)
     {
-        await _dispatcher.EnqueueAsync(async () =>
+        await _windowEx.DispatcherQueue.EnqueueAsync(async () =>
         {
             ShouldShowStoreError = false;
             await GetInstalledExtensionsAsync();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
@@ -23,6 +23,7 @@ using Microsoft.Windows.DevHome.SDK;
 using Projection::DevHome.SetupFlow.ElevatedComponent;
 using Serilog;
 using Windows.Foundation;
+using WinUIEx;
 using SDK = Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.SetupFlow.Models;
@@ -31,7 +32,7 @@ public class ConfigureTargetTask : ISetupTask
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ConfigureTargetTask));
 
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue;
+    private readonly WindowEx _windowEx;
 
     private readonly ISetupFlowStringResource _stringResource;
 
@@ -90,13 +91,14 @@ public class ConfigureTargetTask : ISetupTask
         ISetupFlowStringResource stringResource,
         IComputeSystemManager computeSystemManager,
         ConfigurationFileBuilder configurationFileBuilder,
-        SetupFlowOrchestrator setupFlowOrchestrator)
+        SetupFlowOrchestrator setupFlowOrchestrator,
+        WindowEx windowEx)
     {
         _stringResource = stringResource;
         _computeSystemManager = computeSystemManager;
         _configurationFileBuilder = configurationFileBuilder;
         _setupFlowOrchestrator = setupFlowOrchestrator;
-        _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        _windowEx = windowEx;
         _adaptiveCardRenderingService = Application.Current.GetService<AdaptiveCardRenderingService>();
     }
 
@@ -129,7 +131,7 @@ public class ConfigureTargetTask : ISetupTask
 
     public void OnActionRequired(IApplyConfigurationOperation operation, SDK.ApplyConfigurationActionRequiredEventArgs actionRequiredEventArgs)
     {
-        _log.Information($"adaptive card receieved from extension");
+        _log.Information($"adaptive card received from extension");
         var correctiveCard = actionRequiredEventArgs?.CorrectiveActionCardSession;
 
         if (correctiveCard != null)
@@ -204,7 +206,7 @@ public class ConfigureTargetTask : ISetupTask
             }
 
             // Example of a message that will be displayed in the UI:
-            // ---- Configuration progress recieved! ----
+            // ---- Configuration progress received! ----
             // There was an issue applying part of the configuration using DSC resource: 'GitClone'.Check the extension's logs
             //      - Assert : GitClone[Clone: wil - C:\Users\Public\Documents\source\repos\wil]
             //            - This part of the configuration is now complete
@@ -306,7 +308,7 @@ public class ConfigureTargetTask : ISetupTask
     /// </summary>
     public void RemoveAdaptiveCardPanelFromLoadingUI()
     {
-        _dispatcherQueue.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.TryEnqueue(() =>
         {
             if (ActionCenterMessages.ExtensionAdaptiveCardPanel != null)
             {
@@ -332,7 +334,7 @@ public class ConfigureTargetTask : ISetupTask
                 applyConfigurationOperation.ConfigurationSetStateChanged += OnApplyConfigurationOperationChanged;
                 applyConfigurationOperation.ActionRequired += OnActionRequired;
 
-                // We'll cancell the operation after 10 minutes. This is arbitrary for now and will need to be adjusted in the future.
+                // We'll cancel the operation after 10 minutes. This is arbitrary for now and will need to be adjusted in the future.
                 // but we'll need to give the user the ability to cancel the operation in the UI as well. This is just a safety net.
                 // More work is needed to give the user the ability to cancel the operation as the capability is not currently available.
                 // in the UI of Dev Home's Loading page.
@@ -410,10 +412,10 @@ public class ConfigureTargetTask : ISetupTask
     /// Creates the adaptive card that will appear in the action center of the loading page.
     /// The theming for the adaptive card isn't dynamic but in the future we can make it so.
     /// </summary>
-    /// <param name="session">Adaptive card session sent by the entension when it needs a user to perform an action</param>
+    /// <param name="session">Adaptive card session sent by the extension when it needs a user to perform an action</param>
     public async Task CreateCorrectiveActionPanel(IExtensionAdaptiveCardSession2 session)
     {
-        await _dispatcherQueue.EnqueueAsync(async () =>
+        await _windowEx.DispatcherQueue.EnqueueAsync(async () =>
         {
             var renderer = await _adaptiveCardRenderingService.GetRendererAsync();
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/ComputeSystemViewModelFactory.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/ComputeSystemViewModelFactory.cs
@@ -8,6 +8,7 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
 using DevHome.SetupFlow.ViewModels.Environments;
 using Serilog;
+using WinUIEx;
 
 namespace DevHome.Common.Services;
 
@@ -16,9 +17,14 @@ namespace DevHome.Common.Services;
 /// </summary>
 public class ComputeSystemViewModelFactory
 {
-    public async Task<ComputeSystemCardViewModel> CreateCardViewModelAsync(IComputeSystemManager manager, ComputeSystem computeSystem, ComputeSystemProvider provider, string packageFullName)
+    public async Task<ComputeSystemCardViewModel> CreateCardViewModelAsync(
+        IComputeSystemManager manager,
+        ComputeSystem computeSystem,
+        ComputeSystemProvider provider,
+        string packageFullName,
+        WindowEx windowEx)
     {
-        var cardViewModel = new ComputeSystemCardViewModel(computeSystem, manager);
+        var cardViewModel = new ComputeSystemCardViewModel(computeSystem, manager, windowEx);
 
         try
         {

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/SetupTargetTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/SetupTargetTaskGroup.cs
@@ -3,10 +3,10 @@
 
 using System.Collections.Generic;
 using DevHome.Common.Environments.Services;
-using DevHome.Contracts.Services;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
+using WinUIEx;
 
 namespace DevHome.SetupFlow.TaskGroups;
 
@@ -23,7 +23,8 @@ public class SetupTargetTaskGroup : ISetupTaskGroup
         ISetupFlowStringResource stringResource,
         IComputeSystemManager computeSystemManager,
         ConfigurationFileBuilder configurationFileBuilder,
-        SetupFlowOrchestrator setupFlowOrchestrator)
+        SetupFlowOrchestrator setupFlowOrchestrator,
+        WindowEx windowEx)
     {
         _setupTargetViewModel = setupTargetViewModel;
         _setupTargetReviewViewModel = setupTargetReviewViewModel;
@@ -32,7 +33,8 @@ public class SetupTargetTaskGroup : ISetupTaskGroup
             stringResource,
             computeSystemManager,
             configurationFileBuilder,
-            setupFlowOrchestrator);
+            setupFlowOrchestrator,
+            windowEx);
     }
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -23,7 +23,6 @@ using DevHome.SetupFlow.Views;
 using DevHome.Telemetry;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
@@ -53,7 +52,7 @@ public partial class AddRepoViewModel : ObservableObject
 
     private readonly List<CloningInformation> _previouslySelectedRepos;
 
-    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue;
 
     /// <summary>
     /// Holds all the currently executing tasks to GetRepositories.
@@ -241,7 +240,7 @@ public partial class AddRepoViewModel : ObservableObject
     private bool _isFetchingRepos;
 
     /// <summary>
-    /// PRimary button should not be enabled if not all information is entered.
+    /// Primary button should not be enabled if not all information is entered.
     /// </summary>
     [ObservableProperty]
     private bool _shouldEnablePrimaryButton;
@@ -253,7 +252,7 @@ public partial class AddRepoViewModel : ObservableObject
     private Style _styleForPrimaryButton;
 
     /// <summary>
-    /// If a UI should be shown to ask theuser to log in.
+    /// If a UI should be shown to ask the user to log in.
     /// </summary>
     [ObservableProperty]
     private bool _shouldShowLoginUi;
@@ -273,7 +272,7 @@ public partial class AddRepoViewModel : ObservableObject
     private bool _isCancelling;
 
     /// <summary>
-    /// What to display to the left of the combobox.
+    /// What to display to the left of the ComboBox.
     /// </summary>
     [ObservableProperty]
     private string _selectionOptionsPrefix;
@@ -285,7 +284,7 @@ public partial class AddRepoViewModel : ObservableObject
     private ObservableCollection<string> _selectionOptions;
 
     /// <summary>
-    /// The placeholder text for the selection options combobox
+    /// The placeholder text for the selection options ComboBox
     /// </summary>
     [ObservableProperty]
     private string _selectionOptionsPlaceholderText;
@@ -423,7 +422,7 @@ public partial class AddRepoViewModel : ObservableObject
     private Frame _loginUiContent;
 
     /// <summary>
-    /// Soley used to reset the account drop down when the account page is navigated to.
+    /// Solely used to reset the account drop down when the account page is navigated to.
     /// </summary>
     [ObservableProperty]
     private int _accountIndex;
@@ -516,7 +515,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// The bottom of the MenuFlyout has a button to log into another account.  Handle logging the user in.
     /// </summary>
     /// <remarks>
-    /// This calls MenuItemClick to poulate the list of repos if a new account is detected.
+    /// This calls MenuItemClick to populate the list of repos if a new account is detected.
     /// </remarks>
     [RelayCommand]
     private async Task AddAccountClicked()
@@ -595,11 +594,11 @@ public partial class AddRepoViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Makes the MenuFlyout object used to display multple accounts in the repo tool.
+    /// Makes the MenuFlyout object used to display multiple accounts in the repo tool.
     /// </summary>
     /// <returns>The MenuFlyout to display.</returns>
     /// <remarks>
-    /// The layout is a list of added accounts.  A line seperator.  One menu item to add an account.
+    /// The layout is a list of added accounts.  A line separator.  One menu item to add an account.
     /// </remarks>
     private MenuFlyout ConstructFlyout()
     {
@@ -947,9 +946,9 @@ public partial class AddRepoViewModel : ObservableObject
             TelemetryFactory.Get<ITelemetry>().Log("RepoTool_GetAccount_Event", LogLevel.Critical, new RepoDialogGetAccountEvent(repositoryProviderName, alreadyLoggedIn: true), _activityId);
         }
 
-        // At least with the github extension, LoginId is the account name and does not include
+        // At least with the GitHub extension, LoginId is the account name and does not include
         // @github.com.  I could try parsing the host of the URL and append that to the login id.
-        // But, if other extensions included the @something.com to the loginid, the solution mentioned above
+        // But, if other extensions included the @something.com to the LoginId, the solution mentioned above
         // would produce [username]@[something.com]@[something.com].  Not good.
         // To avoid this, just store the login id.
         Accounts = new ObservableCollection<string>(loggedInAccounts.Select(x => x.LoginId));
@@ -1112,7 +1111,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// Tries to assign a provider to a validated uri.
     /// </summary>
     /// <param name="provider">The provider to test with.</param>
-    /// <param name="cloneLocation">The location the user wnats to clone the repo.</param>
+    /// <param name="cloneLocation">The location the user wants to clone the repo.</param>
     /// <param name="uri">The uri to the repo (Should be a valid uri)</param>
     /// <param name="loginFrame">The frame to show OAUTH login if the user needs to log in.</param>
     /// <returns>non-null cloning information if a provider is selected for cloning.  Null for all other cases.</returns>
@@ -1168,7 +1167,7 @@ public partial class AddRepoViewModel : ObservableObject
             UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlNoAccountsHaveAccess);
             ShouldShowUrlError = true;
 
-            _host.GetService<WindowEx>().DispatcherQueue.TryEnqueue(async () =>
+            _dispatcherQueue.TryEnqueue(async () =>
             {
                 await InitiateAddAccountUserExperienceAsync(provider, loginFrame);
             });
@@ -1183,7 +1182,7 @@ public partial class AddRepoViewModel : ObservableObject
         UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlNoAccountsHaveAccess);
         ShouldShowUrlError = true;
         IsLoggingIn = true;
-        _host.GetService<WindowEx>().DispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
             await InitiateAddAccountUserExperienceAsync(provider, loginFrame);
         });
@@ -1364,7 +1363,7 @@ public partial class AddRepoViewModel : ObservableObject
     /// </summary>
     /// <remarks>
     /// The side effect of this method is _repositoriesForAccount is populated with repositories.
-    /// If _isSearchingEnabled is true, the path string, and combobox will be populated with values.
+    /// If _isSearchingEnabled is true, the path string, and ComboBox will be populated with values.
     /// </remarks>
     /// <param name="repositoryProvider">The provider.  This should match the display name of the extension</param>
     /// <param name="loginId">The login Id to get the repositories for</param>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AppManagementViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AppManagementViewModel.cs
@@ -11,7 +11,6 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Services;
 using Microsoft.Extensions.Hosting;
-using Microsoft.UI.Dispatching;
 using Serilog;
 
 namespace DevHome.SetupFlow.ViewModels;
@@ -24,7 +23,6 @@ public partial class AppManagementViewModel : SetupPageViewModelBase
     private readonly PackageCatalogListViewModel _packageCatalogListViewModel;
     private readonly IWindowsPackageManager _wpm;
     private readonly PackageProvider _packageProvider;
-    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
     private readonly IScreenReaderService _screenReaderService;
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -9,11 +9,12 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
+using DevHome.Common.Extensions;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-
-using Dispatching = Microsoft.UI.Dispatching;
+using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels.Environments;
 
@@ -24,7 +25,7 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemCardViewModel));
 
-    private readonly Dispatching.DispatcherQueue _dispatcher;
+    private readonly WindowEx _windowEx;
 
     private readonly IComputeSystemManager _computeSystemManager;
 
@@ -74,9 +75,9 @@ public partial class ComputeSystemCardViewModel : ObservableObject
         }
     }
 
-    public ComputeSystemCardViewModel(ComputeSystem computeSystem, IComputeSystemManager manager)
+    public ComputeSystemCardViewModel(ComputeSystem computeSystem, IComputeSystemManager manager, WindowEx windowEx)
     {
-        _dispatcher = Dispatching.DispatcherQueue.GetForCurrentThread();
+        _windowEx = windowEx;
         _computeSystemManager = manager;
         ComputeSystemTitle = computeSystem.DisplayName;
         ComputeSystemWrapper = computeSystem;
@@ -86,7 +87,7 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 
     public void OnComputeSystemStateChanged(ComputeSystem sender, ComputeSystemState state)
     {
-        _dispatcher.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.TryEnqueue(() =>
         {
             if (sender.Id == ComputeSystemWrapper.Id)
             {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -14,8 +14,8 @@ using DevHome.Common.Services;
 using DevHome.SetupFlow.Behaviors;
 using DevHome.SetupFlow.Services;
 using DevHome.Telemetry;
-using Microsoft.UI.Dispatching;
 using Serilog;
+using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -25,7 +25,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
     private readonly ICatalogDataSourceLoader _catalogDataSourceLoader;
     private readonly IExtensionService _extensionService;
     private readonly PackageCatalogViewModelFactory _packageCatalogViewModelFactory;
-    private readonly DispatcherQueue _dispatcher;
+    private readonly WindowEx _windowEx;
     private readonly SemaphoreSlim _loadCatalogsSemaphore = new(1, 1);
 
     [ObservableProperty]
@@ -55,10 +55,11 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
     public PackageCatalogListViewModel(
         IExtensionService extensionService,
         ICatalogDataSourceLoader catalogDataSourceLoader,
-        PackageCatalogViewModelFactory packageCatalogViewModelFactory)
+        PackageCatalogViewModelFactory packageCatalogViewModelFactory,
+        WindowEx windowEx)
     {
         _extensionService = extensionService;
-        _dispatcher = DispatcherQueue.GetForCurrentThread();
+        _windowEx = windowEx;
         _catalogDataSourceLoader = catalogDataSourceLoader;
         _packageCatalogViewModelFactory = packageCatalogViewModelFactory;
     }
@@ -171,7 +172,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
 
     private async void OnExtensionChangedAsync(object sender, EventArgs e)
     {
-        await _dispatcher.EnqueueAsync(() => LoadCatalogsAsync());
+        await _windowEx.DispatcherQueue.EnqueueAsync(() => LoadCatalogsAsync());
     }
 
     private void Dispose(bool disposing)

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
@@ -15,6 +15,7 @@ using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.Services;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -22,7 +23,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(SetupTargetViewModel));
 
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
+    private readonly WindowEx _windowEx;
 
     private readonly NotificationService _toastNotificationService;
 
@@ -72,11 +73,12 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
 
     public SetupTargetViewModel(
         ISetupFlowStringResource stringResource,
-        SetupFlowViewModel setupflowModel,
+        SetupFlowViewModel setupFlowModel,
         SetupFlowOrchestrator orchestrator,
         IComputeSystemManager computeSystemManager,
         ComputeSystemViewModelFactory computeSystemViewModelFactory,
-        NotificationService toastNotificationService)
+        NotificationService toastNotificationService,
+        WindowEx windowEx)
         : base(stringResource, orchestrator)
     {
         // Setup initial state for page.
@@ -102,10 +104,10 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         // Add AdvancedCollectionView to make filtering and sorting the list of ComputeSystemsListViewModels easier.
         ComputeSystemsCollectionView = new AdvancedCollectionView(_computeSystemViewModelList, true);
 
-        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        _windowEx = windowEx;
         _computeSystemViewModelFactory = computeSystemViewModelFactory;
         ComputeSystemManagerObj = computeSystemManager;
-        _setupFlowViewModel = setupflowModel;
+        _setupFlowViewModel = setupFlowModel;
         _setupFlowViewModel.EndSetupFlow += OnRemovingComputeSystems;
         _toastNotificationService = toastNotificationService;
     }
@@ -216,26 +218,26 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
     /// since we want to select only one ComputeSystemCardViewModel from one ComputeSystemsListViewModel at a time, we need to deselect
     /// all other cards in every other ComputeSystemsListViewModel object except for the one the user selected. This method will de-select
     /// all the cards in the other ListViewModels and set the ComputeSystemManager's ComputeSystemSetupItem property to the
-    /// ComputeSystem and provider assocated with the currently selected ComputeSystemCardViewModel.
+    /// ComputeSystem and provider associated with the currently selected ComputeSystemCardViewModel.
     /// </summary>
     /// <param name="sender">The ComputeSystemsListViewModel object that contains the ComputeSystemCardViewModel the user selected.</param>
     /// <param name="computeSystem">The compute system wrapper associated with the ComputeSystemCardViewModel.</param>
     public void OnListSelectionChanged(object sender, ComputeSystem computeSystem)
     {
-        if (sender is not ComputeSystemsListViewModel senderlistViewModel)
+        if (sender is not ComputeSystemsListViewModel senderListViewModel)
         {
             return;
         }
 
         foreach (var viewModel in _computeSystemViewModelList)
         {
-            if (senderlistViewModel != viewModel)
+            if (senderListViewModel != viewModel)
             {
                 viewModel.SelectedItem = null;
             }
         }
 
-        ComputeSystemManagerObj.ComputeSystemSetupItem = new(computeSystem, senderlistViewModel.Provider);
+        ComputeSystemManagerObj.ComputeSystemSetupItem = new(computeSystem, senderListViewModel.Provider);
         UpdateNextButtonState();
     }
 
@@ -287,7 +289,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         // We need to run this on a background thread so we don't block the UI thread.
         Task.Run(() =>
         {
-            _dispatcher.EnqueueAsync(async () =>
+            _windowEx.DispatcherQueue.EnqueueAsync(async () =>
             {
                 // Remove any existing ComputeSystemsListViewModels from the list if they exist. E.g when sync button is
                 // pressed.
@@ -385,7 +387,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
 
     public async Task UpdateListViewModelList(ComputeSystemsLoadedData data)
     {
-        await _dispatcher.EnqueueAsync(async () =>
+        await _windowEx.DispatcherQueue.EnqueueAsync(async () =>
         {
             var curListViewModel = new ComputeSystemsListViewModel(data);
 
@@ -398,7 +400,12 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
                 }
 
                 var packageFullName = data.ProviderDetails.ExtensionWrapper.PackageFullName;
-                var card = await _computeSystemViewModelFactory.CreateCardViewModelAsync(ComputeSystemManagerObj, wrapper, curListViewModel.Provider, packageFullName);
+                var card = await _computeSystemViewModelFactory.CreateCardViewModelAsync(
+                    ComputeSystemManagerObj,
+                    wrapper,
+                    curListViewModel.Provider,
+                    packageFullName,
+                    _windowEx);
                 curListViewModel.ComputeSystemCardCollection.Add(card);
                 curListViewModel.CardSelectionChanged += OnListSelectionChanged;
             }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SummaryViewModel.cs
@@ -242,15 +242,7 @@ public partial class SummaryViewModel : SetupPageViewModelBase
         // Send telemetry about the number of next steps tasks found broken down by their type.
         ReportSummaryTaskCounts(_cloneRepoNextSteps.Count);
 
-        BitmapImage statusSymbol;
-        if (_host.GetService<IThemeSelectorService>().Theme == ElementTheme.Dark)
-        {
-            statusSymbol = DarkError;
-        }
-        else
-        {
-            statusSymbol = LightError;
-        }
+        var statusSymbol = _host.GetService<IThemeSelectorService>().IsDarkTheme() ? DarkError : LightError;
 
         foreach (var failedTask in failedTasks)
         {


### PR DESCRIPTION
## Summary of the pull request
Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread() will return null if the calling code isn't running on the UI thread. This can cause crashes, since running on the UI thread is not guaranteed. Instead, we should use the WindowEx.DispatcherQueue, which will always return a valid DispatcherQueue.

ExtensionAdaptiveCardPanel still uses GetForCurrentThread() because I think that is guaranteed to have a DispatcherQueue (please tell me if anyone thinks that's wrong).

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #2504
- [ ] Tests added/passed
- [ ] Documentation updated
