### PR TITLE
Edit dialog's "Browse" button works at 225% text scaling.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -574,6 +574,14 @@ public partial class AddRepoViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    public void SaveRepoUrl(string repoUrl)
+    {
+        Url = repoUrl;
+
+        ToggleCloneButton();
+    }
+
     /// <summary>
     /// Filters all repos down to any that start with text.
     /// A side-effect of filtering is that SelectionChanged fires for every selected repo but only on removal.

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -61,9 +61,14 @@
             <TextBox x:Name="RepoUrlTextBox"
                      x:Uid="RepoUrl"
                      Visibility="{x:Bind AddRepoViewModel.ShowUrlPage, Mode=OneWay}"
-                     TextChanged="RepoUrlTextBox_TextChanged"
                      Text="{x:Bind AddRepoViewModel.Url, Mode=TwoWay}"
-                     Margin="0, 20, 0, 0"/>
+                     Margin="0, 20, 0, 0">
+                <i:Interaction.Behaviors>
+                    <ic:EventTriggerBehavior EventName="TextChanged">
+                        <ic:InvokeCommandAction Command="{x:Bind AddRepoViewModel.SaveRepoUrlCommand}" CommandParameter="{x:Bind RepoUrlTextBox.Text, Mode=OneWay}"/>
+                    </ic:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </TextBox>
             <TextBlock x:Name="UrlErrorTextBlock" Style="{ThemeResource BaseTextBlockStyle}" Text="{x:Bind AddRepoViewModel.UrlParsingError, Mode=OneWay}" Visibility="{x:Bind AddRepoViewModel.ShouldShowUrlError, Mode=OneWay}"/>
 
             <!-- Log into account -->

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -306,17 +306,6 @@ public partial class AddRepoDialog : ContentDialog
         }
     }
 
-    private void RepoUrlTextBox_TextChanged(object sender, RoutedEventArgs e)
-    {
-        // just in case something other than a text box calls this.
-        if (sender is TextBox)
-        {
-            AddRepoViewModel.Url = (sender as TextBox).Text;
-        }
-
-        AddRepoViewModel.ToggleCloneButton();
-    }
-
     /// <summary>
     /// Putting the event in the view so SelectRange can be called.
     /// SelectRange needs a reference to the ListView.

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/EditClonePathDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/EditClonePathDialog.xaml
@@ -53,7 +53,7 @@
             <Grid Visibility="{x:Bind FolderPickerViewModel.ShouldShowFolderPicker, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="5*"/>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="auto"/>
                 </Grid.ColumnDefinitions>
                 <!--Folder picker-->
                 <StackPanel
@@ -83,7 +83,7 @@
                     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/ClonePath_Button" 
                     Click="ChooseCloneLocationButton_Click"  
                     Grid.Column="1" 
-                    Margin="5, 27, 0, 0"
+                    Margin="5, 27, 10, 0"
                     Padding="8 5 10 5"/>
                 </Grid>
             </Grid>


### PR DESCRIPTION
## Summary of the pull request
The browse button in the Edit Clone path Dialog was clipped when scaling is set to 200%+.  Now the text does not clip. :)

Also moved the save repo URL code out of the code-behind and into the view model.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

[Task](https://task.ms/49360355)

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Picture!
![BrowseButtonAt225Percent](https://github.com/microsoft/devhome/assets/2517139/a0c8c1d3-37ce-4a05-bce1-84e6c61549bb)
