### PR TITLE
Wrap WidgetDefinition objects in a COM-safe wrapper

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeHelpers.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Dashboard.Services;
 
@@ -27,10 +27,7 @@ internal sealed class ComSafeHelpers
             }
         }
 
-#pragma warning disable CA1309 // Use ordinal string comparison
-        comSafeWidgetDefinitions.Sort((a, b) => string.Compare(a.DisplayTitle, b.DisplayTitle, StringComparison.CurrentCulture));
-#pragma warning restore CA1309 // Use ordinal string comparison
-
+        comSafeWidgetDefinitions = comSafeWidgetDefinitions.OrderBy(def => def.DisplayTitle).ToList();
         return comSafeWidgetDefinitions;
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeHelpers.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevHome.Dashboard.Services;
+
+namespace DevHome.Dashboard.ComSafeWidgetObjects;
+
+internal sealed class ComSafeHelpers
+{
+    public static async Task<List<ComSafeWidgetDefinition>> GetAllOrderedComSafeWidgetDefinitions(IWidgetHostingService widgetHostingService)
+    {
+        var unsafeWidgetDefinitions = await widgetHostingService.GetWidgetDefinitionsAsync();
+        var comSafeWidgetDefinitions = new List<ComSafeWidgetDefinition>();
+        foreach (var unsafeWidgetDefinition in unsafeWidgetDefinitions)
+        {
+            var id = await ComSafeWidgetDefinition.GetIdFromUnsafeWidgetDefinitionAsync(unsafeWidgetDefinition);
+            if (!string.IsNullOrEmpty(id))
+            {
+                var comSafeWidgetDefinition = new ComSafeWidgetDefinition(id);
+                if (await comSafeWidgetDefinition.Populate())
+                {
+                    comSafeWidgetDefinitions.Add(comSafeWidgetDefinition);
+                }
+            }
+        }
+
+#pragma warning disable CA1309 // Use ordinal string comparison
+        comSafeWidgetDefinitions.Sort((a, b) => string.Compare(a.DisplayTitle, b.DisplayTitle, StringComparison.CurrentCulture));
+#pragma warning restore CA1309 // Use ordinal string comparison
+
+        return comSafeWidgetDefinitions;
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DevHome.Common.Extensions;
+using DevHome.Dashboard.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.Widgets.Hosts;
+using Serilog;
+
+namespace DevHome.Dashboard.ComSafeWidgetObjects;
+
+/// <summary>
+/// Since WidgetDefinitions are OOP COM objects, we need to wrap them in a safe way to handle COM exceptions
+/// that arise when the underlying OOP object vanishes. All WidgetDefinitions should be wrapped in a
+/// ComSafeWidgetDefinition and calls to the WidgetDefinition should be done through the ComSafeWidgetDefinition.
+/// This class will handle the COM exceptions and get a new OOP WidgetDefinition if needed.
+/// All APIs on the IWidgetDefinition and IWidgetDefinition2 interfaces are reflected here.
+/// </summary>
+public class ComSafeWidgetDefinition
+{
+    public bool AllowMultiple { get; private set; }
+
+    public string Description { get; private set; }
+
+    public string DisplayTitle { get; private set; }
+
+    public string Id { get; private set; }
+
+    public WidgetProviderDefinition ProviderDefinition { get; private set; }
+
+    // Since the ProviderDefinition could have died, save the display name and id so we can use it in that case.
+    // These can be removed if we keep a ComSafeWidgetProviderDefinition here.
+    public string ProviderDefinitionDisplayName { get; private set; }
+
+    public string ProviderDefinitionId { get; private set; }
+
+    public string AdditionalInfoUri { get; private set; }
+
+    public bool IsCustomizable { get; private set; }
+
+    public string ProgressiveWebAppHostPackageFamilyName => throw new System.NotImplementedException();
+
+    public WidgetType Type { get; private set; }
+
+    private WidgetDefinition _oopWidgetDefinition;
+
+    private const int RpcServerUnavailable = unchecked((int)0x800706BA);
+    private const int RpcCallFailed = unchecked((int)0x800706BE);
+
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComSafeWidgetDefinition));
+
+    private bool _hasValidProperties;
+    private const int MaxAttempts = 3;
+
+    public ComSafeWidgetDefinition(string widgetDefinitionId)
+    {
+        Id = widgetDefinitionId;
+    }
+
+    public async Task<bool> Populate()
+    {
+        await LazilyLoadOopWidgetDefinition();
+        return _hasValidProperties;
+    }
+
+    /// <summary>
+    /// Gets the theme resources from the widget. Tries multiple times in case of COM exceptions.
+    /// </summary>
+    /// <returns>The theme resources, or null in the case of failure.</returns>
+    public async Task<WidgetThemeResources> GetThemeResourceAsync(WidgetTheme theme)
+    {
+        var attempt = 0;
+        while (attempt++ < MaxAttempts)
+        {
+            try
+            {
+                await LazilyLoadOopWidgetDefinition();
+                return await Task.Run(() => _oopWidgetDefinition.GetThemeResource(theme));
+            }
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
+            {
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
+                await GetNewOopWidgetDefinitionAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Exception getting theme resources from widget:");
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    public async Task<WidgetCapability[]> GetWidgetCapabilitiesAsync()
+    {
+        var attempt = 0;
+        while (attempt++ < MaxAttempts)
+        {
+            try
+            {
+                await LazilyLoadOopWidgetDefinition();
+                return await Task.Run(() => _oopWidgetDefinition.GetWidgetCapabilities());
+            }
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
+            {
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
+                await GetNewOopWidgetDefinitionAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Exception getting widget capabilities from widget:");
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task GetNewOopWidgetDefinitionAsync()
+    {
+        _oopWidgetDefinition = null;
+        await LazilyLoadOopWidgetDefinition();
+    }
+
+    private async Task LazilyLoadOopWidgetDefinition()
+    {
+        var attempt = 0;
+        while (attempt++ < 3 && (_oopWidgetDefinition == null || _hasValidProperties == false))
+        {
+            try
+            {
+                _oopWidgetDefinition ??= await Application.Current.GetService<IWidgetHostingService>().GetWidgetDefinitionAsync(Id);
+
+                if (!_hasValidProperties)
+                {
+                    await Task.Run(() =>
+                    {
+                        AllowMultiple = _oopWidgetDefinition.AllowMultiple;
+                        Description = _oopWidgetDefinition.Description;
+                        DisplayTitle = _oopWidgetDefinition.DisplayTitle;
+                        Id = _oopWidgetDefinition.Id;
+                        ProviderDefinition = _oopWidgetDefinition.ProviderDefinition;
+                        ProviderDefinitionDisplayName = _oopWidgetDefinition.ProviderDefinition.DisplayName;
+                        ProviderDefinitionId = _oopWidgetDefinition.ProviderDefinition.Id;
+                        AdditionalInfoUri = _oopWidgetDefinition.AdditionalInfoUri;
+                        IsCustomizable = _oopWidgetDefinition.IsCustomizable;
+                        Type = _oopWidgetDefinition.Type;
+                        _hasValidProperties = true;
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to get properties of out-of-proc object");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get a WidgetDefinition's ID from a WidgetDefinition object. Tries multiple times in case of COM exceptions.
+    /// </summary>
+    /// <param name="widgetDefinition">WidgetDefinition</param>
+    /// <returns>The Widget's Id, or in the case of failure string.Empty</returns>
+    public static async Task<string> GetIdFromUnsafeWidgetDefinitionAsync(WidgetDefinition widgetDefinition)
+    {
+        var retries = 5;
+
+        return await Task.Run(() =>
+        {
+            while (retries-- > 0)
+            {
+                try
+                {
+                    return widgetDefinition.Id;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}, try {retries} more times");
+                }
+            }
+
+            return string.Empty;
+        });
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -66,7 +66,7 @@ public class ComSafeWidgetDefinition : IDisposable
 
     public async Task<bool> Populate()
     {
-        await LazilyLoadOopWidgetDefinition();
+        await LazilyLoadOopWidgetDefinitionAsync();
         return _hasValidProperties;
     }
 
@@ -81,13 +81,13 @@ public class ComSafeWidgetDefinition : IDisposable
         {
             try
             {
-                await LazilyLoadOopWidgetDefinition();
+                await LazilyLoadOopWidgetDefinitionAsync();
                 return await Task.Run(() => _oopWidgetDefinition.GetThemeResource(theme));
             }
             catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
-                ResetOopWidgetDefinitionAsync();
+                ResetOopWidgetDefinition();
             }
             catch (Exception ex)
             {
@@ -106,13 +106,13 @@ public class ComSafeWidgetDefinition : IDisposable
         {
             try
             {
-                await LazilyLoadOopWidgetDefinition();
+                await LazilyLoadOopWidgetDefinitionAsync();
                 return await Task.Run(() => _oopWidgetDefinition.GetWidgetCapabilities());
             }
             catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
-                ResetOopWidgetDefinitionAsync();
+                ResetOopWidgetDefinition();
             }
             catch (Exception ex)
             {
@@ -124,13 +124,13 @@ public class ComSafeWidgetDefinition : IDisposable
         return null;
     }
 
-    private void ResetOopWidgetDefinitionAsync()
+    private void ResetOopWidgetDefinition()
     {
         _oopWidgetDefinition = null;
         _hasValidProperties = false;
     }
 
-    private async Task LazilyLoadOopWidgetDefinition()
+    private async Task LazilyLoadOopWidgetDefinitionAsync()
     {
         var attempt = 0;
         try

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -87,7 +87,7 @@ public class ComSafeWidgetDefinition : IDisposable
             catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
-                await GetNewOopWidgetDefinitionAsync();
+                ResetOopWidgetDefinitionAsync();
             }
             catch (Exception ex)
             {
@@ -112,7 +112,7 @@ public class ComSafeWidgetDefinition : IDisposable
             catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
-                await GetNewOopWidgetDefinitionAsync();
+                ResetOopWidgetDefinitionAsync();
             }
             catch (Exception ex)
             {
@@ -124,10 +124,10 @@ public class ComSafeWidgetDefinition : IDisposable
         return null;
     }
 
-    private async Task GetNewOopWidgetDefinitionAsync()
+    private void ResetOopWidgetDefinitionAsync()
     {
         _oopWidgetDefinition = null;
-        await LazilyLoadOopWidgetDefinition();
+        _hasValidProperties = false;
     }
 
     private async Task LazilyLoadOopWidgetDefinition()

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -133,12 +133,11 @@ public class ComSafeWidgetDefinition : IDisposable
     private async Task LazilyLoadOopWidgetDefinitionAsync()
     {
         var attempt = 0;
+        await _getDefinitionLock.WaitAsync();
         try
         {
             while (attempt++ < 3 && (_oopWidgetDefinition == null || _hasValidProperties == false))
             {
-                await _getDefinitionLock.WaitAsync();
-
                 try
                 {
                     _oopWidgetDefinition ??= await Application.Current.GetService<IWidgetHostingService>().GetWidgetDefinitionAsync(Id);

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -161,26 +161,21 @@ public class ComSafeWidgetDefinition
     }
 
     /// <summary>
-    /// Get a WidgetDefinition's ID from a WidgetDefinition object. Tries multiple times in case of COM exceptions.
+    /// Get a WidgetDefinition's ID from a WidgetDefinition object.
     /// </summary>
     /// <param name="widgetDefinition">WidgetDefinition</param>
     /// <returns>The Widget's Id, or in the case of failure string.Empty</returns>
     public static async Task<string> GetIdFromUnsafeWidgetDefinitionAsync(WidgetDefinition widgetDefinition)
     {
-        var retries = 5;
-
         return await Task.Run(() =>
         {
-            while (retries-- > 0)
+            try
             {
-                try
-                {
-                    return widgetDefinition.Id;
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}, try {retries} more times");
-                }
+                return widgetDefinition.Id;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
             }
 
             return string.Empty;

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
+using DevHome.Dashboard.ComSafeWidgetObjects;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Dashboard.Views;
@@ -123,13 +124,28 @@ public sealed partial class WidgetControl : UserControl
 
     private async Task AddSizesToWidgetMenuAsync(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel)
     {
-        var widgetDefinition = await Application.Current.GetService<IWidgetHostingService>().GetWidgetDefinitionAsync(widgetViewModel.Widget.DefinitionId);
-        if (widgetDefinition == null)
+        var unsafeWidgetDefinition = await Application.Current.GetService<IWidgetHostingService>().GetWidgetDefinitionAsync(widgetViewModel.Widget.DefinitionId);
+        if (unsafeWidgetDefinition == null)
         {
+            // If we can't get the widgetDefinition, bail and don't show sizes.
             return;
         }
 
-        var capabilities = widgetDefinition.GetWidgetCapabilities();
+        var widgetDefinitionId = await ComSafeWidgetDefinition.GetIdFromUnsafeWidgetDefinitionAsync(unsafeWidgetDefinition);
+        if (string.IsNullOrEmpty(widgetDefinitionId))
+        {
+            // If we can't get the widgetDefinitionId, bail and don't show sizes.
+            return;
+        }
+
+        var comSafeWidgetDefinition = new ComSafeWidgetDefinition(widgetDefinitionId);
+        if (!await comSafeWidgetDefinition.Populate())
+        {
+            // If we can't populate the widgetDefinition, bail and don't show sizes.
+            return;
+        }
+
+        var capabilities = await comSafeWidgetDefinition.GetWidgetCapabilitiesAsync();
         var sizeMenuItems = new List<SelectableMenuFlyoutItem>();
 
         // Add the three possible sizes. Each side should only be enabled if it is included in the widget's capabilities.

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using DevHome.Dashboard.ComSafeWidgetObjects;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Services;
 
@@ -13,7 +13,7 @@ public interface IWidgetIconService
 {
     public void RemoveIconsFromCache(string definitionId);
 
-    public Task<BitmapImage> GetIconFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme theme);
+    public Task<BitmapImage> GetIconFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme);
 
-    public Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme);
+    public Task<Brush> GetBrushForWidgetIconAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using DevHome.Dashboard.ComSafeWidgetObjects;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Services;
 
@@ -12,5 +12,5 @@ public interface IWidgetScreenshotService
 {
     public void RemoveScreenshotsFromCache(string definitionId);
 
-    public Task<BitmapImage> GetScreenshotFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme actualTheme);
+    public Task<BitmapImage> GetScreenshotFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme actualTheme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using DevHome.Dashboard.ComSafeWidgetObjects;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -37,7 +38,7 @@ public class WidgetIconService : IWidgetIconService
         _widgetDarkIconCache.TryRemove(definitionId, out _);
     }
 
-    public async Task<BitmapImage> GetIconFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public async Task<BitmapImage> GetIconFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme)
     {
         var widgetDefinitionId = widgetDefinition.Id;
         BitmapImage bitmapImage;
@@ -60,19 +61,19 @@ public class WidgetIconService : IWidgetIconService
         // If the icon wasn't already in the cache, get it from the widget definition and add it to the cache before returning.
         if (theme == ElementTheme.Dark)
         {
-            bitmapImage = await WidgetIconToBitmapImageAsync(widgetDefinition.GetThemeResource(WidgetTheme.Dark).Icon);
+            bitmapImage = await WidgetIconToBitmapImageAsync((await widgetDefinition.GetThemeResourceAsync(WidgetTheme.Dark)).Icon);
             _widgetDarkIconCache.TryAdd(widgetDefinitionId, bitmapImage);
         }
         else
         {
-            bitmapImage = await WidgetIconToBitmapImageAsync(widgetDefinition.GetThemeResource(WidgetTheme.Light).Icon);
+            bitmapImage = await WidgetIconToBitmapImageAsync((await widgetDefinition.GetThemeResourceAsync(WidgetTheme.Light)).Icon);
             _widgetLightIconCache.TryAdd(widgetDefinitionId, bitmapImage);
         }
 
         return bitmapImage;
     }
 
-    public async Task<Brush> GetBrushForWidgetIconAsync(WidgetDefinition widgetDefinition, ElementTheme theme)
+    public async Task<Brush> GetBrushForWidgetIconAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme)
     {
         var image = await GetIconFromCacheAsync(widgetDefinition, theme);
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DevHome.Dashboard.ComSafeWidgetObjects;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.Widgets.Hosts;
@@ -35,7 +36,7 @@ public class WidgetScreenshotService : IWidgetScreenshotService
         _widgetDarkScreenshotCache.Remove(definitionId, out _);
     }
 
-    public async Task<BitmapImage> GetScreenshotFromCacheAsync(WidgetDefinition widgetDefinition, ElementTheme actualTheme)
+    public async Task<BitmapImage> GetScreenshotFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme actualTheme)
     {
         var widgetDefinitionId = widgetDefinition.Id;
         BitmapImage bitmapImage;
@@ -58,12 +59,12 @@ public class WidgetScreenshotService : IWidgetScreenshotService
         // If the screenshot wasn't already in the cache, get it from the widget definition and add it to the cache before returning.
         if (actualTheme == ElementTheme.Dark)
         {
-            bitmapImage = await WidgetScreenshotToBitmapImageAsync(widgetDefinition.GetThemeResource(WidgetTheme.Dark).GetScreenshots().FirstOrDefault().Image);
+            bitmapImage = await WidgetScreenshotToBitmapImageAsync((await widgetDefinition.GetThemeResourceAsync(WidgetTheme.Dark)).GetScreenshots().FirstOrDefault().Image);
             _widgetDarkScreenshotCache.TryAdd(widgetDefinitionId, bitmapImage);
         }
         else
         {
-            bitmapImage = await WidgetScreenshotToBitmapImageAsync(widgetDefinition.GetThemeResource(WidgetTheme.Light).GetScreenshots().FirstOrDefault().Image);
+            bitmapImage = await WidgetScreenshotToBitmapImageAsync((await widgetDefinition.GetThemeResourceAsync(WidgetTheme.Light)).GetScreenshots().FirstOrDefault().Image);
             _widgetLightScreenshotCache.TryAdd(widgetDefinitionId, bitmapImage);
         }
 

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Contracts.Services;
+using DevHome.Dashboard.ComSafeWidgetObjects;
 using DevHome.Dashboard.Services;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.ViewModels;
 
@@ -28,7 +28,7 @@ public partial class AddWidgetViewModel : ObservableObject
     [ObservableProperty]
     private bool _pinButtonVisibility;
 
-    private WidgetDefinition _selectedWidgetDefinition;
+    private ComSafeWidgetDefinition _selectedWidgetDefinition;
 
     public AddWidgetViewModel(
         IWidgetScreenshotService widgetScreenshotService,
@@ -38,13 +38,13 @@ public partial class AddWidgetViewModel : ObservableObject
         _themeSelectorService = themeSelectorService;
     }
 
-    public async Task SetWidgetDefinition(WidgetDefinition selectedWidgetDefinition)
+    public async Task SetWidgetDefinition(ComSafeWidgetDefinition selectedWidgetDefinition)
     {
         _selectedWidgetDefinition = selectedWidgetDefinition;
         var bitmap = await _widgetScreenshotService.GetScreenshotFromCacheAsync(selectedWidgetDefinition, _themeSelectorService.GetActualTheme());
 
         WidgetDisplayTitle = selectedWidgetDefinition.DisplayTitle;
-        WidgetProviderDisplayTitle = selectedWidgetDefinition.ProviderDefinition.DisplayName;
+        WidgetProviderDisplayTitle = selectedWidgetDefinition.ProviderDefinitionDisplayName;
         WidgetScreenshot = new ImageBrush
         {
             ImageSource = bitmap,

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -35,7 +35,7 @@ namespace DevHome.Dashboard.ViewModels;
 public delegate WidgetViewModel WidgetViewModelFactory(
     ComSafeWidget widget,
     WidgetSize widgetSize,
-    WidgetDefinition widgetDefinition);
+    ComSafeWidgetDefinition widgetDefinition);
 
 public partial class WidgetViewModel : ObservableObject
 {
@@ -50,7 +50,7 @@ public partial class WidgetViewModel : ObservableObject
     private ComSafeWidget _widget;
 
     [ObservableProperty]
-    private WidgetDefinition _widgetDefinition;
+    private ComSafeWidgetDefinition _widgetDefinition;
 
     [ObservableProperty]
     private WidgetSize _widgetSize;
@@ -84,12 +84,12 @@ public partial class WidgetViewModel : ObservableObject
         }
     }
 
-    partial void OnWidgetDefinitionChanged(WidgetDefinition value)
+    partial void OnWidgetDefinitionChanged(ComSafeWidgetDefinition value)
     {
         if (WidgetDefinition != null)
         {
             WidgetDisplayTitle = WidgetDefinition.DisplayTitle;
-            WidgetProviderDisplayTitle = WidgetDefinition.ProviderDefinition.DisplayName;
+            WidgetProviderDisplayTitle = WidgetDefinition.ProviderDefinitionDisplayName;
             IsCustomizable = WidgetDefinition.IsCustomizable;
         }
     }
@@ -97,7 +97,7 @@ public partial class WidgetViewModel : ObservableObject
     public WidgetViewModel(
         ComSafeWidget widget,
         WidgetSize widgetSize,
-        WidgetDefinition widgetDefinition,
+        ComSafeWidgetDefinition widgetDefinition,
         WidgetAdaptiveCardRenderingService adaptiveCardRenderingService,
         WindowEx windowEx)
     {
@@ -324,7 +324,7 @@ public partial class WidgetViewModel : ObservableObject
         TelemetryFactory.Get<ITelemetry>().Log(
             "Dashboard_ReportWidgetInteraction",
             LogLevel.Critical,
-            new ReportWidgetInteractionEvent(WidgetDefinition.ProviderDefinition.Id, WidgetDefinition.Id, args.Action.ActionTypeString));
+            new ReportWidgetInteractionEvent(WidgetDefinition.ProviderDefinitionId, WidgetDefinition.Id, args.Action.ActionTypeString));
 
         // TODO: Handle other ActionTypes
         // https://github.com/microsoft/devhome/issues/644

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -88,7 +88,6 @@ public partial class DashboardView : ToolPage, IDisposable
 
             widgetCatalog!.WidgetProviderDefinitionAdded += WidgetCatalog_WidgetProviderDefinitionAdded;
             widgetCatalog!.WidgetProviderDefinitionDeleted += WidgetCatalog_WidgetProviderDefinitionDeleted;
-            widgetCatalog!.WidgetDefinitionAdded += WidgetCatalog_WidgetDefinitionAdded;
             widgetCatalog!.WidgetDefinitionUpdated += WidgetCatalog_WidgetDefinitionUpdated;
             widgetCatalog!.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
         }
@@ -115,7 +114,6 @@ public partial class DashboardView : ToolPage, IDisposable
 
             widgetCatalog!.WidgetProviderDefinitionAdded -= WidgetCatalog_WidgetProviderDefinitionAdded;
             widgetCatalog!.WidgetProviderDefinitionDeleted -= WidgetCatalog_WidgetProviderDefinitionDeleted;
-            widgetCatalog!.WidgetDefinitionAdded -= WidgetCatalog_WidgetDefinitionAdded;
             widgetCatalog!.WidgetDefinitionUpdated -= WidgetCatalog_WidgetDefinitionUpdated;
             widgetCatalog!.WidgetDefinitionDeleted -= WidgetCatalog_WidgetDefinitionDeleted;
         }
@@ -595,9 +593,6 @@ public partial class DashboardView : ToolPage, IDisposable
     private void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args) =>
         _log.Information("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionDeleted {args.ProviderDefinitionId}");
 
-    private void WidgetCatalog_WidgetDefinitionAdded(WidgetCatalog sender, WidgetDefinitionAddedEventArgs args) =>
-        _log.Information("DashboardView", $"WidgetCatalog_WidgetDefinitionAdded {args.Definition.Id}");
-
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
     {
         var updatedDefinitionId = args.Definition.Id;
@@ -673,7 +668,7 @@ public partial class DashboardView : ToolPage, IDisposable
     }
 
     // If a widget is removed from the list, update the saved positions of the following widgets.
-    // If not updated, widges pinned later may be assigned the same position as existing widgets,
+    // If not updated, widgets pinned later may be assigned the same position as existing widgets,
     // since the saved position may be greater than the number of pinned widgets.
     // Unsubscribe from this event during drag and drop, since the drop event takes care of re-numbering.
     private async void OnPinnedWidgetsCollectionChangedAsync(object sender, NotifyCollectionChangedEventArgs e)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -86,8 +86,6 @@ public partial class DashboardView : ToolPage, IDisposable
                 return false;
             }
 
-            widgetCatalog!.WidgetProviderDefinitionAdded += WidgetCatalog_WidgetProviderDefinitionAdded;
-            widgetCatalog!.WidgetProviderDefinitionDeleted += WidgetCatalog_WidgetProviderDefinitionDeleted;
             widgetCatalog!.WidgetDefinitionUpdated += WidgetCatalog_WidgetDefinitionUpdated;
             widgetCatalog!.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
         }
@@ -112,8 +110,6 @@ public partial class DashboardView : ToolPage, IDisposable
                 return;
             }
 
-            widgetCatalog!.WidgetProviderDefinitionAdded -= WidgetCatalog_WidgetProviderDefinitionAdded;
-            widgetCatalog!.WidgetProviderDefinitionDeleted -= WidgetCatalog_WidgetProviderDefinitionDeleted;
             widgetCatalog!.WidgetDefinitionUpdated -= WidgetCatalog_WidgetDefinitionUpdated;
             widgetCatalog!.WidgetDefinitionDeleted -= WidgetCatalog_WidgetDefinitionDeleted;
         }
@@ -602,12 +598,6 @@ public partial class DashboardView : ToolPage, IDisposable
             _log.Information(ex, $"Error deleting widget");
         }
     }
-
-    private void WidgetCatalog_WidgetProviderDefinitionAdded(WidgetCatalog sender, WidgetProviderDefinitionAddedEventArgs args) =>
-        _log.Information("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionAdded {args.ProviderDefinition.Id}");
-
-    private void WidgetCatalog_WidgetProviderDefinitionDeleted(WidgetCatalog sender, WidgetProviderDefinitionDeletedEventArgs args) =>
-        _log.Information("DashboardView", $"WidgetCatalog_WidgetProviderDefinitionDeleted {args.ProviderDefinitionId}");
 
     private async void WidgetCatalog_WidgetDefinitionUpdated(WidgetCatalog sender, WidgetDefinitionUpdatedEventArgs args)
     {


### PR DESCRIPTION
## Summary of the pull request
Since WidgetDefinition objects are out of process, they can disappear out from under us throwing COMExceptions and crashing Dev Home. Wrap them in a new ComSafeWidgetDefinition wrapper, which catches these exceptions and gets a new, valid object when the old one goes away.

This PR is currently targeted into the branch for #2620, will retarget after that goes in.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2637
- [ ] Tests added/passed
- [ ] Documentation updated
