### PR TITLE
Use Package and Extension display names

### DIFF
--- a/common/Services/ComputeSystemService.cs
+++ b/common/Services/ComputeSystemService.cs
@@ -83,7 +83,7 @@ public class ComputeSystemService : IComputeSystemService
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed to get {nameof(IComputeSystemProvider)} provider from '{extension.Name}'", ex);
+                Log.Error($"Failed to get {nameof(IComputeSystemProvider)} provider from '{extension.PackageFamilyName}/{extension.ExtensionDisplayName}'", ex);
             }
         }
 

--- a/common/Services/IExtensionWrapper.cs
+++ b/common/Services/IExtensionWrapper.cs
@@ -12,68 +12,49 @@ namespace DevHome.Common.Services;
 public interface IExtensionWrapper
 {
     /// <summary>
-    /// Gets name of the extension as mentioned in the manifest
+    /// Gets the DisplayName of the package as mentioned in the manifest
     /// </summary>
-    string Name
-    {
-        get;
-    }
+    string PackageDisplayName { get; }
+
+    /// <summary>
+    /// Gets DisplayName of the extension as mentioned in the manifest
+    /// </summary>
+    string ExtensionDisplayName { get; }
 
     /// <summary>
     /// Gets PackageFullName of the extension
     /// </summary>
-    string PackageFullName
-    {
-        get;
-    }
+    string PackageFullName { get; }
 
     /// <summary>
     /// Gets PackageFamilyName of the extension
     /// </summary>
-    string PackageFamilyName
-    {
-        get;
-    }
+    string PackageFamilyName { get; }
 
     /// <summary>
     /// Gets Publisher of the extension
     /// </summary>
-    string Publisher
-    {
-        get;
-    }
+    string Publisher { get; }
 
     /// <summary>
     /// Gets class id (GUID) of the extension class (which implements IExtension) as mentioned in the manifest
     /// </summary>
-    string ExtensionClassId
-    {
-        get;
-    }
+    string ExtensionClassId { get; }
 
     /// <summary>
     /// Gets the date on which the application package was installed or last updated.
     /// </summary>
-    DateTimeOffset InstalledDate
-    {
-        get;
-    }
+    DateTimeOffset InstalledDate { get; }
 
     /// <summary>
     /// Gets the PackageVersion of the extension
     /// </summary>
-    PackageVersion Version
-    {
-        get;
-    }
+    PackageVersion Version { get; }
 
     /// <summary>
     /// Gets the Unique Id for the extension
     /// </summary>
-    public string ExtensionUniqueId
-    {
-        get;
-    }
+    public string ExtensionUniqueId { get; }
 
     /// <summary>
     /// Checks whether we have a reference to the extension process and we are able to call methods on the interface.

--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -297,7 +297,7 @@ public sealed partial class FeedbackPage : Page
         var extensionsStr = stringResource.GetLocalized("Settings_Feedback_Extensions") + ": \n";
         foreach (var extension in extensions)
         {
-            extensionsStr += extension.PackageFullName + "\n";
+            extensionsStr += extension.PackageFullName + " (" + extension.ExtensionDisplayName + ")\n";
         }
 
         return extensionsStr;

--- a/src/Models/ExtensionWrapper.cs
+++ b/src/Models/ExtensionWrapper.cs
@@ -32,7 +32,8 @@ public class ExtensionWrapper : IExtensionWrapper
 
     public ExtensionWrapper(AppExtension appExtension, string classId)
     {
-        Name = appExtension.DisplayName;
+        PackageDisplayName = appExtension.Package.DisplayName;
+        ExtensionDisplayName = appExtension.DisplayName;
         PackageFullName = appExtension.Package.Id.FullName;
         PackageFamilyName = appExtension.Package.Id.FamilyName;
         ExtensionClassId = classId ?? throw new ArgumentNullException(nameof(classId));
@@ -42,40 +43,21 @@ public class ExtensionWrapper : IExtensionWrapper
         ExtensionUniqueId = appExtension.AppInfo.AppUserModelId + "!" + appExtension.Id;
     }
 
-    public string Name
-    {
-        get;
-    }
+    public string PackageDisplayName { get; }
 
-    public string PackageFullName
-    {
-        get;
-    }
+    public string ExtensionDisplayName { get; }
 
-    public string PackageFamilyName
-    {
-        get;
-    }
+    public string PackageFullName { get; }
 
-    public string ExtensionClassId
-    {
-        get;
-    }
+    public string PackageFamilyName { get; }
 
-    public string Publisher
-    {
-        get;
-    }
+    public string ExtensionClassId { get; }
 
-    public DateTimeOffset InstalledDate
-    {
-        get;
-    }
+    public string Publisher { get; }
 
-    public PackageVersion Version
-    {
-        get;
-    }
+    public DateTimeOffset InstalledDate { get; }
+
+    public PackageVersion Version { get; }
 
     /// <summary>
     /// Gets the unique id for this Dev Home extension. The unique id is a concatenation of:
@@ -86,10 +68,7 @@ public class ExtensionWrapper : IExtensionWrapper
     /// <item>The Extension Id. This is the unique identifier of the extension within the application.</item>
     /// </list>
     /// </summary>
-    public string ExtensionUniqueId
-    {
-        get;
-    }
+    public string ExtensionUniqueId { get; }
 
     public bool IsRunning()
     {

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -59,7 +59,7 @@ public class AccountsService : IAccountsService
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to get {nameof(IDeveloperIdProvider)} provider from '{extension.Name}'", ex);
+                _log.Error($"Failed to get {nameof(IDeveloperIdProvider)} provider from '{extension.PackageFamilyName}/{extension.ExtensionDisplayName}'", ex);
             }
         }
 

