### PR TITLE
Fix exception logging

### DIFF
--- a/HyperVExtension/src/DevSetupAgent/DevAgentService.cs
+++ b/HyperVExtension/src/DevSetupAgent/DevAgentService.cs
@@ -41,13 +41,13 @@ public class DevAgentService : BackgroundService
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Exception in DevAgentService.", ex);
+                    _log.Error(ex, $"Exception in DevAgentService.");
                 }
             }
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to run DevSetupAgent.", ex);
+            _log.Error(ex, $"Failed to run DevSetupAgent.");
             throw;
         }
         finally

--- a/HyperVExtension/src/DevSetupAgent/HostRegistryChannel.cs
+++ b/HyperVExtension/src/DevSetupAgent/HostRegistryChannel.cs
@@ -113,7 +113,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Could not write host message. Response ID: {responseMessage.ResponseId}", ex);
+                    _log.Error(ex, $"Could not write host message. Response ID: {responseMessage.ResponseId}");
                 }
             },
             stoppingToken);
@@ -130,7 +130,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Could not delete host message. Response ID: {responseId}", ex);
+                    _log.Error(ex, $"Could not delete host message. Response ID: {responseId}");
                 }
             },
             stoppingToken);
@@ -207,7 +207,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                         }
                         catch (Exception ex)
                         {
-                            _log.Error($"Could not read host message {valueName}", ex);
+                            _log.Error(ex, $"Could not read host message {valueName}");
                         }
 
                         MessageHelper.DeleteAllMessages(_registryHiveKey, _fromHostRegistryKeyPath, s[0]);
@@ -218,7 +218,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error("Could not read host message.", ex);
+            _log.Error(ex, "Could not read host message.");
         }
 
         return requestMessage;

--- a/HyperVExtension/src/DevSetupAgent/RegistryWatcher.cs
+++ b/HyperVExtension/src/DevSetupAgent/RegistryWatcher.cs
@@ -76,14 +76,14 @@ internal sealed class RegistryWatcher : IDisposable
                                 }
                                 catch (Exception ex)
                                 {
-                                    _log.Error("RegistryChanged delegate failed.", ex);
+                                    _log.Error(ex, "RegistryChanged delegate failed.");
                                 }
                             }
                         }
                     }
                     catch (Exception ex)
                     {
-                        _log.Error("Registry Watcher thread failed.", ex);
+                        _log.Error(ex, "Registry Watcher thread failed.");
                     }
                 });
                 _log.Information("Registry Watcher thread started.");

--- a/HyperVExtension/src/DevSetupAgent/RequestManager.cs
+++ b/HyperVExtension/src/DevSetupAgent/RequestManager.cs
@@ -102,7 +102,7 @@ public class RequestManager : IRequestManager
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to execute request.", ex);
+                _log.Error(ex, $"Failed to execute request.");
             }
         }
     }

--- a/HyperVExtension/src/DevSetupAgent/Requests/RequestFactory.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/RequestFactory.cs
@@ -64,7 +64,7 @@ public class RequestFactory : IRequestFactory
         {
             var messageId = requestContext.RequestMessage.RequestId ?? "<unknown>";
             var requestData = requestContext.RequestMessage.RequestData ?? "<unknown>";
-            _log.Error($"Error processing message. Message ID: {messageId}. Request data: {requestData}", ex);
+            _log.Error(ex, $"Error processing message. Message ID: {messageId}. Request data: {requestData}");
             return new ErrorRequest(requestContext.RequestMessage);
         }
     }

--- a/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
+++ b/HyperVExtension/src/DevSetupEngine/ConfigurationFileHelper.cs
@@ -279,22 +279,21 @@ public class ConfigurationFileHelper
     {
         _log.Information($"WinGet: {diagnosticInformation.Message}");
 
-        var sourceComponent = nameof(WinGet.ConfigurationProcessor);
         switch (diagnosticInformation.Level)
         {
             case WinGet.DiagnosticLevel.Warning:
-                _log.Warning(sourceComponent, diagnosticInformation.Message);
+                _log.Warning(diagnosticInformation.Message);
                 return;
             case WinGet.DiagnosticLevel.Error:
-                _log.Error(sourceComponent, diagnosticInformation.Message);
+                _log.Error(diagnosticInformation.Message);
                 return;
             case WinGet.DiagnosticLevel.Critical:
-                _log.Fatal(sourceComponent, diagnosticInformation.Message);
+                _log.Fatal(diagnosticInformation.Message);
                 return;
             case WinGet.DiagnosticLevel.Verbose:
             case WinGet.DiagnosticLevel.Informational:
             default:
-                _log.Information(sourceComponent, diagnosticInformation.Message);
+                _log.Information(diagnosticInformation.Message);
                 return;
         }
     }

--- a/HyperVExtension/src/DevSetupEngine/PackageOperationException.cs
+++ b/HyperVExtension/src/DevSetupEngine/PackageOperationException.cs
@@ -19,6 +19,6 @@ public class PackageOperationException : Exception
     {
         HResult = (int)errorCode;
         var log = Log.ForContext("SourceContext", nameof(PackageOperationException));
-        log.Error(message, this);
+        log.Error(this, message);
     }
 }

--- a/HyperVExtension/src/DevSetupEngine/Program.cs
+++ b/HyperVExtension/src/DevSetupEngine/Program.cs
@@ -58,7 +58,7 @@ internal sealed class Program
         }
         catch (Exception ex)
         {
-            Log.Error($"Exception: {ex}", ex);
+            Log.Error(ex, $"Exception: {ex}");
             Log.CloseAndFlush();
             return ex.HResult;
         }

--- a/HyperVExtension/src/HyperVExtension.HostGuestCommunication/Providers/MessageHelper.cs
+++ b/HyperVExtension/src/HyperVExtension.HostGuestCommunication/Providers/MessageHelper.cs
@@ -110,7 +110,7 @@ public static class MessageHelper
             catch (Exception ex)
             {
                 var log = Serilog.Log.ForContext("SourceContext", nameof(MessageHelper));
-                log.Error($"Could not read guest message {valueName}", ex);
+                log.Error(ex, $"Could not read guest message {valueName}");
             }
 
             messages.Add(name, value);

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ResponseFactory.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ResponseFactory.cs
@@ -66,7 +66,7 @@ public class ResponseFactory : IResponseFactory
         {
             var messageId = message?.ResponseId ?? "<unknown>";
             var responseData = message?.ResponseData ?? "<unknown>";
-            _log.Error($"Error processing message. Message ID: {messageId}. Request data: {responseData}", ex);
+            _log.Error(ex, $"Error processing message. Message ID: {messageId}. Request data: {responseData}");
             return new ErrorResponse(message!);
         }
     }

--- a/HyperVExtension/src/HyperVExtension/Helpers/PsObjectHelper.cs
+++ b/HyperVExtension/src/HyperVExtension/Helpers/PsObjectHelper.cs
@@ -71,7 +71,7 @@ public class PsObjectHelper
         catch (Exception ex)
         {
             var log = Log.ForContext("SourceContext", nameof(PsObjectHelper));
-            log.Error($"Failed to get property value with name {propertyName} from object with type {type}.", ex);
+            log.Error(ex, $"Failed to get property value with name {propertyName} from object with type {type}.");
         }
 
         return default(T);

--- a/HyperVExtension/src/HyperVExtension/Helpers/Resources.cs
+++ b/HyperVExtension/src/HyperVExtension/Helpers/Resources.cs
@@ -23,7 +23,7 @@ public static class Resources
         }
         catch (Exception ex)
         {
-            log?.Error($"Failed loading resource: {identifier}", ex);
+            log?.Error(ex, $"Failed loading resource: {identifier}");
 
             // If we fail, load the original identifier so it is obvious which resource is missing.
             return identifier;

--- a/HyperVExtension/src/HyperVExtension/HyperVExtension.cs
+++ b/HyperVExtension/src/HyperVExtension/HyperVExtension.cs
@@ -57,7 +57,7 @@ public sealed class HyperVExtension : IExtension, IDisposable
         }
         catch (Exception ex)
         {
-            log.Error($"Failed to get provider for provider type {providerType}", ex);
+            log.Error(ex, $"Failed to get provider for provider type {providerType}");
         }
 
         return provider;

--- a/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -192,7 +192,7 @@ public class HyperVVirtualMachine : IComputeSystem
         catch (Exception ex)
         {
             StateChanged(this, ComputeSystemState.Unknown);
-            _log.Error(OperationErrorString(ComputeSystemOperations.Start), ex);
+            _log.Error(ex, OperationErrorString(ComputeSystemOperations.Start));
             return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
         }
     }
