### PR TITLE
Sever CoreWidgetProvider dependency on DevHome.Common

### DIFF
--- a/HyperVExtension/src/HyperVExtension.HostGuestCommunication/HyperVExtension.HostGuestCommunication.csproj
+++ b/HyperVExtension/src/HyperVExtension.HostGuestCommunication/HyperVExtension.HostGuestCommunication.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.2" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,16 +13,13 @@ Dev Home has a modular architecture that consists of multiple components. These 
 A more detailed look at how the projects are related:
 ```mermaid
 graph TD;
-    DevHome.Logging-->DevHome.Common;
     DevHome.Telemetry-->DevHome.Common;
-    DevHome.Common-->CoreWidgetProvider;
     DevHome.Common-->DevHome;
     DevHome.Common-->DevHome.Customization;
     DevHome.Common-->DevHome.Dashboard;
     DevHome.Common-->DevHome.Experiments;
     DevHome.Common-->DevHome.ExtensionLibrary;
     DevHome.Common-->DevHome.Settings;
-    DevHome.Logging-->DevHome.SetupFlow.Common;
     DevHome.Telemetry-->DevHome.SetupFlow.Common;
     DevHome.SetupFlow.Common-->DevHome.SetupFlow;
     DevHome.SetupFlow.Common-->DevHome.SetupFlow.ElevatedComponent;

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -17,21 +17,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.300.443" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\common\DevHome.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.300.443" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -25,7 +25,11 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.300.443" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
   </ItemGroup>
 

--- a/extensions/CoreWidgetProvider/Helpers/Logging.cs
+++ b/extensions/CoreWidgetProvider/Helpers/Logging.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Windows.Storage;
+
+namespace CoreWidgetProvider.Helpers;
+
+public class Logging
+{
+    public static readonly string LogExtension = ".dhlog";
+
+    public static readonly string LogFolderName = "Logs";
+
+    public static readonly string DefaultLogFileName = "CoreWidgets";
+
+    private static readonly Lazy<string> _logFolderRoot = new(() => Path.Combine(ApplicationData.Current.TemporaryFolder.Path, LogFolderName));
+
+    public static readonly string LogFolderRoot = _logFolderRoot.Value;
+}

--- a/extensions/CoreWidgetProvider/Program.cs
+++ b/extensions/CoreWidgetProvider/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Windows.AppLifecycle;
 using Serilog;
 using Windows.ApplicationModel.Activation;
-using Windows.Storage;
 
 namespace CoreWidgetProvider;
 
@@ -15,7 +14,7 @@ public sealed class Program
     public static void Main([System.Runtime.InteropServices.WindowsRuntime.ReadOnlyArray] string[] args)
     {
         // Set up Logging
-        Environment.SetEnvironmentVariable("DEVHOME_LOGS_ROOT", Path.Join(DevHome.Common.Logging.LogFolderRoot, "CoreWidgets"));
+        Environment.SetEnvironmentVariable("DEVHOME_LOGS_ROOT", Path.Join(Helpers.Logging.LogFolderRoot, "CoreWidgets"));
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("corewidgets_appsettings.json")
             .Build();


### PR DESCRIPTION
## Summary of the pull request
Removes the dependency of the CoreWidgetProvider on DevHome.Common which was added for logging consistency. The logging settings were instead duplicated and the dependency was removed.

## References and relevant issues

## Detailed description of the pull request / Additional comments
* Removed DevHome.Common project references from CoreWidgetProvider .
* Added back project references that CoreWidgetProvider was getting from Common.
* Added logging settings that are a duplicate of the DevHome.Common logging settings.

## Validation steps performed

## PR checklist
- [x] Closes #2533
- [ ] Tests added/passed
- [x] Documentation updated
