### PR TITLE
Enable automated UI tests for local runs

### DIFF
--- a/Test.ps1
+++ b/Test.ps1
@@ -90,7 +90,7 @@ if (-not (Test-Path -Path "AppxPackages")) {
 try {
     foreach ($platform in $env:Build_Platform.Split(",")) {
         foreach ($configuration in $env:Build_Configuration.Split(",")) {
-            # TODO: UI tests are currently disabled in the pipeline until signing is solved
+            # TODO: UI tests are currently disabled in the pipeline until we can run tests as user
             if ($RunUITests) {
                 $DevHomePackage = Get-AppPackage "Microsoft.DevHome" -ErrorAction SilentlyContinue
                 if ($DevHomePackage) {
@@ -122,7 +122,7 @@ try {
             )
 
             & $vstestPath $vstestArgs
-            # TODO: UI tests are currently disabled in the pipeline until signing is solved
+            # TODO: UI tests are currently disabled in the pipeline until we can run tests as user
             if ($RunUITests) {
                 & $vstestPath $winAppTestArgs
             }

--- a/uitest/Dialogs/AddWidgetDialog.cs
+++ b/uitest/Dialogs/AddWidgetDialog.cs
@@ -39,28 +39,7 @@ public class AddWidgetDialog : PageDialog<DashboardPage>
 
     public DashboardPage.WidgetControl AddCPUUsageWidget() => QuickAddWidget(CPUUsageNavigationItem, "CPU");
 
-    public DashboardPage.WidgetControl AddSSHWidget(string configFilePath)
-    {
-        return WaitForWidgetToBeAdded(() =>
-        {
-            Trace.WriteLine($"Clicking on SSH navigation item");
-            SSHNavigationItem.Click();
-
-            // Wait for the widget to be rendered before configuring and
-            // pinning it
-            // TODO: Can we use AccessibilityId for adaptive cards forms?
-            Trace.WriteLine($"Configuring SSH widget: Adding SSH config file path");
-            var container = Driver.WaitUntilVisible(ByWindowsAutomation.ClassName("NamedContainerAutomationPeer"));
-            var input = container.FindElementByClassName("TextBox");
-            input.Clear();
-            input.SendKeys(configFilePath);
-            var submit = container.FindElementByClassName("Button");
-            submit.Click();
-
-            Trace.WriteLine($"Pinning SSH widget");
-            PinButton.Click();
-        });
-    }
+    public DashboardPage.WidgetControl AddSSHWidget() => QuickAddWidget(SSHNavigationItem, "SSH keychain");
 
     private string GetWidgetNavigationItemId(string widgetId) => $"NavViewItem_{Configuration.Widget.IdPrefix}!App!!{Configuration.Widget.Provider}!!{widgetId}";
 

--- a/uitest/WidgetTest.cs
+++ b/uitest/WidgetTest.cs
@@ -47,7 +47,7 @@ public class WidgetTest : DevHomeTestBase
             ["CPU"] = dialog => dialog.AddCPUUsageWidget(),
             ["Network"] = dialog => dialog.AddNetworkUsageWidget(),
             ["Memory"] = dialog => dialog.AddMemoryWidget(),
-            ["SSH keychain"] = dialog => dialog.AddSSHWidget(GetTestAssetPath(@"Widgets\EmptySSHConfig")),
+            ["SSH keychain"] = dialog => dialog.AddSSHWidget(),
         };
         var dashboard = Application.NavigateToDashboardPage();
         dashboard.RemoveAllWidgets();


### PR DESCRIPTION
## Summary of the pull request
Automated UI tests will now work again for local runs.  This can be done by first building DevHome with the Build script, and then running the Test script with -RunUITests.

Example:
1. In admin VS dev prompt: build -Configuration "release" -Platform "x64" -BuildStep "msix"
2. In non-admin prompt: test -Configuration "release" -Platform "x64" -RunUITests

The build step only needs to happen once so that the test script can find the msix to install and run.  UI Tests can be rebuilt easily by loading DevHome.sln in VS and rebuilding the uitest project (make sure you have the correct plat/config set)

This will be enabled in the pipeline in a future change and is currently being worked on.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2290
- [ ] Tests added/passed
- [ ] Documentation updated