@@ -253,7 +253,7 @@ public class HyperVVirtualMachine : IComputeSystem
             catch (Exception ex)
             {
                 StateChanged(this, ComputeSystemState.Unknown);
-                _log.Error(OperationErrorString(ComputeSystemOperations.Terminate), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.Terminate));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -278,7 +278,7 @@ public class HyperVVirtualMachine : IComputeSystem
             catch (Exception ex)
             {
                 StateChanged(this, ComputeSystemState.Unknown);
-                _log.Error(OperationErrorString(ComputeSystemOperations.Delete), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.Delete));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -309,7 +309,7 @@ public class HyperVVirtualMachine : IComputeSystem
             catch (Exception ex)
             {
                 StateChanged(this, ComputeSystemState.Unknown);
-                _log.Error(OperationErrorString(ComputeSystemOperations.Save), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.Save));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -340,7 +340,7 @@ public class HyperVVirtualMachine : IComputeSystem
             catch (Exception ex)
             {
                 StateChanged(this, ComputeSystemState.Unknown);
-                _log.Error(OperationErrorString(ComputeSystemOperations.Pause), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.Pause));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -371,7 +371,7 @@ public class HyperVVirtualMachine : IComputeSystem
             catch (Exception ex)
             {
                 StateChanged(this, ComputeSystemState.Unknown);
-                _log.Error(OperationErrorString(ComputeSystemOperations.Resume), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.Resume));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -393,7 +393,7 @@ public class HyperVVirtualMachine : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error(OperationErrorString(ComputeSystemOperations.CreateSnapshot), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.CreateSnapshot));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -416,7 +416,7 @@ public class HyperVVirtualMachine : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error(OperationErrorString(ComputeSystemOperations.RevertSnapshot), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.RevertSnapshot));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -439,7 +439,7 @@ public class HyperVVirtualMachine : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error(OperationErrorString(ComputeSystemOperations.DeleteSnapshot), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.DeleteSnapshot));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -457,7 +457,7 @@ public class HyperVVirtualMachine : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to launch vmconnect on {DateTime.Now}: VM details: {this}", ex);
+                _log.Error(ex, $"Failed to launch vmconnect on {DateTime.Now}: VM details: {this}");
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -487,7 +487,7 @@ public class HyperVVirtualMachine : IComputeSystem
             catch (Exception ex)
             {
                 StateChanged(this, ComputeSystemState.Unknown);
-                _log.Error(OperationErrorString(ComputeSystemOperations.Restart), ex);
+                _log.Error(ex, OperationErrorString(ComputeSystemOperations.Restart));
                 return new ComputeSystemOperationResult(ex, OperationErrorUnknownString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -536,7 +536,7 @@ public class HyperVVirtualMachine : IComputeSystem
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to GetComputeSystemPropertiesAsync on {DateTime.Now}: VM details: {this}", ex);
+                _log.Error(ex, $"Failed to GetComputeSystemPropertiesAsync on {DateTime.Now}: VM details: {this}");
                 return new List<ComputeSystemProperty>();
             }
         }).AsAsyncOperation();
@@ -708,7 +708,7 @@ public class HyperVVirtualMachine : IComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to apply configuration on {DateTime.Now}: VM details: {this}", ex);
+            _log.Error(ex, $"Failed to apply configuration on {DateTime.Now}: VM details: {this}");
             return operation.CompleteOperation(new HostGuestCommunication.ApplyConfigurationResult(ex.HResult, ex.Message));
         }
     }
@@ -721,7 +721,7 @@ public class HyperVVirtualMachine : IComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to apply configuration on {DateTime.Now}: VM details: {this}", ex);
+            _log.Error(ex, $"Failed to apply configuration on {DateTime.Now}: VM details: {this}");
             return new ApplyConfigurationOperation(this, ex);
         }
     }

--- a/HyperVExtension/src/HyperVExtension/Models/VirtualMachineCreation/VMGalleryVMCreationOperation.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/VirtualMachineCreation/VMGalleryVMCreationOperation.cs
@@ -139,7 +139,7 @@ public sealed class VMGalleryVMCreationOperation : IVMGalleryVMCreationOperation
             }
             catch (Exception ex)
             {
-                _log.Error("Operation to create compute system failed", ex);
+                _log.Error(ex, "Operation to create compute system failed");
                 ComputeSystemResult = new CreateComputeSystemResult(ex, ex.Message, ex.Message);
             }
 
@@ -161,7 +161,7 @@ public sealed class VMGalleryVMCreationOperation : IVMGalleryVMCreationOperation
         }
         catch (Exception ex)
         {
-            _log.Error("Failed to update progress", ex);
+            _log.Error(ex, "Failed to update progress");
         }
     }
 
@@ -173,7 +173,7 @@ public sealed class VMGalleryVMCreationOperation : IVMGalleryVMCreationOperation
         }
         catch (Exception ex)
         {
-            _log.Error("Failed to update progress", ex);
+            _log.Error(ex, "Failed to update progress");
         }
     }
 
@@ -221,7 +221,7 @@ public sealed class VMGalleryVMCreationOperation : IVMGalleryVMCreationOperation
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to delete file {file.Path}", ex);
+            _log.Error(ex, $"Failed to delete file {file.Path}");
         }
     }
 

--- a/HyperVExtension/src/HyperVExtension/Models/VmCredentialAdaptiveCardSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/VmCredentialAdaptiveCardSession.cs
@@ -163,7 +163,7 @@ public sealed class VmCredentialAdaptiveCardSession : IExtensionAdaptiveCardSess
             }
             catch (Exception ex)
             {
-                _log.Error($"Exception in OnAction: {ex}");
+                _log.Error(ex, $"Exception in OnAction: {ex}");
                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, ex, "Something went wrong", ex.Message);
             }
 

--- a/HyperVExtension/src/HyperVExtension/Models/WaitForLoginAdaptiveCardSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/WaitForLoginAdaptiveCardSession.cs
@@ -144,7 +144,7 @@ public sealed class WaitForLoginAdaptiveCardSession : IExtensionAdaptiveCardSess
             }
             catch (Exception ex)
             {
-                _log.Error($"Exception in OnAction: {ex}");
+                _log.Error(ex, $"Exception in OnAction: {ex}");
                 operationResult = new ProviderOperationResult(ProviderOperationStatus.Failure, ex, "Something went wrong", ex.Message);
             }
 

--- a/HyperVExtension/src/HyperVExtension/Providers/HyperVProvider.cs
+++ b/HyperVExtension/src/HyperVExtension/Providers/HyperVProvider.cs
@@ -75,7 +75,7 @@ public class HyperVProvider : IComputeSystemProvider
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to retrieved all virtual machines on: {DateTime.Now}", ex);
+                _log.Error(ex, $"Failed to retrieved all virtual machines on: {DateTime.Now}");
                 return new ComputeSystemsResult(ex, OperationErrorString, ex.Message);
             }
         }).AsAsyncOperation();
@@ -105,7 +105,7 @@ public class HyperVProvider : IComputeSystemProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to create a new virtual machine on: {DateTime.Now}", ex);
+            _log.Error(ex, $"Failed to create a new virtual machine on: {DateTime.Now}");
 
             // Dev Home will handle null values as failed operations. We can't throw because this is an out of proc
             // COM call, so we'll lose the error information. We'll log the error and return null.

--- a/HyperVExtension/src/HyperVExtension/Services/PowerShellService.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/PowerShellService.cs
@@ -60,7 +60,7 @@ public class PowerShellService : IPowerShellService, IDisposable
         catch (Exception ex)
         {
             var commandStrings = string.Join(Environment.NewLine, commandLineStatements.Select(cmd => cmd.ToString()));
-            _log.Error($"Error running PowerShell commands: {commandStrings}", ex);
+            _log.Error(ex, $"Error running PowerShell commands: {commandStrings}");
             throw;
         }
     }

--- a/HyperVExtension/src/HyperVExtension/Services/VMGalleryService.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/VMGalleryService.cs
@@ -87,7 +87,7 @@ public sealed class VMGalleryService : IVMGalleryService
         }
         catch (Exception ex)
         {
-            _log.Error($"Unable to retrieve VM gallery images", ex);
+            _log.Error(ex, $"Unable to retrieve VM gallery images");
         }
 
         return _imageList;

--- a/common/Environments/Helpers/ComputeSystemHelpers.cs
+++ b/common/Environments/Helpers/ComputeSystemHelpers.cs
@@ -35,7 +35,7 @@ public static class ComputeSystemHelpers
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to get thumbnail for compute system {computeSystemWrapper}.", ex);
+            Log.Error(ex, $"Failed to get thumbnail for compute system {computeSystemWrapper}.");
             return null;
         }
     }
@@ -56,7 +56,7 @@ public static class ComputeSystemHelpers
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to get all properties for compute system {computeSystemWrapper}.", ex);
+            Log.Error(ex, $"Failed to get all properties for compute system {computeSystemWrapper}.");
             return propertyList;
         }
     }

--- a/common/Environments/Helpers/StringResourceHelper.cs
+++ b/common/Environments/Helpers/StringResourceHelper.cs
@@ -26,7 +26,7 @@ public static class StringResourceHelper
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to get resource for key {key}.", ex);
+            Log.Error(ex, $"Failed to get resource for key {key}.");
             return key;
         }
     }

--- a/common/Environments/Models/CardProperty.cs
+++ b/common/Environments/Models/CardProperty.cs
@@ -142,7 +142,7 @@ public partial class CardProperty : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to load icon from ms-resource: {iconPathUri} for package: {packageFullName} due to error:", ex);
+            Log.Error(ex, $"Failed to load icon from ms-resource: {iconPathUri} for package: {packageFullName} due to error:");
         }
 
         return new BitmapImage();
@@ -200,7 +200,7 @@ public partial class CardProperty : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Failed to convert size in bytes to ulong. Error: {ex}");
+            Log.Error(ex, $"Failed to convert size in bytes to ulong. Error: {ex}");
             return string.Empty;
         }
     }

