### PR TITLE
Populate ComSafeWidgets after creation, handle failures

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeHelpers.cs
@@ -20,7 +20,7 @@ internal sealed class ComSafeHelpers
             if (!string.IsNullOrEmpty(id))
             {
                 var comSafeWidgetDefinition = new ComSafeWidgetDefinition(id);
-                if (await comSafeWidgetDefinition.Populate())
+                if (await comSafeWidgetDefinition.PopulateAsync())
                 {
                     comSafeWidgetDefinitions.Add(comSafeWidgetDefinition);
                 }

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
@@ -56,6 +56,17 @@ public class ComSafeWidget
     }
 
     /// <summary>
+    /// ComSafeWidgets must be populated before use to guarantee their properties are valid.
+    /// Calling methods will populate the object, but referencing properties cannot.
+    /// </summary>
+    /// <returns>true if the ComSafeWidget was successfully populated, false if not.</returns>
+    public async Task<bool> PopulateAsync()
+    {
+        await LazilyLoadOopWidget();
+        return _hasValidProperties;
+    }
+
+    /// <summary>
     /// Gets the card template from the widget. Tries multiple times in case of COM exceptions.
     /// </summary>
     /// <returns>The card template, or empty JSON in the case of failure.</returns>
@@ -328,26 +339,21 @@ public class ComSafeWidget
     }
 
     /// <summary>
-    /// Get a widget's ID from a widget object. Tries multiple times in case of COM exceptions.
+    /// Get a widget's ID from a widget object.
     /// </summary>
     /// <param name="widget">Widget</param>
     /// <returns>The Widget's Id, or in the case of failure string.Empty</returns>
     public static async Task<string> GetIdFromUnsafeWidgetAsync(Widget widget)
     {
-        var retries = 5;
-
         return await Task.Run(() =>
         {
-            while (retries-- > 0)
+            try
             {
-                try
-                {
-                    return widget.Id;
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}, try {retries} more times");
-                }
+                return widget.Id;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, $"Failed to operate on out-of-proc object with error code: 0x{ex.HResult:x}");
             }
 
             return string.Empty;

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -176,7 +176,7 @@ public class ComSafeWidgetDefinition : IDisposable
     /// Get a WidgetDefinition's ID from a WidgetDefinition object.
     /// </summary>
     /// <param name="widgetDefinition">WidgetDefinition</param>
-    /// <returns>The Widget's Id, or in the case of failure string.Empty</returns>
+    /// <returns>The WidgetDefinition's Id, or in the case of failure string.Empty</returns>
     public static async Task<string> GetIdFromUnsafeWidgetDefinitionAsync(WidgetDefinition widgetDefinition)
     {
         return await Task.Run(() =>

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidgetDefinition.cs
@@ -64,7 +64,12 @@ public class ComSafeWidgetDefinition : IDisposable
         Id = widgetDefinitionId;
     }
 
-    public async Task<bool> Populate()
+    /// <summary>
+    /// ComSafeWidgetDefinitions must be populated before use to guarantee their properties are valid.
+    /// Calling methods will populate the object, but referencing properties cannot.
+    /// </summary>
+    /// <returns>true if the ComSafeWidgetDefinition was successfully populated, false if not.</returns>
+    public async Task<bool> PopulateAsync()
     {
         await LazilyLoadOopWidgetDefinitionAsync();
         return _hasValidProperties;

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -139,7 +139,7 @@ public sealed partial class WidgetControl : UserControl
         }
 
         var comSafeWidgetDefinition = new ComSafeWidgetDefinition(widgetDefinitionId);
-        if (!await comSafeWidgetDefinition.Populate())
+        if (!await comSafeWidgetDefinition.PopulateAsync())
         {
             // If we can't populate the widgetDefinition, bail and don't show sizes.
             return;

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -92,7 +92,11 @@ public sealed partial class AddWidgetDialog : ContentDialog
             var id = await ComSafeWidget.GetIdFromUnsafeWidgetAsync(unsafeWidget);
             if (!string.IsNullOrEmpty(id))
             {
-                comSafeCurrentlyPinnedWidgets.Add(new ComSafeWidget(id));
+                var comSafeWidget = new ComSafeWidget(id);
+                if (await comSafeWidget.PopulateAsync())
+                {
+                    comSafeCurrentlyPinnedWidgets.Add(comSafeWidget);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary of the pull request
Fixes issue where we were able to pin multiples of widgets where AllowMultiple = false, maybe other ones not yet found.
With lazy loading, ComSafeWidgets were only loaded with properties when a method was called on them. In the case that a property was called first, the ComSafeWidget didn't have its properties set, and would return the default (which, in the case of AllowMultiple, is true). We should call PopulateAsync() on all ComSafe* objects after new-ing them up. This was already done for ComSafeWidgetDefinitions.

## Validation steps performed
Validated locally.

## PR checklist
- [ ] Closes #2735
- [ ] Tests added/passed
- [ ] Documentation updated
