### PR TITLE
IDL changes for pinning

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -22,7 +22,7 @@ parameters:
 variables:
  # MSIXVersion's second part should always be odd to account for stub app's version
   MSIXVersion: '0.1201'
-  VersionOfSDK: '0.300'
+  VersionOfSDK: '0.400'
   solution: '**/DevHome.sln'
   appxPackageDir: 'AppxPackages'
   testOutputArtifactDir: 'TestResults'

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/ComputeSystemPinnedResult.cpp
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/ComputeSystemPinnedResult.cpp
@@ -1,0 +1,26 @@
+#include "pch.h"
+#include "ComputeSystemPinnedResult.h"
+#include "ComputeSystemPinnedResult.g.cpp"
+
+namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
+{
+    ComputeSystemPinnedResult::ComputeSystemPinnedResult(bool isPinned) :
+        m_isPinned(isPinned), m_result(ProviderOperationStatus::Success, S_OK, hstring(), hstring())
+    {
+    }
+
+    ComputeSystemPinnedResult::ComputeSystemPinnedResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText) :
+        m_isPinned(false), m_result(ProviderOperationStatus::Failure, e, displayMessage, diagnosticText)
+    {
+    }
+
+    bool ComputeSystemPinnedResult::IsPinned()
+    {
+        return m_isPinned;
+    }
+
+    winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult ComputeSystemPinnedResult::Result()
+    {
+        return m_result;
+    }
+}

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/ComputeSystemPinnedResult.h
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/ComputeSystemPinnedResult.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "ComputeSystemPinnedResult.g.h"
+
+namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
+{
+    struct ComputeSystemPinnedResult : ComputeSystemPinnedResultT<ComputeSystemPinnedResult>
+    {
+        ComputeSystemPinnedResult() = default;
+
+        ComputeSystemPinnedResult(bool isPinned);
+        ComputeSystemPinnedResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
+        bool IsPinned();
+        winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult Result();
+
+    private:
+        bool m_isPinned;
+        ProviderOperationResult m_result;
+    };
+}
+namespace winrt::Microsoft::Windows::DevHome::SDK::factory_implementation
+{
+    struct ComputeSystemPinnedResult : ComputeSystemPinnedResultT<ComputeSystemPinnedResult, implementation::ComputeSystemPinnedResult>
+    {
+    };
+}

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -1,6 +1,6 @@
 namespace Microsoft.Windows.DevHome.SDK
 {
-    [contractversion(3)]
+    [contractversion(4)]
     apicontract DevHomeContract {}
 
     [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]
@@ -578,6 +578,8 @@ namespace Microsoft.Windows.DevHome.SDK
         DeleteSnapshot = 0x00000400,
         ApplyConfiguration = 0x00000800,
         ModifyProperties = 0x00001000,
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)] PinToStartMenu = 0x00002000,
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)] PinToTaskbar = 0x00004000,
     };
 
     // Enumeration that define a compute systems state.
@@ -706,6 +708,34 @@ namespace Microsoft.Windows.DevHome.SDK
             get;
         };
     };
+
+    // The result object returned to Dev Home when it requests to know if the Compute System is currently pinned
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)]
+    runtimeclass ComputeSystemPinnedResult
+    {
+        // Used when retrieval of the Pinned status was successful
+        ComputeSystemPinnedResult(Boolean isPinned);
+
+        // Used when retrieval of the Pinned status was unsuccessful
+        // The extension can provide Dev Home with an error message to be displayed in the UI, by providing
+        // a non-empty value for the displayMessage. diagnosticText can be used to send non-localized error
+        // information back to Dev Home
+        ComputeSystemPinnedResult(HRESULT e, String displayMessage, String diagnosticText);
+
+        // A Boolean that tells whether or not the Compute System is pinned to the Shell surface in question
+        Boolean IsPinned
+        {
+            get;
+        };
+
+        // The result of the operation. This contains the ProviderOperationStatus enum value that tells Dev Home
+        // whether the result was successful or failed. It is created based on the constructor that was used.
+        ProviderOperationResult Result
+        {
+            get;
+        };
+    };
+
 
     // An enum value that extensions will use in the ComputeSystemProperty to tell Dev Home if the property is
     // one of the predefined properties or a custom property. Dev Home will use this value as a way to keep