--- a/common/Environments/Models/ComputeSystem.cs
+++ b/common/Environments/Models/ComputeSystem.cs
@@ -63,7 +63,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"OnComputeSystemStateChanged for: {this} failed due to exception", ex);
+            _log.Error(ex, $"OnComputeSystemStateChanged for: {this} failed due to exception");
         }
     }
 
@@ -75,7 +75,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"GetStateAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"GetStateAsync for: {this} failed due to exception");
             return new ComputeSystemStateResult(ex, errorString, ex.Message);
         }
     }
@@ -88,7 +88,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"StartAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"StartAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -101,7 +101,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"ShutDownAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"ShutDownAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -114,7 +114,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"RestartAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"RestartAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -127,7 +127,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"TerminateAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"TerminateAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -140,7 +140,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"DeleteAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"DeleteAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -153,7 +153,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"SaveAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"SaveAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -166,7 +166,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"PauseAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"PauseAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -179,7 +179,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"ResumeAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"ResumeAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -192,7 +192,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"CreateSnapshotAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"CreateSnapshotAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -205,7 +205,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"RevertSnapshotAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"RevertSnapshotAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -218,7 +218,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"DeleteSnapshotAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"DeleteSnapshotAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -231,7 +231,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"ModifyPropertiesAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"ModifyPropertiesAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -244,7 +244,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"GetComputeSystemThumbnailAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"GetComputeSystemThumbnailAsync for: {this} failed due to exception");
             return new ComputeSystemThumbnailResult(ex, errorString, ex.Message);
         }
     }
@@ -257,7 +257,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"GetComputeSystemPropertiesAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"GetComputeSystemPropertiesAsync for: {this} failed due to exception");
             return new List<ComputeSystemProperty>();
         }
     }
@@ -270,7 +270,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"ConnectAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"ConnectAsync for: {this} failed due to exception");
             return new ComputeSystemOperationResult(ex, errorString, ex.Message);
         }
     }
@@ -283,7 +283,7 @@ public class ComputeSystem
         }
         catch (Exception ex)
         {
-            _log.Error($"ApplyConfiguration for: {this} failed due to exception", ex);
+            _log.Error(ex, $"ApplyConfiguration for: {this} failed due to exception");
             throw;
         }
     }

--- a/common/Environments/Models/ComputeSystemProvider.cs
+++ b/common/Environments/Models/ComputeSystemProvider.cs
@@ -52,7 +52,7 @@ public class ComputeSystemProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"CreateAdaptiveCardSessionForDeveloperId for: {this} failed due to exception", ex);
+            _log.Error(ex, $"CreateAdaptiveCardSessionForDeveloperId for: {this} failed due to exception");
             return new ComputeSystemAdaptiveCardResult(ex, errorString, ex.Message);
         }
     }
@@ -65,7 +65,7 @@ public class ComputeSystemProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"CreateAdaptiveCardSessionForComputeSystem for: {this} failed due to exception", ex);
+            _log.Error(ex, $"CreateAdaptiveCardSessionForComputeSystem for: {this} failed due to exception");
             return new ComputeSystemAdaptiveCardResult(ex, errorString, ex.Message);
         }
     }
@@ -78,7 +78,7 @@ public class ComputeSystemProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"GetComputeSystemsAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"GetComputeSystemsAsync for: {this} failed due to exception");
             return new ComputeSystemsResult(ex, errorString, ex.Message);
         }
     }
@@ -92,7 +92,7 @@ public class ComputeSystemProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"GetComputeSystemsAsync for: {this} failed due to exception", ex);
+            _log.Error(ex, $"GetComputeSystemsAsync for: {this} failed due to exception");
             return new FailedCreateComputeSystemOperation(ex, StringResourceHelper.GetResource("CreationOperationStoppedUnexpectedly"));
         }
     }

--- a/common/Environments/Models/CreateComputeSystemOperation.cs
+++ b/common/Environments/Models/CreateComputeSystemOperation.cs
@@ -112,7 +112,7 @@ public class CreateComputeSystemOperation : IDisposable
             }
             catch (Exception ex)
             {
-                _log.Error($"StartOperation failed for provider {ProviderDetails.ComputeSystemProvider}", ex);
+                _log.Error(ex, $"StartOperation failed for provider {ProviderDetails.ComputeSystemProvider}");
                 CreateComputeSystemResult = new CreateComputeSystemResult(ex, StringResourceHelper.GetResource("CreationOperationStoppedUnexpectedly"), ex.Message);
                 Completed?.Invoke(this, CreateComputeSystemResult);
             }
@@ -145,7 +145,7 @@ public class CreateComputeSystemOperation : IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to remove event handlers for {this}", ex);
+            _log.Error(ex, $"Failed to remove event handlers for {this}");
         }
     }
 
@@ -157,7 +157,7 @@ public class CreateComputeSystemOperation : IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to cancel operation for {this}", ex);
+            _log.Error(ex, $"Failed to cancel operation for {this}");
         }
     }
 

--- a/common/Environments/Services/ComputeSystemManager.cs
+++ b/common/Environments/Services/ComputeSystemManager.cs
@@ -77,17 +77,17 @@ public class ComputeSystemManager : IComputeSystemManager
             {
                 if (innerEx is TaskCanceledException)
                 {
-                    _log.Error($"Failed to get retrieve all compute systems from all compute system providers due to cancellation", innerEx);
+                    _log.Error(innerEx, $"Failed to get retrieve all compute systems from all compute system providers due to cancellation");
                 }
                 else
                 {
-                    _log.Error($"Failed to get retrieve all compute systems from all compute system providers ", innerEx);
+                    _log.Error(innerEx, $"Failed to get retrieve all compute systems from all compute system providers ");
                 }
             }
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to get retrieve all compute systems from all compute system providers ", ex);
+            _log.Error(ex, $"Failed to get retrieve all compute systems from all compute system providers ");
         }
     }
 

--- a/common/Helpers/AdaptiveCardHelpers.cs
+++ b/common/Helpers/AdaptiveCardHelpers.cs
@@ -32,7 +32,7 @@ public static class AdaptiveCardHelpers
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to load image icon", ex);
+            _log.Error(ex, $"Failed to load image icon");
             return new ImageIcon();
         }
     }

--- a/common/Helpers/Deployment.cs
+++ b/common/Helpers/Deployment.cs
@@ -37,7 +37,7 @@ public static class Deployment
                 // We do not want this identifer's access to ever create a problem in the
                 // application, so if we can't get it, return empty guid. An empty guid is also a
                 // signal that the data is unknown for filtering purposes.
-                Log.Error($"Failed getting Deployment Identifier", ex);
+                Log.Error(ex, $"Failed getting Deployment Identifier");
                 return Guid.Empty;
             }
         }

--- a/common/Models/ExtensionAdaptiveCardSession.cs
+++ b/common/Models/ExtensionAdaptiveCardSession.cs
@@ -21,8 +21,6 @@ public class ExtensionAdaptiveCardSession
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ExtensionAdaptiveCardSession));
 
-    private readonly string _componentName = "ExtensionAdaptiveCardSession";
-
     public IExtensionAdaptiveCardSession Session { get; private set; }
 
     public event TypedEventHandler<ExtensionAdaptiveCardSession, ExtensionAdaptiveCardSessionStoppedEventArgs>? Stopped;
@@ -45,7 +43,7 @@ public class ExtensionAdaptiveCardSession
         }
         catch (Exception ex)
         {
-            _log.Error(_componentName, $"Initialize failed due to exception", ex);
+            _log.Error(ex, $"Initialize failed due to exception");
             return new ProviderOperationResult(ProviderOperationStatus.Failure, ex, ex.Message, ex.Message);
         }
     }
@@ -63,7 +61,7 @@ public class ExtensionAdaptiveCardSession
         }
         catch (Exception ex)
         {
-           _log.Error(_componentName, $"Dispose failed due to exception", ex);
+           _log.Error(ex, $"Dispose failed due to exception");
         }
     }
 
@@ -75,7 +73,7 @@ public class ExtensionAdaptiveCardSession
         }
         catch (Exception ex)
         {
-           _log.Error(_componentName, $"OnAction failed due to exception", ex);
+           _log.Error(ex, $"OnAction failed due to exception");
            return new ProviderOperationResult(ProviderOperationStatus.Failure, ex, ex.Message, ex.Message);
         }
     }

--- a/common/Services/AdaptiveCardRenderingService.cs
+++ b/common/Services/AdaptiveCardRenderingService.cs
@@ -119,7 +119,7 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
             }
             catch (Exception ex)
             {
-                _log.Error("Error retrieving HostConfig", ex);
+                _log.Error(ex, "Error retrieving HostConfig");
             }
 
             _windowEx.DispatcherQueue.TryEnqueue(() =>

--- a/common/Services/AppInstallManagerService.cs
+++ b/common/Services/AppInstallManagerService.cs
@@ -97,7 +97,7 @@ public class AppInstallManagerService : IAppInstallManagerService
         }
         catch (Exception ex)
         {
-            _log.Error("Package installation Failed", ex);
+            _log.Error(ex, "Package installation Failed");
         }
 
         return false;

--- a/common/Services/ComputeSystemService.cs
+++ b/common/Services/ComputeSystemService.cs
@@ -83,7 +83,7 @@ public class ComputeSystemService : IComputeSystemService
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed to get {nameof(IComputeSystemProvider)} provider from '{extension.PackageFamilyName}/{extension.ExtensionDisplayName}'", ex);
+                Log.Error(ex, $"Failed to get {nameof(IComputeSystemProvider)} provider from '{extension.PackageFamilyName}/{extension.ExtensionDisplayName}'");
             }
         }
 

