### PR TITLE
Increase build timeout to 2 hours

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -129,6 +129,7 @@ extends:
       - ${{ each configuration in parameters.Configurations }}:
         - ${{ each platform in parameters.Platforms }}:
           - job: Build_${{ platform }}_${{ configuration }}
+            timeoutInMinutes: 120
             steps:
             - task: NuGetToolInstaller@1
 


### PR DESCRIPTION
## Summary of the pull request
Build stage is hovering around 1 hour which is the default timeout.  Increasing to 2 hours to prevent incorrectly failing builds.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
