### PR TITLE
Change GetWidgetsAsync to always return a valid list

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetHostingService.cs
@@ -9,17 +9,34 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetHostingService
 {
+    /// <summary>Get the list of current widgets from the WidgetService.</summary>
+    /// <returns>A list of widgets, or empty list if there were no widgets or the list could not be retrieved.</returns>
     public Task<Widget[]> GetWidgetsAsync();
 
+    /// <summary>Gets the widget with the given ID.</summary>
+    /// <returns>The widget, or null if one could not be retrieved.</returns>
     public Task<Widget> GetWidgetAsync(string widgetId);
 
+    /// <summary>Create and return a new widget.</summary>
+    /// <returns>The new widget, or null if one could not be created.</returns>
     public Task<Widget> CreateWidgetAsync(string widgetDefinitionId, WidgetSize widgetSize);
 
+    /// <summary>Get the catalog of widgets from the WidgetService.</summary>
+    /// <returns>The catalog of widgets, or null if one could not be created.</returns>
     public Task<WidgetCatalog> GetWidgetCatalogAsync();
 
+    /// <summary>Get the list of WidgetProviderDefinitions from the WidgetService.</summary>
+    /// <returns>A list of WidgetProviderDefinitions, or an empty list if there were no widgets
+    /// or the list could not be retrieved.</returns>
     public Task<WidgetProviderDefinition[]> GetProviderDefinitionsAsync();
 
+    /// <summary>Get the list of WidgetDefinitions from the WidgetService.</summary>
+    /// <returns>A list of WidgetDefinitions, or an empty list if there were no widgets
+    /// or the list could not be retrieved.</returns>
     public Task<WidgetDefinition[]> GetWidgetDefinitionsAsync();
 
+    /// <summary>Get the WidgetDefinition for the given WidgetDefinitionId from the WidgetService.</summary>
+    /// <returns>The WidgetDefinition, or null if the widget definition could not be found
+    /// or there was an error retrieving it.</returns>
     public Task<WidgetDefinition> GetWidgetDefinitionAsync(string widgetDefinitionId);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -26,7 +26,7 @@ public class WidgetHostingService : IWidgetHostingService
     /// <summary>
     /// Get the list of current widgets from the WidgetService.
     /// </summary>
-    /// <returns>A list of widgets, or null if there were no widgets or the list could not be retrieved.</returns>
+    /// <returns>A list of widgets, or empty list if there were no widgets or the list could not be retrieved.</returns>
     public async Task<Widget[]> GetWidgetsAsync()
     {
         var attempt = 0;
@@ -35,7 +35,7 @@ public class WidgetHostingService : IWidgetHostingService
             try
             {
                 _widgetHost ??= await Task.Run(() => WidgetHost.Register(new WidgetHostContext("BAA93438-9B07-4554-AD09-7ACCD7D4F031")));
-                return await Task.Run(() => _widgetHost.GetWidgets());
+                return await Task.Run(() => _widgetHost.GetWidgets()) ?? [];
             }
             catch (COMException ex) when (ex.HResult == RpcServerUnavailable || ex.HResult == RpcCallFailed)
             {
@@ -52,7 +52,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
         }
 
-        return null;
+        return [];
     }
 
     /// <summary>Gets the widget with the given ID.</summary>

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -23,10 +23,7 @@ public class WidgetHostingService : IWidgetHostingService
 
     private const int MaxAttempts = 3;
 
-    /// <summary>
-    /// Get the list of current widgets from the WidgetService.
-    /// </summary>
-    /// <returns>A list of widgets, or empty list if there were no widgets or the list could not be retrieved.</returns>
+    /// <inheritdoc />
     public async Task<Widget[]> GetWidgetsAsync()
     {
         var attempt = 0;
@@ -55,8 +52,7 @@ public class WidgetHostingService : IWidgetHostingService
         return [];
     }
 
-    /// <summary>Gets the widget with the given ID.</summary>
-    /// <returns>The widget, or null if one could not be retrieved.</returns>
+    /// <inheritdoc />
     public async Task<Widget> GetWidgetAsync(string widgetId)
     {
         var attempt = 0;
@@ -83,10 +79,7 @@ public class WidgetHostingService : IWidgetHostingService
         return null;
     }
 
-    /// <summary>
-    /// Create and return a new widget.
-    /// </summary>
-    /// <returns>The new widget, or null if one could not be created.</returns>
+    /// <inheritdoc />
     public async Task<Widget> CreateWidgetAsync(string widgetDefinitionId, WidgetSize widgetSize)
     {
         var attempt = 0;
@@ -113,10 +106,7 @@ public class WidgetHostingService : IWidgetHostingService
         return null;
     }
 
-    /// <summary>
-    /// Get the catalog of widgets from the WidgetService.
-    /// </summary>
-    /// <returns>The catalog of widgets, or null if one could not be created.</returns>
+    /// <inheritdoc />
     public async Task<WidgetCatalog> GetWidgetCatalogAsync()
     {
         var attempt = 0;
@@ -149,11 +139,7 @@ public class WidgetHostingService : IWidgetHostingService
         return _widgetCatalog;
     }
 
-    /// <summary>
-    /// Get the list of WidgetProviderDefinitions from the WidgetService.
-    /// </summary>
-    /// <returns>A list of WidgetProviderDefinitions, or an empty list if there were no widgets
-    /// or the list could not be retrieved.</returns>
+    /// <inheritdoc />
     public async Task<WidgetProviderDefinition[]> GetProviderDefinitionsAsync()
     {
         var attempt = 0;
@@ -182,11 +168,7 @@ public class WidgetHostingService : IWidgetHostingService
         return [];
     }
 
-    /// <summary>
-    /// Get the list of WidgetDefinitions from the WidgetService.
-    /// </summary>
-    /// <returns>A list of WidgetDefinitions, or an empty list if there were no widgets
-    /// or the list could not be retrieved.</returns>
+    /// <inheritdoc />
     public async Task<WidgetDefinition[]> GetWidgetDefinitionsAsync()
     {
         var attempt = 0;
@@ -215,11 +197,7 @@ public class WidgetHostingService : IWidgetHostingService
         return [];
     }
 
-    /// <summary>
-    /// Get the WidgetDefinition for the given WidgetDefinitionId from the WidgetService.
-    /// </summary>
-    /// <returns>The WidgetDefinition, or null if the widget definition could not be found
-    /// or there was an error retrieving it.</returns>
+    /// <inheritdoc />
     public async Task<WidgetDefinition> GetWidgetDefinitionAsync(string widgetDefinitionId)
     {
         var attempt = 0;

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -224,7 +224,7 @@ public partial class DashboardView : ToolPage, IDisposable
             _log.Information($"Pin default widgets");
             await PinDefaultWidgetsAsync();
         }
-        else if (hostWidgets != null)
+        else
         {
             await RestorePinnedWidgetsAsync(hostWidgets);
         }
@@ -237,7 +237,7 @@ public partial class DashboardView : ToolPage, IDisposable
         if (unsafeHostWidgets.Length == 0)
         {
             _log.Information($"Found 0 widgets for this host");
-            return null;
+            return [];
         }
 
         var comSafeHostWidgets = new List<ComSafeWidget>();

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -217,8 +217,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private async Task InitializePinnedWidgetListAsync(bool isFirstDashboardRun)
     {
         var hostWidgets = await GetPreviouslyPinnedWidgets();
-
-        if ((hostWidgets == null || hostWidgets.Length == 0) && isFirstDashboardRun)
+        if ((hostWidgets.Length == 0) && isFirstDashboardRun)
         {
             // If it's the first time the Dashboard has been displayed and we have no other widgets pinned to a
             // different version of Dev Home, pin some default widgets.
@@ -235,8 +234,7 @@ public partial class DashboardView : ToolPage, IDisposable
     {
         _log.Information("Get widgets for current host");
         var unsafeHostWidgets = await ViewModel.WidgetHostingService.GetWidgetsAsync();
-
-        if (unsafeHostWidgets == null)
+        if (unsafeHostWidgets.Length == 0)
         {
             _log.Information($"Found 0 widgets for this host");
             return null;
@@ -380,7 +378,7 @@ public partial class DashboardView : ToolPage, IDisposable
         await widget.DeleteAsync();
 
         var newWidgetList = await ViewModel.WidgetHostingService.GetWidgetsAsync();
-        length = (newWidgetList == null) ? 0 : newWidgetList.Length;
+        length = newWidgetList.Length;
         _log.Information($"After delete, {length} widgets for this host");
     }
 


### PR DESCRIPTION
## Summary of the pull request
Changes GetWidgetsAsync to always return a list instead of a list or null. Returning null is what the underlying GetWidgets() returns and that seems to slip through the nullable type checking. This change ensures GetWidgetsAsync always returns a list of Widgets, or an empty list if there were errors or null was returned from GetWidgets().

This fixes the empty pin widgets dialog when there were no widgets because the list was null and not checked, causing the dialog to crash. Null check is no longer required and this method will always have a valid list.

## References and relevant issues
Closes #2686 

## Detailed description of the pull request / Additional comments
* Updated GetWidgetsAsync to always return an empty list if GetWidgets returns null or there was an error.
* Updated callers of GetWidgetsAsync to no longer need to check for null where null was being checked.
* Updated GetPreviouslyPinnedWidgets to also return empty list instead of null.
* Updated callers of GetPreviouslyPinnedWidgets to no longer need to check for null.
* Updated comments on GetWidgetAsync to indicate it no longer can return null.
 
## Validation steps performed
* Manually verified pinning works when there are no widgets.
* Pinned a widget, removed it, pinned another one.
* Verifed restarting devhome recovers the widgets as expected and they remain pinned.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