--- a/common/Services/NotificationService.cs
+++ b/common/Services/NotificationService.cs
@@ -25,8 +25,6 @@ public class NotificationService
 
     private readonly IWindowsIdentityService _windowsIdentityService;
 
-    private readonly string _componentName = "NotificationService";
-
     private readonly string _hyperVText = "Hyper-V";
 
     private readonly string _microsoftText = "Microsoft";
@@ -81,7 +79,7 @@ public class NotificationService
             }
             catch (Exception ex)
             {
-                _log.Error(_componentName, $"Unable to launch computer management due to exception", ex);
+                _log.Error(ex, $"Unable to launch computer management due to exception");
             }
         }
     }
@@ -124,7 +122,7 @@ public class NotificationService
         }
         else
         {
-            _log.Error(_componentName, "Notification queue is not initialized");
+            _log.Error("Notification queue is not initialized");
         }
     }
 
@@ -149,7 +147,7 @@ public class NotificationService
                     var user = _windowsIdentityService.GetCurrentUserName();
                     if (user == null)
                     {
-                        _log.Error(_componentName, "Unable to get the current user name");
+                        _log.Error("Unable to get the current user name");
                         return;
                     }
 
@@ -185,7 +183,7 @@ public class NotificationService
                     }
                     catch (Exception ex)
                     {
-                        _log.Error(_componentName, "Unable to add the user to the Hyper-V Administrators group", ex);
+                        _log.Error(ex, "Unable to add the user to the Hyper-V Administrators group");
                         ShowUnableToAddToHyperVAdminGroupNotification();
                     }
                 });
@@ -209,7 +207,7 @@ public class NotificationService
             }
             else
             {
-                _log.Error(_componentName, "Notification queue is not initialized");
+                _log.Error("Notification queue is not initialized");
             }
         }
     }

--- a/extensions/CoreWidgetProvider/Helpers/GPUStats.cs
+++ b/extensions/CoreWidgetProvider/Helpers/GPUStats.cs
@@ -113,7 +113,7 @@ internal sealed class GPUStats : IDisposable
                 }
                 catch (InvalidOperationException ex)
                 {
-                    Log.Warning("GPUStats", "Failed to get next value", ex);
+                    Log.Warning(ex, "GPUStats", "Failed to get next value");
                     Log.Information("GPUStats", "Calling GetGPUPerfCounters again");
                     GetGPUPerfCounters();
                 }

--- a/extensions/CoreWidgetProvider/Helpers/NetworkStats.cs
+++ b/extensions/CoreWidgetProvider/Helpers/NetworkStats.cs
@@ -87,7 +87,7 @@ internal sealed class NetworkStats : IDisposable
             }
             catch (Exception ex)
             {
-                Log.Error("Error getting network data.", ex);
+                Log.Error(ex, "Error getting network data.");
             }
         }
     }

--- a/extensions/CoreWidgetProvider/Helpers/Resources.cs
+++ b/extensions/CoreWidgetProvider/Helpers/Resources.cs
@@ -23,7 +23,7 @@ public static class Resources
         }
         catch (Exception ex)
         {
-            log?.Error($"Failed loading resource: {identifier}", ex);
+            log?.Error(ex, $"Failed loading resource: {identifier}");
 
             // If we fail, load the original identifier so it is obvious which resource is missing.
             return identifier;

--- a/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
@@ -140,7 +140,7 @@ internal abstract class CoreWidget : WidgetImpl
         }
         catch (Exception e)
         {
-            Log.Error("Error getting template.", e);
+            Log.Error(e, "Error getting template.");
             return string.Empty;
         }
     }

--- a/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -83,7 +83,7 @@ internal sealed class SSHWalletWidget : CoreWidget
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             var content = new JsonObject
             {
                 { "errorMessage", e.Message },
@@ -309,7 +309,7 @@ internal sealed class SSHWalletWidget : CoreWidget
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed getting configuration information for input config file path: {data}", ex);
+                Log.Error(ex, $"Failed getting configuration information for input config file path: {data}");
 
                 configurationData = FillConfigurationData(false, data, 0, Resources.GetResource(@"SSH_Widget_Template/ErrorProcessingConfigFile", Log));
 

--- a/extensions/CoreWidgetProvider/Widgets/SystemCPUUsageWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SystemCPUUsageWidget.cs
@@ -56,7 +56,7 @@ internal sealed class SystemCPUUsageWidget : CoreWidget, IDisposable
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving stats.", e);
+            Log.Error(e, "Error retrieving stats.");
             var content = new JsonObject
             {
                 { "errorMessage", e.Message },

--- a/extensions/CoreWidgetProvider/Widgets/SystemGPUUsageWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SystemGPUUsageWidget.cs
@@ -58,7 +58,7 @@ internal sealed class SystemGPUUsageWidget : CoreWidget, IDisposable
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             var content = new JsonObject
             {
                 { "errorMessage", e.Message },

--- a/extensions/CoreWidgetProvider/Widgets/SystemMemoryWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SystemMemoryWidget.cs
@@ -75,7 +75,7 @@ internal sealed class SystemMemoryWidget : CoreWidget, IDisposable
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             var content = new JsonObject
             {
                 { "errorMessage", e.Message },

--- a/extensions/CoreWidgetProvider/Widgets/SystemNetworkUsageWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SystemNetworkUsageWidget.cs
@@ -76,7 +76,7 @@ internal sealed class SystemNetworkUsageWidget : CoreWidget, IDisposable
         }
         catch (Exception e)
         {
-            Log.Error("Error retrieving data.", e);
+            Log.Error(e, "Error retrieving data.");
             var content = new JsonObject
             {
                 { "errorMessage", e.Message },

--- a/extensions/CoreWidgetProvider/Widgets/WidgetProvider.cs
+++ b/extensions/CoreWidgetProvider/Widgets/WidgetProvider.cs
@@ -64,7 +64,7 @@ internal sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
         }
         catch (Exception e)
         {
-            Log.Error("Failed retrieving list of running widgets.", e);
+            Log.Error(e, "Failed retrieving list of running widgets.");
             return;
         }
 

--- a/settings/DevHome.Settings/Views/AboutPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml.cs
@@ -44,7 +44,7 @@ public sealed partial class AboutPage : Page
         catch (Exception e)
         {
             var log = Log.ForContext("SourceContext", "AboutPage");
-            log.Error($"Error opening log location", e);
+            log.Error(e, $"Error opening log location");
         }
     }
 #endif

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -114,7 +114,7 @@ public sealed partial class AccountsPage : Page
         }
         catch (Exception ex)
         {
-            _log.Error($"ShowLoginUIAsync(): loginUIContentDialog failed.", ex);
+            _log.Error(ex, $"ShowLoginUIAsync(): loginUIContentDialog failed.");
         }
 
         accountProvider.RefreshLoggedInAccounts();
@@ -186,7 +186,7 @@ public sealed partial class AccountsPage : Page
             }
             catch (Exception ex)
             {
-                _log.Error($"Exception thrown while calling {nameof(accountProvider.DeveloperIdProvider)}.{nameof(accountProvider.DeveloperIdProvider.ShowLogonSession)}: ", ex);
+                _log.Error(ex, $"Exception thrown while calling {nameof(accountProvider.DeveloperIdProvider)}.{nameof(accountProvider.DeveloperIdProvider.ShowLogonSession)}: ");
             }
 
             accountProvider.RefreshLoggedInAccounts();

--- a/src/Services/AccountsService.cs
+++ b/src/Services/AccountsService.cs
@@ -59,7 +59,7 @@ public class AccountsService : IAccountsService
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to get {nameof(IDeveloperIdProvider)} provider from '{extension.PackageFamilyName}/{extension.ExtensionDisplayName}'", ex);
+                _log.Error(ex, $"Failed to get {nameof(IDeveloperIdProvider)} provider from '{extension.PackageFamilyName}/{extension.ExtensionDisplayName}'");
             }
         }
 

--- a/src/Services/DSCFileActivationHandler.cs
+++ b/src/Services/DSCFileActivationHandler.cs
@@ -98,7 +98,7 @@ public class DSCFileActivationHandler : ActivationHandler<FileActivatedEventArgs
         }
         catch (Exception ex)
         {
-            _log.Error("Error executing the DSC activation flow", ex);
+            _log.Error(ex, "Error executing the DSC activation flow");
         }
     }
 }

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -65,7 +65,7 @@ public class InitializationViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            _log.Information("Installing WidgetService failed: ", ex);
+            _log.Information(ex, "Installing WidgetService failed: ");
         }
 
         // Install the DevHomeGitHubExtension, unless it's already installed or a dev build is running.
@@ -82,7 +82,7 @@ public class InitializationViewModel : ObservableObject
             }
             catch (Exception ex)
             {
-                _log.Information("Installing DevHomeGitHubExtension failed: ", ex);
+                _log.Information(ex, "Installing DevHomeGitHubExtension failed: ");
             }
         }
 

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
@@ -113,7 +113,7 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Error in MoveDirectory. Error: {ex}");
+            Log.Error(ex, $"Error in MoveDirectory. Error: {ex}");
         }
     }
 
