### PR TITLE
Get WidgetHost and WidgetCatalog objects safely

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -123,8 +123,12 @@ public sealed partial class WidgetControl : UserControl
 
     private async Task AddSizesToWidgetMenuAsync(MenuFlyout widgetMenuFlyout, WidgetViewModel widgetViewModel)
     {
-        var widgetCatalog = await Application.Current.GetService<IWidgetHostingService>().GetWidgetCatalogAsync();
-        var widgetDefinition = await Task.Run(() => widgetCatalog.GetWidgetDefinition(widgetViewModel.Widget.DefinitionId));
+        var widgetDefinition = await Application.Current.GetService<IWidgetHostingService>().GetWidgetDefinitionAsync(widgetViewModel.Widget.DefinitionId);
+        if (widgetDefinition == null)
+        {
+            return;
+        }
+
         var capabilities = widgetDefinition.GetWidgetCapabilities();
         var sizeMenuItems = new List<SelectableMenuFlyoutItem>();
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -9,9 +9,15 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
-    public Task<WidgetCatalog> GetWidgetCatalogAsync();
-
     public Task<Widget[]> GetWidgetsAsync();
 
     public Task<Widget> CreateWidgetAsync(string widgetDefinitionId, WidgetSize widgetSize);
+
+    public Task<WidgetCatalog> GetWidgetCatalogAsync();
+
+    public Task<WidgetProviderDefinition[]> GetProviderDefinitionsAsync();
+
+    public Task<WidgetDefinition[]> GetWidgetDefinitionsAsync();
+
+    public Task<WidgetDefinition> GetWidgetDefinitionAsync(string widgetDefinitionId);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 
 namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
-    public Task<WidgetHost> GetWidgetHostAsync();
-
     public Task<WidgetCatalog> GetWidgetCatalogAsync();
+
+    public Task<Widget[]> GetWidgetsAsync();
+
+    public Task<Widget> CreateWidgetAsync(string widgetDefinitionId, WidgetSize widgetSize);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -38,6 +38,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetHost = null;
+
+                // If the host died, the catalog probably did too.
+                _widgetCatalog = null;
             }
             catch (Exception ex)
             {
@@ -79,6 +82,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetHost = null;
+
+                // If the host died, the catalog probably did too.
+                _widgetCatalog = null;
             }
             catch (Exception ex)
             {
@@ -120,6 +126,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
+
+                // If the catalog died, the host probably did too.
+                _widgetHost = null;
             }
         }
 
@@ -156,6 +165,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
+
+                // If the catalog died, the host probably did too.
+                _widgetHost = null;
             }
         }
 
@@ -193,6 +205,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
+
+                // If the catalog died, the host probably did too.
+                _widgetHost = null;
             }
         }
 
@@ -230,6 +245,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
+
+                // If the catalog died, the host probably did too.
+                _widgetHost = null;
             }
         }
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -110,4 +110,100 @@ public class WidgetHostingService : IWidgetHostingService
 
         return _widgetCatalog;
     }
