### PR TITLE
Fixing bug where user could not invoke selectable menu flyout action with Narrator's scan mode on

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/SelectableMenuFlyoutItem.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/SelectableMenuFlyoutItem.cs
@@ -47,7 +47,7 @@ public class SelectableMenuFlyoutItemAutomationPeer : MenuFlyoutItemAutomationPe
 
     public void Select()
     {
-        IsSelected = true;
+        Invoke();
     }
 
     protected override string GetClassNameCore()

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -204,7 +204,7 @@ public sealed partial class WidgetControl : UserControl
         };
         menuSizeItem.Icon = fontIcon;
         var peer = FrameworkElementAutomationPeer.FromElement(menuSizeItem) as SelectableMenuFlyoutItemAutomationPeer;
-        peer.Select();
+        peer.AddToSelection();
     }
 
     private void AddCustomizeToWidgetMenu(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel)


### PR DESCRIPTION
## Summary of the pull request
When the Narrator's scan mode is on, the user cannot use the keyboard to select the widget's size. This PR fix the issue.
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/49658657
## Detailed description of the pull request / Additional comments
When the Narrator's scan mode is on, the Automation Peer's `Select` method from the `SelectionItem` pattern gets the priority on the keyboard action, going over the `Invoke` from the invoke pattern. This PR makes the `Select` to call `Invoke` whenever it is called, as the behaviour should always be the same.
## Validation steps performed

## PR checklist
- [ ] Closes #2546
- [ ] Tests added/passed
- [ ] Documentation updated