@@ -125,7 +125,7 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Error in SetEnvironmentVariable. Error: {ex}");
+            Log.Error(ex, $"Error in SetEnvironmentVariable. Error: {ex}");
         }
     }
 

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -175,7 +175,7 @@ public partial class DevDriveInsightsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Error loading Dev Drives data. Error: {ex}");
+            Log.Error(ex, $"Error loading Dev Drives data. Error: {ex}");
         }
     }
 
@@ -195,7 +195,7 @@ public partial class DevDriveInsightsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Error loading Dev Drive Optimizers data. Error: {ex}");
+            Log.Error(ex, $"Error loading Dev Drive Optimizers data. Error: {ex}");
         }
     }
 
@@ -215,7 +215,7 @@ public partial class DevDriveInsightsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Log.Error($"Error loading Dev Drive Optimized data. Error: {ex}");
+            Log.Error(ex, $"Error loading Dev Drive Optimized data. Error: {ex}");
         }
     }
 

--- a/tools/Customization/DevHome.Customization/ViewModels/QuietBackgroundProcessesViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/QuietBackgroundProcessesViewModel.cs
@@ -110,7 +110,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
             catch (Exception ex)
             {
                 SessionStateText = GetStatusString("SessionError");
-                _log.Error("QuietBackgroundProcessesSession::Start failed", ex);
+                _log.Error(ex, "QuietBackgroundProcessesSession::Start failed");
             }
         }
         else
@@ -124,7 +124,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
             catch (Exception ex)
             {
                 SessionStateText = GetStatusString("UnableToCancelSession");
-                _log.Error("QuietBackgroundProcessesSession::Stop failed", ex);
+                _log.Error(ex, "QuietBackgroundProcessesSession::Stop failed");
             }
         }
     }
@@ -142,7 +142,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
         catch (Exception ex)
         {
             SessionStateText = GetStatusString("SessionError");
-            _log.Error("QuietBackgroundProcessesSession::IsActive failed", ex);
+            _log.Error(ex, "QuietBackgroundProcessesSession::IsActive failed");
         }
 
         return false;
@@ -157,7 +157,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
         catch (Exception ex)
         {
             SessionStateText = GetStatusString("SessionError");
-            _log.Error("QuietBackgroundProcessesSession::TimeLeftInSeconds failed", ex);
+            _log.Error(ex, "QuietBackgroundProcessesSession::TimeLeftInSeconds failed");
             return 0;
         }
     }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -115,7 +115,7 @@ public sealed partial class WidgetControl : UserControl
                 }
                 catch (Exception ex)
                 {
-                    _log.Error($"Didn't delete Widget {widgetIdToDelete}", ex);
+                    _log.Error(ex, $"Didn't delete Widget {widgetIdToDelete}");
                 }
             }
         }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetAdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetAdaptiveCardRenderingService.cs
@@ -115,7 +115,7 @@ public class WidgetAdaptiveCardRenderingService : IAdaptiveCardRenderingService,
             }
             catch (Exception ex)
             {
-                _log.Error("Error retrieving HostConfig", ex);
+                _log.Error(ex, "Error retrieving HostConfig");
             }
 
             _windowEx.DispatcherQueue.TryEnqueue(() =>

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -119,7 +119,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error("Exception in WidgetHost.Register:", ex);
+                _log.Error(ex, "Exception in WidgetHost.Register:");
             }
         }
 
@@ -136,7 +136,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error("Exception in WidgetCatalog.GetDefault:", ex);
+                _log.Error(ex, "Exception in WidgetCatalog.GetDefault:");
             }
         }
 

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -155,7 +155,7 @@ public partial class WidgetViewModel : ObservableObject
             }
             catch (Exception ex)
             {
-                _log.Warning("There was an error expanding the Widget template with data: ", ex);
+                _log.Warning(ex, "There was an error expanding the Widget template with data: ");
                 ShowErrorCard("WidgetErrorCardDisplayText");
                 return;
             }
@@ -192,7 +192,7 @@ public partial class WidgetViewModel : ObservableObject
                 }
                 catch (Exception ex)
                 {
-                    _log.Error("Error rendering widget card: ", ex);
+                    _log.Error(ex, "Error rendering widget card: ");
                     WidgetFrameworkElement = GetErrorCard("WidgetErrorCardDisplayText");
                 }
             });

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -94,7 +94,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error("Exception in SubscribeToWidgetCatalogEvents:", ex);
+            _log.Error(ex, "Exception in SubscribeToWidgetCatalogEvents:");
             return false;
         }
 
@@ -287,7 +287,7 @@ public partial class DashboardView : ToolPage, IDisposable
             }
             catch (Exception ex)
             {
-                _log.Error($"RestorePinnedWidgets(): ", ex);
+                _log.Error(ex, $"RestorePinnedWidgets(): ");
             }
         }
 
@@ -374,7 +374,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error($"PinDefaultWidget failed: ", ex);
+            _log.Error(ex, $"PinDefaultWidget failed: ");
         }
     }
 
@@ -424,7 +424,7 @@ public partial class DashboardView : ToolPage, IDisposable
             }
             catch (Exception ex)
             {
-                _log.Warning($"Creating widget failed: ", ex);
+                _log.Warning(ex, $"Creating widget failed: ");
                 var mainWindow = Application.Current.GetService<WindowEx>();
                 var stringResource = new StringResource("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
                 await mainWindow.ShowErrorMessageDialogAsync(
@@ -464,7 +464,7 @@ public partial class DashboardView : ToolPage, IDisposable
                     {
                         // TODO Support concurrency in dashboard. Today concurrent async execution can cause insertion errors.
                         // https://github.com/microsoft/devhome/issues/1215
-                        _log.Warning($"Couldn't insert pinned widget", ex);
+                        _log.Warning(ex, $"Couldn't insert pinned widget");
                     }
                 });
             }
@@ -479,7 +479,7 @@ public partial class DashboardView : ToolPage, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _log.Information($"Error deleting widget", ex);
+                    _log.Information(ex, $"Error deleting widget");
                 }
             }
         });

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -261,7 +261,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
             var result = mapping.Value.Result;
             await _notificationService.ShowNotificationAsync(provider.DisplayName, result.DisplayMessage, InfoBarSeverity.Error);
 
-            _log.Error($"Error occurred while adding Compute systems to environments page for provider: {provider.Id}", result.DiagnosticText, result.ExtendedError);
+            _log.Error($"Error occurred while adding Compute systems to environments page for provider: {provider.Id}. {result.DiagnosticText}, {result.ExtendedError}");
             data.DevIdToComputeSystemMap.Remove(mapping.Key);
         }
 
@@ -296,7 +296,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
             }
             catch (Exception ex)
             {
-                _log.Error($"Exception occurred while adding Compute systems to environments page for provider: {provider.Id}", ex);
+                _log.Error(ex, $"Exception occurred while adding Compute systems to environments page for provider: {provider.Id}");
             }
         });
     }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -124,7 +124,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            _log.Error("Error retrieving packages", ex);
+            _log.Error(ex, "Error retrieving packages");
             ShouldShowStoreError = true;
         }
 

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevDriveFormatter/DevDriveFormatter.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevDriveFormatter/DevDriveFormatter.cs
@@ -88,7 +88,7 @@ public class DevDriveFormatter
         }
         catch (CimException e)
         {
-            _log.Error($"A CimException occurred while formatting Dev Drive Error.", e);
+            _log.Error(e, $"A CimException occurred while formatting Dev Drive Error.");
             return e.HResult;
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Elevation/IPCSetup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Elevation/IPCSetup.cs
@@ -296,7 +296,7 @@ public static class IPCSetup
         }
         catch (Exception e)
         {
-            Log.Error($"Error occurring while setting up elevated process:", e);
+            Log.Error(e, $"Error occurring while setting up elevated process:");
 
             // Release the "mutex" if there is any error.
             // On success, the mutex will be released after work is done.
@@ -386,7 +386,7 @@ public static class IPCSetup
         }
         catch (Exception e)
         {
-            Log.Error($"Error occurred during setup.", e);
+            Log.Error(e, $"Error occurred during setup.");
             mappedMemory.HResult = e.HResult;
         }
 

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/ElevatedComponentOperation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/ElevatedComponentOperation.cs
@@ -43,7 +43,7 @@ public sealed class ElevatedComponentOperation : IElevatedComponentOperation
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to parse tasks arguments", e);
+            _log.Error(e, $"Failed to parse tasks arguments");
             throw;
         }
     }
@@ -182,7 +182,7 @@ public sealed class ElevatedComponentOperation : IElevatedComponentOperation
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to validate or execute operation", e);
+            _log.Error(e, $"Failed to validate or execute operation");
             EndOperation(taskArguments, false);
             throw;
         }

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedConfigurationTask.cs
@@ -56,7 +56,7 @@ public sealed class ElevatedConfigurationTask
             }
             catch (Exception e)
             {
-                log.Error($"Failed to apply configuration.", e);
+                log.Error(e, $"Failed to apply configuration.");
                 taskResult.TaskSucceeded = false;
             }
 

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedInstallTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/Tasks/ElevatedInstallTask.cs
@@ -100,7 +100,7 @@ public sealed class ElevatedInstallTask
             }
             catch (Exception e)
             {
-                _log.Error("Elevated app install failed.", e);
+                _log.Error(e, "Elevated app install failed.");
                 result.TaskSucceeded = false;
             }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
