### PR TITLE
Fix Hyper-V extension launching vmconnect.exe behind the Dev Home window when the user launches a VM

### DIFF
--- a/HyperVExtension/src/HyperVExtension/Helpers/HyperVStrings.cs
+++ b/HyperVExtension/src/HyperVExtension/Helpers/HyperVStrings.cs
@@ -96,7 +96,4 @@ public static class HyperVStrings
     public const string RunningState = "Running";
     public const string PausedState = "Paused";
     public const string SavedState = "Saved";
-
-    // Hyper-V scripts
-    public const string VmConnectScript = "vmconnect.exe localhost -G";
 }

--- a/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -19,7 +19,6 @@ using Serilog;
 using Windows.Foundation;
 using Windows.Storage;
 using Windows.Storage.Streams;
-using Windows.UI.UIAutomation;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using SDK = Microsoft.Windows.DevHome.SDK;

--- a/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -469,7 +469,11 @@ public class HyperVVirtualMachine : IComputeSystem
                     // If vmconnect has an error, it will be displayed to the user in a message dialog
                     // outside of our control.
                     vmConnectProcess.Start();
-                    
+
+                    // Note: Just because the vmconnect.exe launches in the foreground does not mean it will launch
+                    // in front of the Dev Home window. Since the vmconnect.exe is a separate process being launched
+                    // outside of Dev Home, it will not be parented to the Dev Home window. The shell will launch it
+                    // in its last known location.
                     PInvoke.SetForegroundWindow((HWND)vmConnectProcess.MainWindowHandle);
                 }
 

--- a/HyperVExtension/src/HyperVExtension/NativeMethods.txt
+++ b/HyperVExtension/src/HyperVExtension/NativeMethods.txt
@@ -6,3 +6,4 @@ S_OK
 MAX_PATH
 SFBS_FLAGS
 StrFormatByteSizeEx
+SetForegroundWindow

--- a/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
@@ -432,34 +432,6 @@ public class HyperVManager : IHyperVManager, IDisposable
         }
     }
 
-    /// <inheritdoc cref="IHyperVManager.ConnectToVirtualMachine"/>
-    public void ConnectToVirtualMachine(Guid vmId)
-    {
-        StartVirtualMachineManagementService();
-        AddVirtualMachineToOperationsMap(vmId);
-
-        try
-        {
-            // Build command line statement to connect to the VM.
-            var commandLineStatements = new StatementBuilder()
-                .AddScript($"{HyperVStrings.VmConnectScript} {vmId}", true)
-                .Build();
-
-            var result = _powerShellService.Execute(commandLineStatements, PipeType.PipeOutput);
-
-            // Note: We use the vmconnect application to connect to the VM. VM connect will display a message box with
-            // an error if one occurs. We will only throw this error if an error occurs within the PowerShell session.
-            if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
-            {
-                throw new HyperVManagerException($"Unable to launch VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
-            }
-        }
-        finally
-        {
-            RemoveVirtualMachineFromOperationsMap(vmId);
-        }
-    }
-
     /// <inheritdoc cref="IHyperVManager.GetVirtualMachineCheckpoints"/>
     public IEnumerable<Checkpoint> GetVirtualMachineCheckpoints(Guid vmId)
     {

--- a/HyperVExtension/src/HyperVExtension/Services/IHyperVManager.cs
+++ b/HyperVExtension/src/HyperVExtension/Services/IHyperVManager.cs
@@ -63,10 +63,6 @@ public interface IHyperVManager
     /// <returns> True if the virtual machine was removed successfully, false otherwise.</returns>
     public bool RemoveVirtualMachine(Guid vmId);
 
-    /// <summary> Starts a remote session a Hyper-V virtual machine.</summary>
-    /// <param name="vmId"> The id of the virtual machine.</param>
-    public void ConnectToVirtualMachine(Guid vmId);
-
     /// <summary> Gets a list of all checkpoints for a Hyper-V virtual machine.</summary>
     /// <param name="vmId"> The id of the virtual machine.</param>
     /// <returns> A list of checkpoints and their parent checkpoints </returns>

--- a/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVManagerTest.cs
+++ b/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVManagerTest.cs
@@ -303,24 +303,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
     }
 
     [TestMethod]
-    public void ConnectToVirtualMachineDoesNotThrow()
-    {
-        // Arrange
-        SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
-        var hyperVManager = TestHost.GetService<IHyperVManager>();
-        SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() =>
-            {
-                // Simulate PowerShell won't return an object here, so simulate this.
-                return CreatePSObjectCollection(new PSCustomObjectMock());
-            });
-
-        // This should not throw an exception
-        hyperVManager.ConnectToVirtualMachine(Guid.NewGuid());
-    }
-
-    [TestMethod]
     public void GetVirtualMachineCheckpointsReturnCheckpoints()
     {
         // Arrange


### PR DESCRIPTION
## Summary of the pull request
Currently sometimes the vmconnect window that is launched when the user clicks the launch button within the environments page, opens directly behind the Dev Home Window. This makes it look like the Hyper-V extension did not launch vmconnect.

This change makes sure that the vmconnect.exe window launches in the foreground always.

Changes:

- Before we invoked vmconnect.exe through powershell. Now we launch it directly via [ProcessStartInfo](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo?view=net-8.0) and the [process](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process?view=net-8.0) classes to launch the exe directly.
- Removed unused using statement from HyperVVirtualMachine.cs

Video:

https://github.com/microsoft/devhome/assets/105318831/86e12d46-b251-4ec6-a911-1716807382db



## References and relevant issues

## Detailed description of the pull request / Additional comments

Note: Since the launch happens from the extension itself, and Dev Home has no way of interacting with the vmconnect process. Even if it launches in the foreground, it may not be in front of Dev Homes main Window. The shell will launch it in the last place  it was launched on the monitor.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