+
+    public async Task<WidgetProviderDefinition[]> GetProviderDefinitionsAsync()
+    {
+        // If we already have a WidgetCatalog, check if the COM object is still alive.
+        if (_widgetCatalog != null)
+        {
+            try
+            {
+                return await Task.Run(() => _widgetCatalog.GetProviderDefinitions());
+            }
+            catch (Exception ex)
+            {
+                _log.Warning("Exception trying to use WidgetCatalog", ex);
+                _widgetCatalog = null;
+            }
+        }
+
+        if (_widgetCatalog == null)
+        {
+            try
+            {
+                _widgetCatalog = await Task.Run(() => WidgetCatalog.GetDefault());
+                return await Task.Run(() => _widgetCatalog.GetProviderDefinitions());
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Exception in GetWidgetDefinitionAsync:", ex);
+            }
+        }
+
+        return [];
+    }
+
+    public async Task<WidgetDefinition[]> GetWidgetDefinitionsAsync()
+    {
+        // If we already have a WidgetCatalog, check if the COM object is still alive.
+        if (_widgetCatalog != null)
+        {
+            try
+            {
+                return await Task.Run(() => _widgetCatalog.GetWidgetDefinitions());
+            }
+            catch (Exception ex)
+            {
+                _log.Warning("WidgetCatalog was not still alive", ex.Message);
+                _widgetCatalog = null;
+            }
+        }
+
+        if (_widgetCatalog == null)
+        {
+            try
+            {
+                _widgetCatalog = await Task.Run(() => WidgetCatalog.GetDefault());
+                return await Task.Run(() => _widgetCatalog.GetWidgetDefinitions());
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Exception in GetWidgetDefinitionAsync:", ex);
+            }
+        }
+
+        return [];
+    }
+
+    public async Task<WidgetDefinition> GetWidgetDefinitionAsync(string widgetDefinitionId)
+    {
+        // If we already have a WidgetCatalog, check if the COM object is still alive.
+        if (_widgetCatalog != null)
+        {
+            try
+            {
+                return await Task.Run(() => _widgetCatalog.GetWidgetDefinition(widgetDefinitionId));
+            }
+            catch (Exception ex)
+            {
+                _log.Warning("WidgetCatalog was not still alive", ex.Message);
+                _widgetCatalog = null;
+            }
+        }
+
+        if (_widgetCatalog == null)
+        {
+            try
+            {
+                _widgetCatalog = await Task.Run(() => WidgetCatalog.GetDefault());
+                return await Task.Run(() => _widgetCatalog.GetWidgetDefinition(widgetDefinitionId));
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Exception in GetWidgetDefinitionAsync:", ex);
+            }
+        }
+
+        return null;
+    }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -87,7 +87,7 @@ public class WidgetHostingService : IWidgetHostingService
         {
             try
             {
-                await Task.Run(() => _widgetCatalog.GetType());
+                await Task.Run(() => _widgetCatalog.GetProviderDefinitions());
             }
             catch (Exception ex)
             {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -17,6 +17,21 @@ public class WidgetHostingService : IWidgetHostingService
 
     public async Task<WidgetHost> GetWidgetHostAsync()
     {
+        // If we already have a WidgetHost, check if the COM object is still alive and use it if it is.
+        if (_widgetHost != null)
+        {
+            try
+            {
+                await Task.Run(() => _widgetHost.GetWidgets());
+                return _widgetHost;
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Exception trying to use WidgetHost");
+                _widgetHost = null;
+            }
+        }
+
         if (_widgetHost == null)
         {
             try
@@ -34,6 +49,20 @@ public class WidgetHostingService : IWidgetHostingService
 
     public async Task<WidgetCatalog> GetWidgetCatalogAsync()
     {
+        // If we already have a WidgetCatalog, check if the COM object is still alive and use it if it is.
+        if (_widgetCatalog != null)
+        {
+            try
+            {
+                await Task.Run(() => _widgetCatalog.GetType());
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Exception trying to use WidgetCatalog");
+                _widgetCatalog = null;
+            }
+        }
+
         if (_widgetCatalog == null)
         {
             try

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -21,9 +21,13 @@ public class WidgetHostingService : IWidgetHostingService
     private const int RpcServerUnavailable = unchecked((int)0x800706BA);
     private const int RpcCallFailed = unchecked((int)0x800706BE);
 
+    /// <summary>
+    /// Get the list of current widgets from the WidgetService.
+    /// </summary>
+    /// <returns>A list of widgets, or null if there were no widgets or the list could not be retrieved.</returns>
     public async Task<Widget[]> GetWidgetsAsync()
     {
-        // If we already have a WidgetHost, check if the COM object is still alive and use it if it is.
+        // If we already have a WidgetHost, check if the OOP COM object is still alive and use it if it is.
         if (_widgetHost != null)
         {
             try
@@ -37,6 +41,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
         }
 
+        // If we lost the object, create a new one. This call will get the WidgetService back up and running.
         if (_widgetHost == null)
         {
             try
@@ -50,9 +55,13 @@ public class WidgetHostingService : IWidgetHostingService
             }
         }
 
-        return [];
+        return null;
     }
 
+    /// <summary>
+    /// Create and return a new widget.
+    /// </summary>
+    /// <returns>The new widget, or null if one could ont be created.</returns>
     public async Task<Widget> CreateWidgetAsync(string widgetDefinitionId, WidgetSize widgetSize)
     {
         // If we already have a WidgetHost, check if the COM object is still alive and use it if it is.
@@ -85,6 +94,10 @@ public class WidgetHostingService : IWidgetHostingService
         return null;
     }
 
+    /// <summary>
+    /// Get the catalog of widgets from the WidgetService.
+    /// </summary>
+    /// <returns>The catalog of widgets, or null if one could ont be created.</returns>
     public async Task<WidgetCatalog> GetWidgetCatalogAsync()
     {
         // If we already have a WidgetCatalog, check if the COM object is still alive and use it if it is.
@@ -116,6 +129,11 @@ public class WidgetHostingService : IWidgetHostingService
         return _widgetCatalog;
     }
 
+    /// <summary>
+    /// Get the list of WidgetProviderDefinitions from the WidgetService.
+    /// </summary>
+    /// <returns>A list of WidgetProviderDefinitions, or an empty list if there were no widgets
+    /// or the list could not be retrieved.</returns>
     public async Task<WidgetProviderDefinition[]> GetProviderDefinitionsAsync()
     {
         // If we already have a WidgetCatalog, check if the COM object is still alive.
@@ -141,13 +159,18 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error("Exception in GetWidgetDefinitionAsync:", ex);
+                _log.Error(ex, "Exception in GetWidgetDefinitionAsync:");
             }
         }
 
         return [];
     }
 
+    /// <summary>
+    /// Get the list of WidgetDefinitions from the WidgetService.
+    /// </summary>
+    /// <returns>A list of WidgetDefinitions, or an empty list if there were no widgets
+    /// or the list could not be retrieved.</returns>
     public async Task<WidgetDefinition[]> GetWidgetDefinitionsAsync()
     {
         // If we already have a WidgetCatalog, check if the COM object is still alive.
@@ -173,13 +196,18 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error("Exception in GetWidgetDefinitionAsync:", ex);
+                _log.Error(ex, "Exception in GetWidgetDefinitionAsync:");
             }
         }
 
         return [];
     }
 
+    /// <summary>
+    /// Get the WidgetDefinition for the given WidgetDefinitionId from the WidgetService.
+    /// </summary>
+    /// <returns>The WidgetDefinition, or null if the widget definition could not be found
+    /// or there was an error retrieving it.</returns>
     public async Task<WidgetDefinition> GetWidgetDefinitionAsync(string widgetDefinitionId)
     {
         // If we already have a WidgetCatalog, check if the COM object is still alive.
@@ -205,7 +233,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error("Exception in GetWidgetDefinitionAsync:", ex);
+                _log.Error(ex, "Exception in GetWidgetDefinitionAsync:");
             }
         }
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -39,6 +39,10 @@ public class WidgetHostingService : IWidgetHostingService
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetHost = null;
             }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Exception getting widgets from service:");
