### PR TITLE
[Customization] Make dev drive query async to avoid UI delay

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
@@ -7,11 +7,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using Microsoft.UI.Xaml;
 using Windows.System;
+using WinUIEx;
 
 namespace DevHome.Customization.ViewModels;
 
@@ -19,15 +21,37 @@ public partial class MainPageViewModel : ObservableObject
 {
     private INavigationService NavigationService { get; }
 
+    private readonly WindowEx _windowEx;
+
     public ObservableCollection<Breadcrumb> Breadcrumbs { get; }
 
+    [ObservableProperty]
+    private bool _anyDevDrivesPresent;
+
     public MainPageViewModel(
-        INavigationService navigationService)
+        INavigationService navigationService,
+        WindowEx windowEx)
     {
         NavigationService = navigationService;
+        _windowEx = windowEx;
 
         var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
         Breadcrumbs = [new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!)];
+    }
+
+    public async Task LoadViewModelContentAsync()
+    {
+        await Task.Run(async () =>
+        {
+            // Getting all dev drives can be an expensive operation so should not be queried on the UI thread.
+            var anyDevDrivesPresent = Application.Current.GetService<IDevDriveManager>().GetAllDevDrivesThatExistOnSystem().Any();
+
+            // Update the UI thread
+            await _windowEx.DispatcherQueue.EnqueueAsync(() =>
+            {
+                AnyDevDrivesPresent = anyDevDrivesPresent;
+            });
+        });
     }
 
     [RelayCommand]
@@ -47,6 +71,4 @@ public partial class MainPageViewModel : ObservableObject
     {
         NavigationService.NavigateTo(typeof(DevDriveInsightsViewModel).FullName!);
     }
-
-    public bool AnyDevDrivesPresent => Application.Current.GetService<IDevDriveManager>().GetAllDevDrivesThatExistOnSystem().Any();
 }

--- a/tools/Customization/DevHome.Customization/Views/MainPageView.cs
+++ b/tools/Customization/DevHome.Customization/Views/MainPageView.cs
@@ -20,5 +20,11 @@ public sealed partial class MainPageView : UserControl
         InitializeComponent();
 
         ViewModel = Application.Current.GetService<MainPageViewModel>();
+        this.DataContext = ViewModel;
+    }
+
+    private async void UserControl_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.LoadViewModelContentAsync();
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/MainPageView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/MainPageView.xaml
@@ -3,8 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ui="using:CommunityToolkit.WinUI"
-    xmlns:views="using:DevHome.Customization.Views">
+    xmlns:views="using:DevHome.Customization.Views"
+    Loaded="UserControl_Loaded">
+    <UserControl.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    </UserControl.Resources>
 
     <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
         <!--  Primary settings group (untitled)  -->
@@ -22,7 +27,7 @@
             AutomationProperties.AccessibilityView="Control"
             AutomationProperties.AutomationId="NavigateDevDriveInsightsCardButton"
             Command="{x:Bind ViewModel.NavigateToDevDriveInsightsPageCommand}"
-            Visibility="{x:Bind ViewModel.AnyDevDrivesPresent}"
+            Visibility="{Binding AnyDevDrivesPresent, Converter={StaticResource BoolToVisibilityConverter}}"
             IsClickEnabled="True" >
             <controls:SettingsCard.HeaderIcon>
                 <FontIcon Glyph="&#xE3AF;" FontFamily="{ThemeResource AmcFluentIcons}"/>


### PR DESCRIPTION
## Summary of the pull request
GetAllDevDrivesThatExistOnSystem causes a noticeable delay when navigating to Windows customization.

## References and relevant issues
#2591 

## Detailed description of the pull request / Additional comments
This offloads the GetAllDevDrivesThatExistOnSystem query to an async method invoked via UserControl Loaded. The DevDrive settings card is shown asynchronously once that completes and a dev drive is found.  

## Validation steps performed
Tested by injecting a delay into GetAllDevDrivesThatExistOnSystem and ensured that while blocked Windows customization could be navigated to and freely interacted with.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
