### PR TITLE
Removing comment.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ISetupTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ISetupTask.cs
@@ -42,10 +42,6 @@ public interface ISetupTask
     /// <remarks>
     /// This will be used to guide whether we show a warning to the user about possible reboots
     /// before beginning the setup.
-    /// TODO: We need to figure a story around how to handle reboots and the different cases.
-    ///       Setting up WSL (future) will require us to reboot the machine to finish, but other
-    ///       tasks like installing an app may trigger a reboot out of our control.
-    /// https://github.com/microsoft/devhome/issues/637
     /// </remarks>
     public bool RequiresReboot
     {


### PR DESCRIPTION
## Summary of the pull request
DevHome has not needed to consider other restarting scenarios and the dev team can contemplate these other scenarios when they show up.  This comment isn't needed.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #637 
- [ ] Tests added/passed
- [ ] Documentation updated
