### PR TITLE
Scale widget size with system Text Size

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetBoard.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetBoard.cs
@@ -3,9 +3,13 @@
 
 using System;
 using System.Linq;
+using CommunityToolkit.WinUI;
+using DevHome.Common.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
+using Windows.UI.ViewManagement;
+using WinUIEx;
 
 namespace DevHome.Dashboard.Controls;
 
@@ -13,6 +17,9 @@ public sealed class WidgetBoard : Panel
 {
     private double _columnWidth;
     private const int _maxColumns = 4;
+
+    private readonly UISettings _uiSettings = new();
+    private double _textScale = 1.0;
 
     // We need to control the HorizontalAlignment, so hide this property.
 #pragma warning disable SA1306 // Field names should begin with lower-case letter
@@ -33,6 +40,9 @@ public sealed class WidgetBoard : Panel
     {
         RegisterPropertyChangedCallback(Panel.HorizontalAlignmentProperty, OnHorizontalAlignmentChanged);
         HorizontalAlignment = HorizontalAlignment.Left;
+
+        _textScale = _uiSettings.TextScaleFactor;
+        _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChanged;
     }
 
     /// <summary>
@@ -119,7 +129,7 @@ public sealed class WidgetBoard : Panel
         var availableWidth = availableSize.Width - Padding.Left - Padding.Right;
         var availableHeight = availableSize.Height - Padding.Top - Padding.Bottom;
 
-        _columnWidth = Math.Min(WidgetWidth, availableWidth);
+        _columnWidth = Math.Min(WidgetWidth * _textScale, availableWidth);
         var numColumns = Math.Max(1, (int)Math.Floor(availableWidth / _columnWidth));
         numColumns = numColumns > _maxColumns ? _maxColumns : numColumns;
 
@@ -251,5 +261,14 @@ public sealed class WidgetBoard : Panel
         }
 
         InvalidateMeasure();
+    }
+
+    private void HandleTextScaleFactorChanged(UISettings sender, object args)
+    {
+        Application.Current.GetService<WindowEx>().DispatcherQueue.EnqueueAsync(() =>
+        {
+            _textScale = sender.TextScaleFactor;
+            InvalidateMeasure();
+        });
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -30,8 +30,8 @@
         </Grid.RowDefinitions>
 
         <!-- Widget header: icon, title, menu -->
-        <Grid Grid.Row="0" CornerRadius="7">
-            <StackPanel Orientation="Horizontal" Margin="16,10,0,0" Spacing="8">
+        <Grid Grid.Row="0" Padding="16,10,16,0">
+            <StackPanel Orientation="Horizontal" Spacing="8">
                 <Rectangle Width="16" Height="16" x:Name="WidgetHeaderIcon" />
                 <TextBlock AutomationProperties.AutomationId="WidgetTitle"
                            Text="{x:Bind WidgetSource.WidgetDisplayTitle, Mode=OneWay}"
@@ -44,7 +44,9 @@
                     x:Uid="WidgetMoreOptionsButton"
                     AutomationProperties.AutomationId="WidgetMoreOptionsButton"
                     FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{ThemeResource CaptionTextBlockFontSize}"
-                    VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10,16,0" BorderThickness="0" Padding="5"
+                    VerticalAlignment="Top" HorizontalAlignment="Right"
+                    BorderThickness="0"
+                    Padding="5"
                     Background="Transparent"
                     Click="OpenWidgetMenuAsync">
                 <Button.Flyout>
@@ -54,12 +56,15 @@
         </Grid>
 
         <!-- Widget content -->
-        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridLeft" Width="7"
-                      HorizontalAlignment="Left" />
-        <Grid Grid.Row="1" x:Name="ScollBarOffsetGridRight" Width="7"
-                      HorizontalAlignment="Right" />
-        <ScrollViewer Grid.Row="1" x:Name="WidgetScrollViewer" Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}"
-                      VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" Padding="7,0" />
-
+        <!-- Each widget has a 16px margin around it in which content cannot be placed.
+             https://learn.microsoft.com/en-us/windows/apps/design/widgets/widgets-design-fundamentals
+             Adaptive cards render with 8px padding on each side and the widget has a 1px border,
+             so we add 7px more of padding on the left and right.-->
+        <ScrollViewer Grid.Row="1" 
+                      x:Name="WidgetScrollViewer"
+                      Content="{x:Bind WidgetSource.WidgetFrameworkElement, Mode=OneWay}"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollMode="Disabled"
+                      Padding="7,0" />
     </Grid>
 </UserControl>

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -25,7 +25,7 @@
           Background="{ThemeResource WidgetCardBackground}"
           BorderThickness="1">
         <Grid.RowDefinitions>
