### PR TITLE
Update environments to show supported operations dynamically based the state change events.

### DIFF
--- a/tools/Environments/DevHome.Environments/CustomControls/CardFlyout.xaml.cs
+++ b/tools/Environments/DevHome.Environments/CustomControls/CardFlyout.xaml.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using DevHome.Environments.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -27,25 +28,70 @@ public sealed partial class CardFlyout : MenuFlyout
     private static void ItemsLoaded(DependencyObject dependencyObj, DependencyPropertyChangedEventArgs args)
     {
         var flyout = (CardFlyout)dependencyObj;
+
+        if (args.OldValue != null)
+        {
+            var oldOperationsViewModel = (INotifyCollectionChanged)args.OldValue;
+
+            // Unsubscribe from CollectionChanged for the old collection
+            oldOperationsViewModel.CollectionChanged -= flyout.OperationsViewModelCollectionChanged;
+        }
+
+        if (args.NewValue != null)
+        {
+            var newOperationsViewModel = (ObservableCollection<OperationsViewModel>)args.NewValue;
+
+            // Subscribe to CollectionChanged for the new collection
+            newOperationsViewModel.CollectionChanged += flyout.OperationsViewModelCollectionChanged;
+        }
+
         flyout.FillOperations();
     }
 
     private void FillOperations()
     {
         Items.Clear();
-
         if (ItemsViewModels != null)
         {
             foreach (var item in ItemsViewModels)
             {
-                var flyoutItem = new MenuFlyoutItem
+                Items.Add(CreateFlyoutItem(item));
+            }
+        }
+    }
+
+    private MenuFlyoutItem CreateFlyoutItem(OperationsViewModel viewModel)
+    {
+        return new MenuFlyoutItem
+        {
+            Text = viewModel.Name,
+            Icon = new FontIcon { Glyph = viewModel.IconGlyph },
+            Command = viewModel.InvokeActionCommand,
+            MinWidth = MinimumWidthOfItems,
+        };
+    }
+
+    private void OperationsViewModelCollectionChanged(object? sender, NotifyCollectionChangedEventArgs viewModelCollectionChangedArgs)
+    {
+        // Collection was cleared
+        if (viewModelCollectionChangedArgs.Action == NotifyCollectionChangedAction.Reset)
+        {
+            Items.Clear();
+        }
+
+        if (viewModelCollectionChangedArgs.NewItems == null)
+        {
+            return;
+        }
+
+        if (viewModelCollectionChangedArgs.NewItems.Count > 0 && viewModelCollectionChangedArgs.Action == NotifyCollectionChangedAction.Add)
+        {
+            foreach (var item in viewModelCollectionChangedArgs.NewItems)
+            {
+                if (item is OperationsViewModel operationViewModels)
                 {
-                    Text = item.Name,
-                    Icon = new FontIcon { Glyph = item.IconGlyph },
-                    Command = item.InvokeActionCommand,
-                    MinWidth = MinimumWidthOfItems,
-                };
-                Items.Add(flyoutItem);
+                    Items.Add(CreateFlyoutItem(operationViewModels));
+                }
             }
         }
     }

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -24,7 +24,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
     public bool IsCreateComputeSystemOperation { get; protected set; }
 
     // Will hold the supported actions that the user can perform on in the UI. E.g Remove button
-    public ObservableCollection<OperationsViewModel>? DotOperations { get; protected set; }
+    public ObservableCollection<OperationsViewModel> DotOperations { get; protected set; } = new();
 
     [ObservableProperty]
     private ComputeSystemState _state;

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -270,8 +270,6 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
                 "Environment_OperationInvoked_Event",
                 LogLevel.Measure,
                 new EnvironmentOperationUserEvent(completionStatus, data.ComputeSystemOperation, ComputeSystem!.AssociatedProviderId, data.AdditionalContext, data.ActivityId));
-
-            IsOperationInProgress = false;
         });
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -10,6 +11,7 @@ using Antlr4.Runtime.Misc;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.WinUI;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
@@ -42,7 +44,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     private readonly IComputeSystemManager _computeSystemManager;
 
     // Launch button operations
-    public ObservableCollection<OperationsViewModel> LaunchOperations { get; set; }
+    public ObservableCollection<OperationsViewModel> LaunchOperations { get; set; } = new();
 
     public ObservableCollection<CardProperty> Properties { get; set; } = new();
 
