### PR TITLE
Ignore zip package when building just the msix

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -176,6 +176,9 @@ Try {
         if (-not([string]::IsNullOrWhiteSpace($VersionOfSDK))) {
           $msbuildArgs += ("/p:DevHomeSDKVersion="+$env:sdk_version)
         }
+        if ($BuildStep -ieq "msix") {
+          $msbuildArgs += ("/p:IgnoreZipPackages=true")
+        }
 
         & $msbuildPath $msbuildArgs
         if (-not($IsAzurePipelineBuild) -And $isAdmin) {

--- a/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
+++ b/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
@@ -76,10 +76,10 @@
     x86 binaries can be deployed on both x64 and x86 VMs.
     -->
   <ItemGroup>
-    <None Include="..\DevSetupAgent\bin\x86\$(Configuration)\DevSetupAgent_x86.zip" Condition="('$(Platform)'=='x64' or '$(Platform)'=='x86') and ('$(BuildingInsideVisualStudio)' != 'True' or Exists('..\HyperVExtension\src\DevSetupAgent\bin\x86\$(Configuration)\DevSetupAgent_x86.zip'))">
+    <None Include="..\DevSetupAgent\bin\x86\$(Configuration)\DevSetupAgent_x86.zip" Condition="('$(Platform)'=='x64' or '$(Platform)'=='x86') and ('$(BuildingInsideVisualStudio)' != 'True' or Exists('..\HyperVExtension\src\DevSetupAgent\bin\x86\$(Configuration)\DevSetupAgent_x86.zip')) and ('$(IgnoreZipPackages)' != 'True')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="..\DevSetupAgent\bin\arm64\$(Configuration)\DevSetupAgent_arm64.zip" Condition="'$(Platform)'=='arm64' and ('$(BuildingInsideVisualStudio)' != 'True' or Exists('..\HyperVExtension\src\DevSetupAgent\bin\arm64\$(Configuration)\DevSetupAgent_arm64.zip'))">
+    <None Include="..\DevSetupAgent\bin\arm64\$(Configuration)\DevSetupAgent_arm64.zip" Condition="'$(Platform)'=='arm64' and ('$(BuildingInsideVisualStudio)' != 'True' or Exists('..\HyperVExtension\src\DevSetupAgent\bin\arm64\$(Configuration)\DevSetupAgent_arm64.zip')) and ('$(IgnoreZipPackages)' != 'True')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
When doing a local build with -BuildStep 'msix', don't require DevSetupAgent_*.zip which only gets built with 'fullmsix' or 'all'.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
