### PR TITLE
Add SupportedInteraces back into CoreExtension

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -86,6 +86,7 @@
                 <Activation>
                   <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
                 </Activation>
+                <!-- ExtensionService expects SupportedInterfaces to be defined, even if it is empty -->
                 <SupportedInterfaces />
               </DevHomeProvider>
             </uap3:Properties>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -86,6 +86,7 @@
                 <Activation>
                   <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
                 </Activation>
+                <SupportedInterfaces />
               </DevHomeProvider>
             </uap3:Properties>
           </uap3:AppExtension>


### PR DESCRIPTION
## Summary of the pull request
When separating out the extensions in #2532, SupportedInterfaces was dropped from the Core Extension. But we expect all extensions to have this element defined, so it broke the Extension system.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
