### PR TITLE
Handle a missing PropertySet gracefully

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -86,7 +86,7 @@
                 <Activation>
                   <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
                 </Activation>
-                <!-- ExtensionService expects SupportedInterfaces to be defined, even if it is empty -->
+                <!-- Best practice is to define SupportedInterfaces, even if it is empty -->
                 <SupportedInterfaces />
               </DevHomeProvider>
             </uap3:Properties>

--- a/src/Services/ExtensionService.cs
+++ b/src/Services/ExtensionService.cs
@@ -313,12 +313,12 @@ public class ExtensionService : IExtensionService, IDisposable
 
     private IPropertySet? GetSubPropertySet(IPropertySet propSet, string name)
     {
-        return propSet[name] as IPropertySet;
+        return propSet.TryGetValue(name, out var value) ? value as IPropertySet : null;
     }
 
     private object[]? GetSubPropertySetArray(IPropertySet propSet, string name)
     {
-        return propSet[name] as object[];
+        return propSet.TryGetValue(name, out var value) ? value as object[] : null;
     }
 
     /// <summary>
@@ -330,7 +330,6 @@ public class ExtensionService : IExtensionService, IDisposable
     {
         var propSetList = new List<string>();
         var singlePropertySet = GetSubPropertySet(activationPropSet, CreateInstanceProperty);
-        var propertySetArray = GetSubPropertySetArray(activationPropSet, CreateInstanceProperty);
         if (singlePropertySet != null)
         {
             var classId = GetProperty(singlePropertySet, ClassIdProperty);
@@ -341,19 +340,23 @@ public class ExtensionService : IExtensionService, IDisposable
                 propSetList.Add(classId);
             }
         }
-        else if (propertySetArray != null)
+        else
         {
-            foreach (var prop in propertySetArray)
+            var propertySetArray = GetSubPropertySetArray(activationPropSet, CreateInstanceProperty);
+            if (propertySetArray != null)
             {
-                if (prop is not IPropertySet propertySet)
+                foreach (var prop in propertySetArray)
                 {
-                    continue;
-                }
+                    if (prop is not IPropertySet propertySet)
+                    {
+                        continue;
+                    }
 
-                var classId = GetProperty(propertySet, ClassIdProperty);
-                if (classId != null)
-                {
-                    propSetList.Add(classId);
+                    var classId = GetProperty(propertySet, ClassIdProperty);
+                    if (classId != null)
+                    {
+                        propSetList.Add(classId);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary of the pull request

#2532 showed us that a missing PropertySet can crash Dev Home. Instead, have it handle it gracefully. All callers of GetSubPropertySet() properly handle the null return case.

## Validation steps performed
Validated locally with extension that does not define `SupportedInterfaces`.