### PR TITLE
Make create environment button respond to experimentation key being enabled/disabled

### DIFF
--- a/tools/Environments/DevHome.Environments/Helpers/EnvironmentsExtensionsService.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/EnvironmentsExtensionsService.cs
@@ -8,6 +8,7 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
+using DevHome.Common.Services;
 using DevHome.Environments.TestModels;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
@@ -18,9 +19,16 @@ public class EnvironmentsExtensionsService
 {
     private readonly IComputeSystemManager _computeSystemManager;
 
-    public EnvironmentsExtensionsService(IComputeSystemManager computeSystemManager)
+    private const string EnvironmentsCreationFlowFeatureName = "EnvironmentsCreationFlow";
+
+    private readonly IExperimentationService _experimentationService;
+
+    public bool IsEnvironmentCreationEnabled => _experimentationService.IsFeatureEnabled(EnvironmentsCreationFlowFeatureName);
+
+    public EnvironmentsExtensionsService(IComputeSystemManager computeSystemManager, IExperimentationService experimentationService)
     {
         _computeSystemManager = computeSystemManager;
+        _experimentationService = experimentationService;
     }
 
     public async Task GetComputeSystemsAsync(bool useDebugValues, Func<ComputeSystemsLoadedData, Task> callback)

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -31,7 +31,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
     private readonly WindowEx _windowEx;
 
-    private readonly EnvironmentsExtensionsService _extensionsService;
+    private readonly EnvironmentsExtensionsService _environmentExtensionsService;
 
     private readonly NotificationService _notificationService;
 
@@ -68,6 +68,9 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _shouldShowCreationHeader;
 
+    [ObservableProperty]
+    private bool _shouldShowCreateEnvironmentButton;
+
     public ObservableCollection<string> Providers { get; set; }
 
     private CancellationTokenSource _cancellationTokenSource = new();
@@ -80,7 +83,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
         WindowEx windowEx)
     {
         _computeSystemManager = manager;
-        _extensionsService = extensionsService;
+        _environmentExtensionsService = extensionsService;
         _notificationService = notificationService;
         _windowEx = windowEx;
         _navigationService = navigationService;
@@ -191,6 +194,8 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
                 return;
             }
 
+            ShouldShowCreateEnvironmentButton = _environmentExtensionsService.IsEnvironmentCreationEnabled;
+
             // If the page has already loaded once, then we don't need to re-load the compute systems as that can take a while.
             // The user can click the sync button to refresh the compute systems. However, there may be new operations that have started
             // since the last time the page was loaded. So we need to add those to the view model quickly.
@@ -213,7 +218,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
         }
 
         ShowLoadingShimmer = true;
-        await _extensionsService.GetComputeSystemsAsync(useDebugValues, AddAllComputeSystemsFromAProvider);
+        await _environmentExtensionsService.GetComputeSystemsAsync(useDebugValues, AddAllComputeSystemsFromAProvider);
         ShowLoadingShimmer = false;
 
         lock (_lock)

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -197,6 +197,7 @@
                 Grid.Column="3" 
                 Style="{ThemeResource AccentButtonStyle}" 
                 HorizontalAlignment="Right"
+                Visibility="{x:Bind ViewModel.ShouldShowCreateEnvironmentButton, Mode=OneWay}"
                 Command="{x:Bind ViewModel.CreateEnvironmentButtonCommand}" >
                 <Grid>
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary of the pull request
Currently the environments page is not checking if the environment creation key is enabled/disabled, so the "Create Environment" button is still being shown when the environment creation experimental feature is disabled. This PR stitches up the visibility of the button to a flag that checks the enablement of the experiment key. 

See video:


https://github.com/microsoft/devhome/assets/105318831/bd64ed2e-9845-4f11-b080-815e2372aad3




## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
