### PR TITLE
Only show quiet mode view when the feature is present

### DIFF
--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/QuietBackgroundProcessesView.xaml
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/QuietBackgroundProcessesView.xaml
@@ -7,7 +7,7 @@
     Loaded="UserControl_Loaded">
 
     <StackPanel Orientation="Vertical"
-                Visibility="{x:Bind ViewModel.IsQuietBackgroundProcessesFeatureEnabled, Mode=OneWay}">
+                Visibility="{x:Bind ViewModel.IsFeaturePresent, Mode=OneWay}">
         <ctControls:SettingsExpander x:Uid="QuietBackgroundProcesses" IsExpanded="False" Margin="{ThemeResource SettingsCardMargin}">
 
             <!-- Header icon -->


### PR DESCRIPTION
## Summary of the pull request
Quiet mode is only supported on certain versions of Windows and should not be shown on unsupported versions.
![image](https://github.com/microsoft/devhome/assets/7259210/f2bfa965-22b6-4c0a-915c-ec381ed68128)

## Detailed description of the pull request / Additional comments
Switch to using IsFeaturePresent which is only set when IsQuietBackgroundProcessesFeatureEnabled is already true and the feature is actually supported by the OS.

## Validation steps performed
Run Dev Home on Windows 10 to verify the card is not visible.
Confirm that the feature is never visible when toggle in experimental settings is disabled
Confirm that the feature is visible on the latest Win11 build with the experimental setting toggle enabled

## PR checklist
- [ ] Closes #2704 
- [ ] Tests added/passed
- [ ] Documentation updated
