### PR TITLE
Fix telemetry privacy tagging for ProductAndServicePerformance events

### DIFF
--- a/common/TelemetryEvents/DeveloperId/DeveloperIdEvent.cs
+++ b/common/TelemetryEvents/DeveloperId/DeveloperIdEvent.cs
@@ -12,10 +12,11 @@ using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.Common.TelemetryEvents.DeveloperId;
 
+// This is an event for things which are not direct user actions.
 [EventData]
 public class DeveloperIdEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public string DeveloperId
     {

--- a/common/TelemetryEvents/DeveloperId/DeveloperIdUserEvent.cs
+++ b/common/TelemetryEvents/DeveloperId/DeveloperIdUserEvent.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace DevHome.Common.TelemetryEvents.DeveloperId;
+
+// This is an event for user-initiated actions.
+[EventData]
+public class DeveloperIdUserEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public string DeveloperId
+    {
+        get;
+    }
+
+    public DeveloperIdUserEvent(string providerName, IDeveloperId devId)
+    {
+        DeveloperId = DeveloperIdHelper.GetHashedDeveloperId(providerName, devId);
+    }
+
+    public DeveloperIdUserEvent(string providerName, IEnumerable<IDeveloperId> devIds)
+    {
+        DeveloperId = string.Join(" , ", devIds.Select(devId => DeveloperIdHelper.GetHashedDeveloperId(providerName, devId)));
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // The only sensitive strings is the developerID.  GetHashedDeveloperId is used to hash the developerId.
+    }
+}