+            }
         }
 
         // If we lost the object, create a new one. This call will get the WidgetService back up and running.
@@ -76,6 +80,10 @@ public class WidgetHostingService : IWidgetHostingService
                 _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetHost = null;
             }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Exception creating a widget:");
+            }
         }
 
         if (_widgetHost == null)
@@ -87,7 +95,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error(ex, "Exception getting widgets from service:");
+                _log.Error(ex, "Exception creating a widget:");
             }
         }
 
@@ -97,23 +105,12 @@ public class WidgetHostingService : IWidgetHostingService
     /// <summary>
     /// Get the catalog of widgets from the WidgetService.
     /// </summary>
-    /// <returns>The catalog of widgets, or null if one could ont be created.</returns>
+    /// <returns>The catalog of widgets, or null if one could not be created.
+    /// The returned OOP COM object is not guaranteed to still be alive.</returns>
     public async Task<WidgetCatalog> GetWidgetCatalogAsync()
     {
-        // If we already have a WidgetCatalog, check if the COM object is still alive and use it if it is.
-        if (_widgetCatalog != null)
-        {
-            try
-            {
-                await Task.Run(() => _widgetCatalog.GetProviderDefinitions());
-            }
-            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
-            {
-                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
-                _widgetCatalog = null;
-            }
-        }
-
+        // Don't check whether the existing WidgetCatalog COM object is still alive and just return what we have.
+        // If the object is dead and we try to subscribe to an event on it, the calling code will handle the error.
         if (_widgetCatalog == null)
         {
             try

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -34,9 +34,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 return await Task.Run(() => _widgetHost.GetWidgets());
             }
-            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
-                _log.Warning(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetHost = null;
             }
         }
