### PR TITLE
Split WidgetHostingService and WidgetServiceService

### DIFF
--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -18,7 +18,7 @@ public class InitializationViewModel : ObservableObject
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(InitializationViewModel));
 
     private readonly IThemeSelectorService _themeSelector;
-    private readonly IWidgetHostingService _widgetHostingService;
+    private readonly IWidgetServiceService _widgetServiceService;
     private readonly IAppInstallManagerService _appInstallManagerService;
     private readonly IPackageDeploymentService _packageDeploymentService;
 
@@ -35,12 +35,12 @@ public class InitializationViewModel : ObservableObject
 
     public InitializationViewModel(
         IThemeSelectorService themeSelector,
-        IWidgetHostingService widgetHostingService,
+        IWidgetServiceService widgetServiceService,
         IAppInstallManagerService appInstallManagerService,
         IPackageDeploymentService packageDeploymentService)
     {
         _themeSelector = themeSelector;
-        _widgetHostingService = widgetHostingService;
+        _widgetServiceService = widgetServiceService;
         _appInstallManagerService = appInstallManagerService;
         _packageDeploymentService = packageDeploymentService;
     }
@@ -50,16 +50,16 @@ public class InitializationViewModel : ObservableObject
         // Install the widget service if we're on Windows 10 and it's not already installed.
         try
         {
-            if (_widgetHostingService.CheckForWidgetServiceAsync())
+            if (_widgetServiceService.CheckForWidgetServiceAsync())
             {
                 _log.Information("Skipping installing WidgetService, already installed.");
             }
             else
             {
-                if (_widgetHostingService.GetWidgetServiceState() == WidgetHostingService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
+                if (_widgetServiceService.GetWidgetServiceState() == WidgetServiceService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
                 {
                     // We're on Windows 10 and don't have the widget service, try to install it.
-                    await _widgetHostingService.TryInstallingWidgetService();
+                    await _widgetServiceService.TryInstallingWidgetService();
                 }
             }
         }

--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceExtensions
                 ActivatorUtilities.CreateInstance<WidgetViewModel>(sp, widget, widgetSize, widgetDefinition));
 
         // Services
+        services.AddSingleton<IWidgetServiceService, WidgetServiceService>();
         services.AddSingleton<IWidgetHostingService, WidgetHostingService>();
         services.AddSingleton<IWidgetIconService, WidgetIconService>();
         services.AddSingleton<IWidgetScreenshotService, WidgetScreenshotService>();

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -3,18 +3,11 @@
 
 using System.Threading.Tasks;
 using Microsoft.Windows.Widgets.Hosts;
-using static DevHome.Dashboard.Services.WidgetHostingService;
 
 namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
-    public bool CheckForWidgetServiceAsync();
-
-    public Task<bool> TryInstallingWidgetService();
-
-    public WidgetServiceStates GetWidgetServiceState();
-
     public Task<WidgetHost> GetWidgetHostAsync();
 
     public Task<WidgetCatalog> GetWidgetCatalogAsync();

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using static DevHome.Dashboard.Services.WidgetServiceService;
+
+namespace DevHome.Dashboard.Services;
+
+public interface IWidgetServiceService
+{
+    public bool CheckForWidgetServiceAsync();
+
+    public Task<bool> TryInstallingWidgetService();
+
+    public WidgetServiceStates GetWidgetServiceState();
+}

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -2,12 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using DevHome.Common.Helpers;
-using DevHome.Common.Services;
-using DevHome.Dashboard.Helpers;
-using DevHome.Services;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
 
@@ -17,97 +12,8 @@ public class WidgetHostingService : IWidgetHostingService
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetHostingService));
 
-    private readonly IPackageDeploymentService _packageDeploymentService;
-    private readonly IAppInstallManagerService _appInstallManagerService;
-
     private WidgetHost _widgetHost;
     private WidgetCatalog _widgetCatalog;
