### PR TITLE
Fix a broken URL in feedback

### DIFF
--- a/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/FeedbackPage.xaml.cs
@@ -329,7 +329,7 @@ public sealed partial class FeedbackPage : Page
 
     private async void BuildExtensionButtonClicked(object sender, RoutedEventArgs e)
     {
-        await Launcher.LaunchUriAsync(new("https://go.microsoft.com/fwlink/?linkid=2234795"));
+        await Launcher.LaunchUriAsync(new("https://github.com/microsoft/devhome/blob/main/docs/extensions/readme.md"));
     }
 
     private async void ReportSecurityButtonClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request
The old Learn More URL under Create an extension causes a 404.

## References and relevant issues
#2679

## Detailed description of the pull request / Additional comments
Changes the broken URL to a GitHub link.

## Validation steps performed
1. Open Dev Home
2. Click Settings
3. Click Feedback
4. Under Create an extension, click Learn more
5. The URL does not return a 404 error

## PR checklist
- [x] Closes #2679
- [ ] Tests added/passed
- [ ] Documentation updated
