### PR TITLE
Make the ComputeSystemImage look proportional

### DIFF
--- a/common/Environments/CustomControls/CardBody.xaml
+++ b/common/Environments/CustomControls/CardBody.xaml
@@ -35,7 +35,7 @@
                             Source="{x:Bind ComputeSystemImage, Mode=OneWay}"
                             Width="{StaticResource ComputeSystemImage64px}"
                             Height="{StaticResource ComputeSystemImage64px}"
-                            Stretch="Fill"/>
+                            Stretch="Uniform"/>
                     </Border>
                 </Grid>
             </Viewbox>


### PR DESCRIPTION
## Summary of the pull request

Make the ComputeSystemImage look proportional.

## References and relevant issues

Before the fix:

![image](https://github.com/microsoft/devhome/assets/8397379/b621baff-5cb3-479a-a1fe-4e15d8cbebaf)

After the fix:

![image](https://github.com/microsoft/devhome/assets/8397379/2255e58d-6c83-4045-aef2-9c9a5cfc4821)

## Detailed description of the pull request / Additional comments

The fix allows to maintain the image proportions in case it is not square.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