@@ -68,21 +70,17 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         AssociatedProviderId = ComputeSystem.AssociatedProviderId!;
         ComputeSystemId = ComputeSystem.Id!;
         _removalAction = removalAction;
-        ShouldShowLaunchOperation = true;
 
         if (!string.IsNullOrEmpty(ComputeSystem.SupplementalDisplayName))
         {
             AlternativeName = new string("(" + ComputeSystem.SupplementalDisplayName + ")");
         }
 
-        LaunchOperations = new ObservableCollection<OperationsViewModel>(DataExtractor.FillLaunchButtonOperations(ComputeSystem));
-        DotOperations = new ObservableCollection<OperationsViewModel>(DataExtractor.FillDotButtonOperations(ComputeSystem));
         HeaderImage = CardProperty.ConvertMsResourceToIcon(provider.Icon, packageFullName);
         ComputeSystem.StateChanged += _computeSystemManager.OnComputeSystemStateChanged;
         _computeSystemManager.ComputeSystemStateChanged += OnComputeSystemStateChanged;
 
         _stringResource = new StringResource("DevHome.Environments.pri", "DevHome.Environments/Resources");
-        RegisterForAllOperationMessages();
     }
 
     public async Task InitializeCardDataAsync()
@@ -90,14 +88,14 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         await InitializeStateAsync();
         await SetBodyImageAsync();
         await SetPropertiesAsync();
-        await InitializePinDataAsync();
+        await InitializeOperationDataAsync();
     }
 
-    private async Task InitializePinDataAsync()
+    private async Task InitializeOperationDataAsync()
     {
-        // We know ComputeSystem and DotOperations are initialized in the constructor so it's safe to use
-        var operations = new ObservableCollection<OperationsViewModel>(await DataExtractor.FillDotButtonPinOperationsAsync(ComputeSystem!));
-        foreach (var operation in operations)
+        RegisterForAllOperationMessages(DataExtractor.FillDotButtonOperations(ComputeSystem!), DataExtractor.FillLaunchButtonOperations(ComputeSystem!));
+
+        foreach (var operation in await DataExtractor.FillDotButtonPinOperationsAsync(ComputeSystem!))
         {
             DotOperations!.Add(operation);
         }
@@ -132,11 +130,15 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 
     public void OnComputeSystemStateChanged(ComputeSystem sender, ComputeSystemState newState)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _windowEx.DispatcherQueue.EnqueueAsync(async () =>
         {
             if (sender.Id == ComputeSystem!.Id)
             {
-                UpdateOperationsPostCreation(State, newState);
+                // The supported operations for a compute system can change based on the current state of the compute system.
+                // So we need to rebuild the dot and launch operations that appear in the UI based on the current
+                // supported operations of the compute system. InitializeOperationDataAsync will take care of this for us, by using
+                // the DataExtractor helper.
+                await InitializeOperationDataAsync();
                 State = newState;
                 StateColor = ComputeSystemHelpers.GetColorBasedOnState(newState);
                 SetupOperationProgressBasedOnState();
@@ -278,18 +280,25 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     /// DotOperation and LaunchOperation lists. When there is an operation this ViewModel will receive the started and
     /// the completed messages.
     /// </summary>
-    private void RegisterForAllOperationMessages()
+    private void RegisterForAllOperationMessages(List<OperationsViewModel> dotOperations, List<OperationsViewModel> launchOperations)
     {
         _log.Information($"Registering ComputeSystemViewModel '{Name}' from provider '{ProviderDisplayName}' with WeakReferenceMessenger at {DateTime.Now}");
 
-        foreach (var dotOperation in DotOperations!)
+        // Unregister from all operation messages
+        WeakReferenceMessenger.Default.UnregisterAll(this);
+        LaunchOperations.Clear();
+        DotOperations!.Clear();
+
+        foreach (var dotOperation in dotOperations)
         {
+            DotOperations.Add(dotOperation);
             WeakReferenceMessenger.Default.Register<ComputeSystemOperationStartedMessage, OperationsViewModel>(this, dotOperation);
             WeakReferenceMessenger.Default.Register<ComputeSystemOperationCompletedMessage, OperationsViewModel>(this, dotOperation);
         }
 
-        foreach (var launchOperation in LaunchOperations!)
+        foreach (var launchOperation in launchOperations)
         {
+            LaunchOperations.Add(launchOperation);
             WeakReferenceMessenger.Default.Register<ComputeSystemOperationStartedMessage, OperationsViewModel>(this, launchOperation);
             WeakReferenceMessenger.Default.Register<ComputeSystemOperationCompletedMessage, OperationsViewModel>(this, launchOperation);
         }
@@ -323,7 +332,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
             IsOperationInProgress = false;
         }
 
-        if ((State != ComputeSystemState.Creating) || (State != ComputeSystemState.Deleting))
+        if ((State != ComputeSystemState.Creating) && (State != ComputeSystemState.Deleting))
         {
             ShouldShowLaunchOperation = true;
         }
@@ -331,26 +340,6 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         if (State == ComputeSystemState.Deleted)
         {
             RemoveComputeSystem();
-        }
-    }
-
-    private void UpdateOperationsPostCreation(ComputeSystemState previousState, ComputeSystemState newState)
-    {
-        // supported operations may have changed after creation, so we'll update them
-        if ((previousState == ComputeSystemState.Creating) && (previousState != newState))
-        {
-            LaunchOperations.Clear();
-            DotOperations!.Clear();
-
-            foreach (var buttonOperation in DataExtractor.FillLaunchButtonOperations(ComputeSystem!))
-            {
-                LaunchOperations.Add(buttonOperation);
-            }
-
-            foreach (var dotOperation in DataExtractor.FillDotButtonOperations(ComputeSystem!))
-            {
-                LaunchOperations.Add(dotOperation);
-            }
         }
     }
 }

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -42,7 +42,7 @@
                     x:Uid="ms-resource:///DevHome.Environments/Resources/LaunchButton"
                     Style="{StaticResource CardBodySplitButtonStyle}">
                     <SplitButton.Flyout>
-                        <customControls:CardFlyout ItemsViewModels="{x:Bind LaunchOperations}"/>
+                        <customControls:CardFlyout ItemsViewModels="{x:Bind LaunchOperations, Mode=OneWay}"/>
                     </SplitButton.Flyout>
                 </SplitButton>
             </DataTemplate>
@@ -53,7 +53,7 @@
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}">
                         <Button.Flyout>
-                            <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations}"/>
+                            <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}"/>
                         </Button.Flyout>
                     </Button>
                 </Grid>
