### PR TITLE
Fix timestamp log format

### DIFF
--- a/HyperVExtension/src/DevSetupAgent/appsettings_hypervsetupagent.json
+++ b/HyperVExtension/src/DevSetupAgent/appsettings_hypervsetupagent.json
@@ -12,7 +12,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -20,7 +20,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\hyperv_setupagent.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/HyperVExtension/src/DevSetupEngine/appsettings_hypervsetup.json
+++ b/HyperVExtension/src/DevSetupEngine/appsettings_hypervsetup.json
@@ -6,7 +6,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -14,7 +14,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\hyperv_setup.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/HyperVExtension/src/HyperVExtensionServer/appsettings_hyperv.json
+++ b/HyperVExtension/src/HyperVExtensionServer/appsettings_hyperv.json
@@ -6,7 +6,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -14,7 +14,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\hyperv.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/extensions/CoreWidgetProvider/corewidgets_appsettings.json
+++ b/extensions/CoreWidgetProvider/corewidgets_appsettings.json
@@ -6,7 +6,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -14,7 +14,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\corewidgets.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -15,7 +15,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Debug"
         }
       },
@@ -23,7 +23,7 @@
         "Name": "File",
         "Args": {
           "path": "%DEVHOME_LOGS_ROOT%\\devhome.dhlog",
-          "outputTemplate": "[{Timestamp:yyyy/mm/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
+          "outputTemplate": "[{Timestamp:yyyy/MM/dd HH:mm:ss.fff} {Level:u3}] ({SourceContext}) {Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Information",
           "rollingInterval": "Day"
         }


### PR DESCRIPTION
## Summary of the pull request
Timestamp format was incorrect for the logging, putting minutes instead of months and creating an invalid timestamp. It also fails to parse as a DateTime which broke tooling.

## References and relevant issues
Closes #2567 

## Detailed description of the pull request / Additional comments
* Fixed output format to use correct format specifier for Month.

## Validation steps performed
* Verified log format is correct with the fix.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
