### PR TITLE
Fixing link being cut off form small cards on What's new page

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -274,7 +274,7 @@
                                             Style="{ThemeResource BodyTextStyle}"
                                             Text="{x:Bind Title}" />
 
-                                        <controls:WrapPanel Margin="0 16 0 20">
+                                        <StackPanel Margin="0 16 0 20">
                                             <TextBlock
                                                 Margin="0 0 0 5"
                                                 TextWrapping="Wrap"
@@ -290,7 +290,7 @@
                                                 Padding="0"
                                                 Margin="0"
                                                 Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
-                                        </controls:WrapPanel>
+                                        </StackPanel>
                                     </StackPanel>
                                 </ScrollViewer>
 

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -274,7 +274,7 @@
                                             Style="{ThemeResource BodyTextStyle}"
                                             Text="{x:Bind Title}" />
 
-                                        <controls:WrapPanel Orientation="Vertical" Margin="0 16 0 20">
+                                        <controls:WrapPanel Margin="0 16 0 20">
                                             <TextBlock
                                                 Margin="0 0 0 5"
                                                 TextWrapping="Wrap"


### PR DESCRIPTION
## Summary of the pull request
Removed the vertical orientation from the wrapper control which was creating another vertical column due the lack of vertical space in the stack panel, and changed this control back to stack pannel, as wrapping is no more needed with the scroll enabled.
![image](https://github.com/microsoft/devhome/assets/13912953/8be4b79c-1d6c-4212-99e4-ae03b0a58acc)

## References and relevant issues
#2093 
## Detailed description of the pull request / Additional comments
When the big card was first added, design team decided it should have the text wrapped if there was not enough size for it, but this was later changed to a scroll view for accessibility reasons, so a regular StackPanel is now enough for it.
## Validation steps performed

## PR checklist
- [ ] Closes #2093 
- [ ] Tests added/passed
- [ ] Documentation updated
