### PR TITLE
Correctly show/hide experimental features in stable builds

### DIFF
--- a/docs/ExperimentalFeatures.md
+++ b/docs/ExperimentalFeatures.md
@@ -24,7 +24,7 @@ This is useful for features that are not ready for general use, but can be teste
         "visible": true
       },
       {
-        "buildType": "release",
+        "buildType": "stable",
         "enabledByDefault": false,
         "visible": false
       }

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -45,7 +45,7 @@
         {
           "buildType": "dev",
           "enabledByDefault": true,
-          "visible": true
+          "visible": false
         },
         {
           "buildType": "canary",
@@ -53,7 +53,7 @@
           "visible": true
         },
         {
-          "buildType": "release",
+          "buildType": "stable",
           "enabledByDefault": false,
           "visible": false
         }
@@ -74,7 +74,7 @@
           "visible": false
         },
         {
-          "buildType": "release",
+          "buildType": "stable",
           "enabledByDefault": false,
           "visible": false
         }
@@ -95,7 +95,7 @@
           "visible": false
         },
         {
-          "buildType": "release",
+          "buildType": "stable",
           "enabledByDefault": false,
           "visible": false
         }
@@ -116,7 +116,7 @@
           "visible": true
         },
         {
-          "buildType": "release",
+          "buildType": "stable",
           "enabledByDefault": false,
           "visible": false
         }


### PR DESCRIPTION
## Summary of the pull request
Public builds were referenced as "release" in the doc and NavConfig.json but internally were "stable".  Mismatch caused default behavior which was for local "dev" builds.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2573
- [ ] Tests added/passed
- [ ] Documentation updated
