### PR TITLE
Change SeekerEvent privacy tag

### DIFF
--- a/common/TelemetryEvents/SeekerEvent.cs
+++ b/common/TelemetryEvents/SeekerEvent.cs
@@ -13,7 +13,7 @@ namespace DevHome.Common.TelemetryEvents;
 [EventData]
 public class SeekerEvent : EventBase
 {
-    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
 
     public bool IsSeeker
     {


### PR DESCRIPTION
## Summary of the pull request
The privacy tag on the SeekerEvent is incorrect. As this is not a user-initiated action, the privacy tag should be ProductAndServicePerformance. The user-initiated event for enabling experimental features is ExperimentalFeature_Toggled_Event.

## References and relevant issues
Internal bug for this.

## Detailed description of the pull request / Additional comments
* Changed the privacy tag on the event.

## Validation steps performed
* Build

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