--- a/common/TelemetryEvents/SetupFlow/AppInstallEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/AppInstallEvent.cs
@@ -16,7 +16,7 @@ public class AppInstallEvent : EventBase
 
     public string SourceId { get; }
 
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public AppInstallEvent(string packageId, string sourceId)
     {

--- a/common/TelemetryEvents/SetupFlow/AppInstallUserEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/AppInstallUserEvent.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents.SetupFlow;
+
+[EventData]
+public class AppInstallUserEvent : EventBase
+{
+    public string PackageId { get; }
+
+    public string SourceId { get; }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+
+    public AppInstallUserEvent(string packageId, string sourceId)
+    {
+        PackageId = packageId;
+        SourceId = sourceId;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/common/TelemetryEvents/SetupFlow/LoadingRetryEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/LoadingRetryEvent.cs
@@ -14,7 +14,7 @@ public class LoadingRetryEvent : EventBase
 {
     public int NumberOfFailedTasks { get; }
 
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public LoadingRetryEvent(int numberOfFailedTasks)
     {

--- a/common/TelemetryEvents/SetupFlow/SearchEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/SearchEvent.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents.SetupFlow;
+
+[EventData]
+public class SearchEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public SearchEvent()
+    {
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -97,14 +97,14 @@ public class AccountsService : IAccountsService
 
             if (authenticationState == AuthenticationState.LoggedIn)
             {
-                TelemetryFactory.Get<ITelemetry>().Log("Login_DevId_Event", LogLevel.Critical, new DeveloperIdEvent(devIdProvider.DisplayName, developerId));
+                TelemetryFactory.Get<ITelemetry>().Log("Login_DevId_Event", LogLevel.Critical, new DeveloperIdUserEvent(devIdProvider.DisplayName, developerId));
 
                 // Bring focus back to DevHome after login
                 _ = PInvoke.SetForegroundWindow((HWND)Process.GetCurrentProcess().MainWindowHandle);
             }
             else if (authenticationState == AuthenticationState.LoggedOut)
             {
-                TelemetryFactory.Get<ITelemetry>().Log("Logout_DevId_Event", LogLevel.Critical, new DeveloperIdEvent(devIdProvider.DisplayName, developerId));
+                TelemetryFactory.Get<ITelemetry>().Log("Logout_DevId_Event", LogLevel.Critical, new DeveloperIdUserEvent(devIdProvider.DisplayName, developerId));
             }
         }
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/TelemetryEvents/ReportInstalledExtensionEvent.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/TelemetryEvents/ReportInstalledExtensionEvent.cs
@@ -13,7 +13,7 @@ namespace DevHome.ExtensionLibrary.TelemetryEvents;
 [EventData]
 public class ReportInstalledExtensionEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public Guid DeploymentIdentifier
     {

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/TelemetryEvents/ConfigurationSetResultEvent.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/TelemetryEvents/ConfigurationSetResultEvent.cs
@@ -23,7 +23,7 @@ internal sealed class ConfigurationSetResultEvent : EventBase
 
     public int ExceptionHResult => _setResult.ResultCode?.HResult ?? 0;
 
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public ConfigurationSetResultEvent(ConfigurationSet configSet, ApplyConfigurationSetResult setResult)
     {

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/TelemetryEvents/ConfigurationUnitResultEvent.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/TelemetryEvents/ConfigurationUnitResultEvent.cs
@@ -25,7 +25,7 @@ internal sealed class ConfigurationUnitResultEvent : EventBase
 
     public bool RebootRequired => _unitResult.RebootRequired;
 
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public ConfigurationUnitResultEvent(ApplyConfigurationUnitResult unitResult)
     {

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
@@ -111,7 +111,7 @@ internal sealed class CreateDevDriveTask : ISetupTask
             try
             {
                 // Critical level approved by subhasan
-                TelemetryFactory.Get<ITelemetry>().Log("CreateDevDrive_CreatingDevDrive_Event", LogLevel.Critical, new EmptyEvent(), _activityId);
+                TelemetryFactory.Get<ITelemetry>().Log("CreateDevDrive_CreatingDevDrive_Event", LogLevel.Critical, new DevDriveCreationEvent(), _activityId);
                 var manager = _host.GetService<IDevDriveManager>();
                 var validation = manager.GetDevDriveValidationResults(DevDrive);
                 manager.RemoveAllDevDrives();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
@@ -281,7 +281,7 @@ public class InstallPackageTask : ISetupTask
 
     private void ReportAppSelectedForInstallEvent()
     {
-        TelemetryFactory.Get<ITelemetry>().Log("AppInstall_AppSelected", LogLevel.Critical, new AppInstallEvent(_package.Id, _package.CatalogId), _activityId);
+        TelemetryFactory.Get<ITelemetry>().Log("AppInstall_AppSelected", LogLevel.Critical, new AppInstallUserEvent(_package.Id, _package.CatalogId), _activityId);
     }
 
     private void ReportAppInstallSucceededEvent()

--- a/tools/SetupFlow/DevHome.SetupFlow/TelemetryEvents/DevDriveCreationEvent.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TelemetryEvents/DevDriveCreationEvent.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.SetupFlow.Common.TelemetryEvents;
+
+[EventData]
+internal sealed class DevDriveCreationEvent : EventBase
+{
+    public DevDriveCreationEvent()
+    {
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+}

--- a/tools/SetupFlow/DevHome.SetupFlow/TelemetryEvents/DevDriveTriggeredEvent.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TelemetryEvents/DevDriveTriggeredEvent.cs
@@ -37,5 +37,5 @@ internal sealed class DevDriveTriggeredEvent : EventBase
     public uint diskMediaType => (uint)_devDrive.DriveMediaType;
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -150,7 +150,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
     [RelayCommand]
     public async Task RestartFailedTasksAsync()
     {
-        TelemetryFactory.Get<ITelemetry>().LogCritical("Loading_RestartFailedTasks_Event");
+        TelemetryFactory.Get<ITelemetry>().Log("Loading_RestartFailedTasks_Event", LogLevel.Critical, new LoadingRetryEvent(_failedTasks.Count), _activityId);
         _log.Information("Restarting all failed tasks");
 
         // Keep the number of successful tasks and needs attention tasks the same.

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SearchViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SearchViewModel.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents.SetupFlow;
 using DevHome.SetupFlow.Exceptions;
 using DevHome.SetupFlow.Services;
 using DevHome.Telemetry;
@@ -92,7 +93,7 @@ public partial class SearchViewModel : ObservableObject
         {
             // Run the search on a separate (non-UI) thread to prevent lagging the UI.
             _log.Information($"Running package search for query [{text}]");
-            TelemetryFactory.Get<ITelemetry>().LogCritical("Search_SerchingForApplication_Event");
+            TelemetryFactory.Get<ITelemetry>().Log("Search_SearchingForApplication_Event", LogLevel.Critical, new SearchEvent());
             var matches = await Task.Run(async () => await _wpm.SearchAsync(text, SearchResultLimit), cancellationToken);
 
             // Don't update the UI if the operation was canceled


### PR DESCRIPTION
## Summary of the pull request

Several telemetry events that are actually ProductAndServicePerformance events were tagged as ProductAndServiceUsage events, which has different privacy policies and requirements. This pull request corrects the privacy tagging on those events.

## References and relevant issues

A dozen or so privacy bugs which I will not reference here.

## Detailed description of the pull request / Additional comments

Telemetry events fixed by changing to ProductAndServicePerformance tagging:

- Loading_RestartFailedTasks_Event
- Search_SerchingForApplication_Event
- ConfigurationFile_Result
- AppInstall_InstallFailed
- AppInstall_InstallSucceeded
- ConfigurationFile_UnitResult
- CreateDevDriveTriggered
- Startup_DevId_Event
- Loading_FailedTasks_Event
- Extension_ReportInstalled
- CreateDevDrive_CreatingDevDrive_Event

Telemetry Events also impacted by the change because they shared a type or had a separate tagging from a similar event which was being used for both:

- AppInstall_AppSelected
- Login_DevId_Event
- Logout_DevId_Event

The above events retain their ProductAndServiceUsage tagging but are now represented by new events in the code.

Also fixed a spelling error in the name of one of the above events: Search_SerchingForApplication_Event -> Search_SearchingForApplication_Event. As this is now a performance event which does not require additional metadata this should not cause problems.

## Validation steps performed

Build and tests passed. As these are essentially only tagging changes this should be sufficient for these changes.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