@@ -49,9 +49,9 @@ public class WidgetHostingService : IWidgetHostingService
                 _widgetHost = await Task.Run(() => WidgetHost.Register(new WidgetHostContext("BAA93438-9B07-4554-AD09-7ACCD7D4F031")));
                 return await Task.Run(() => _widgetHost.GetWidgets());
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                _log.Error(e, "Exception getting widgets from service:");
+                _log.Error(ex, "Exception getting widgets from service:");
             }
         }
 
@@ -71,9 +71,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 return await Task.Run(async () => await _widgetHost.CreateWidgetAsync(widgetDefinitionId, widgetSize));
             }
-            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
-                _log.Warning(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetHost = null;
             }
         }
@@ -85,9 +85,9 @@ public class WidgetHostingService : IWidgetHostingService
                 _widgetHost = await Task.Run(() => WidgetHost.Register(new WidgetHostContext("BAA93438-9B07-4554-AD09-7ACCD7D4F031")));
                 return await Task.Run(async () => await _widgetHost.CreateWidgetAsync(widgetDefinitionId, widgetSize));
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                _log.Error(e, "Exception getting widgets from service:");
+                _log.Error(ex, "Exception getting widgets from service:");
             }
         }
 
@@ -107,9 +107,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 await Task.Run(() => _widgetCatalog.GetProviderDefinitions());
             }
-            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
-                _log.Warning(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
             }
         }
@@ -120,9 +120,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 _widgetCatalog = await Task.Run(() => WidgetCatalog.GetDefault());
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                _log.Error(e, "Exception in WidgetCatalog.GetDefault:");
+                _log.Error(ex, "Exception in WidgetCatalog.GetDefault:");
             }
         }
 
@@ -143,9 +143,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 return await Task.Run(() => _widgetCatalog.GetProviderDefinitions());
             }
-            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
-                _log.Warning(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
             }
         }
@@ -180,9 +180,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 return await Task.Run(() => _widgetCatalog.GetWidgetDefinitions());
             }
-            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
-                _log.Warning(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
             }
         }
@@ -217,9 +217,9 @@ public class WidgetHostingService : IWidgetHostingService
             {
                 return await Task.Run(() => _widgetCatalog.GetWidgetDefinition(widgetDefinitionId));
             }