-            <RowDefinition Height="36" />
+            <RowDefinition Height="{x:Bind HeaderHeight, Mode=OneWay}" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml
@@ -5,10 +5,21 @@
     x:Class="DevHome.Dashboard.Controls.WidgetControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:helpers="using:DevHome.Dashboard.Helpers"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     AutomationProperties.Name="{x:Bind WidgetSource.WidgetDisplayTitle}">
 
-    <Grid Width="300" Height="{x:Bind helpers:WidgetHelpers.GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize), Mode=OneWay}" 
+    <i:Interaction.Behaviors>
+        <ic:EventTriggerBehavior EventName="Loaded">
+            <ic:InvokeCommandAction Command="{x:Bind LoadedCommand}" />
+        </ic:EventTriggerBehavior>
+        <ic:EventTriggerBehavior EventName="Unloaded">
+            <ic:InvokeCommandAction Command="{x:Bind UnloadedCommand}" />
+        </ic:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
+
+    <Grid Width="{x:Bind WidgetWidth, Mode=OneWay}"
+          Height="{x:Bind WidgetHeight, Mode=OneWay}"
           CornerRadius="7"
           BorderBrush="{ThemeResource WidgetCardBorderBrush}"
           Background="{ThemeResource WidgetCardBackground}"

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -79,18 +79,18 @@ public sealed partial class WidgetControl : UserControl
     [RelayCommand]
     private void OnLoaded()
     {
-        _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChanged;
+        _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChangedAsync;
     }
 
     [RelayCommand]
     private void OnUnloaded()
     {
-        _uiSettings.TextScaleFactorChanged -= HandleTextScaleFactorChanged;
+        _uiSettings.TextScaleFactorChanged -= HandleTextScaleFactorChangedAsync;
     }
 
-    private void HandleTextScaleFactorChanged(UISettings sender, object args)
+    private async void HandleTextScaleFactorChangedAsync(UISettings sender, object args)
     {
-        try
+        await Application.Current.GetService<WindowEx>().DispatcherQueue.EnqueueAsync(() =>
         {
             if (WidgetSource == null)
             {
@@ -98,11 +98,7 @@ public sealed partial class WidgetControl : UserControl
             }
 
             SetScaledWidthAndHeight(sender.TextScaleFactor);
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, "Failed to handle text scale factor changed.");
-        }
+        });
     }
 
     private static double GetPixelHeightFromWidgetSize(WidgetSize size)
@@ -118,12 +114,9 @@ public sealed partial class WidgetControl : UserControl
 
     private void SetScaledWidthAndHeight(double textScale)
     {
-        Application.Current.GetService<WindowEx>().DispatcherQueue.EnqueueAsync(() =>
-        {
-            HeaderHeight = new GridLength(_headerHeightUnscaled * textScale);
-            WidgetHeight = GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize) * textScale;
-            WidgetWidth = WidgetHelpers.WidgetPxWidth * textScale;
-        });
+        HeaderHeight = new GridLength(_headerHeightUnscaled * textScale);
+        WidgetHeight = GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize) * textScale;
+        WidgetWidth = WidgetHelpers.WidgetPxWidth * textScale;
     }
 
     private async void OpenWidgetMenuAsync(object sender, RoutedEventArgs e)

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -35,7 +35,11 @@ public sealed partial class WidgetControl : UserControl
 
     private readonly StringResource _stringResource;
 
