### PR TITLE
Make environment configuration available in Canary 

### DIFF
--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -45,7 +45,7 @@
         {
           "buildType": "dev",
           "enabledByDefault": true,
-          "visible": false
+          "visible": true
         },
         {
           "buildType": "canary",
@@ -55,7 +55,7 @@
         {
           "buildType": "stable",
           "enabledByDefault": false,
-          "visible": false
+          "visible": true
         }
       ]
     },
@@ -70,13 +70,13 @@
         },
         {
           "buildType": "canary",
-          "enabledByDefault": false,
-          "visible": false
+          "enabledByDefault": true,
+          "visible": true
         },
         {
           "buildType": "stable",
           "enabledByDefault": false,
-          "visible": false
+          "visible": true
         }
       ]
     },
@@ -118,7 +118,7 @@
         {
           "buildType": "stable",
           "enabledByDefault": false,
-          "visible": false
+          "visible": true
         }
       ]
     }


### PR DESCRIPTION
## Summary of the pull request
Currently only environment creation and management are available in Canary builds. Environment configuration should be available too. I forgot to turn it on in the nav config with the last PR. So, this PR updates all to be available in Canary and also makes them visible in release but off by default.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