--- a/tools/Environments/DevHome.Environments/TestModels/TestExtensionWrapper.cs
+++ b/tools/Environments/DevHome.Environments/TestModels/TestExtensionWrapper.cs
@@ -12,7 +12,9 @@ namespace DevHome.Environments.TestModels;
 
 public class TestExtensionWrapper : IExtensionWrapper
 {
-    public string Name => throw new NotImplementedException();
+    public string PackageDisplayName => throw new NotImplementedException();
+
+    public string ExtensionDisplayName => throw new NotImplementedException();
 
     public string PackageFullName => "Microsoft.Windows.DevHome.Dev_0.0.0.0_x64__8wekyb3d8bbwe";
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -79,7 +79,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
         InstalledPackagesList.Clear();
 
-        extensionWrappers = extensionWrappers.OrderBy(extensionWrapper => extensionWrapper.Name);
+        extensionWrappers = extensionWrappers.OrderBy(extensionWrapper => extensionWrapper.PackageDisplayName);
 
         foreach (var extensionWrapper in extensionWrappers)
         {
@@ -90,7 +90,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
             }
 
             var hasSettingsProvider = extensionWrapper.HasProviderType(ProviderType.Settings);
-            var extension = new InstalledExtensionViewModel(extensionWrapper.Name, extensionWrapper.ExtensionUniqueId, hasSettingsProvider);
+            var extension = new InstalledExtensionViewModel(extensionWrapper.ExtensionDisplayName, extensionWrapper.ExtensionUniqueId, hasSettingsProvider);
 
             // Each extension is shown under the package that contains it. Check if we have the package in the list
             // already and if not, create it and add it to the list of packages. Then add the extension to that
@@ -99,7 +99,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
             if (package == null)
             {
                 package = new InstalledPackageViewModel(
-                    extensionWrapper.Name,
+                    extensionWrapper.PackageDisplayName,
                     extensionWrapper.Publisher,
                     extensionWrapper.PackageFamilyName,
                     extensionWrapper.InstalledDate,

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionSettingsViewModel.cs
@@ -46,7 +46,7 @@ public partial class ExtensionSettingsViewModel : ObservableObject
             if ((_navigationService.LastParameterUsed != null) &&
                 ((string)_navigationService.LastParameterUsed == extensionWrapper.ExtensionUniqueId))
             {
-                FillBreadcrumbBar(extensionWrapper.Name);
+                FillBreadcrumbBar(extensionWrapper.ExtensionDisplayName);
 
                 var settingsProvider = Task.Run(() => extensionWrapper.GetProviderAsync<ISettingsProvider>()).Result;
                 if (settingsProvider != null)

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/InstalledPackageViewModel.cs
@@ -87,7 +87,7 @@ public partial class InstalledExtensionViewModel : ObservableObject
 public partial class InstalledPackageViewModel : ObservableObject
 {
     [ObservableProperty]
-    private string _title;
+    private string _displayName;
 
     [ObservableProperty]
     private string _publisher;
@@ -103,9 +103,9 @@ public partial class InstalledPackageViewModel : ObservableObject
 
     public ObservableCollection<InstalledExtensionViewModel> InstalledExtensionsList { get; set; }
 
-    public InstalledPackageViewModel(string title, string publisher, string packageFamilyName, DateTimeOffset installedDate, PackageVersion version)
+    public InstalledPackageViewModel(string displayName, string publisher, string packageFamilyName, DateTimeOffset installedDate, PackageVersion version)
     {
-        _title = title;
+        _displayName = displayName;
         _publisher = publisher;
         _packageFamilyName = packageFamilyName;
         _installedDate = installedDate;

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -62,7 +62,7 @@
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.InstalledPackagesList, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewmodels:InstalledPackageViewModel">
-                            <ctControls:SettingsExpander Header="{x:Bind Title}"
+                            <ctControls:SettingsExpander Header="{x:Bind DisplayName}"
                                                    Description="{x:Bind GeneratePackageDetails(Version,Publisher , InstalledDate), Mode=OneWay}"
                                                    Margin="{ThemeResource SettingsCardMargin}"
                                                    ItemsSource="{x:Bind InstalledExtensionsList}"
@@ -87,7 +87,7 @@
                                 </Button>
                                 <ctControls:SettingsExpander.ItemTemplate>
                                     <DataTemplate x:DataType="viewmodels:InstalledExtensionViewModel">
-                                        <ctControls:SettingsCard x:Uid="ManageExtensionCard"
+                                        <ctControls:SettingsCard Header="{x:Bind DisplayName}"
                                                            CornerRadius="0,0,3,3"
                                                            IsClickEnabled="{x:Bind HasSettingsProvider}"
                                                            Command="{x:Bind NavigateSettingsCommand}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -60,7 +60,7 @@ internal sealed class RepositoryProvider
 
     public string DisplayName => _repositoryProvider.DisplayName;
 
-    public string ExtensionDisplayName => _extensionWrapper.Name;
+    public string ExtensionDisplayName => _extensionWrapper.ExtensionDisplayName;
 
     /// <summary>
     /// Starts the extension if it isn't running.

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProviders.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProviders.cs
@@ -37,7 +37,7 @@ internal sealed class RepositoryProviders
 
     public RepositoryProviders(IEnumerable<IExtensionWrapper> extensionWrappers)
     {
-        _providers = extensionWrappers.ToDictionary(extensionWrapper => extensionWrapper.Name, extensionWrapper => new RepositoryProvider(extensionWrapper));
+        _providers = extensionWrappers.ToDictionary(extensionWrapper => extensionWrapper.ExtensionDisplayName, extensionWrapper => new RepositoryProvider(extensionWrapper));
     }
 
     public void StartAllExtensions()

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetFeaturedApplicationsDataSource.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetFeaturedApplicationsDataSource.cs
@@ -171,7 +171,7 @@ public sealed class WinGetFeaturedApplicationsDataSource : WinGetPackageDataSour
         var extensions = await _extensionService.GetInstalledExtensionsAsync(ProviderType.FeaturedApplications);
         foreach (var extension in extensions)
         {
-            var extensionName = extension.Name;
+            var extensionName = extension.PackageFamilyName;
             try
             {
                 _log.Information($"Getting featured applications provider from extension '{extensionName}'");

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -706,7 +706,7 @@ public partial class AddRepoViewModel : ObservableObject
 
         var extensions = extensionWrappers.Where(
             extension => extension.HasProviderType(ProviderType.Repository) &&
-            extension.HasProviderType(ProviderType.DeveloperId)).OrderBy(extensionWrapper => extensionWrapper.Name);
+            extension.HasProviderType(ProviderType.DeveloperId)).OrderBy(extensionWrapper => extensionWrapper.ExtensionDisplayName);
 
         _providers = new RepositoryProviders(extensions);
 


### PR DESCRIPTION
## Summary of the pull request
Now that we properly define two extensions in #2532, we need to use the proper DisplayNames when available. Removes ExtensionWrapper.Name and replaces it with ExtensionWrapper.PackageDisplayName, and ExtensionWrapper.ExtensionDisplayName.

To fix #2505: Qualify the Package with the ExtensionDisplayName in the Feedback page.

To fix #2378: Use the PackageDisplayName and ExtensionDisplayName on the extension library pages.
![image](https://github.com/microsoft/devhome/assets/47155823/52db1bc2-1f06-47cf-802d-77ef076fe64e)


## PR checklist
- [x] Closes #2505
- [x] Closes #2378
- [ ] Tests added/passed
- [ ] Documentation updated