-            catch (COMException e) when (e.HResult == RpcServerUnavailable || e.HResult == RpcCallFailed)
+            catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
-                _log.Warning(e, $"Failed to operate on out-of-proc object with error code: 0x{e.HResult:x}");
+                _log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
                 _widgetCatalog = null;
             }
         }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -63,18 +63,9 @@ public sealed partial class AddWidgetDialog : ContentDialog
     {
         AddWidgetNavigationView.MenuItems.Clear();
 
-        var catalog = await _hostingService.GetWidgetCatalogAsync();
-
-        if (catalog is null)
-        {
-            // We should never have gotten here if we don't have a WidgetCatalog.
-            _log.Error($"Opened the AddWidgetDialog, but WidgetCatalog is null.");
-            return;
-        }
-
         // Show the providers and widgets underneath them in alphabetical order.
-        var providerDefinitions = await Task.Run(() => catalog!.GetProviderDefinitions().OrderBy(x => x.DisplayName));
-        var widgetDefinitions = await Task.Run(() => catalog!.GetWidgetDefinitions().OrderBy(x => x.DisplayTitle));
+        var providerDefinitions = (await _hostingService.GetProviderDefinitionsAsync()).OrderBy(x => x.DisplayName);
+        var widgetDefinitions = (await _hostingService.GetWidgetDefinitionsAsync()).OrderBy(x => x.DisplayTitle);
 
         _log.Information($"Filling available widget list, found {providerDefinitions.Count()} providers and {widgetDefinitions.Count()} widgets");
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -52,8 +52,15 @@ public sealed partial class AddWidgetDialog : ContentDialog
     [RelayCommand]
     public async Task OnLoadedAsync()
     {
-        var widgetCatalog = await _hostingService.GetWidgetCatalogAsync();
-        widgetCatalog.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
+        try
+        {
+            var widgetCatalog = await _hostingService.GetWidgetCatalogAsync();
+            widgetCatalog.WidgetDefinitionDeleted += WidgetCatalog_WidgetDefinitionDeleted;
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Exception in OnLoadedAsync:", ex);
+        }
 
         await FillAvailableWidgetsAsync();
         SelectFirstWidgetByDefault();
@@ -263,8 +270,15 @@ public sealed partial class AddWidgetDialog : ContentDialog
         _selectedWidget = null;
         ViewModel = null;
 
-        var widgetCatalog = await _hostingService.GetWidgetCatalogAsync();
-        widgetCatalog!.WidgetDefinitionDeleted -= WidgetCatalog_WidgetDefinitionDeleted;
+        try
+        {
+            var widgetCatalog = await _hostingService.GetWidgetCatalogAsync();
+            widgetCatalog.WidgetDefinitionDeleted -= WidgetCatalog_WidgetDefinitionDeleted;
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Exception in HideDialogAsync:", ex);
+        }
 
         this.Hide();
     }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -59,7 +59,11 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
         catch (Exception ex)
         {
-            _log.Error("Exception in OnLoadedAsync:", ex);
+            // If there was an error getting the widget catalog, log it and continue.
+            // If a WidgetDefinition is deleted while the dialog is open, we won't know to remove it from
+            // the list automatically, but we can show a helpful error message if the user tries to pin it.
+            // https://github.com/microsoft/devhome/issues/2623
+            _log.Error(ex, "Exception in AddWidgetDialog.OnLoadedAsync:");
         }
 
         await FillAvailableWidgetsAsync();
@@ -277,7 +281,8 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
         catch (Exception ex)
         {
-            _log.Error("Exception in HideDialogAsync:", ex);
+            // If there was an error getting the widget catalog, log it and continue.
+            _log.Error(ex, "Exception in HideDialogAsync:");
         }
 
         this.Hide();

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -64,9 +64,8 @@ public sealed partial class AddWidgetDialog : ContentDialog
         AddWidgetNavigationView.MenuItems.Clear();
 
         var catalog = await _hostingService.GetWidgetCatalogAsync();
-        var host = await _hostingService.GetWidgetHostAsync();
 
-        if (catalog is null || host is null)
+        if (catalog is null)
         {
             // We should never have gotten here if we don't have a WidgetCatalog.
             _log.Error($"Opened the AddWidgetDialog, but WidgetCatalog is null.");
@@ -82,7 +81,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
         // Fill NavigationView Menu with Widget Providers, and group widgets under each provider.
         // Tag each item with the widget or provider definition, so that it can be used to create
         // the widget if it is selected later.
-        var currentlyPinnedWidgets = await Task.Run(() => host.GetWidgets());
+        var currentlyPinnedWidgets = await _hostingService.GetWidgetsAsync();
         foreach (var providerDef in providerDefinitions)
         {
             if (await WidgetHelpers.IsIncludedWidgetProviderAsync(providerDef))

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -120,7 +120,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error("Exception in UnsubscribeFromWidgetCatalogEventsAsync:", ex);
+            _log.Error(ex, "Exception in UnsubscribeFromWidgetCatalogEventsAsync:");
         }
     }
 
@@ -152,7 +152,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error("Exception in UnsubscribeFromWidgets:", ex);
+            _log.Error(ex, "Exception in UnsubscribeFromWidgets:");
         }
 
         await UnsubscribeFromWidgetCatalogEventsAsync();