-
-    private WidgetServiceStates _widgetServiceState = WidgetServiceStates.Unknown;
-
-    public WidgetServiceStates GetWidgetServiceState() => _widgetServiceState;
-
-    public enum WidgetServiceStates
-    {
-        HasWebExperienceGoodVersion,
-        HasWebExperienceNoOrBadVersion,
-        HasStoreWidgetServiceGoodVersion,
-        HasStoreWidgetServiceNoOrBadVersion,
-        Unknown,
-    }
-
-    public WidgetHostingService(IPackageDeploymentService packageDeploymentService, IAppInstallManagerService appInstallManagerService)
-    {
-        _packageDeploymentService = packageDeploymentService;
-        _appInstallManagerService = appInstallManagerService;
-    }
-
-    public bool CheckForWidgetServiceAsync()
-    {
-        // If we're on Windows 11, check if we have the right WebExperiencePack version of the WidgetService.
-        if (RuntimeHelper.IsOnWindows11)
-        {
-            if (HasValidWebExperiencePack())
-            {
-                _log.Information("On Windows 11, HasWebExperienceGoodVersion");
-                _widgetServiceState = WidgetServiceStates.HasWebExperienceGoodVersion;
-                return true;
-            }
-            else
-            {
-                _log.Information("On Windows 11, HasWebExperienceNoOrBadVersion");
-                _widgetServiceState = WidgetServiceStates.HasWebExperienceNoOrBadVersion;
-                return false;
-            }
-        }
-        else
-        {
-            // If we're on Windows 10, check if we have the store version installed.
-            if (HasValidWidgetServicePackage())
-            {
-                _log.Information("On Windows 10, HasStoreWidgetServiceGoodVersion");
-                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceGoodVersion;
-                return true;
-            }
-            else
-            {
-                _log.Information("On Windows 10, HasStoreWidgetServiceNoOrBadVersion");
-                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
-                return false;
-            }
-        }
-    }
-
-    public async Task<bool> TryInstallingWidgetService()
-    {
-        _log.Information("Try installing widget service...");
-        var installedSuccessfully = await _appInstallManagerService.TryInstallPackageAsync(WidgetHelpers.WidgetServiceStorePackageId);
-        _widgetServiceState = installedSuccessfully ? WidgetServiceStates.HasStoreWidgetServiceGoodVersion : WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
-        _log.Information($"InstalledSuccessfully == {installedSuccessfully}, {_widgetServiceState}");
-        return installedSuccessfully;
-    }
-
-    private bool HasValidWebExperiencePack()
-    {
-        var minSupportedVersion400 = new Version(423, 3800);
-        var minSupportedVersion500 = new Version(523, 3300);
-        var version500 = new Version(500, 0);
-
-        // Ensure the application is installed, and the version is high enough.
-        var packages = _packageDeploymentService.FindPackagesForCurrentUser(
-            WidgetHelpers.WebExperiencePackageFamilyName,
-            (minSupportedVersion400, version500),
-            (minSupportedVersion500, null));
-        return packages.Any();
-    }
-
-    private bool HasValidWidgetServicePackage()
-    {
-        var minSupportedVersion = new Version(1, 0, 0, 0);
-
-        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetServicePackageFamilyName, (minSupportedVersion, null));
-        return packages.Any();
-    }
 
     public async Task<WidgetHost> GetWidgetHostAsync()
     {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DevHome.Common.Helpers;
+using DevHome.Common.Services;
+using DevHome.Dashboard.Helpers;
+using DevHome.Services;
+using Serilog;
+
+namespace DevHome.Dashboard.Services;
+
+public class WidgetServiceService : IWidgetServiceService
+{
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetHostingService));
+
+    private readonly IPackageDeploymentService _packageDeploymentService;
+    private readonly IAppInstallManagerService _appInstallManagerService;
+
+    private WidgetServiceStates _widgetServiceState = WidgetServiceStates.Unknown;
+
+    public WidgetServiceStates GetWidgetServiceState() => _widgetServiceState;
+
+    public enum WidgetServiceStates
+    {
+        HasWebExperienceGoodVersion,
+        HasWebExperienceNoOrBadVersion,
+        HasStoreWidgetServiceGoodVersion,
+        HasStoreWidgetServiceNoOrBadVersion,
+        Unknown,
+    }
+
+    public WidgetServiceService(IPackageDeploymentService packageDeploymentService, IAppInstallManagerService appInstallManagerService)
+    {
+        _packageDeploymentService = packageDeploymentService;
+        _appInstallManagerService = appInstallManagerService;
+    }
+
+    public bool CheckForWidgetServiceAsync()
+    {
+        // If we're on Windows 11, check if we have the right WebExperiencePack version of the WidgetService.
+        if (RuntimeHelper.IsOnWindows11)
+        {
+            if (HasValidWebExperiencePack())
+            {
+                _log.Information("On Windows 11, HasWebExperienceGoodVersion");
+                _widgetServiceState = WidgetServiceStates.HasWebExperienceGoodVersion;
+                return true;
+            }
+            else
+            {
+                _log.Information("On Windows 11, HasWebExperienceNoOrBadVersion");
+                _widgetServiceState = WidgetServiceStates.HasWebExperienceNoOrBadVersion;
+                return false;
+            }
+        }
+        else
+        {
+            // If we're on Windows 10, check if we have the store version installed.
+            if (HasValidWidgetServicePackage())
+            {
+                _log.Information("On Windows 10, HasStoreWidgetServiceGoodVersion");
+                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceGoodVersion;
+                return true;
+            }
+            else
+            {
+                _log.Information("On Windows 10, HasStoreWidgetServiceNoOrBadVersion");
+                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
+                return false;
+            }
+        }
+    }
+
+    public async Task<bool> TryInstallingWidgetService()
+    {
+        _log.Information("Try installing widget service...");
+        var installedSuccessfully = await _appInstallManagerService.TryInstallPackageAsync(WidgetHelpers.WidgetServiceStorePackageId);
+        _widgetServiceState = installedSuccessfully ? WidgetServiceStates.HasStoreWidgetServiceGoodVersion : WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
+        _log.Information($"InstalledSuccessfully == {installedSuccessfully}, {_widgetServiceState}");
+        return installedSuccessfully;
+    }
+
+    private bool HasValidWebExperiencePack()
+    {
+        var minSupportedVersion400 = new Version(423, 3800);
+        var minSupportedVersion500 = new Version(523, 3300);
+        var version500 = new Version(500, 0);
+
+        // Ensure the application is installed, and the version is high enough.
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(
+            WidgetHelpers.WebExperiencePackageFamilyName,
+            (minSupportedVersion400, version500),
+            (minSupportedVersion500, null));
+        return packages.Any();
+    }
+
+    private bool HasValidWidgetServicePackage()
+    {
+        var minSupportedVersion = new Version(1, 0, 0, 0);
+
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetServicePackageFamilyName, (minSupportedVersion, null));
+        return packages.Any();
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -9,6 +9,8 @@ namespace DevHome.Dashboard.ViewModels;
 
 public partial class DashboardViewModel : ObservableObject
 {
+    public IWidgetServiceService WidgetServiceService { get; }
+
     public IWidgetHostingService WidgetHostingService { get; }
 
     public IWidgetIconService WidgetIconService { get; }
@@ -22,10 +24,12 @@ public partial class DashboardViewModel : ObservableObject
     private bool _hasWidgetService;
 
     public DashboardViewModel(
+        IWidgetServiceService widgetServiceService,
         IWidgetHostingService widgetHostingService,
         IWidgetIconService widgetIconService,
         IWidgetScreenshotService widgetScreenshotService)
     {
+        WidgetServiceService = widgetServiceService;
         WidgetHostingService = widgetHostingService;
         WidgetIconService = widgetIconService;
         WidgetScreenshotService = widgetScreenshotService;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -23,7 +23,6 @@ using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Navigation;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
@@ -139,7 +138,7 @@ public partial class DashboardView : ToolPage, IDisposable
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
         ViewModel.IsLoading = true;
 
-        if (ViewModel.WidgetHostingService.CheckForWidgetServiceAsync())
+        if (ViewModel.WidgetServiceService.CheckForWidgetServiceAsync())
         {
             ViewModel.HasWidgetService = true;
             if (await SubscribeToWidgetCatalogEventsAsync())
@@ -161,9 +160,9 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         else
         {
-            var widgetServiceState = ViewModel.WidgetHostingService.GetWidgetServiceState();
-            if (widgetServiceState == WidgetHostingService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion ||
-                widgetServiceState == WidgetHostingService.WidgetServiceStates.HasWebExperienceNoOrBadVersion)
+            var widgetServiceState = ViewModel.WidgetServiceService.GetWidgetServiceState();
+            if (widgetServiceState == WidgetServiceService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion ||
+                widgetServiceState == WidgetServiceService.WidgetServiceStates.HasWebExperienceNoOrBadVersion)
             {
                 // Show error message that updating may help
                 UpdateWidgetsMessageStackPanel.Visibility = Visibility.Visible;


### PR DESCRIPTION
## Summary of the pull request
Splits the WidgetHostingService into the WidgetHostingService and WidgetServiceService. They make more sense apart.
* WidgetServiceService determines what version (if any) of the WidgetService is on the machine, and whether it's a high enough version
* WidgetHostingService gets us the WidgetHost and WidgetCatalog objects.

No code is changed, just moved between classes.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
