### PR TITLE
Fix HighContrast issues in Widgets and WhatsNewPage

### DIFF
--- a/src/App.xaml
+++ b/src/App.xaml
@@ -16,6 +16,7 @@
                 <ResourceDictionary Source="/Styles/WindowTitleBar_ThemeResources.xaml" />
 
                 <!-- Resources from other projects -->
+                <ResourceDictionary Source="ms-appx:///DevHome.Dashboard/Styles/Dashboard_ThemeResources.xaml" />
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlow_ThemeResources.xaml" />
                 <ResourceDictionary Source="ms-appx:///DevHome.Common/Environments/Styles/HorizontalCardStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -29,6 +29,9 @@
                     <Color x:Key="ButtonAccentForeground">#000000</Color>
                     <Color x:Key="LearnMoreForeground">#60CDFF</Color>
                 </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <x:String x:Key="Background">/Assets/WhatsNewPage/DarkTheme/Background.png</x:String>
+                </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Page.Resources>

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -5,29 +5,14 @@
     x:Class="DevHome.Dashboard.Controls.WidgetControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:DevHome.Dashboard.Helpers"
-    mc:Ignorable="d"
     AutomationProperties.Name="{x:Bind WidgetSource.WidgetDisplayTitle}">
 
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light">
-                    <Color x:Key="WidgetBorderColor">#0F000000</Color>
-                    <Color x:Key="WidgetBackgroundColor">#B4FFFFFF</Color>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <Color x:Key="WidgetBorderColor">#1A000000</Color>
-                    <Color x:Key="WidgetBackgroundColor">#0CFFFFFF</Color>
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-
     <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize), Mode=OneWay}" 
-          CornerRadius="7" BorderBrush="{ThemeResource WidgetBorderColor}" Background="{ThemeResource WidgetBackgroundColor}" BorderThickness="1">
+          CornerRadius="7"
+          BorderBrush="{ThemeResource WidgetCardBorderBrush}"
+          Background="{ThemeResource WidgetCardBackground}"
+          BorderThickness="1">
         <Grid.RowDefinitions>
             <RowDefinition Height="36" />
             <RowDefinition Height="*" />

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <None Remove="Assets\HostConfigDark.json" />
     <None Remove="Assets\HostConfigLight.json" />
+    <None Remove="Styles\Dashboard_ThemeResources.xaml" />
     <None Remove="Views\AddWidgetDialog.xaml" />
     <None Remove="Views\DashboardView.xaml" />
     <None Remove="Views\WidgetControl.xaml" />
@@ -31,6 +32,7 @@
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
     <Content Include=".\BuildAssets\Microsoft.Windows.Widgets.Internal.winmd" Link="Microsoft.Windows.Widgets.Internal.winmd" CopyToOutputDirectory="PreserveNewest" />
     <Content Include=".\BuildAssets\Microsoft.Windows.Widgets.winmd" Link="Microsoft.Windows.Widgets.winmd" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Styles\Dashboard_ThemeResources.xaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dashboard/DevHome.Dashboard/Styles/Dashboard_ThemeResources.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Styles/Dashboard_ThemeResources.xaml
@@ -1,0 +1,56 @@
+﻿<ResourceDictionary 
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <StaticResource x:Key="WidgetCardBackground" ResourceKey="CardBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+
+            <StaticResource x:Key="WidgetCardForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="WidgetCardForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="WidgetCardForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="WidgetCardForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
+            <StaticResource x:Key="WidgetCardBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="WidgetCardBackground" ResourceKey="CardBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+
+            <StaticResource x:Key="WidgetCardForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="WidgetCardForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="WidgetCardForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="WidgetCardForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
+            <StaticResource x:Key="WidgetCardBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushPointerOver" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushPressed" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <StaticResource x:Key="WidgetCardBackground" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="WidgetCardBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
+
+            <StaticResource x:Key="WidgetCardForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="WidgetCardForegroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="WidgetCardForegroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="WidgetCardForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+
+            <StaticResource x:Key="WidgetCardBorderBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="WidgetCardBorderBrushDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request
Add better theme resource colors for widgets, including for HighContrast mode. Colors based on [SettingsCard](https://github.com/CommunityToolkit/Windows/blob/426b887898c5c8ec7ef5ed29e1b7adec7489e33b/components/SettingsControls/src/SettingsCard/SettingsCard.xaml#L12). More colors are included than used, in case we ever bring back clickability/hover states on widgets.

Also, use Dark version of WhatsNewPage background in high contrast mode, since it fits better.

![image](https://github.com/microsoft/devhome/assets/47155823/8a48c003-54c7-4cef-8e8f-af80a5c8c8a8)

![image](https://github.com/microsoft/devhome/assets/47155823/8b4cbfeb-c39d-4194-96ed-e223915259b7)

## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/49362243

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