@@ -169,7 +169,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         catch (Exception ex)
         {
-            _log.Error("Exception in UnsubscribeFromWidgets:", ex);
+            _log.Error(ex, "Exception in UnsubscribeFromWidgets:");
         }
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -199,8 +199,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private async Task<Widget[]> GetPreviouslyPinnedWidgets()
     {
         _log.Information("Get widgets for current host");
-        var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
-        var hostWidgets = await Task.Run(() => widgetHost?.GetWidgets());
+        var hostWidgets = await ViewModel.WidgetHostingService.GetWidgetsAsync();
 
         if (hostWidgets == null)
         {
@@ -315,15 +314,14 @@ public partial class DashboardView : ToolPage, IDisposable
 
     private async Task DeleteAbandonedWidgetAsync(Widget widget)
     {
-        var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
-
-        var length = await Task.Run(() => widgetHost!.GetWidgets().Length);
+        var widgetList = await ViewModel.WidgetHostingService.GetWidgetsAsync();
+        var length = await Task.Run(() => widgetList.Length);
         _log.Information($"Found abandoned widget, try to delete it...");
         _log.Information($"Before delete, {length} widgets for this host");
 
         await widget.DeleteAsync();
 
-        var newWidgetList = await Task.Run(() => widgetHost.GetWidgets());
+        var newWidgetList = await ViewModel.WidgetHostingService.GetWidgetsAsync();
         length = (newWidgetList == null) ? 0 : newWidgetList.Length;
         _log.Information($"After delete, {length} widgets for this host");
     }
@@ -355,10 +353,9 @@ public partial class DashboardView : ToolPage, IDisposable
         try
         {
             // Create widget
-            var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
             var size = WidgetHelpers.GetDefaultWidgetSize(defaultWidgetDefinition.GetWidgetCapabilities());
             var id = defaultWidgetDefinition.Id;
-            var newWidget = await Task.Run(async () => await widgetHost?.CreateWidgetAsync(id, size));
+            var newWidget = await ViewModel.WidgetHostingService.CreateWidgetAsync(id, size);
             _log.Information($"Created default widget {id}");
 
             // Set custom state on new widget.
@@ -409,8 +406,7 @@ public partial class DashboardView : ToolPage, IDisposable
             try
             {
                 var size = WidgetHelpers.GetDefaultWidgetSize(newWidgetDefinition.GetWidgetCapabilities());
-                var widgetHost = await ViewModel.WidgetHostingService.GetWidgetHostAsync();
-                newWidget = await Task.Run(async () => await widgetHost?.CreateWidgetAsync(newWidgetDefinition.Id, size));
+                newWidget = await ViewModel.WidgetHostingService.CreateWidgetAsync(newWidgetDefinition.Id, size);
 
                 // Set custom state on new widget.
                 var position = PinnedWidgets.Count;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -359,7 +359,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private async Task DeleteAbandonedWidgetAsync(Widget widget)
     {
         var widgetList = await ViewModel.WidgetHostingService.GetWidgetsAsync();
-        var length = await Task.Run(() => widgetList.Length);
+        var length = widgetList.Length;
         _log.Information($"Found abandoned widget, try to delete it...");
         _log.Information($"Before delete, {length} widgets for this host");
 


### PR DESCRIPTION
## Summary of the pull request

Since WidgetHost and WidgetCatalog objects are out of process, they can disappear out from under us throwing COMExceptions and crashing Dev Home. This will happen, for example, if the WidgetService.exe process dies while Dev Home is running.

Before, we saved the WidgetHost and WidgetCatalog objects in the WidgetHostingService, and handed them out so that different parts of the Dashboard could call methods on them. This was unsafe, since there was no guarantee the objects were still alive. Instead we put the relevant methods in the Service itself, so the Service can handle ensuring the object is still good and recovering if it has died. Even in the error case, the caller does not have to worry about exceptions being thrown by these methods.

#2620 relies on this change to get valid WidgetHost objects, so that there we can get valid Widget objects from the WidgetHost.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