@@ -232,7 +232,7 @@ public partial class CloneRepoTask : ObservableObject, ISetupTask
 
                 if (result.Status == ProviderOperationStatus.Failure)
                 {
-                    _log.Error($"Could not clone {RepositoryToClone.DisplayName} because {result.DisplayMessage}", result.ExtendedError);
+                    _log.Error(result.ExtendedError, $"Could not clone {RepositoryToClone.DisplayName} because {result.DisplayMessage}");
                     TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_CouldNotClone_Event", LogLevel.Critical, new ExceptionEvent(result.ExtendedError.HResult, result.DisplayMessage));
 
                     _actionCenterErrorMessage.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.CloneRepoErrorForActionCenter, RepositoryToClone.DisplayName, result.DisplayMessage);
@@ -242,7 +242,7 @@ public partial class CloneRepoTask : ObservableObject, ISetupTask
             }
             catch (Exception e)
             {
-                _log.Error($"Could not clone {RepositoryToClone.DisplayName}", e);
+                _log.Error(e, $"Could not clone {RepositoryToClone.DisplayName}");
                 _actionCenterErrorMessage.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.CloneRepoErrorForActionCenter, RepositoryToClone.DisplayName, e.HResult.ToString("X", CultureInfo.CurrentCulture));
                 TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_CouldNotClone_Event", LogLevel.Critical, new ExceptionEvent(e.HResult));
                 return TaskFinishedState.Failure;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -124,7 +124,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         }
         catch (Exception e)
         {
-            _log.Error(e.Message, e);
+            _log.Error(e, e.Message);
             RepositoryTypeIcon = GetGitIcon(theme);
             return;
         }
@@ -259,7 +259,7 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
                 }
                 catch (Exception e)
                 {
-                    _log.Error(e.Message, e);
+                    _log.Error(e, e.Message);
                 }
             }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
@@ -214,7 +214,7 @@ public class ConfigureTargetTask : ISetupTask
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to process configuration progress data on target machine.'{ComputeSystemName}'", ex);
+            _log.Error(ex, $"Failed to process configuration progress data on target machine.'{ComputeSystemName}'");
         }
     }
 
@@ -254,7 +254,7 @@ public class ConfigureTargetTask : ISetupTask
 
             if (resultStatus == ProviderOperationStatus.Failure)
             {
-                _log.Error($"Extension failed to configure config file with exception. Diagnostic text: {result.DiagnosticText}", result.ExtendedError);
+                _log.Error(result.ExtendedError, $"Extension failed to configure config file with exception. Diagnostic text: {result.DiagnosticText}");
                 throw new SDKApplyConfigurationSetResultException(applyConfigurationResult.Result.DiagnosticText);
             }
 
@@ -288,7 +288,7 @@ public class ConfigureTargetTask : ISetupTask
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to apply configuration on target machine. '{ComputeSystemName}'", ex);
+            _log.Error(ex, $"Failed to apply configuration on target machine. '{ComputeSystemName}'");
         }
 
         var tempResultInfo = !string.IsNullOrEmpty(resultInformation) ? resultInformation : string.Empty;
@@ -371,7 +371,7 @@ public class ConfigureTargetTask : ISetupTask
             }
             catch (Exception e)
             {
-                _log.Error($"Failed to apply configuration on target machine.", e);
+                _log.Error(e, $"Failed to apply configuration on target machine.");
                 return TaskFinishedState.Failure;
             }
         }).AsAsyncOperation();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTask.cs
@@ -107,7 +107,7 @@ public class ConfigureTask : ISetupTask
             }
             catch (Exception e)
             {
-                _log.Error($"Failed to apply configuration.", e);
+                _log.Error(e, $"Failed to apply configuration.");
                 return TaskFinishedState.Failure;
             }
         }).AsAsyncOperation();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CreateDevDriveTask.cs
@@ -129,7 +129,7 @@ internal sealed class CreateDevDriveTask : ISetupTask
             catch (Exception ex)
             {
                 result = ex.HResult;
-                _log.Error($"Failed to create Dev Drive.", ex);
+                _log.Error(ex, $"Failed to create Dev Drive.");
                 _actionCenterMessages.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.DevDriveErrorWithReason, _stringResource.GetLocalizedErrorMsg(ex.HResult, Identity.Component.DevDrive));
                 TelemetryFactory.Get<ITelemetry>().LogException("CreatingDevDriveException", ex);
                 return TaskFinishedState.Failure;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/GenericRepository.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/GenericRepository.cs
@@ -51,22 +51,22 @@ internal sealed class GenericRepository : Microsoft.Windows.DevHome.SDK.IReposit
                 }
                 catch (RecurseSubmodulesException recurseException)
                 {
-                    _log.Error("Could not clone all sub modules", recurseException);
+                    _log.Error(recurseException, "Could not clone all sub modules");
                     throw;
                 }
                 catch (UserCancelledException userCancelledException)
                 {
-                    _log.Error("The user stoped the clone operation", userCancelledException);
+                    _log.Error(userCancelledException, "The user stoped the clone operation");
                     throw;
                 }
                 catch (NameConflictException nameConflictException)
                 {
-                    _log.Error(string.Empty, nameConflictException);
+                    _log.Error(nameConflictException, nameConflictException.ToString());
                     throw;
                 }
                 catch (Exception e)
                 {
-                    _log.Error("Could not clone the repository", e);
+                    _log.Error(e, "Could not clone the repository");
                     throw;
                 }
             }

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
@@ -153,7 +153,7 @@ public class InstallPackageTask : ISetupTask
             catch (Exception e)
             {
                 ReportAppInstallFailedEvent();
-                _log.Error($"Exception thrown while installing package.", e);
+                _log.Error(e, $"Exception thrown while installing package.");
                 return TaskFinishedState.Failure;
             }
         }).AsAsyncOperation();
@@ -189,7 +189,7 @@ public class InstallPackageTask : ISetupTask
             catch (Exception e)
             {
                 ReportAppInstallFailedEvent();
-                _log.Error($"Exception thrown while installing package.", e);
+                _log.Error(e, $"Exception thrown while installing package.");
                 return TaskFinishedState.Failure;
             }
         }).AsAsyncOperation();

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -77,7 +77,7 @@ internal sealed class RepositoryProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"Could not get repository provider from extension.", ex);
+            _log.Error(ex, $"Could not get repository provider from extension.");
         }
     }
 
@@ -199,7 +199,7 @@ internal sealed class RepositoryProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"ShowLoginUIAsync(): loginUIContentDialog failed.", ex);
+            _log.Error(ex, $"ShowLoginUIAsync(): loginUIContentDialog failed.");
         }
 
         return null;
@@ -224,7 +224,7 @@ internal sealed class RepositoryProvider
         var developerIdsResult = _devIdProvider.GetLoggedInDeveloperIds();
         if (developerIdsResult.Result.Status != ProviderOperationStatus.Success)
         {
-            _log.Error($"Could not get logged in accounts.  Message: {developerIdsResult.Result.DisplayMessage}", developerIdsResult.Result.ExtendedError);
+            _log.Error(developerIdsResult.Result.ExtendedError, $"Could not get logged in accounts.  Message: {developerIdsResult.Result.DisplayMessage}");
             return new List<IDeveloperId>();
         }
 
@@ -251,7 +251,7 @@ internal sealed class RepositoryProvider
                 }
                 else
                 {
-                    _log.Error($"Could not get repositories.  Message: {result.Result.DisplayMessage}", result.Result.ExtendedError);
+                    _log.Error(result.Result.ExtendedError, $"Could not get repositories.  Message: {result.Result.DisplayMessage}");
                 }
             }
             else
@@ -264,7 +264,7 @@ internal sealed class RepositoryProvider
                 }
                 else
                 {
-                    _log.Error($"Could not get repositories.  Message: {result.Result.DisplayMessage}", result.Result.ExtendedError);
+                    _log.Error(result.Result.ExtendedError, $"Could not get repositories.  Message: {result.Result.DisplayMessage}");
                 }
             }
         }
@@ -282,7 +282,7 @@ internal sealed class RepositoryProvider
         }
         catch (Exception ex)
         {
-            _log.Error($"Could not get repositories.  Message: {ex}");
+            _log.Error(ex, $"Could not get repositories.  Message: {ex}");
         }
 
         _repositories[developerId] = repoSearchInformation.Repositories;
@@ -304,7 +304,7 @@ internal sealed class RepositoryProvider
             }
             else
             {
-                _log.Error($"Could not get repositories.  Message: {result.Result.DisplayMessage}", result.Result.ExtendedError);
+                _log.Error(result.Result.ExtendedError, $"Could not get repositories.  Message: {result.Result.DisplayMessage}");
             }
         }
         catch (AggregateException aggregateException)
@@ -316,12 +316,12 @@ internal sealed class RepositoryProvider
             }
             else
             {
-                _log.Error(aggregateException.Message, aggregateException);
+                _log.Error(aggregateException, aggregateException.Message);
             }
         }
         catch (Exception ex)
         {
-            _log.Error($"Could not get repositories.  Message: {ex}", ex);
+            _log.Error(ex, $"Could not get repositories.  Message: {ex}");
         }
 
         _repositories[developerId] = repoSearchInformation.Repositories;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/WinGetPackage.cs
