### PR TITLE
Changing Width to MinWidth to fix clipping button content in Extensions page

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -74,7 +74,7 @@
                                     <!-- This StackPanel is a workaround for the bug https://github.com/CommunityToolkit/Windows/issues/396 -->
                                     <Button x:Uid="MoreOptionsButton"
                                             Content="&#xe712;"
-                                            Height="36" Width="36"
+                                            Height="36" MinWidth="36"
                                             FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                             Background="Transparent"
                                             BorderThickness="0">


### PR DESCRIPTION
## Summary of the pull request
### Before
![image](https://github.com/microsoft/devhome/assets/13912953/c3c655cd-c6a3-4ced-b5e3-6721a01d294c)
### After
![image](https://github.com/microsoft/devhome/assets/13912953/628136f3-9978-4bc5-8d9d-4edccfd0f318)

## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/49656778
## Detailed description of the pull request / Additional comments
Changed Width to MinWidth so the button's content don't get clipped when there is lack of space.
## Validation steps performed

## PR checklist
- [ ] Closes #2612
- [ ] Tests added/passed
- [ ] Documentation updated
