### PR TITLE
Standardizing login behavior in the repo tool.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -1157,12 +1156,6 @@ public partial class AddRepoViewModel : ObservableObject
         // 2. The repo is not public and no logged iin accounts have access to the repo.
         // Ask the user to log in and try again.
         await LogUserIn(provider.ExtensionDisplayName);
-
-        // User did not log in.
-        if (Accounts.Count == 0)
-        {
-            return;
-        }
 
         cloningInformation = MakeCloningInformationFromUrl(provider, cloneLocation, uri);
         if (cloningInformation != null)

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -1126,6 +1126,8 @@ public partial class AddRepoViewModel : ObservableObject
         // Causing GetCloningInformationFromURL to fall back to git.
         var provider = _providers?.CanAnyProviderSupportThisUri(uri);
 
+        // This code is duplicated once.  If cloningInformation is null the user is asked to log in.
+        // DevHome then makes another attempt to get the repo information from the URL.
         var cloningInformation = MakeCloningInformationFromUrl(provider, cloneLocation, uri);
         if (cloningInformation != null)
         {
@@ -1146,7 +1148,6 @@ public partial class AddRepoViewModel : ObservableObject
 
             EverythingToClone.Add(cloningInformation);
             ShouldEnablePrimaryButton = true;
-            ShouldShowUrlError = false;
 
             return;
         }
@@ -1177,7 +1178,6 @@ public partial class AddRepoViewModel : ObservableObject
 
             EverythingToClone.Add(cloningInformation);
             ShouldEnablePrimaryButton = true;
-            ShouldShowUrlError = false;
 
             return;
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -97,7 +97,7 @@
                     <TextBlock Grid.Column="0" x:Uid="LoginUIDialogTitle" HorizontalAlignment="Left"
                        Style="{ThemeResource SubtitleTextBlockStyle}" 
                        Margin="16,10,0,0"/>
-                    <Button Command="{x:Bind AddRepoViewModel.CancelButtonPressedCommand, Mode=OneWay}" Visibility="{x:Bind AddRepoViewModel.ShouldShowXButtonInLoginUi, Mode=OneWay}" Grid.Column="1" DataContext="{x:Bind}" Style="{ThemeResource AlternateCloseButtonStyle}" VerticalAlignment="Center">
+                    <Button Command="{x:Bind AddRepoViewModel.CancelButtonPressedCommand, Mode=OneWay}" Grid.Column="1" DataContext="{x:Bind}" Style="{ThemeResource AlternateCloseButtonStyle}" VerticalAlignment="Center">
                         <Button.Content>
                             <SymbolIcon Symbol="Cancel"/>
                         </Button.Content>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -5,18 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
-using LibGit2Sharp;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.Windows.DevHome.SDK;
-using WinUIEx;
 using static DevHome.SetupFlow.Models.Common;
 
 namespace DevHome.SetupFlow.Views;
@@ -176,19 +173,11 @@ public partial class AddRepoDialog : ContentDialog
             var deferral = args.GetDeferral();
             await AddRepoViewModel.AddRepositoryViaUri(AddRepoViewModel.Url, AddRepoViewModel.FolderPickerViewModel.CloneLocation);
 
-            _host.GetService<WindowEx>().DispatcherQueue.TryEnqueue(() =>
-            {
-                AddRepoContentDialog.CloseButtonText = originalCloseButtonText;
-            });
+            AddRepoContentDialog.CloseButtonText = originalCloseButtonText;
 
             // If the repo was not added.
             if (numberOfReposToCloneCount == AddRepoViewModel.EverythingToClone.Count)
             {
-                _host.GetService<WindowEx>().DispatcherQueue.TryEnqueue(() =>
-                {
-                    AddRepoContentDialog.CloseButtonText = originalCloseButtonText;
-                });
-
                 AddRepoViewModel.ShouldEnablePrimaryButton = false;
                 args.Cancel = true;
                 deferral.Complete();
@@ -208,14 +197,7 @@ public partial class AddRepoDialog : ContentDialog
                 var deferral = args.GetDeferral();
                 await AddRepoViewModel.ChangeToRepoPageAsync();
 
-                if (AddRepoViewModel.Accounts.Count == 0)
-                {
-                    AddRepoContentDialog.CloseButtonText = originalCloseButtonText;
-                    AddRepoViewModel.IsLoggingIn = false;
-                    AddRepoViewModel.IsCancelling = true;
-                    AddRepoViewModel.ShouldShowLoginUi = false;
-                    AddRepoViewModel.ShouldShowXButtonInLoginUi = false;
-                }
+                AddRepoContentDialog.CloseButtonText = originalCloseButtonText;
 
                 deferral.Complete();
             }


### PR DESCRIPTION
## Summary of the pull request
Because of the rushed implementation to add MSAL the repo tool had different look & feels depending on the tab the user is in.  Both tabs implemented cancelling the logins differently.

Because of the two different styles, the code was horrible, and the dialog could easily get into a bad state.

This code does

1. Refactors the login code so make it easier to read.
2. Makes the login UI the same between URL and Account.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #2418 
- [x] Closes #2416
- [x] Closes #2418
- [x] Closes #1764
- [ ] Tests added/passed
- [ ] Documentation updated

Movies!
Log-on behavior showing
1. Asking to connect on the account tab.
2. Cancelling the login
3.  Asking to connect on the URL tab.
4. Cancelling the login
5. Asking to  connect on the URL tab and switching to the Account tab without logging in.
6. Having the log in wait (30 seconds) elapse.
![RepoToolLoginBehavior](https://github.com/microsoft/devhome/assets/2517139/d8277f14-b94e-4134-914f-9cb3db2ab608)


Logging-in via the Account tab.
![AccountLoggingIn](https://github.com/microsoft/devhome/assets/2517139/2409e06c-e7d0-49e8-8f18-52bec4a4cb4e)

Logging-in via the URL tab
![LoggingInWithUrl](https://github.com/microsoft/devhome/assets/2517139/81d5cb4d-c60f-4161-9a0f-1ac3de69ecec)

