### PR TITLE
Workaround on accessibility bug on SettingsCard

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -70,21 +70,23 @@
                                 <ctControls:SettingsExpander.HeaderIcon>
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
                                 </ctControls:SettingsExpander.HeaderIcon>
-                                <Button x:Uid="MoreOptionsButton"
-                                        Content="&#xe712;"
-                                        Height="36" Width="36"
-                                        FontFamily="{StaticResource SymbolThemeFontFamily}" 
-                                        Background="Transparent"
-                                        BorderThickness="0">
-                                    <Button.Flyout>
-                                        <MenuFlyout>
-                                            <MenuFlyoutItem
-                                                x:Uid="UninstallItem"
-                                                Command="{x:Bind UninstallButtonCommand}">
-                                            </MenuFlyoutItem>
-                                        </MenuFlyout>
-                                    </Button.Flyout>
-                                </Button>
+                                <StackPanel>
+                                    <Button x:Uid="MoreOptionsButton"
+                                            Content="&#xe712;"
+                                            Height="36" Width="36"
+                                            FontFamily="{StaticResource SymbolThemeFontFamily}" 
+                                            Background="Transparent"
+                                            BorderThickness="0">
+                                        <Button.Flyout>
+                                            <MenuFlyout>
+                                                <MenuFlyoutItem
+                                                    x:Uid="UninstallItem"
+                                                    Command="{x:Bind UninstallButtonCommand}">
+                                                </MenuFlyoutItem>
+                                            </MenuFlyout>
+                                        </Button.Flyout>
+                                    </Button>
+                                </StackPanel>
                                 <ctControls:SettingsExpander.ItemTemplate>
                                     <DataTemplate x:DataType="viewmodels:InstalledExtensionViewModel">
                                         <ctControls:SettingsCard x:Uid="ManageExtensionCard"
@@ -116,6 +118,7 @@
                                                Description="{x:Bind Publisher}"
                                                Margin="{ThemeResource SettingsCardMargin}"
                                                CornerRadius="3"
+                                               AutomationProperties.Name="{x:Bind Title}"
                                                IsClickEnabled="False">
                                 <ctControls:SettingsCard.HeaderIcon>
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -71,6 +71,7 @@
                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
                                 </ctControls:SettingsExpander.HeaderIcon>
                                 <StackPanel>
+                                    <!-- This StackPanel is a workaround for the bug https://github.com/CommunityToolkit/Windows/issues/396 -->
                                     <Button x:Uid="MoreOptionsButton"
                                             Content="&#xe712;"
                                             Height="36" Width="36"


### PR DESCRIPTION
## Summary of the pull request
One of the last changes on SettingsCards control behaviour made it to use the Content of a Button as accessible name whenever its content is a Button, as seen [here](https://github.com/CommunityToolkit/Windows/blob/main/components/SettingsControls/src/SettingsCard/SettingsCard.cs#L100). This is making the cards on the extension library not having a meaningful accessible name, and making the narrator say nothing as the name of the group when the button is focused.

To fix this, we manually set the accessible name of the SettingCards of the not installed extensions and we put the button inside a StackPanel on the Expander, so it not use the button's content as accessible name.
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/49362208
https://dev.azure.com/microsoft/OS/_workitems/edit/49362247
## Detailed description of the pull request / Additional comments
As the code on the above link shows, the SettingsCard behaviour is: if the Content of the card is a button, use the button's content as accessible name. This makes all our card that have buttons on the extensions library page to have the accesible name as just the button's text, which is not meaningful on most of the cases and is not desirable on buttons where the content is an icon, as it can't even be narrated.

As this behaviour only happens when the content base class is Button or TextBlock, putting it inside a StackPanel mitigates this with the cost of having a additional group nested.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