@@ -65,7 +65,7 @@
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}">
                         <Button.Flyout>
-                            <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations}"/>
+                            <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}" />
                         </Button.Flyout>
                     </Button>
                 </Grid>


### PR DESCRIPTION
## Summary of the pull request
This PR aims to allow the compute system operations that appear in the horizontal dots menu flyout and the launch split button menu flyout to be dynamically updated based on the state of the compute system. For background, each compute system view model contains an observable collection with view models for both of the flyouts. Each item in the collection is a view model that contains a relay command.

Changes:

1. I updated the card flyout control to subscribe/unsubscribe to collection changed events so when the collection is cleared and new items are added the list of menuflyout items are updated.
2. I also consolidated the InitializePinDataAsync and UpdateOperationsPostCreation methods into the InitializeOperationDataAsync method where we now populate the dot and launch observable collections.
3.Upon a state change, we call the InitializeOperationDataAsync to clear and add the supported operations for the compute system
4. Removed line where we set the IsOperationInProgress to false after the extension completes the operation, as we will rely on the state of the compute system to tell us when the progress bar should not be shown. This is needed for providers like Dev box where an operation may not be completely done just because the extension returns the completed result. (Cloud operations can take a while so the Dev Box extension polls the Dev Center for the status of the operation which could take minutes).  The initial result returned to Dev Home in that case would just be that the request was sent successfully and the operation has initiated without errors. We use this method  https://github.com/microsoft/devhome/blob/356fc88954475d83e066162674905907dd805d73/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs#L298 to check if the compute system's state is transitioning into/out of a processing state. 


Video of flow: (takes 20 - 40 minutes to create a Dev Box in the cloud so paused and unpaused video when I received the creation email). Key parts to take note of is, the launch button no longer appearing during creation, and after creation the dot and launch operations now appear based on the supported operations of the compute system.


https://github.com/microsoft/devhome/assets/105318831/49f8132c-7e95-4696-84cf-bcf5e96180c1


## References and relevant issues
Also updated  dev box in azure extension to show correct state immediately after creation: https://github.com/microsoft/DevHomeAzureExtension/pull/163

## Detailed description of the pull request / Additional comments

## Validation steps performed
Tested and confirmed it is now working as expected with change: 
## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