@@ -133,7 +133,7 @@ public class WinGetPackage : IWinGetPackage
         }
         catch (Exception e)
         {
-            _log.Error($"Unable to validate if the version {versionInfo.Version} is in the list of available versions", e);
+            _log.Error(e, $"Unable to validate if the version {versionInfo.Version} is in the list of available versions");
         }
 
         return versionInfo.Version;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/WingetConfigure/SDKOpenConfigurationSetResult.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/WingetConfigure/SDKOpenConfigurationSetResult.cs
@@ -49,7 +49,7 @@ public class SDKOpenConfigurationSetResult
     public string GetErrorMessage()
     {
         var log = Log.ForContext("SourceContext", nameof(SDKOpenConfigurationSetResult));
-        log.Error($"Extension failed to open the configuration file provided by Dev Home: Field: {Field}, Value: {Value}, Line: {Line}, Column: {Column}", ResultCode);
+        log.Error(ResultCode, $"Extension failed to open the configuration file provided by Dev Home: Field: {Field}, Value: {Value}, Line: {Line}, Column: {Column}");
         return _setupFlowStringResource.GetLocalized(StringResourceKey.SetupTargetConfigurationOpenConfigFailed);
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/AppManagementInitializer.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/AppManagementInitializer.cs
@@ -74,7 +74,7 @@ public class AppManagementInitializer : IAppManagementInitializer
         }
         catch (Exception e)
         {
-            _log.Error($"Unable to correctly initialize app management at the moment. Further attempts will be performed later.", e);
+            _log.Error(e, $"Unable to correctly initialize app management at the moment. Further attempts will be performed later.");
         }
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/CatalogDataSourceLoader.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/CatalogDataSourceLoader.cs
@@ -72,7 +72,7 @@ public class CatalogDataSourceLoader : ICatalogDataSourceLoader, IDisposable
         }
         catch (Exception e)
         {
-            _log.Error($"Exception thrown while initializing data source of type {dataSource.GetType().Name}", e);
+            _log.Error(e, $"Exception thrown while initializing data source of type {dataSource.GetType().Name}");
         }
     }
 
@@ -89,7 +89,7 @@ public class CatalogDataSourceLoader : ICatalogDataSourceLoader, IDisposable
         }
         catch (Exception e)
         {
-            _log.Error($"Exception thrown while loading data source of type {dataSource.GetType().Name}", e);
+            _log.Error(e, $"Exception thrown while loading data source of type {dataSource.GetType().Name}");
         }
 
         return null;

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/ComputeSystemViewModelFactory.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/ComputeSystemViewModelFactory.cs
@@ -37,7 +37,7 @@ public class ComputeSystemViewModelFactory
         catch (Exception ex)
         {
             var log = Log.ForContext("SourceContext", nameof(ComputeSystemViewModelFactory));
-            log.Error($"Failed to get initial properties for compute system {computeSystem}. Error: {ex.Message}");
+            log.Error(ex, $"Failed to get initial properties for compute system {computeSystem}. Error: {ex.Message}");
         }
 
         return cardViewModel;

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/ConfigurationFileBuilder.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/ConfigurationFileBuilder.cs
@@ -138,7 +138,7 @@ public class ConfigurationFileBuilder
             }
             catch (Exception e)
             {
-                _log.Error($"Error creating a repository resource entry", e);
+                _log.Error(e, $"Error creating a repository resource entry");
             }
         }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
@@ -251,7 +251,7 @@ public class DevDriveManager : IDevDriveManager
         catch (Exception ex)
         {
             // Log then return empty list, don't show the user their existing dev drive. Not catastrophic failure.
-            _log.Error($"Failed to get existing Dev Drives.", ex);
+            _log.Error(ex, $"Failed to get existing Dev Drives.");
             return new List<IDevDrive>();
         }
     }
@@ -280,7 +280,7 @@ public class DevDriveManager : IDevDriveManager
         }
         catch (Exception ex)
         {
-            _log.Error($"Unable to get available Free Space for {root}.", ex);
+            _log.Error(ex, $"Unable to get available Free Space for {root}.");
             validationSuccessful = false;
         }
 
@@ -372,7 +372,7 @@ public class DevDriveManager : IDevDriveManager
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to validate selected Drive letter ({devDrive.DriveLocation.FirstOrDefault()}).", ex);
+            _log.Error(ex, $"Failed to validate selected Drive letter ({devDrive.DriveLocation.FirstOrDefault()}).");
             returnSet.Add(DevDriveValidationResult.DriveLetterNotAvailable);
         }
 
@@ -405,7 +405,7 @@ public class DevDriveManager : IDevDriveManager
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to get Available Drive letters.", ex);
+            _log.Error(ex, $"Failed to get Available Drive letters.");
         }
 
         return driveLetterSet.ToList();

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGet/WinGetCatalogConnector.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGet/WinGetCatalogConnector.cs
@@ -223,7 +223,7 @@ internal sealed class WinGetCatalogConnector : IWinGetCatalogConnector, IDisposa
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to create or connect to search catalog.", e);
+            _log.Error(e, $"Failed to create or connect to search catalog.");
         }
     }
 
@@ -241,7 +241,7 @@ internal sealed class WinGetCatalogConnector : IWinGetCatalogConnector, IDisposa
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to create or connect to 'winget' catalog source.", e);
+            _log.Error(e, $"Failed to create or connect to 'winget' catalog source.");
         }
     }
 
@@ -259,7 +259,7 @@ internal sealed class WinGetCatalogConnector : IWinGetCatalogConnector, IDisposa
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to create or connect to 'msstore' catalog source.", e);
+            _log.Error(e, $"Failed to create or connect to 'msstore' catalog source.");
         }
     }
 
@@ -278,7 +278,7 @@ internal sealed class WinGetCatalogConnector : IWinGetCatalogConnector, IDisposa
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to create or connect to custom catalog with name {catalogName}", e);
+            _log.Error(e, $"Failed to create or connect to custom catalog with name {catalogName}");
             return null;
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGet/WinGetDeployment.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGet/WinGetDeployment.cs
@@ -53,7 +53,7 @@ internal sealed class WinGetDeployment : IWinGetDeployment
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to create dummy {nameof(PackageManager)} COM object. WinGet COM Server is not available.", e);
+            _log.Error(e, $"Failed to create dummy {nameof(PackageManager)} COM object. WinGet COM Server is not available.");
             return false;
         }
     }
@@ -70,7 +70,7 @@ internal sealed class WinGetDeployment : IWinGetDeployment
         }
         catch (Exception e)
         {
-            _log.Error("Failed to check if AppInstaller has an update, defaulting to false", e);
+            _log.Error(e, "Failed to check if AppInstaller has an update, defaulting to false");
             return false;
         }
     }
@@ -87,12 +87,12 @@ internal sealed class WinGetDeployment : IWinGetDeployment
         }
         catch (RegisterPackageException e)
         {
-            _log.Error($"Failed to register AppInstaller", e);
+            _log.Error(e, $"Failed to register AppInstaller");
             return false;
         }
         catch (Exception e)
         {
-            _log.Error("An unexpected error occurred when registering AppInstaller", e);
+            _log.Error(e, "An unexpected error occurred when registering AppInstaller");
             return false;
         }
     }
@@ -106,7 +106,7 @@ internal sealed class WinGetDeployment : IWinGetDeployment
         }
         catch (Exception e)
         {
-            _log.Error("An unexpected error occurred when checking if configuration is unstubbed", e);
+            _log.Error(e, "An unexpected error occurred when checking if configuration is unstubbed");
             return false;
         }
     }
@@ -123,7 +123,7 @@ internal sealed class WinGetDeployment : IWinGetDeployment
         }
         catch (Exception e)
         {
-            _log.Error("An unexpected error occurred when unstubbing configuration", e);
+            _log.Error(e, "An unexpected error occurred when unstubbing configuration");
             return false;
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGet/WinGetRecovery.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGet/WinGetRecovery.cs
@@ -45,12 +45,12 @@ internal sealed class WinGetRecovery : IWinGetRecovery
                 }
                 catch (CatalogNotInitializedException e)
                 {
-                    _log.Error($"Catalog used by the action is not initialized", e);
+                    _log.Error(e, $"Catalog used by the action is not initialized");
                     await RecoveryAsync(attempt);
                 }
                 catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed || e.HResult == PackageUpdating)
                 {
-                    _log.Error($"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}", e);
+                    _log.Error(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
                     await RecoveryAsync(attempt);
                 }
             }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetFeaturedApplicationsDataSource.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetFeaturedApplicationsDataSource.cs
@@ -90,7 +90,7 @@ public sealed class WinGetFeaturedApplicationsDataSource : WinGetPackageDataSour
                     }
                     catch (Exception e)
                     {
-                        _log.Error($"Error loading packages from featured applications group.", e);
+                        _log.Error(e, $"Error loading packages from featured applications group.");
                     }
                 }
             });
@@ -197,7 +197,7 @@ public sealed class WinGetFeaturedApplicationsDataSource : WinGetPackageDataSour
                     }
                     else
                     {
-                        _log.Error($"Failed to get featured applications groups from extension '{extensionName}': {groupsResult.Result.DiagnosticText}", groupsResult.Result.ExtendedError);
+                        _log.Error(groupsResult.Result.ExtendedError, $"Failed to get featured applications groups from extension '{extensionName}': {groupsResult.Result.DiagnosticText}");
                     }
                 }
                 else
