### PR TITLE
App Extension separation for default Dev Home Extensions

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -25,7 +25,7 @@
       </OutOfProcessServer>
     </Extension>
   </Extensions>
-  <Identity Name="Microsoft.Windows.DevHome.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.1299.449.658" />
+  <Identity Name="Microsoft.Windows.DevHome.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
     <DisplayName>Dev Home (Dev)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
@@ -80,12 +80,22 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionCoreExt">
+            <uap3:Properties>
+              <DevHomeProvider>
+                <Activation>
+                  <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
+                </Activation>
+              </DevHomeProvider>
+            </uap3:Properties>
+          </uap3:AppExtension>
+        </uap3:Extension>
+        <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionHyperVExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
                   <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
-                  <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
                 </Activation>
                 <SupportedInterfaces>
                   <ComputeSystem />

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -80,7 +80,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionCoreExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameCoreExt" Description="ms-resource:AppDescriptionCoreExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
@@ -91,7 +91,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionHyperVExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameHyperVExt" Description="ms-resource:AppDescriptionHyperVExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -300,14 +300,14 @@
   </data>
   <data name="AppDescriptionHyperVExt" xml:space="preserve">
     <value>Hyper-V Extension</value>
-    <comment>Hyper-V Extension Description</comment>
+    <comment>{Locked="Hyper-V"} Extension Description</comment>
   </data>
   <data name="AppDisplayNameCoreExt" xml:space="preserve">
-    <value>Core Widgets</value>
+    <value>Core Widget Extension</value>
     <comment>Core Extension Display Name</comment>
   </data>
   <data name="AppDisplayNameHyperVExt" xml:space="preserve">
-    <value>Hyper-V</value>
-    <comment>Hyper-V Extension Display Name</comment>
+    <value>Hyper-V Extension</value>
+    <comment>{Locked="Hyper-V"} Extension Display Name</comment>
   </data>
 </root>

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -294,4 +294,20 @@
     <value>Navigation pane closed</value>
     <comment>Navigation pane has been closed</comment>
   </data>
+  <data name="AppDescriptionCoreExt" xml:space="preserve">
+    <value>Core Widget Extension</value>
+    <comment>Core Extension Description</comment>
+  </data>
+  <data name="AppDescriptionHyperVExt" xml:space="preserve">
+    <value>Hyper-V Extension</value>
+    <comment>Hyper-V Extension Description</comment>
+  </data>
+  <data name="AppDisplayNameCoreExt" xml:space="preserve">
+    <value>Core Widgets</value>
+    <comment>Core Extension Display Name</comment>
+  </data>
+  <data name="AppDisplayNameHyperVExt" xml:space="preserve">
+    <value>Hyper-V</value>
+    <comment>Hyper-V Extension Display Name</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request

Refactors app extension definitions in the appxmanifest to declare separate app extensions for the Core Extension (Core Widgets) and the Hyper-V extension. 

## References and relevant issues

## Detailed description of the pull request / Additional comments

- Created new app extension definition for Hyper-V
- Refactored Hyper-V extension out of the Core Extension
- Created new string references for each extension so they have differentiated display.


## Validation steps performed

Confirmed Core Widgets still work as expected.

## PR checklist
- [x] Closes #2538
- [x] Tests added/passed
- [x] Documentation updated
