### PR TITLE
Fix classIds pointing to wrong extensions in package.manifest

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -84,7 +84,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
+                  <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
                 </Activation>
                 <!-- ExtensionService expects SupportedInterfaces to be defined, even if it is empty -->
                 <SupportedInterfaces />
@@ -97,7 +97,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
+                  <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
                 </Activation>
                 <SupportedInterfaces>
                   <ComputeSystem />


### PR DESCRIPTION
## Summary of the pull request

Looks like after the package.manifest change of Dev Home the class Ids were switched between the Hyper-V extension and the core extension. I missed that in my review of that PR

The classId `F8B26528-976A-488C-9B40-7198FB425C9E` belongs to the Hyper-V extension
https://github.com/microsoft/devhome/blob/584e03892bbf5e3448b373719710f8006e6235bd/HyperVExtension/src/HyperVExtension/HyperVExtension.cs#L13

and the classId `426A52D6-8007-4894-A946-CF80F39507F1` belongs to the core extension for the core widget provider https://github.com/microsoft/devhome/blob/584e03892bbf5e3448b373719710f8006e6235bd/extensions/CoreWidgetProvider/Widgets/CoreExtension.cs#L11

Without this change the Hyper-v provider is never found

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Confirmed that both Hyper-V and core widget provider can now be spun up by dev home.
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