-    private readonly double _headerHeightUnscaled = 36;
+    // Each widget has a 16px margin around it and a 48px Attribution area in which content cannot be placed.
+    // https://learn.microsoft.com/en-us/windows/apps/design/widgets/widgets-design-fundamentals
+    // Adaptive cards render with 8px padding on each side, so we subtract that from the header height,
+    // as well as 1px for the border.
+    private const double _headerHeightUnscaled = 39;
 
     private SelectableMenuFlyoutItem _currentSelectedSize;
 

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -35,7 +35,12 @@ public sealed partial class WidgetControl : UserControl
 
     private readonly StringResource _stringResource;
 
+    private readonly double _headerHeightUnscaled = 36;
+
     private SelectableMenuFlyoutItem _currentSelectedSize;
+
+    [ObservableProperty]
+    private GridLength _headerHeight;
 
     [ObservableProperty]
     private double _widgetHeight;
@@ -115,6 +120,7 @@ public sealed partial class WidgetControl : UserControl
     {
         Application.Current.GetService<WindowEx>().DispatcherQueue.EnqueueAsync(() =>
         {
+            HeaderHeight = new GridLength(_headerHeightUnscaled * textScale);
             WidgetHeight = GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize) * textScale;
             WidgetWidth = WidgetHelpers.WidgetPxWidth * textScale;
         });

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -41,9 +41,11 @@ internal sealed class WidgetHelpers
 
     public const string DevHomeHostName = "DevHome";
 
-    private const double WidgetPxHeightSmall = 146;
-    private const double WidgetPxHeightMedium = 304;
-    private const double WidgetPxHeightLarge = 462;
+    public const double WidgetPxHeightSmall = 146;
+    public const double WidgetPxHeightMedium = 304;
+    public const double WidgetPxHeightLarge = 462;
+
+    public const double WidgetPxWidth = 300;
 
     public static WidgetSize GetLargestCapabilitySize(WidgetCapability[] capabilities)
     {
@@ -82,17 +84,6 @@ internal sealed class WidgetHelpers
             // Return something in case new sizes are added.
             return capabilities[0].Size;
         }
-    }
-
-    public static double GetPixelHeightFromWidgetSize(WidgetSize size)
-    {
-        return size switch
-        {
-            WidgetSize.Small => WidgetPxHeightSmall,
-            WidgetSize.Medium => WidgetPxHeightMedium,
-            WidgetSize.Large => WidgetPxHeightLarge,
-            _ => 0,
-        };
     }
 
     public static async Task<bool> IsIncludedWidgetProviderAsync(WidgetProviderDefinition provider)


### PR DESCRIPTION
## Summary of the pull request
There are a few accessibility bugs around text being cut off inside widgets when system text scaling is turned up (Windows Settings > Accessibility > Text size). The Windows Widget Board (`🪟+w`) scales up the entire widget to match the text scaling, so we will, too. For example, the normal widget width is 300 pixels. If text scaling is at 200%, our widgets will become 600 px wide. Height also scales.
![image](https://github.com/microsoft/devhome/assets/47155823/f3682203-c42e-4729-9fe8-de849780f4b2)

## References and relevant issues
https://task.ms/49360547
https://task.ms/49658528

## Detailed description of the pull request / Additional comments
* WidgetControl  and WidgetBoard both need to listen for text scale changed events and respond.
* Widget header (icon, title, "more options" menu" also scales up.
* Updating widget sizes must be done on the UI thread.
* `GetPixelHeightFromWidgetSize` moves to WidgetControl since that is the only place it is used.

## Validation steps performed

## PR checklist
- [ ] Closes #2638
- [ ] Tests added/passed
- [ ] Documentation updated
