### PR TITLE
Copy DevSetupAgent dependencies (Microsoft.Management.Configuration.*) to the output directory.

### DIFF
--- a/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
+++ b/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
@@ -24,6 +24,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Configuration.OutOfProc" Version="1.7.10091-preview">
+      <GeneratePathProperty>True</GeneratePathProperty>
+    </PackageReference>
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
@@ -48,4 +51,12 @@
   <ItemGroup>
     <ReferenceCopyLocalPaths Include="$(ProjectDir)..\DevSetupEngineIdl\bin\$(Platform)\$(Configuration)\\Microsoft.Windows.DevHome.DevSetupEngine.winmd" />
   </ItemGroup>
+  
+  <!--DevSetupAgent doesn't use Microsoft.WindowsPackageManager.Configuration.OutOfProc package directly.-->
+  <!--DevSetupEngine uses it, but these dependencies are not copied to DevSetupAgent TargetDir.-->
+  <!--To fix this, we need to copy these files to the TargetDir manually.-->
+  <Target Name="CopyWinmdToTargetDir" BeforeTargets="BeforeBuild">
+    <Copy SourceFiles="$(PkgMicrosoft_WindowsPackageManager_Configuration_OutOfProc)\runtimes\win10-$(Platform)\native\Microsoft.Management.Configuration.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="$(PkgMicrosoft_WindowsPackageManager_Configuration_OutOfProc)\runtimes\win10-$(Platform)\native\Microsoft.Management.Configuration.winmd" DestinationFolder="$(TargetDir)" />
+  </Target>
 </Project>

--- a/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
+++ b/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
@@ -75,4 +75,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <Target Name="CopyWinmdToTargetDir" BeforeTargets="BeforeBuild">
+    <Copy SourceFiles="$(PkgMicrosoft_WindowsPackageManager_Configuration_OutOfProc)\runtimes\win10-$(Platform)\native\Microsoft.Management.Configuration.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="$(PkgMicrosoft_WindowsPackageManager_Configuration_OutOfProc)\runtimes\win10-$(Platform)\native\Microsoft.Management.Configuration.winmd" DestinationFolder="$(TargetDir)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary of the pull request
Build stopped copying Microsoft.Management.Configuration.winmd and Microsoft.Management.Configuration.dll files to the output directory of DevSetupAgent (presumably after changing RIDs in project files). DevSetupAgent.exe does not use those files directly, but DevSetupEngine.exe does. 
This change adds copy commands to DevSetupAgent and DevSetupEngine projects to get those files into the output.

## Validation steps performed
Tested build from VS and build.ps1 script.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
