### PR TITLE
update source context for serilog in a few files to match the correct class name

### DIFF
--- a/HyperVExtension/src/HyperVExtension/Models/VMGalleryCreationAdaptiveCardSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/VMGalleryCreationAdaptiveCardSession.cs
@@ -26,7 +26,7 @@ public enum SessionState
 
 public class VMGalleryCreationAdaptiveCardSession : IExtensionAdaptiveCardSession2
 {
-    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(HyperVVirtualMachine));
+    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(VMGalleryCreationAdaptiveCardSession));
 
     private readonly string _pathToInitialCreationFormTemplate = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", "InitialVMGalleryCreationForm.json");
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -14,7 +14,7 @@ namespace DevHome.Dashboard.Services;
 
 public class WidgetServiceService : IWidgetServiceService
 {
-    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetHostingService));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetServiceService));
 
     private readonly IPackageDeploymentService _packageDeploymentService;
     private readonly IAppInstallManagerService _appInstallManagerService;

--- a/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
@@ -21,7 +21,7 @@ namespace DevHome.Environments.ViewModels;
 /// </summary>
 public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBase
 {
-    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemViewModel));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(CreateComputeSystemOperationViewModel));
 
     private readonly IComputeSystemManager _computeSystemManager;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
@@ -30,7 +30,7 @@ namespace DevHome.SetupFlow.ViewModels.Environments;
 /// </summary>
 public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBase, IRecipient<CreationProviderChangedMessage>
 {
-    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(SelectEnvironmentProviderViewModel));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(EnvironmentCreationOptionsViewModel));
 
     private readonly AdaptiveCardRenderingService _adaptiveCardRenderingService;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -27,7 +27,7 @@ namespace DevHome.SetupFlow.ViewModels;
 
 public partial class LoadingViewModel : SetupPageViewModelBase
 {
-    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ConfigurationFileViewModel));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(LoadingViewModel));
 
     private readonly IHost _host;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -30,7 +30,7 @@ namespace DevHome.SetupFlow.ViewModels;
 /// </summary>
 public partial class MainPageViewModel : SetupPageViewModelBase
 {
-    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(EnvironmentsSetupFlowFeatureName));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(MainPageViewModel));
 
     private const string EnvironmentsSetupFlowFeatureName = "EnvironmentsSetupTargetFlow";
 


### PR DESCRIPTION
## Summary of the pull request
Fixes the "SourceContext" part for the Serilog logs.

I went through every file  in Dev Home to confirm they all use the correct source context based on the class used. 

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
confirmed built and environments and widgets still working
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