@@ -207,7 +207,7 @@ public sealed class WinGetFeaturedApplicationsDataSource : WinGetPackageDataSour
             }
             catch (Exception e)
             {
-                _log.Error($"Error loading featured applications from extension {extensionName}", e);
+                _log.Error(e, $"Error loading featured applications from extension {extensionName}");
             }
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetPackageJsonDataSource.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetPackageJsonDataSource.cs
@@ -159,7 +159,7 @@ public class WinGetPackageJsonDataSource : WinGetPackageDataSource
         }
         catch (Exception e)
         {
-            _log.Error($"Error loading packages from winget catalog.", e);
+            _log.Error(e, $"Error loading packages from winget catalog.");
         }
 
         return null;
@@ -184,7 +184,7 @@ public class WinGetPackageJsonDataSource : WinGetPackageDataSource
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to get icon for JSON package {package.Uri}.", e);
+            _log.Error(e, $"Failed to get icon for JSON package {package.Uri}.");
         }
 
         _log.Warning($"No icon found for JSON package {package.Uri}. A default one will be provided.");

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetPackageRestoreDataSource.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/WinGetPackageRestoreDataSource.cs
@@ -97,7 +97,7 @@ public class WinGetPackageRestoreDataSource : WinGetPackageDataSource
         }
         catch (Exception e)
         {
-            _log.Error($"Error loading packages from winget restore catalog.", e);
+            _log.Error(e, $"Error loading packages from winget restore catalog.");
         }
 
         return result;
@@ -130,7 +130,7 @@ public class WinGetPackageRestoreDataSource : WinGetPackageDataSource
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to get icon for restore package {appInfo.Id}", e);
+            _log.Error(e, $"Failed to get icon for restore package {appInfo.Id}");
         }
 
         _log.Warning($"No {theme} icon found for restore package {appInfo.Id}. A default one will be provided.");

--- a/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
@@ -104,7 +104,7 @@ public static class DevDriveUtil
             }
             catch (Exception ex)
             {
-                Log.Error($"Unable to query for Dev Drive enablement: {ex.Message}");
+                Log.Error(ex, $"Unable to query for Dev Drive enablement: {ex.Message}");
                 return false;
             }
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -1051,7 +1051,7 @@ public partial class AddRepoViewModel : ObservableObject
             }
             catch (Exception e)
             {
-                _log.Error($"Invalid URL {uri.OriginalString}", e);
+                _log.Error(e, $"Invalid URL {uri.OriginalString}");
                 UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlValidationBadUrl);
                 ShouldShowUrlError = true;
                 return;
@@ -1248,7 +1248,7 @@ public partial class AddRepoViewModel : ObservableObject
             }
             catch (Exception ex)
             {
-                _log.Error($"Exception thrown while calling show logon session", ex);
+                _log.Error(ex, $"Exception thrown while calling show logon session");
             }
         }
     }
@@ -1335,7 +1335,7 @@ public partial class AddRepoViewModel : ObservableObject
             }
             catch (Exception ex)
             {
-                _log.Error($"Exception thrown while selecting repositories from the return object", ex);
+                _log.Error(ex, $"Exception thrown while selecting repositories from the return object");
                 _allRepositories = new();
             }
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
@@ -89,7 +89,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to initialize elevated process.", e);
+            _log.Error(e, $"Failed to initialize elevated process.");
         }
     }
 
@@ -113,7 +113,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to get configuration unit details.", e);
+            _log.Error(e, $"Failed to get configuration unit details.");
         }
     }
 
@@ -134,7 +134,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to open file picker.", e);
+            _log.Error(e, $"Failed to open file picker.");
             return false;
         }
     }
@@ -184,7 +184,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         }
         catch (OpenConfigurationSetException e)
         {
-            _log.Error($"Opening configuration set failed.", e);
+            _log.Error(e, $"Opening configuration set failed.");
             await _mainWindow.ShowErrorMessageDialogAsync(
                 StringResource.GetLocalized(StringResourceKey.ConfigurationViewTitle, file.Name),
                 GetErrorMessage(e),
@@ -192,7 +192,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
         }
         catch (Exception e)
         {
-            _log.Error($"Unknown error while opening configuration set.", e);
+            _log.Error(e, $"Unknown error while opening configuration set.");
 
             await _mainWindow.ShowErrorMessageDialogAsync(
                 file.Name,

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -269,7 +269,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
         }
         catch (Exception e)
         {
-            _log.Error("Failed to open folder picker.", e);
+            _log.Error(e, "Failed to open folder picker.");
         }
     }
 
@@ -509,7 +509,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
         }
         catch (Exception ex)
         {
-            _log.Error($"Failed to refresh the drive letter to size mapping.", ex);
+            _log.Error(ex, $"Failed to refresh the drive letter to size mapping.");
 
             // Clear the mapping since it can't be refreshed. This shouldn't happen unless DriveInfo.GetDrives() fails. In that case we won't know which drive
             // in the list is causing GetDrives()'s to throw. If there are values inside the dictionary at this point, they could be stale. Clearing the list

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemsListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemsListViewModel.cs
@@ -146,7 +146,7 @@ public partial class ComputeSystemsListViewModel : ObservableObject
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to filter Compute system cards. Error: {ex.Message}");
+                _log.Error(ex, $"Failed to filter Compute system cards. Error: {ex.Message}");
             }
 
             return true;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
@@ -181,7 +181,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
             }
             catch (Exception ex)
             {
-                _log.Error($"Failed to get creation options adaptive card from provider {_curProviderDetails.ComputeSystemProvider.Id}.", ex);
+                _log.Error(ex, $"Failed to get creation options adaptive card from provider {_curProviderDetails.ComputeSystemProvider.Id}.");
                 SessionErrorMessage = ex.Message;
             }
         });

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
@@ -146,7 +146,7 @@ public partial class FolderPickerViewModel : ObservableObject
         }
         catch (Exception e)
         {
-            _log.Error("Failed to open folder picker", e);
+            _log.Error(e, "Failed to open folder picker");
             return null;
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -93,7 +93,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to load catalogs.", e);
+            _log.Error(e, $"Failed to load catalogs.");
         }
         finally
         {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
@@ -164,7 +164,7 @@ public partial class ReviewViewModel : SetupPageViewModelBase
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to initialize elevated process.", e);
+            _log.Error(e, $"Failed to initialize elevated process.");
         }
     }
 
@@ -188,7 +188,7 @@ public partial class ReviewViewModel : SetupPageViewModelBase
         }
         catch (Exception e)
         {
-            _log.Error($"Failed to download configuration file.", e);
+            _log.Error(e, $"Failed to download configuration file.");
         }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SearchViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SearchViewModel.cs
@@ -128,7 +128,7 @@ public partial class SearchViewModel : ObservableObject
         }
         catch (Exception e)
         {
-            _log.Error($"Search error.", e);
+            _log.Error(e, $"Search error.");
             return (SearchResultStatus.ExceptionThrown, null);
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
@@ -196,7 +196,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         }
         catch (Exception ex)
         {
-            _log.Error($"Error filtering ComputeSystemsListViewModel", ex);
+            _log.Error(ex, $"Error filtering ComputeSystemsListViewModel");
         }
 
         return true;
@@ -366,7 +366,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         }
         catch (Exception ex)
         {
-            _log.Error($"Error loading ComputeSystemViewModels data", ex);
+            _log.Error(ex, $"Error loading ComputeSystemViewModels data");
         }
 
         ShouldShowShimmerBelowList = false;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/CreateEnvironmentReviewView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/CreateEnvironmentReviewView.xaml.cs
@@ -74,7 +74,7 @@ public sealed partial class CreateEnvironmentReviewView : UserControl, IRecipien
         catch (Exception ex)
         {
             // Log the exception
-            _log.Error("Error adding adaptive card UI in CreateEnvironmentReviewView", ex);
+            _log.Error(ex, "Error adding adaptive card UI in CreateEnvironmentReviewView");
         }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/EnvironmentCreationOptionsView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/EnvironmentCreationOptionsView.xaml.cs
@@ -72,7 +72,7 @@ public sealed partial class EnvironmentCreationOptionsView : UserControl, IRecip
         catch (Exception ex)
         {
             // Log the exception
-            _log.Error("Error adding adaptive card UI in EnvironmentCreationOptionsView", ex);
+            _log.Error(ex, "Error adding adaptive card UI in EnvironmentCreationOptionsView");
         }
     }
 }


### PR DESCRIPTION
## Summary of the pull request
This fixes the ordering of exception logging such that exceptions will be properly logge.d

## References and relevant issues
Closes #2577

## Detailed description of the pull request / Additional comments
Serilog has multiple valid logging signatures, but the only one that logs exceptions is if the exception is the first argument. Exceptions can be placed validly as 2nd, 3rd, etc. arguments after a string but those are assumed to be part of the message template and otherwise ignored. This resulted in valid log messages but exceptions that were intended to be logged were not being logged.

* Fixed all Error, Warning, Debug, and Information logging that included an exception at the end of the message and move dit to the front of the message so it would be logged instead of swallowed.
* Added a few exceptions to Errors that could have had them but didn't.
* Fixed a few improperly formatted log messages that survived the initial log conversion that were valid but not logging what the author wanted it to log.

## Validation steps performed
* Build validation with all changes.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
