### PR TITLE
Wrap Widget objects in a COM-safe wrapper

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Helpers/ComSafeWidget.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/ComSafeWidget.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DevHome.Common.Extensions;
+using DevHome.Dashboard.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.Widgets;
+using Microsoft.Windows.Widgets.Hosts;
+using Windows.Foundation;
+
+namespace DevHome.Dashboard.Helpers;
+
+/// <summary>
+/// Since Widgets are OOP COM objects, we need to wrap them in a safe way to handle COM exceptions
+/// that arise when the underlying OOP object vanishes. All Widgets should be wrapped in a
+/// ComSafeWidget and calls to the widget should be done through the ComSafeWidget.
+/// This class will handle the COM exceptions and get a new OOP Widget if needed.
+/// All APIs on the IWidget and IWidget2 interfaces are reflected here.
+/// </summary>
+public class ComSafeWidget
+{
+    public Widget OopWidget { get; set; }
+
+    // Not currently used.
+    public DateTimeOffset DataLastUpdated => throw new NotImplementedException();
+
+    public string DefinitionId { get; private set; }
+
+    public string Id { get; private set; }
+
+    // Not currently used.
+    public DateTimeOffset TemplateLastUpdated => throw new NotImplementedException();
+
+    private const int RpcServerUnavailable = unchecked((int)0x800706BA);
+    private const int RpcCallFailed = unchecked((int)0x800706BE);
+
+    public ComSafeWidget(Widget widget)
+    {
+        OopWidget = widget;
+        DefinitionId = widget.DefinitionId;
+        Id = widget.Id;
+        widget.WidgetUpdated += OopWidgetUpdated;
+    }
+
+    public event TypedEventHandler<ComSafeWidget, WidgetUpdatedEventArgs> WidgetUpdated = (_, _) => { };
+
+    private void OopWidgetUpdated(Widget sender, WidgetUpdatedEventArgs args)
+    {
+        WidgetUpdated.Invoke(this, args);
+    }
+
+    public async Task<string> GetCardTemplateAsync()
+    {
+        return await Task.Run(async () =>
+        {
+            try
+            {
+                return await OopWidget.GetCardTemplateAsync();
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                return await OopWidget.GetCardTemplateAsync();
+            }
+        });
+    }
+
+    public async Task<string> GetCardDataAsync()
+    {
+        return await Task.Run(async () =>
+        {
+            try
+            {
+                return await OopWidget.GetCardDataAsync();
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                return await OopWidget.GetCardDataAsync();
+            }
+        });
+    }
+
+    public async Task<string> GetCustomStateAsync()
+    {
+        return await Task.Run(async () =>
+        {
+            try
+            {
+                return await OopWidget.GetCustomStateAsync();
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                return await OopWidget.GetCustomStateAsync();
+            }
+        });
+    }
+
+    public async Task<WidgetSize> GetSizeAsync()
+    {
+        return await Task.Run(async () =>
+        {
+            try
+            {
+                return await OopWidget.GetSizeAsync();
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                return await OopWidget.GetSizeAsync();
+            }
+        });
+    }
+
+    public async Task NotifyActionInvokedAsync(string verb, string data)
+    {
+        await Task.Run(async () =>
+        {
+            try
+            {
+                await OopWidget.NotifyActionInvokedAsync(verb, data);
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                await OopWidget.NotifyActionInvokedAsync(verb, data);
+            }
+        });
+    }
+
+    public async Task DeleteAsync()
+    {
+        await Task.Run(async () =>
+        {
+            try
+            {
+                await OopWidget.DeleteAsync();
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                await OopWidget.DeleteAsync();
+            }
+        });
+    }
+
+    public async Task SetCustomStateAsync(string state)
+    {
+        await Task.Run(async () =>
+        {
+            try
+            {
+                await OopWidget.SetCustomStateAsync(state);
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                await OopWidget.SetCustomStateAsync(state);
+            }
+        });
+    }
+
+    public async Task SetSizeAsync(WidgetSize widgetSize)
+    {
+        await Task.Run(async () =>
+        {
+            try
+            {
+                await OopWidget.SetSizeAsync(widgetSize);
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                await OopWidget.SetSizeAsync(widgetSize);
+            }
+        });
+    }
+
+    public async Task NotifyCustomizationRequestedAsync()
+    {
+        await Task.Run(async () =>
+        {
+            try
+            {
+                await OopWidget.NotifyCustomizationRequestedAsync();
+            }
+            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            {
+                await GetNewOopWidgetAsync();
+                await OopWidget.NotifyCustomizationRequestedAsync();
+            }
+        });
+    }
+
+    // Not currently used.
+    public IAsyncAction NotifyAnalyticsInfoAsync(string analyticsInfo) => throw new NotImplementedException();
+
+    // Not currently used.
+    public IAsyncAction NotifyErrorInfoAsync(string errorInfo) => throw new NotImplementedException();
+
+    private async Task GetNewOopWidgetAsync()
+    {
+        var hostingService = Application.Current.GetService<IWidgetHostingService>();
+        var host = await hostingService.GetWidgetHostAsync();
+        OopWidget = host.GetWidget(Id);
+
+        DefinitionId = OopWidget.DefinitionId;
+        Id = OopWidget.Id;
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -123,7 +123,7 @@ internal sealed class WidgetHelpers
         return JsonSerializer.Serialize(state, SourceGenerationContext.Default.WidgetCustomState);
     }
 
-    public static async Task SetPositionCustomStateAsync(Widget widget, int ordinal)
+    public static async Task SetPositionCustomStateAsync(ComSafeWidget widget, int ordinal)
     {
         var stateStr = await widget.GetCustomStateAsync();
         var state = JsonSerializer.Deserialize(stateStr, SourceGenerationContext.Default.WidgetCustomState);

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -9,6 +9,7 @@ using AdaptiveCards.Templating;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Renderers;
 using DevHome.Common.Services;
+using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.TelemetryEvents;
 using DevHome.Telemetry;
@@ -32,7 +33,7 @@ namespace DevHome.Dashboard.ViewModels;
 /// <param name="widgetDefinition">WidgetDefinition</param>
 /// <returns>Widget view model</returns>
 public delegate WidgetViewModel WidgetViewModelFactory(
-    Widget widget,
+    ComSafeWidget widget,
     WidgetSize widgetSize,
     WidgetDefinition widgetDefinition);
 
@@ -46,7 +47,7 @@ public partial class WidgetViewModel : ObservableObject
     private RenderedAdaptiveCard _renderedCard;
 
     [ObservableProperty]
-    private Widget _widget;
+    private ComSafeWidget _widget;
 
     [ObservableProperty]
     private WidgetDefinition _widgetDefinition;
@@ -66,7 +67,7 @@ public partial class WidgetViewModel : ObservableObject
     [ObservableProperty]
     private FrameworkElement _widgetFrameworkElement;
 
-    partial void OnWidgetChanging(Widget value)
+    partial void OnWidgetChanging(ComSafeWidget value)
     {
         if (Widget != null)
         {
@@ -74,7 +75,7 @@ public partial class WidgetViewModel : ObservableObject
         }
     }
 
-    partial void OnWidgetChanged(Widget value)
+    partial void OnWidgetChanged(ComSafeWidget value)
     {
         if (Widget != null)
         {
@@ -94,7 +95,7 @@ public partial class WidgetViewModel : ObservableObject
     }
 
     public WidgetViewModel(
-        Widget widget,
+        ComSafeWidget widget,
         WidgetSize widgetSize,
         WidgetDefinition widgetDefinition,
         WidgetAdaptiveCardRenderingService adaptiveCardRenderingService,
@@ -329,7 +330,7 @@ public partial class WidgetViewModel : ObservableObject
         // https://github.com/microsoft/devhome/issues/644
     }
 
-    private async void HandleWidgetUpdated(Widget sender, WidgetUpdatedEventArgs args)
+    private async void HandleWidgetUpdated(ComSafeWidget sender, WidgetUpdatedEventArgs args)
     {
         _log.Debug($"HandleWidgetUpdated for widget {sender.Id}");
         await RenderWidgetFrameworkElementAsync();

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -300,8 +300,9 @@ public partial class DashboardView : ToolPage, IDisposable
         foreach (var orderedWidget in restoredWidgetsWithPosition)
         {
             var widget = orderedWidget.Value;
-            var size = await widget.GetSizeAsync();
-            await InsertWidgetInPinnedWidgetsAsync(widget, size, finalPlace++);
+            var comSafeWidget = new ComSafeWidget(widget);
+            var size = await comSafeWidget.GetSizeAsync();
+            await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, finalPlace++);
         }
 
         // Go through the newly created list of pinned widgets and update any positions that may have changed.
@@ -360,6 +361,7 @@ public partial class DashboardView : ToolPage, IDisposable
             var size = WidgetHelpers.GetDefaultWidgetSize(defaultWidgetDefinition.GetWidgetCapabilities());
             var id = defaultWidgetDefinition.Id;
             var newWidget = await Task.Run(async () => await widgetHost?.CreateWidgetAsync(id, size));
+            var comSafeWidget = new ComSafeWidget(newWidget);
             _log.Information($"Created default widget {id}");
 
             // Set custom state on new widget.
@@ -369,7 +371,7 @@ public partial class DashboardView : ToolPage, IDisposable
             await newWidget.SetCustomStateAsync(newCustomState);
 
             // Put new widget on the Dashboard.
-            await InsertWidgetInPinnedWidgetsAsync(newWidget, size, position);
+            await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, position);
             _log.Information($"Inserted default widget {id} at position {position}");
         }
         catch (Exception ex)
@@ -412,6 +414,7 @@ public partial class DashboardView : ToolPage, IDisposable
                 var size = WidgetHelpers.GetDefaultWidgetSize(newWidgetDefinition.GetWidgetCapabilities());
                 var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
                 newWidget = await Task.Run(async () => await widgetHost?.CreateWidgetAsync(newWidgetDefinition.Id, size));
+                var comSafeWidget = new ComSafeWidget(newWidget);
 
                 // Set custom state on new widget.
                 var position = PinnedWidgets.Count;
@@ -420,7 +423,7 @@ public partial class DashboardView : ToolPage, IDisposable
                 await newWidget.SetCustomStateAsync(newCustomState);
 
                 // Put new widget on the Dashboard.
-                await InsertWidgetInPinnedWidgetsAsync(newWidget, size, position);
+                await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, position);
             }
             catch (Exception ex)
             {
@@ -435,7 +438,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
     }
 
-    private async Task InsertWidgetInPinnedWidgetsAsync(Widget widget, WidgetSize size, int index)
+    private async Task InsertWidgetInPinnedWidgetsAsync(ComSafeWidget widget, WidgetSize size, int index)
     {
         await Task.Run(async () =>
         {


### PR DESCRIPTION
## Summary of the pull request
Since Widget objects are out of process, they can disappear out from under us throwing COMExceptions and crashing Dev Home. Wrap them in a new `ComSafeWidget` wrapper, which catches these exceptions and gets a new, valid object when the old one goes away.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