@@ -936,6 +966,31 @@ namespace Microsoft.Windows.DevHome.SDK
         // via a string.
         IApplyConfigurationOperation CreateApplyConfigurationOperation(String configuration);
     };
+
+    // An interface that represents a remote machine, local VM or container. Specifically this interface
+    // allows the extension to be pinned or unpinned from the Start Menu or Taskbar, and allows the calling
+    // app to check whether or not the extension is pinned.
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)] 
+    interface IComputeSystem2 requires IComputeSystem
+    {
+        // Pins the Compute System to the Start Menu
+        Windows.Foundation.IAsyncOperation<ComputeSystemOperationResult> PinToStartMenuAsync();
+
+        // Unpins the Compute System from the Start Menu
+        Windows.Foundation.IAsyncOperation<ComputeSystemOperationResult> UnpinFromStartMenuAsync();
+
+        // Pins the Compute System to the Taskbar
+        Windows.Foundation.IAsyncOperation<ComputeSystemOperationResult> PinToTaskbarAsync();
+
+        // Unpins the Compute System from the Taskbar
+        Windows.Foundation.IAsyncOperation<ComputeSystemOperationResult> UnpinFromTaskbarAsync();
+
+        // Returns whether or not the Compute System is pinned to the Start Menu
+        Windows.Foundation.IAsyncOperation<ComputeSystemPinnedResult> GetIsPinnedToStartMenuAsync();
+
+        // Returns whether or not the Compute System is pinned to the taskbar
+        Windows.Foundation.IAsyncOperation<ComputeSystemPinnedResult> GetIsPinnedToTaskbarAsync();
+    }
 
     // The current state of a configuration set.
     [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 2)]

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -578,8 +578,10 @@ namespace Microsoft.Windows.DevHome.SDK
         DeleteSnapshot = 0x00000400,
         ApplyConfiguration = 0x00000800,
         ModifyProperties = 0x00001000,
-        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)] PinToStartMenu = 0x00002000,
-        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)] PinToTaskbar = 0x00004000,
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)]
+        PinToStartMenu = 0x00002000,
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 4)]
+        PinToTaskbar = 0x00004000,
     };
 
     // Enumeration that define a compute systems state.

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
@@ -206,6 +206,7 @@
     <ClInclude Include="ApplyConfigurationUnitResult.h" />
     <ClInclude Include="ComputeSystemAdaptiveCardResult.h" />
     <ClInclude Include="ComputeSystemOperationResult.h" />
+    <ClInclude Include="ComputeSystemPinnedResult.h" />
     <ClInclude Include="ComputeSystemProperty.h" />
     <ClInclude Include="ComputeSystemsResult.h" />
     <ClInclude Include="ComputeSystemStateResult.h" />
@@ -238,6 +239,7 @@
     <ClCompile Include="ApplyConfigurationUnitResult.cpp" />
     <ClCompile Include="ComputeSystemAdaptiveCardResult.cpp" />
     <ClCompile Include="ComputeSystemOperationResult.cpp" />
+    <ClCompile Include="ComputeSystemPinnedResult.cpp" />
     <ClCompile Include="ComputeSystemProperty.cpp" />
     <ClCompile Include="ComputeSystemsResult.cpp" />
     <ClCompile Include="ComputeSystemStateResult.cpp" />


### PR DESCRIPTION
## Summary of the pull request
Adding stuff to the Devhome SDK IDL to support pinning extensions to the shell.

## References and relevant issues

## Detailed description of the pull request / Additional comments
This is the first change needed for the upcoming Start Menu / Taskbar pinning of Dev Environments. This change adds a new interface with 6 new methods to enable pin/unpin operations , as well as a new runtimeclass and new enum values to support these methods. These changes have gone through the API change review and have been approved.

## Validation steps performed
Built the DevhomeSDK sln.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
