### PR TITLE
Making Banner's Close button icon text AccessibilityView raw

### DIFF
--- a/common/Views/CloseButton.xaml
+++ b/common/Views/CloseButton.xaml
@@ -12,5 +12,6 @@
 
     <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"
                FontSize="{ThemeResource BodyTextBlockFontSize}"
+               AutomationProperties.AccessibilityView="Raw"
                Text="&#xE711;" />
 </Button>


### PR DESCRIPTION
## Summary of the pull request
When Scan mode is activated, the narrator can focus the icon inside the close button's content. This PR fixes this issue.
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/45042479
## Detailed description of the pull request / Additional comments
With scan mode on, the narrator try to focus on every text, including the icon inside the banner's close button. Changing the accessibility view to `Raw` removes it from the list of controls observable by the narrator. Then, only the entire button can be focused.
## Validation steps performed

## PR checklist
- [ ] Closes #2546
- [ ] Tests added/passed
- [ ] Documentation updated
