### PR TITLE
[Customization] Make quiet mode initialization async to avoid UI delay

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/QuietBackgroundProcessesViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/QuietBackgroundProcessesViewModel.cs
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.WinUI;
 using DevHome.Common.Services;
 using DevHome.QuietBackgroundProcesses;
 using Microsoft.UI.Xaml;
 using Serilog;
+using WinUIEx;
 
 namespace DevHome.Customization.ViewModels;
 
@@ -19,6 +22,9 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
 
     private readonly TimeSpan _zero = new(0, 0, 0);
     private readonly TimeSpan _oneSecond = new(0, 0, 1);
+
+    private readonly WindowEx _windowEx;
+
 #nullable enable
     private QuietBackgroundProcessesSession? _session;
 #nullable disable
@@ -58,25 +64,52 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
 
     public bool IsQuietBackgroundProcessesFeatureEnabled => _experimentationService.IsFeatureEnabled("QuietBackgroundProcessesExperiment");
 
-    public QuietBackgroundProcessesViewModel(IExperimentationService experimentationService)
+    public QuietBackgroundProcessesViewModel(
+        IExperimentationService experimentationService,
+        WindowEx windowEx)
     {
         _experimentationService = experimentationService;
-        IsFeaturePresent = QuietBackgroundProcessesSessionManager.IsFeaturePresent();
+        _windowEx = windowEx;
+    }
 
-        var running = false;
-        if (IsFeaturePresent)
+    public async Task LoadViewModelContentAsync()
+    {
+        await Task.Run(async () =>
         {
-            // Check if an existing quiet session is running.
-            // Note: GetIsActive() won't ever launch a UAC prompt, but GetTimeRemaining() will if no session is running - so be careful with call order
-            running = GetIsActive();
-        }
-        else
-        {
-            SessionStateText = GetStatusString("FeatureNotSupported");
-        }
+            if (!IsQuietBackgroundProcessesFeatureEnabled)
+            {
+                return;
+            }
 
-        // Resume countdown if there's an existing quiet window
-        SetQuietSessionRunningState(running);
+            var isFeaturePresent = QuietBackgroundProcessesSessionManager.IsFeaturePresent();
+            var running = false;
+            long? timeLeftInSeconds = null;
+            if (isFeaturePresent)
+            {
+                // Check if an existing quiet session is running.
+                // Note: GetIsActive() won't ever launch a UAC prompt, but GetTimeRemaining() will if no session is running - so be careful with call order
+                running = GetIsActive();
+                if (running)
+                {
+                    timeLeftInSeconds = GetTimeRemaining();
+                }
+            }
+
+            // Update the UI thread
+            await _windowEx.DispatcherQueue.EnqueueAsync(() =>
+            {
+                IsFeaturePresent = isFeaturePresent;
+                if (IsFeaturePresent)
+                {
+                    // Resume countdown if there's an existing quiet window
+                    SetQuietSessionRunningState(running, timeLeftInSeconds);
+                }
+                else
+                {
+                    SessionStateText = GetStatusString("FeatureNotSupported");
+                }
+            });
+        });
     }
 
     private void SetQuietSessionRunningState(bool running, long? timeLeftInSeconds = null)

--- a/tools/Customization/DevHome.Customization/Views/QuietBackgroundProcessesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/QuietBackgroundProcessesView.xaml
@@ -3,7 +3,8 @@
     x:Class="DevHome.Customization.Views.QuietBackgroundProcessesView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls">
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
+    Loaded="UserControl_Loaded">
 
     <StackPanel Orientation="Vertical"
                 Visibility="{x:Bind ViewModel.IsQuietBackgroundProcessesFeatureEnabled, Mode=OneWay}">

--- a/tools/Customization/DevHome.Customization/Views/QuietBackgroundProcessesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/QuietBackgroundProcessesView.xaml.cs
@@ -21,4 +21,9 @@ public sealed partial class QuietBackgroundProcessesView : UserControl
 
         ViewModel = Application.Current.GetService<QuietBackgroundProcessesViewModel>();
     }
+
+    private async void UserControl_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.LoadViewModelContentAsync();
+    }
 }


### PR DESCRIPTION
## Summary of the pull request
Make quiet mode's view model initialization async on user control loaded to avoid delays when navigating to Windows customization L1 page. 

## References and relevant issues
#2591 

## Detailed description of the pull request / Additional comments
Loading QuietBackgroundProcessesSessionManager the first time and making OOP calls during ViewModel initialization on the UI thread can cause noticeable delays when navigating to the Windows customization page. 

## Validation steps performed
Navigate to Windows customization and ensure UI is responsive, even while injecting a long delay in loading QuietBackgroundProcessesSessionManager or calling IsFeaturePresent, GetIsActive or GetTimeRemaining to make sure those calls do not block the UI thread.

## PR checklist
- [ ] Closes #2591
- [ ] Tests added/passed
- [ ] Documentation updated
