### PR TITLE
Dev drive insights: Refactored Caches and added dotnet

### DIFF
--- a/tools/Customization/DevHome.Customization/Helpers/DevDriveCacheData.cs
+++ b/tools/Customization/DevHome.Customization/Helpers/DevDriveCacheData.cs
@@ -15,7 +15,7 @@ public partial class DevDriveCacheData
 
     public string? CacheName { get; set; }
 
-    public string? CacheDirectory { get; set; }
+    public List<string>? CacheDirectory { get; set; }
 
     public string? ExampleDirectory { get; set; }
 }

--- a/tools/Customization/DevHome.Customization/Helpers/DevDriveCacheData.cs
+++ b/tools/Customization/DevHome.Customization/Helpers/DevDriveCacheData.cs
@@ -7,9 +7,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DevHome.Customization.ViewModels.DevDriveInsights;
+namespace DevHome.Customization.Helpers;
 
-public partial class DevDriveCacheViewModel
+public partial class DevDriveCacheData
 {
     public string? EnvironmentVariable { get; set; }
 

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCacheViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCacheViewModel.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DevHome.Customization.ViewModels.DevDriveInsights;
+
+public partial class DevDriveCacheViewModel
+{
+    public string? EnvironmentVariable { get; set; }
+
+    public string? CacheName { get; set; }
+
+    public string? CacheDirectory { get; set; }
+
+    public string? ExampleDirectory { get; set; }
+}

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -266,10 +266,9 @@ public partial class DevDriveInsightsViewModel : ObservableObject
             {
                 var subDirectories = Directory.GetDirectories(_localAppDataPath + "\\Packages", "*", SearchOption.TopDirectoryOnly);
                 var matchingSubdirectory = subDirectories.FirstOrDefault(subdir => subdir.StartsWith(cacheDirectory, StringComparison.OrdinalIgnoreCase));
-                var alternateFullDirectoryPath = matchingSubdirectory + "\\localcache\\local" + cacheDirectory;
-                if (Directory.Exists(alternateFullDirectoryPath))
+                if (Directory.Exists(matchingSubdirectory))
                 {
-                    return alternateFullDirectoryPath;
+                    return matchingSubdirectory;
                 }
             }
         }

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -49,6 +49,10 @@ public partial class DevDriveInsightsViewModel : ObservableObject
 
     private IEnumerable<IDevDrive> ExistingDevDrives { get; set; } = Enumerable.Empty<IDevDrive>();
 
+    private static readonly string LocalAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+    private static readonly string UserProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
     public DevDriveInsightsViewModel(IDevDriveManager devDriveManager, OptimizeDevDriveDialogViewModelFactory optimizeDevDriveDialogViewModelFactory)
     {
         _optimizeDevDriveDialogViewModelFactory = optimizeDevDriveDialogViewModelFactory;
@@ -231,11 +235,14 @@ public partial class DevDriveInsightsViewModel : ObservableObject
     [
         new DevDriveCacheViewModel
         {
-            CacheName = "Pip cache (Python)", EnvironmentVariable = "PIP_CACHE_DIR", CacheDirectory = "\\pip\\cache",
+            CacheName = "Pip cache (Python)", EnvironmentVariable = "PIP_CACHE_DIR", CacheDirectory = $"{LocalAppDataPath}\\pip\\cache",
             ExampleDirectory = "D:\\packages\\pip\\cache",
+        },
+        new DevDriveCacheViewModel
+        {
+            CacheName = "NuGet cache (dotnet)", EnvironmentVariable = "NUGET_PACKAGES", CacheDirectory = $"{UserProfilePath}\\.nuget\\packages",
+            ExampleDirectory = "D:\\packages\\NuGet\\Cache",
         }
-
-        // Add more cache directories and their corresponding environment variables here
     ];
 
     private string? GetExistingCacheLocation(DevDriveCacheViewModel cache)
@@ -261,11 +268,11 @@ public partial class DevDriveInsightsViewModel : ObservableObject
         return null;
     }
 
-    private bool CacheInDevDrive(string existingPipCacheLocation)
+    private bool CacheInDevDrive(string existingCacheLocation)
     {
         foreach (var existingDrive in ExistingDevDrives)
         {
-            if (existingPipCacheLocation.StartsWith(existingDrive.DriveLetter.ToString(), StringComparison.OrdinalIgnoreCase))
+            if (existingCacheLocation.StartsWith(existingDrive.DriveLetter.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -268,6 +268,11 @@ public partial class DevDriveInsightsViewModel : ObservableObject
                 var matchingSubdirectory = subDirectories.FirstOrDefault(subdir => subdir.StartsWith(cacheDirectory, StringComparison.OrdinalIgnoreCase));
                 if (Directory.Exists(matchingSubdirectory))
                 {
+                    if (matchingSubdirectory.Contains("PythonSoftwareFoundation"))
+                    {
+                        return Path.Join(matchingSubdirectory, "Local", "pip", "cache");
+                    }
+
                     return matchingSubdirectory;
                 }
             }


### PR DESCRIPTION
## Summary of the pull request
Refactored DevInsights to not just check for pip caches, by looping a collection

## Detailed description of the pull request / Additional comments

More caches can be cleanly added to the Dev Insights page

![image](https://github.com/microsoft/devhome/assets/32421608/8fea1489-f604-483a-91d4-0cfc362bc5f3)


