### PR TITLE
Summary and loading margins.  Replacing www. with empty in repo URLs.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloneRepoTask.cs
@@ -247,9 +247,11 @@ public partial class CloneRepoTask : ObservableObject, ISetupTask
             }
             catch (Exception e)
             {
-                _log.Error(e, $"Could not clone {RepositoryToClone.DisplayName}");
-                _actionCenterErrorMessage.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.CloneRepoErrorForActionCenter, RepositoryToClone.DisplayName, e.HResult.ToString("X", CultureInfo.CurrentCulture));
-                TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_CouldNotClone_Event", LogLevel.Critical, new ExceptionEvent(e.HResult));
+                _log.Error(e, $"Could not clone {RepositoryToClone.DisplayName} because {e.Message}");
+                TelemetryFactory.Get<ITelemetry>().LogError("CloneTask_CouldNotClone_Event", LogLevel.Critical, new ExceptionEvent(e.HResult, e.Message));
+
+                _actionCenterErrorMessage.PrimaryMessage = _stringResource.GetLocalized(StringResourceKey.CloneRepoErrorForActionCenter, RepositoryToClone.DisplayName, e.Message);
+                WasCloningSuccessful = false;
                 return TaskFinishedState.Failure;
             }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/GenericRepository.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/GenericRepository.cs
@@ -31,7 +31,17 @@ internal sealed class GenericRepository : Microsoft.Windows.DevHome.SDK.IReposit
     public GenericRepository(Uri cloneUri)
     {
         _displayName = cloneUri.Segments[cloneUri.Segments.Length - 1].ToString().Replace("/", string.Empty);
-        _cloneUri = cloneUri;
+
+        if (cloneUri.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+        {
+            var locationOfHost = cloneUri.OriginalString.IndexOf("www.", StringComparison.OrdinalIgnoreCase);
+            var originalStringWithoutHost = cloneUri.OriginalString.Remove(locationOfHost, 4);
+            _cloneUri = new Uri(originalStringWithoutHost);
+        }
+        else
+        {
+            _cloneUri = cloneUri;
+        }
     }
 
     public IAsyncAction CloneRepositoryAsync(string cloneDestination, IDeveloperId developerId)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -52,7 +52,7 @@
     </UserControl.Resources>
 
     <!-- Page split layout -->
-    <Grid RowSpacing="10" MaxWidth="{ThemeResource MaxPageContentWidth}">
+    <Grid RowSpacing="10" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*"/>
             <ColumnDefinition Width="*" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -61,7 +61,7 @@
         VerticalScrollBarVisibility="Auto"
         Padding="0,0,10,0">
         <StackPanel>
-            <Grid RowSpacing="5" MaxWidth="{ThemeResource MaxPageContentWidth}">
+            <Grid RowSpacing="5" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="auto"/>
                     <RowDefinition Height="auto"/>
@@ -363,7 +363,8 @@
                         <!-- Repos cloned -->
                         <Grid Padding="0,13" Visibility="{x:Bind ViewModel.TargetCloneResults, Converter={StaticResource CollectionVisibilityConverter}}"
                             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
-                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}">
+                            BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}"
+                              HorizontalAlignment="Stretch">
                             <Expander MaxHeight="200">
                                 <Expander.Header>
                                     <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -364,7 +364,7 @@
                         <Grid Padding="0,13" Visibility="{x:Bind ViewModel.TargetCloneResults, Converter={StaticResource CollectionVisibilityConverter}}"
                             BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" 
                             BorderThickness="{ThemeResource TopNavigationViewContentGridBorderThickness}"
-                              HorizontalAlignment="Stretch">
+                            HorizontalAlignment="Stretch">
                             <Expander MaxHeight="200">
                                 <Expander.Header>
                                     <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ReposClonedDisplay" Style="{ThemeResource BodyStrongTextBlockStyle}"/>


### PR DESCRIPTION
## Summary of the pull request
Mis-read a UI change that resulted in the loading screen and summary screen missing their margins.  Re-adding them.  Also, re-adding the double line in the summary screen.

Fixing two additional issues.
1. Failing cloning with the Generic Provider now displays the error message.  Not the HResult.
2. www. is stripped from the uri host when cloning with the generic repository.  LibGit2 does not like URLs with www.


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2605
- [ ] Tests added/passed
- [ ] Documentation updated


Pictures!

Loading screen.
![LoadingScreenWithMargins](https://github.com/microsoft/devhome/assets/2517139/b88ebd15-372c-477a-90e7-8e318d72e5e3)

Summary screen.
![SummaryWithMargins](https://github.com/microsoft/devhome/assets/2517139/d73e19ca-627b-4288-ae76-f38dfcd7685d)


