### PR TITLE
Enabling DevHome to recognize when the same file is removed.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -262,7 +262,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
             {
                 _log.Information($"Selected Dev Drive location: {location.Path}");
 
-                // If the user encounteres an error, like file already exists, then they fix the issue
+                // If the user encounters an error, like file already exists, then they fix the issue
                 // (deleted the file) DevHome won't check if the issue is resolved.  A user needs to
                 // re-enter a path.  If the path is the same as the previously entered path Location
                 // will not update because the two string values are similiar.

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -143,6 +143,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     /// This is the location that we will save the virtual disk file to.
     /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DriveLabel))]
     [NotifyCanExecuteChangedFor(nameof(SaveButtonCommand))]
     private string _location;
 
@@ -260,6 +261,16 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
             if (!string.IsNullOrWhiteSpace(location?.Path))
             {
                 _log.Information($"Selected Dev Drive location: {location.Path}");
+
+                // If the user removed the file and wants to clone to the same location
+                // change Location to empty to force setting Location to location.path and
+                // enabling DevDrive validation.
+                if (FileNameAndSizeErrorList.Contains(DevDriveValidationResult.FileNameAlreadyExists)
+                    && string.Equals(Location, location.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    Location = string.Empty;
+                }
+
                 Location = location.Path;
             }
             else

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -262,12 +262,13 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
             {
                 _log.Information($"Selected Dev Drive location: {location.Path}");
 
-                // If the user removed the file and wants to clone to the same location
-                // change Location to empty to force setting Location to location.path and
-                // enabling DevDrive validation.
-                if (FileNameAndSizeErrorList.Contains(DevDriveValidationResult.FileNameAlreadyExists)
-                    && string.Equals(Location, location.Path, StringComparison.OrdinalIgnoreCase))
+                // If the user encounteres an error, like file already exists, then they fix the issue
+                // (deleted the file) DevHome won't check if the issue is resolved.  A user needs to
+                // re-enter a path.  If the path is the same as the previously entered path Location
+                // will not update because the two string values are similiar.
+                if (string.Equals(Location, location.Path, StringComparison.OrdinalIgnoreCase))
                 {
+                    // Change Location to empty to force Location updates.
                     Location = string.Empty;
                 }
 


### PR DESCRIPTION
## Summary of the pull request
A user can not remove the "A file with the same name already exists" error in the DevDrive window by removing the file if they want to clone to the same location.  This prevents users from cloning a DevDrive even if the file is removed.

The PR lets users add a DevDrive after getting the "A file with the same name exists" error.  This can be done in two steps
1. The user removes the offending file.
2. The user re-enters the path (Either by browsing, or typing into the text box).

This is done in two steps.
1. Make the location change validate the drive label.
2. When the location changes, and the "A File already exists..." error is displayed, and the new location is the same as the old one, change Location to empty, then let it change to the "new" location.

## References and relevant issues

## Detailed description of the pull request / Additional comments

[ObservableProperty] will not fire a changed event if the new value is the same as the old value.  Added a change to string.empty to make the validation code path light up.


## Validation steps performed
Cloned a repo into a new dev drive after triggering the "A file already exists..." error.

## PR checklist
- [ ] Closes #2419
- [ ] Tests added/passed
- [ ] Documentation updated
