### PR TITLE
[Hyper-V Extension] Change KVP names in Hyper-V Host-Guest communication.

### DIFF
--- a/HyperVExtension/src/DevSetupAgent/HostRegistryChannel.cs
+++ b/HyperVExtension/src/DevSetupAgent/HostRegistryChannel.cs
@@ -15,7 +15,7 @@ namespace HyperVExtension.DevSetupAgent;
 /// https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn798287(v=ws.11)
 /// "HKLM\SOFTWARE\Microsoft\Virtual Machine\External" contains data pushed to the guest from the host by a user
 /// "HKLM\SOFTWARE\Microsoft\Virtual Machine\Guest" contains data created on the guest. This data is available to the host as non-intrinsic data.
-/// Host client will create registry value named "DevSetup{<GUID>}~<index>~<total>" with JSON message as a string value.
+/// Host client will create registry value named "DevSetup{<number>}~<index>~<total>" with JSON message as a string value.
 /// The name of the registry value becomes "MessageId" and will be used for response so the client can match
 /// request with response.
 /// </summary>
@@ -43,7 +43,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
         // If running x86 version on x64 OS, we need to open 64-bit registry view.
         _registryHiveKey = RegistryKey.OpenBaseKey(registryChannelSettings.RegistryHive, RegistryView.Registry64);
 
-        // Search and delete all existing registry values with name "DevSetup{<GUID>}"
+        // Search and delete all existing registry values with name "DevSetup{<number>}"
         MessageHelper.DeleteAllMessages(_registryHiveKey, _toHostRegistryKeyPath, MessageHelper.MessageIdStart);
         MessageHelper.DeleteAllMessages(_registryHiveKey, _fromHostRegistryKeyPath, MessageHelper.MessageIdStart);
 
@@ -66,7 +66,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
             while (!stoppingToken.IsCancellationRequested)
             {
                 requestMessage = TryReadMessage();
-                if (!string.IsNullOrEmpty(requestMessage.RequestId))
+                if (!string.IsNullOrEmpty(requestMessage.CommunicationId))
                 {
                     break;
                 }
@@ -108,29 +108,29 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                     foreach (var subString in responseMessage.ResponseData.SplitByLength(MaxValueCount))
                     {
                         index++;
-                        regKey.SetValue($"{responseMessage.ResponseId}{MessageHelper.Separator}{index}{totalStr}", subString, RegistryValueKind.String);
+                        regKey.SetValue($"{responseMessage.CommunicationId}{MessageHelper.Separator}{index}{totalStr}", subString, RegistryValueKind.String);
                     }
                 }
                 catch (Exception ex)
                 {
-                    _log.Error(ex, $"Could not write host message. Response ID: {responseMessage.ResponseId}");
+                    _log.Error(ex, $"Could not write host message. Response ID: {responseMessage.CommunicationId}");
                 }
             },
             stoppingToken);
     }
 
-    public async void DeleteResponseMessageAsync(string responseId, CancellationToken stoppingToken)
+    public async void DeleteResponseMessageAsync(string communicationId, CancellationToken stoppingToken)
     {
         await Task.Run(
             () =>
             {
                 try
                 {
-                    MessageHelper.DeleteAllMessages(_registryHiveKey, _toHostRegistryKeyPath, responseId);
+                    MessageHelper.DeleteAllMessages(_registryHiveKey, _toHostRegistryKeyPath, communicationId);
                 }
                 catch (Exception ex)
                 {
-                    _log.Error(ex, $"Could not delete host message. Response ID: {responseId}");
+                    _log.Error(ex, $"Could not delete host message. Response ID: {communicationId}");
                 }
             },
             stoppingToken);
@@ -143,7 +143,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
         {
             // Messages are split in parts to workaround HyperV KVP service the 2048 bytes limit of registry value.
             // We need to merge all parts of the message before processing it.
-            // TODO: Modify this class to use MessageHelper.MergeMessageParts (requires changing return valu and handling in the caller).
+            // TODO: Modify this class to use MessageHelper.MergeMessageParts (requires changing return value and handling in the caller).
             HashSet<string> ignoreMessages = new();
             var regKey = _registryHiveKey.OpenSubKey(_fromHostRegistryKeyPath, true);
             var valueNames = regKey?.GetValueNames();
@@ -168,7 +168,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                         var count = 0;
                         foreach (var valueNameTmp in valueNames)
                         {
-                            if (valueNameTmp.StartsWith(s[0] + $"{MessageHelper.Separator}", StringComparison.InvariantCultureIgnoreCase))
+                            if (valueNameTmp.StartsWith($"{s[0]}{MessageHelper.Separator}", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 if (!MessageHelper.IsValidMessageName(valueNameTmp.Split(MessageHelper.Separator), out var indeTmp, out var totalTmp))
                                 {
@@ -187,14 +187,14 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                         }
 
                         // Merge all parts of the message
-                        // Preserve message GUID, delete the value and create response even if reading failed.
-                        requestMessage.RequestId = s[0];
+                        // Preserve communication id ("DevSetup{<number>}"), delete the value and create response even if reading failed.
+                        requestMessage.CommunicationId = s[0];
                         try
                         {
                             var sb = new StringBuilder();
                             for (var i = 1; i <= total; i++)
                             {
-                                var value1 = (string?)regKey!.GetValue(s[0] + $"{MessageHelper.Separator}{i}{MessageHelper.Separator}{total}");
+                                var value1 = (string?)regKey!.GetValue($"{requestMessage.CommunicationId}{MessageHelper.Separator}{i}{MessageHelper.Separator}{total}");
                                 if (value1 == null)
                                 {
                                     throw new InvalidOperationException($"Could not read guest message {valueName}");
@@ -210,7 +210,7 @@ public sealed class HostRegistryChannel : IHostChannel, IDisposable
                             _log.Error(ex, $"Could not read host message {valueName}");
                         }
 
-                        MessageHelper.DeleteAllMessages(_registryHiveKey, _fromHostRegistryKeyPath, s[0]);
+                        MessageHelper.DeleteAllMessages(_registryHiveKey, _fromHostRegistryKeyPath, requestMessage.CommunicationId);
                         break;
                     }
                 }

--- a/HyperVExtension/src/DevSetupAgent/IHostChannel.cs
+++ b/HyperVExtension/src/DevSetupAgent/IHostChannel.cs
@@ -12,5 +12,5 @@ public interface IHostChannel
 
     void SendMessageAsync(IResponseMessage responseMessage, CancellationToken stoppingToken);
 
-    void DeleteResponseMessageAsync(string responseId, CancellationToken stoppingToken);
+    void DeleteResponseMessageAsync(string communicationId, CancellationToken stoppingToken);
 }

--- a/HyperVExtension/src/DevSetupAgent/IProgressHandler.cs
+++ b/HyperVExtension/src/DevSetupAgent/IProgressHandler.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HyperVExtension.DevSetupAgent;
+
+/// <summary>
+/// Interface to report request execution progress.
+/// </summary>
+public interface IProgressHandler
+{
+    public void Progress(IHostResponse progressResponse, CancellationToken stoppingToken);
+}

--- a/HyperVExtension/src/DevSetupAgent/ProgressHandler.cs
+++ b/HyperVExtension/src/DevSetupAgent/ProgressHandler.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HyperVExtension.DevSetupAgent;
+
+/// <summary>
+/// Helper progress handler class to report request execution progress.
+/// </summary>
+internal sealed class ProgressHandler : IProgressHandler
+{
+    private readonly IHostChannel _hostChannel;
+    private readonly string _communicationId;
+    private uint _progressCounter;
+
+    public ProgressHandler(IHostChannel hostChannel, string communicationId)
+    {
+        _hostChannel = hostChannel;
+        _communicationId = communicationId;
+    }
+
+    public void Progress(IHostResponse progressResponse, CancellationToken stoppingToken)
+    {
+        var progressCommunicationId = _communicationId + $"_Progress_{++_progressCounter}";
+        var responseMessage = new ResponseMessage(progressCommunicationId, progressResponse.GetResponseData());
+        _hostChannel.SendMessageAsync(responseMessage, stoppingToken);
+    }
+}

--- a/HyperVExtension/src/DevSetupAgent/Requests/AckRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/AckRequest.cs
@@ -8,6 +8,8 @@ namespace HyperVExtension.DevSetupAgent;
 /// </summary>
 internal sealed class AckRequest : RequestBase
 {
+    public const string RequestTypeId = "Ack";
+
     public AckRequest(IRequestContext requestContext)
         : base(requestContext)
     {
@@ -18,7 +20,7 @@ internal sealed class AckRequest : RequestBase
 
     public override bool IsStatusRequest => true;
 
-    public override IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken)
+    public override IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken)
     {
         Task.Run(
             () =>
@@ -27,6 +29,6 @@ internal sealed class AckRequest : RequestBase
             },
             stoppingToken);
 
-        return new AckResponse(RequestMessage.RequestId!);
+        return new AckResponse(RequestMessage.CommunicationId!);
     }
 }

--- a/HyperVExtension/src/DevSetupAgent/Requests/ErrorNoTypeRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/ErrorNoTypeRequest.cs
@@ -15,7 +15,7 @@ internal sealed class ErrorNoTypeRequest : ErrorRequest
 
     public override string RequestType => "ErrorNoType";
 
-    public override IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken)
+    public override IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken)
     {
         return new ErrorNoTypeResponse(RequestId);
     }

--- a/HyperVExtension/src/DevSetupAgent/Requests/ErrorRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/ErrorRequest.cs
@@ -12,7 +12,7 @@ internal class ErrorRequest : IHostRequest
     public ErrorRequest(IRequestMessage requestMessage, Exception? ex = null)
     {
         Timestamp = DateTime.UtcNow;
-        RequestId = requestMessage.RequestId!;
+        RequestId = requestMessage.CommunicationId!;
         Error = ex;
     }
 
@@ -26,7 +26,7 @@ internal class ErrorRequest : IHostRequest
 
     public DateTime Timestamp { get; }
 
-    public virtual IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken)
+    public virtual IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken)
     {
         return new ErrorResponse(RequestId, Error);
     }

--- a/HyperVExtension/src/DevSetupAgent/Requests/ErrorUnsupportedRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/ErrorUnsupportedRequest.cs
@@ -15,7 +15,7 @@ internal sealed class ErrorUnsupportedRequest : RequestBase
 
     public override bool IsStatusRequest => true;
 
-    public override IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken)
+    public override IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken)
     {
         return new ErrorUnsupportedRequestResponse(RequestId, RequestType);
     }

--- a/HyperVExtension/src/DevSetupAgent/Requests/GetStateRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/GetStateRequest.cs
@@ -4,13 +4,14 @@
 namespace HyperVExtension.DevSetupAgent;
 
 /// <summary>
-/// Class used to handle request for service version (RequestType = GetVersion).
+/// Class used to handle request for service state (RequestType = GetState).
+/// Returns the number of requests in the queue.
 /// </summary>
-internal sealed class GetVersionRequest : RequestBase
+internal sealed class GetStateRequest : RequestBase
 {
-    public const string RequestTypeId = "GetVersion";
+    public const string RequestTypeId = "GetState";
 
-    public GetVersionRequest(IRequestContext requestContext)
+    public GetStateRequest(IRequestContext requestContext)
         : base(requestContext)
     {
     }
@@ -19,6 +20,6 @@ internal sealed class GetVersionRequest : RequestBase
 
     public override IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken)
     {
-        return new GetVersionResponse(RequestId);
+        return new GetStateResponse(RequestId, RequestContext.RequestsInQueue);
     }
 }

--- a/HyperVExtension/src/DevSetupAgent/Requests/IHostRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/IHostRequest.cs
@@ -3,8 +3,6 @@
 
 namespace HyperVExtension.DevSetupAgent;
 
-public delegate void ProgressHandler(IHostResponse progressResponse, CancellationToken stoppingToken);
-
 /// <summary>
 /// Interface for handling requests from client (host machine).
 /// </summary>
@@ -20,5 +18,5 @@ public interface IHostRequest
 
     DateTime Timestamp { get; }
 
-    IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken);
+    IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken);
 }

--- a/HyperVExtension/src/DevSetupAgent/Requests/IRequestContext.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/IRequestContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
+using HyperVExtension.HostGuestCommunication;
 
 namespace HyperVExtension.DevSetupAgent;
 
@@ -15,4 +16,6 @@ public interface IRequestContext
     IHostChannel HostChannel { get; set; }
 
     JsonNode? JsonData { get; set; }
+
+    List<RequestsInQueue> RequestsInQueue { get; set; }
 }

--- a/HyperVExtension/src/DevSetupAgent/Requests/IRequestMessage.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/IRequestMessage.cs
@@ -8,7 +8,7 @@ namespace HyperVExtension.DevSetupAgent;
 /// </summary>
 public interface IRequestMessage
 {
-    string? RequestId { get; set; }
+    string? CommunicationId { get; set; }
 
     string? RequestData { get; set; }
 }

--- a/HyperVExtension/src/DevSetupAgent/Requests/IsUserLoggedInRequest.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/IsUserLoggedInRequest.cs
@@ -15,6 +15,8 @@ namespace HyperVExtension.DevSetupAgent;
 /// </summary>
 internal sealed class IsUserLoggedInRequest : RequestBase
 {
+    public const string RequestTypeId = "IsUserLoggedIn";
+
     private static readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(IsUserLoggedInRequest));
 
     public IsUserLoggedInRequest(IRequestContext requestContext)
@@ -24,10 +26,10 @@ internal sealed class IsUserLoggedInRequest : RequestBase
 
     public override bool IsStatusRequest => true;
 
-    public override IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken)
+    public override IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken)
     {
         var loggedInUsers = EnumerateLogonSessions();
-        return new IsUserLoggedInResponse(RequestMessage.RequestId!, loggedInUsers);
+        return new IsUserLoggedInResponse(RequestId, loggedInUsers);
     }
 
     private static List<string> EnumerateLogonSessions()

--- a/HyperVExtension/src/DevSetupAgent/Requests/NtStatusException.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/NtStatusException.cs
@@ -22,7 +22,7 @@ internal sealed class NtStatusException : Exception
     public NtStatusException(string? message, int ntStatus)
         : base(message)
     {
-        // NTStatus is not an HRESULT, but we will uonly use it to pass error back to the caller
+        // NTStatus is not an HRESULT, but we will only use it to pass error back to the caller
         // for diagnostic. Conversion to HRESULT can be done in more that one way and can be not 1 to 1 mapping anyway
         HResult = ntStatus;
     }

--- a/HyperVExtension/src/DevSetupAgent/Requests/RequestBase.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/RequestBase.cs
@@ -38,7 +38,7 @@ internal abstract class RequestBase : IHostRequest
 
     public virtual DateTime Timestamp { get; }
 
-    public abstract IHostResponse Execute(ProgressHandler progressHandler, CancellationToken stoppingToken);
+    public abstract IHostResponse Execute(IProgressHandler progressHandler, CancellationToken stoppingToken);
 
     public IRequestMessage RequestMessage => RequestContext.RequestMessage;
 

--- a/HyperVExtension/src/DevSetupAgent/Requests/RequestContext.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/RequestContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
+using HyperVExtension.HostGuestCommunication;
 
 namespace HyperVExtension.DevSetupAgent;
 
@@ -10,10 +11,14 @@ namespace HyperVExtension.DevSetupAgent;
 /// </summary>
 internal sealed class RequestContext : IRequestContext
 {
-    public RequestContext(IRequestMessage requestMessage, IHostChannel channel)
+    public RequestContext(
+        IRequestMessage requestMessage,
+        IHostChannel channel,
+        List<RequestsInQueue> requestsInQueue)
     {
         RequestMessage = requestMessage;
         HostChannel = channel;
+        RequestsInQueue = requestsInQueue;
     }
 
     public IRequestMessage RequestMessage
@@ -27,6 +32,11 @@ internal sealed class RequestContext : IRequestContext
     }
 
     public JsonNode? JsonData
+    {
+        get; set;
+    }
+
+    public List<RequestsInQueue> RequestsInQueue
     {
         get; set;
     }

--- a/HyperVExtension/src/DevSetupAgent/Requests/RequestFactory.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/RequestFactory.cs
@@ -17,11 +17,11 @@ public class RequestFactory : IRequestFactory
 
     private static readonly Dictionary<string, CreateRequestDelegate> _requestFactories = new()
     {
-        // TODO: Define request type constants in one place
-        { "GetVersion", (requestContext) => new GetVersionRequest(requestContext) },
-        { "Configure", (requestContext) => new ConfigureRequest(requestContext) },
-        { "Ack", (requestContext) => new AckRequest(requestContext) },
-        { "IsUserLoggedIn", (requestContext) => new IsUserLoggedInRequest(requestContext) },
+        { GetVersionRequest.RequestTypeId, (requestContext) => new GetVersionRequest(requestContext) },
+        { GetStateRequest.RequestTypeId, (requestContext) => new GetStateRequest(requestContext) },
+        { ConfigureRequest.RequestTypeId, (requestContext) => new ConfigureRequest(requestContext) },
+        { AckRequest.RequestTypeId, (requestContext) => new AckRequest(requestContext) },
+        { IsUserLoggedInRequest.RequestTypeId, (requestContext) => new IsUserLoggedInRequest(requestContext) },
     };
 
     public RequestFactory()
@@ -35,14 +35,14 @@ public class RequestFactory : IRequestFactory
         {
             if (!string.IsNullOrEmpty(requestContext.RequestMessage.RequestData))
             {
-                _log.Information($"Received message: ID: '{requestContext.RequestMessage.RequestId}' Data: '{requestContext.RequestMessage.RequestData}'");
+                _log.Information($"Received message: ID: '{requestContext.RequestMessage.CommunicationId}' Data: '{requestContext.RequestMessage.RequestData}'");
                 var requestJson = JsonNode.Parse(requestContext.RequestMessage.RequestData);
                 var requestType = (string?)requestJson?["RequestType"];
                 if (requestType != null)
                 {
+                    requestContext.JsonData = requestJson!;
                     if (_requestFactories.TryGetValue(requestType, out var createRequest))
                     {
-                        requestContext.JsonData = requestJson!;
                         return createRequest(requestContext);
                     }
                     else
@@ -56,13 +56,13 @@ public class RequestFactory : IRequestFactory
             else
             {
                 // We have message id but no data, log error. Send error response.
-                _log.Information($"Received message with empty data: ID: {requestContext.RequestMessage.RequestId}");
+                _log.Information($"Received message with empty data: ID: {requestContext.RequestMessage.CommunicationId}");
                 return new ErrorRequest(requestContext.RequestMessage);
             }
         }
         catch (Exception ex)
         {
-            var messageId = requestContext.RequestMessage.RequestId ?? "<unknown>";
+            var messageId = requestContext.RequestMessage.CommunicationId ?? "<unknown>";
             var requestData = requestContext.RequestMessage.RequestData ?? "<unknown>";
             _log.Error(ex, $"Error processing message. Message ID: {messageId}. Request data: {requestData}");
             return new ErrorRequest(requestContext.RequestMessage);

--- a/HyperVExtension/src/DevSetupAgent/Requests/RequestMessage.cs
+++ b/HyperVExtension/src/DevSetupAgent/Requests/RequestMessage.cs
@@ -8,7 +8,7 @@ namespace HyperVExtension.DevSetupAgent;
 /// </summary>
 internal struct RequestMessage : IRequestMessage
 {
-    public string? RequestId { get; set; }
+    public string? CommunicationId { get; set; }
 
     public string? RequestData { get; set; }
 }

--- a/HyperVExtension/src/DevSetupAgent/Responses/AckResponse.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/AckResponse.cs
@@ -11,7 +11,7 @@ namespace HyperVExtension.DevSetupAgent;
 internal sealed class AckResponse : ResponseBase
 {
     public AckResponse(string requestId)
-        : base(requestId, "Ack")
+        : base(requestId, AckRequest.RequestTypeId)
     {
         SendResponse = false;
     }

--- a/HyperVExtension/src/DevSetupAgent/Responses/ConfigureResponse.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/ConfigureResponse.cs
@@ -58,9 +58,16 @@ internal sealed class ConfigureResponse : ResponseBase
     private readonly ApplyConfigurationResult _applyConfigurationResult;
 
     public ConfigureResponse(string requestId, IApplyConfigurationResult applyConfigurationResult)
-        : base(requestId, "Configure")
+        : base(requestId, ConfigureRequest.RequestTypeId)
     {
         _applyConfigurationResult = new ApplyConfigurationResult().Populate(applyConfigurationResult);
+        GenerateJsonData();
+    }
+
+    public ConfigureResponse(string requestId, int resultCode, string? resultDescription = null)
+        : base(requestId, ConfigureRequest.RequestTypeId)
+    {
+        _applyConfigurationResult = new ApplyConfigurationResult(resultCode, resultDescription);
         GenerateJsonData();
     }
 

--- a/HyperVExtension/src/DevSetupAgent/Responses/GetStateResponse.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/GetStateResponse.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using HyperVExtension.HostGuestCommunication;
+
+namespace HyperVExtension.DevSetupAgent;
+
+/// <summary>
+/// Class to generate response to GetState request.
+/// Output IDs of requests that are in queue to let client know if VM is busy processing previous requests.
+/// </summary>
+internal sealed class GetStateResponse : ResponseBase
+{
+    public GetStateResponse(string requestId, List<RequestsInQueue> requestsInQueue)
+        : base(requestId, GetStateRequest.RequestTypeId)
+    {
+        StateData = new StateData(requestsInQueue);
+        GenerateJsonData();
+    }
+
+    public StateData StateData { get; private set; }
+
+    protected override void GenerateJsonData()
+    {
+        base.GenerateJsonData();
+
+        var stateData = JsonSerializer.Serialize(StateData);
+        JsonData![nameof(StateData)] = stateData;
+    }
+}

--- a/HyperVExtension/src/DevSetupAgent/Responses/GetVersionResponse.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/GetVersionResponse.cs
@@ -9,9 +9,8 @@ namespace HyperVExtension.DevSetupAgent;
 internal sealed class GetVersionResponse : ResponseBase
 {
     public GetVersionResponse(string requestId)
-        : base(requestId)
+        : base(requestId, GetVersionRequest.RequestTypeId)
     {
-        RequestType = "GetVersion";
         GenerateJsonData();
     }
 }

--- a/HyperVExtension/src/DevSetupAgent/Responses/IHostResponse.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/IHostResponse.cs
@@ -24,7 +24,7 @@ public interface IHostResponse
 
     DateTime Timestamp { get; set; }
 
-    IResponseMessage GetResponseMessage();
+    string GetResponseData();
 
     bool SendResponse { get; set; }
 }

--- a/HyperVExtension/src/DevSetupAgent/Responses/IResponseMessage.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/IResponseMessage.cs
@@ -8,7 +8,7 @@ namespace HyperVExtension.DevSetupAgent;
 /// </summary>
 public interface IResponseMessage
 {
-    string ResponseId { get; set; }
+    string CommunicationId { get; set; }
 
     string ResponseData { get; set; }
 }

--- a/HyperVExtension/src/DevSetupAgent/Responses/ProgressResponse.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/ProgressResponse.cs
@@ -25,7 +25,7 @@ internal sealed class ProgressResponse : ResponseBase
     private uint ProgressCounter { get; }
 
     public ProgressResponse(string requestId, IConfigurationSetChangeData progressData, uint progressCounter)
-        : base(requestId, "Configure")
+        : base(requestId, ConfigureRequest.RequestTypeId)
     {
         _progressData = new ConfigurationSetChangeData().Populate(progressData);
         ProgressCounter = progressCounter;

--- a/HyperVExtension/src/DevSetupAgent/Responses/ResponseBase.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/ResponseBase.cs
@@ -47,14 +47,14 @@ internal class ResponseBase : IHostResponse
 
     public virtual DateTime Timestamp { get; set; }
 
-    public virtual IResponseMessage GetResponseMessage()
+    public virtual string GetResponseData()
     {
         if (JsonData == null)
         {
             GenerateJsonData();
         }
 
-        return new ResponseMessage(ResponseId, JsonData!.ToJsonString());
+        return JsonData!.ToJsonString();
     }
 
     public virtual bool SendResponse { get; set; }

--- a/HyperVExtension/src/DevSetupAgent/Responses/ResponseMessage.cs
+++ b/HyperVExtension/src/DevSetupAgent/Responses/ResponseMessage.cs
@@ -10,11 +10,11 @@ internal struct ResponseMessage : IResponseMessage
 {
     public ResponseMessage(string requestId, string responseData)
     {
-        ResponseId = requestId;
+        CommunicationId = requestId;
         ResponseData = responseData;
     }
 
-    public string ResponseId { get; set; }
+    public string CommunicationId { get; set; }
 
     public string ResponseData { get; set; }
 }

--- a/HyperVExtension/src/HyperVExtension.HostGuestCommunication/RequestsInQueue.cs
+++ b/HyperVExtension/src/HyperVExtension.HostGuestCommunication/RequestsInQueue.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HyperVExtension.HostGuestCommunication;
+
+public class RequestsInQueue
+{
+    public RequestsInQueue(string communicationId, string requestId)
+    {
+        CommunicationId = communicationId;
+        RequestId = requestId;
+    }
+
+    public string CommunicationId { get; set; }
+
+    public string RequestId { get; set; }
+}

--- a/HyperVExtension/src/HyperVExtension.HostGuestCommunication/StateData.cs
+++ b/HyperVExtension/src/HyperVExtension.HostGuestCommunication/StateData.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace HyperVExtension.HostGuestCommunication;
+
+// Helper class to return DevSetupAgent state to the client.
+public class StateData
+{
+    public StateData(List<RequestsInQueue> requestsInQueue)
+    {
+        RequestsInQueue = requestsInQueue;
+    }
+
+    public List<RequestsInQueue> RequestsInQueue { get; private set; }
+}

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpSession.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpSession.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Nodes;
+using HyperVExtension.HostGuestCommunication;
+
 namespace HyperVExtension.CommunicationWithGuest;
 
 /// <summary>
@@ -8,10 +11,11 @@ namespace HyperVExtension.CommunicationWithGuest;
 /// </summary>
 internal sealed class GuestKvpSession : IDisposable
 {
+    private static uint _nextCommunicationIdCounter = 1;
     private readonly Guid _vmId;
     private readonly GuestKvpChannel _channel;
     private readonly ResponseFactory _responseFactory = new();
-    private Dictionary<string, IResponseMessage> _processedMessages = new();
+    private HashSet<string> _processedMessages = new(StringComparer.OrdinalIgnoreCase);
     private bool _disposed;
 
     public GuestKvpSession(Guid vmId)
@@ -20,30 +24,47 @@ internal sealed class GuestKvpSession : IDisposable
         _channel = new GuestKvpChannel(vmId);
     }
 
-    public void SendRequest(IHostRequest request, CancellationToken stoppingToken)
+    public uint SendRequest(IHostRequest request, CancellationToken stoppingToken)
     {
-        _channel.SendMessage(request.GetRequestMessage(), stoppingToken);
+        var communicationIdCounter = _nextCommunicationIdCounter++;
+        _channel.SendMessage(request.GetRequestMessage(), communicationIdCounter, stoppingToken);
+        return communicationIdCounter;
     }
 
-    public List<IGuestResponse> WaitForResponse(string responseId, TimeSpan timeout, bool expectProgressResponse, CancellationToken stoppingToken)
+    public List<IGuestResponse> WaitForResponse(uint communicationIdCounter, string requestId, TimeSpan timeout, bool expectProgressResponse, CancellationToken stoppingToken)
     {
+        var communicationId = $"{MessageHelper.DevSetupPrefix}{{{communicationIdCounter}}}";
         var result = new List<IGuestResponse>();
-        var responseMessages = _channel.WaitForResponseMessages(responseId, timeout, expectProgressResponse, stoppingToken);
+        var responseMessages = _channel.WaitForResponseMessages(communicationId, timeout, expectProgressResponse, stoppingToken);
 
         // There is no way for host to remove messages from guest kvp. So, we need to keep track of processed messages.
         // If we find that we received the same message as in previous call of this method, we will ignore it.
         // Host will send "AckRequest" to let guest know that it can remove the message from kvp.
-        var newProcessedMessages = new Dictionary<string, IResponseMessage>();
+        var newProcessedMessages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var responseMessage in responseMessages)
         {
-            if (!_processedMessages.ContainsKey(responseMessage.ResponseId))
+            if (!_processedMessages.Contains(responseMessage.CommunicationId))
             {
-                result.Add(_responseFactory.CreateResponse(responseMessage));
-                _channel.SendMessage(new AckRequest(responseMessage.ResponseId).GetRequestMessage(), stoppingToken);
-            }
+                var response = _responseFactory.CreateResponse(responseMessage);
+                if (requestId.Equals(response.RequestId, StringComparison.OrdinalIgnoreCase))
+                {
+                    newProcessedMessages.Add(responseMessage.CommunicationId);
 
-            newProcessedMessages[responseMessage.ResponseId] = responseMessage;
+                    result.Add(response);
+                    _channel.SendMessage(new AckRequest(responseMessage.CommunicationId).GetRequestMessage(), _nextCommunicationIdCounter++, stoppingToken);
+
+                    // We've received response to request with communicationId, so we can remove kvp entries for
+                    // this communicationId as they've been processed on Hyper-V side.
+                    _channel.CleanUp(communicationId);
+                }
+            }
+            else
+            {
+                // We've already processed this message in previous call of this method, but it was not deleted yet
+                // on Hyper-V side, so keep it in processed messages list.
+                newProcessedMessages.Add(responseMessage.CommunicationId);
+            }
         }
 
         _processedMessages = newProcessedMessages;
@@ -66,6 +87,14 @@ internal sealed class GuestKvpSession : IDisposable
             }
 
             _disposed = true;
+        }
+    }
+
+    internal void SetNextCommunicationIdCounter(uint communicationIdCounter)
+    {
+        if (communicationIdCounter > _nextCommunicationIdCounter)
+        {
+            _nextCommunicationIdCounter = communicationIdCounter;
         }
     }
 }

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Requests/ConfigureRequest.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Requests/ConfigureRequest.cs
@@ -8,10 +8,12 @@ namespace HyperVExtension.CommunicationWithGuest;
 /// </summary>
 internal sealed class ConfigureRequest : RequestBase
 {
+    public const string RequestTypeId = "Configure";
+
     private readonly string _configureYaml;
 
     public ConfigureRequest(string configureYaml)
-        : base("Configure")
+        : base(RequestTypeId)
     {
         _configureYaml = configureYaml;
         GenerateJsonData();

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Requests/GetStateRequest.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Requests/GetStateRequest.cs
@@ -4,13 +4,13 @@
 namespace HyperVExtension.CommunicationWithGuest;
 
 /// <summary>
-/// Class to generate GetVersion request.
+/// Class to generate GetState request.
 /// </summary>
-internal sealed class GetVersionRequest : RequestBase
+internal sealed class GetStateRequest : RequestBase
 {
-    public const string RequestTypeId = "GetVersion";
+    public const string RequestTypeId = "GetState";
 
-    public GetVersionRequest()
+    public GetStateRequest()
         : base(RequestTypeId)
     {
         GenerateJsonData();

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Requests/IsUserLoggedInRequest.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Requests/IsUserLoggedInRequest.cs
@@ -8,8 +8,10 @@ namespace HyperVExtension.CommunicationWithGuest;
 /// </summary>
 internal sealed class IsUserLoggedInRequest : RequestBase
 {
+    public const string RequestTypeId = "IsUserLoggedIn";
+
     public IsUserLoggedInRequest()
-        : base("IsUserLoggedIn")
+        : base(RequestTypeId)
     {
         GenerateJsonData();
     }

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ErrorNoTypeResponse.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ErrorNoTypeResponse.cs
@@ -4,31 +4,21 @@
 namespace HyperVExtension.CommunicationWithGuest;
 
 /// <summary>
-/// Class used to handle requests that have no request type.
-/// It creates an error response JSON to send back to the client.
+/// Class that represents a broken response from Hyper-V with request or response type.
+/// This should only happen in case of a programming error that we'd need to investigate.
 /// </summary>
-internal sealed class ErrorNoTypeResponse : IGuestResponse
+internal sealed class ErrorNoTypeResponse : ErrorResponse
 {
-    public ErrorNoTypeResponse(IResponseMessage message)
+    public ErrorNoTypeResponse(IResponseMessage? responseMessage)
+        : base(responseMessage)
     {
-        Timestamp = DateTime.UtcNow;
-        ResponseId = message.ResponseId!;
-        RequestId = message.ResponseId!;
+        if ((responseMessage != null) && (responseMessage.ResponseData != null))
+        {
+            ErrorDescription = $"Missing Response or Request type. Response data: '{responseMessage.ResponseData}'";
+        }
+        else
+        {
+            ErrorDescription = $"Missing Response or Request type.";
+        }
     }
-
-    public string RequestId { get; set; }
-
-    public string RequestType { get; set; } = "<unknown>";
-
-    public string ResponseId { get; set; }
-
-    public string ResponseType { get; set; } = "<unknown>";
-
-    public uint Status { get; set; } = 0xFFFFFFFF;
-
-    public string ErrorDescription { get; set; } = "Missing Response or Request type.";
-
-    public uint Version { get; set; } = 1;
-
-    public DateTime Timestamp { get; set; }
 }

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ErrorResponse.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ErrorResponse.cs
@@ -4,28 +4,35 @@
 namespace HyperVExtension.CommunicationWithGuest;
 
 /// <summary>
-/// Class used to handle invalid requests (for example an exception while parsing request JSON).
-/// It creates an error response to send back to the client.
+/// Class used to handle invalid responses (for example an exception while parsing request JSON).
+/// This should only happen in case of a programming error that we'd need to investigate.
 /// </summary>
-internal sealed class ErrorResponse : IGuestResponse
+internal class ErrorResponse : IGuestResponse
 {
-    public ErrorResponse(IResponseMessage responseMessage)
+    public ErrorResponse(IResponseMessage? responseMessage)
     {
-        ResponseId = responseMessage.ResponseId!;
         Timestamp = DateTime.UtcNow;
+        if ((responseMessage != null) && (responseMessage.ResponseData != null))
+        {
+            ErrorDescription = $"Missing response data. Response data: '{responseMessage.ResponseData}'";
+        }
+        else
+        {
+            ErrorDescription = $"Missing response data.";
+        }
     }
 
     public string RequestId { get; set; } = "<unknown>";
 
     public string RequestType { get; set; } = "<unknown>";
 
-    public string ResponseId { get; set; }
+    public string ResponseId { get; set; } = "<unknown>";
 
-    public string ResponseType { get; set; } = "ErrorNoData";
+    public string ResponseType { get; set; } = "<unknown>";
 
     public uint Status { get; set; } = 0x80004005; // E_FAIL
 
-    public string ErrorDescription { get; set; } = "Missing Request data.";
+    public string ErrorDescription { get; set; }
 
     public uint Version { get; set; } = 1;
 

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/GetStateResponse.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/GetStateResponse.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using HyperVExtension.HostGuestCommunication;
+
+namespace HyperVExtension.CommunicationWithGuest;
+
+/// <summary>
+/// Class used to handle response for service state (RequestType = GetState).
+/// </summary>
+internal sealed class GetStateResponse : ResponseBase
+{
+    public GetStateResponse(IResponseMessage responseMessage, JsonNode jsonData)
+        : base(responseMessage, jsonData)
+    {
+        StateData = GetRequiredValue<StateData>(nameof(StateData));
+    }
+
+    public StateData StateData { get; }
+}

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/IResponseMessage.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/IResponseMessage.cs
@@ -8,7 +8,7 @@ namespace HyperVExtension.CommunicationWithGuest;
 /// </summary>
 public interface IResponseMessage
 {
-    string ResponseId { get; set; }
+    string CommunicationId { get; set; }
 
     string ResponseData { get; set; }
 }

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ResponseBase.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ResponseBase.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using HyperVExtension.HostGuestCommunication;
 
 namespace HyperVExtension.CommunicationWithGuest;
 
@@ -111,5 +113,24 @@ internal class ResponseBase : IGuestResponse
         {
             throw new ArgumentException($"{valueName} cannot be empty.", ex);
         }
+    }
+
+    protected T GetRequiredValue<T>(string nodeName)
+    {
+        // Calling JsonSerializer.Deserialize directly on JasonNode fails (why?), but deserializing
+        // from the original string works.
+        var node = (string?)JsonData[nodeName];
+        if (node == null)
+        {
+            throw new JsonException($"Missing {nodeName} in JSON data.");
+        }
+
+        var result = JsonSerializer.Deserialize<T>(node);
+        if (result == null)
+        {
+            throw new JsonException($"Failed to deserialize {nodeName} from JSON data.");
+        }
+
+        return result;
     }
 }

--- a/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ResponseMessage.cs
+++ b/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/Responses/ResponseMessage.cs
@@ -8,13 +8,13 @@ namespace HyperVExtension.CommunicationWithGuest;
 /// </summary>
 internal struct ResponseMessage : IResponseMessage
 {
-    public ResponseMessage(string requestId, string responseData)
+    public ResponseMessage(string communicationId, string responseData)
     {
-        ResponseId = requestId;
+        CommunicationId = communicationId;
         ResponseData = responseData;
     }
 
-    public string ResponseId { get; set; }
+    public string CommunicationId { get; set; }
 
     public string ResponseData { get; set; }
 }

--- a/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -12,6 +12,7 @@ using HyperVExtension.Common.Extensions;
 using HyperVExtension.CommunicationWithGuest;
 using HyperVExtension.Exceptions;
 using HyperVExtension.Helpers;
+using HyperVExtension.HostGuestCommunication;
 using HyperVExtension.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Windows.DevHome.SDK;
@@ -580,8 +581,7 @@ public class HyperVVirtualMachine : IComputeSystem
 
         try
         {
-            // TODO: Check if VM is already running. Set progress to Starting VM if needed.
-            // Hyper-V KVP service can set succeed even if VM is not running and VM will receive
+            // Start VM first. Hyper-V KVP service can set succeed even if VM is not running and VM will receive
             // registry key changes next time it starts.
             var startResult = Start(string.Empty);
             if (startResult.Result.Status == ProviderOperationStatus.Failure)
@@ -589,18 +589,39 @@ public class HyperVVirtualMachine : IComputeSystem
                 return operation.CompleteOperation(new HostGuestCommunication.ApplyConfigurationResult(startResult.Result.ExtendedError.HResult, startResult.Result.DisplayMessage));
             }
 
-            var guestSession = new GuestKvpSession(Guid.Parse(Id));
+            using var guestSession = new GuestKvpSession(Guid.Parse(Id));
 
             // Query VM by sending a request to DevSetupAgent.
-            var getVersionRequest = new GetVersionRequest();
-            guestSession.SendRequest(getVersionRequest, CancellationToken.None);
-            var getVersionResponses = guestSession.WaitForResponse(getVersionRequest.RequestId, TimeSpan.FromSeconds(15), true, CancellationToken.None);
-            if (getVersionResponses.Count > 0)
+            var getStateRequest = new GetStateRequest();
+            var communicationId = guestSession.SendRequest(getStateRequest, CancellationToken.None);
+            var getStateResponses = guestSession.WaitForResponse(communicationId, getStateRequest.RequestId, TimeSpan.FromSeconds(15), false, CancellationToken.None);
+            if (getStateResponses.Count > 0)
             {
-                var response = getVersionResponses[0];
-                if (response is GetVersionResponse getVersionResponse)
+                var response = getStateResponses[0];
+                if (response is GetStateResponse getStateResponse)
                 {
-                    // TODO: Check if VM can accept new Configure requests. Or if we need to update DevSetupAgent to a new version.
+                    // Check if VM can accept new Configure requests. We don't support reporting progress for requests
+                    // that were started somehow outside of this operation yet. So for now, abort this operation.
+                    // This could only happen if Dev Home was restarted while a configuration task was running.
+                    if (getStateResponse.StateData.RequestsInQueue.Count > 0)
+                    {
+                        // Set CommunicationId counter to the value higher than the highest CommunicationId in the queue
+                        // to avoid conflicts with previous requests.
+                        uint communicationIdCounter = 1; // We've already sent at least one message.
+                        foreach (var request in getStateResponse.StateData.RequestsInQueue)
+                        {
+                            var currentCounter = MessageHelper.GetCounterFromCommunicationId(request.CommunicationId);
+                            if (currentCounter > communicationIdCounter)
+                            {
+                                communicationIdCounter = currentCounter;
+                            }
+                        }
+
+                        guestSession.SetNextCommunicationIdCounter(communicationIdCounter);
+
+                        _log.Error($"VM is busy with another configuration task. VM details: {this}");
+                        return operation.CompleteOperation(new HostGuestCommunication.ApplyConfigurationResult(HRESULT.E_ABORT, "VM is busy with another configuration task"));
+                    }
                 }
                 else
                 {
@@ -642,8 +663,8 @@ public class HyperVVirtualMachine : IComputeSystem
             for (var i = 0; i < MaxRetryAttempts; i++)
             {
                 var userLoggedInRequest = new IsUserLoggedInRequest();
-                guestSession.SendRequest(userLoggedInRequest, CancellationToken.None);
-                var userLoggedInResponses = guestSession.WaitForResponse(userLoggedInRequest.RequestId, TimeSpan.FromSeconds(15), true, CancellationToken.None);
+                communicationId = guestSession.SendRequest(userLoggedInRequest, CancellationToken.None);
+                var userLoggedInResponses = guestSession.WaitForResponse(communicationId, userLoggedInRequest.RequestId, TimeSpan.FromSeconds(15), false, CancellationToken.None);
                 if (userLoggedInResponses.Count > 0)
                 {
                     var response = userLoggedInResponses[0];
@@ -684,7 +705,7 @@ public class HyperVVirtualMachine : IComputeSystem
             }
 
             var configureRequest = new ConfigureRequest(operation.Configuration);
-            guestSession.SendRequest(configureRequest, CancellationToken.None);
+            communicationId = guestSession.SendRequest(configureRequest, CancellationToken.None);
 
             // Wait for response. 5 hours is an arbitrary period of time that should be big enough
             // for most scenarios.
@@ -698,7 +719,7 @@ public class HyperVVirtualMachine : IComputeSystem
             var startTime = DateTime.Now;
             while ((DateTime.Now - startTime) < waitTime)
             {
-                var responses = guestSession.WaitForResponse(configureRequest.RequestId, TimeSpan.FromSeconds(30), true, CancellationToken.None);
+                var responses = guestSession.WaitForResponse(communicationId, configureRequest.RequestId, TimeSpan.FromSeconds(30), true, CancellationToken.None);
 
                 foreach (var response in responses)
                 {
@@ -715,7 +736,7 @@ public class HyperVVirtualMachine : IComputeSystem
                         LogApplyConfigurationProgress(configureProgressResponse.ProgressData);
 
                         // Create SDK's result. Set Completed status and event.
-                        operation.SetProgress(ConfigurationSetState.InProgress, configureProgressResponse.ProgressData, null);
+                        operation.SetProgress(SDK.ConfigurationSetState.InProgress, configureProgressResponse.ProgressData, null);
                     }
                     else
                     {
@@ -755,7 +776,7 @@ public class HyperVVirtualMachine : IComputeSystem
         var powerShell = _host.GetService<IPowerShellService>();
         var credentialsAdaptiveCardSession = new VmCredentialAdaptiveCardSession(_host, operation, attemptNumber);
 
-        operation.SetProgress(ConfigurationSetState.WaitingForAdminUserLogon, null, credentialsAdaptiveCardSession);
+        operation.SetProgress(SDK.ConfigurationSetState.WaitingForAdminUserLogon, null, credentialsAdaptiveCardSession);
 
         (var userName, var password) = credentialsAdaptiveCardSession.WaitForCredentials();
 
@@ -776,7 +797,7 @@ public class HyperVVirtualMachine : IComputeSystem
         // Ask user to login to the VM and wait for confirmation.
         var waitForLoginAdaptiveCardSession = new WaitForLoginAdaptiveCardSession(_host, operation, attemptNumber);
 
-        operation.SetProgress(ConfigurationSetState.WaitingForUserLogon, null, waitForLoginAdaptiveCardSession);
+        operation.SetProgress(SDK.ConfigurationSetState.WaitingForUserLogon, null, waitForLoginAdaptiveCardSession);
 
         return waitForLoginAdaptiveCardSession.WaitForUserResponse();
     }

--- a/HyperVExtension/test/DevSetupAgent.Test/DevSetupAgent.Test.csproj
+++ b/HyperVExtension/test/DevSetupAgent.Test/DevSetupAgent.Test.csproj
@@ -29,6 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ReferenceCopyLocalPaths Include="$(ProjectDir)..\DevSetupEngineProjection\bin\$(Platform)\$(Configuration)\**\Microsoft.Windows.DevHome.DevSetupEngine.winmd" />
+    <ReferenceCopyLocalPaths Include="$(ProjectDir)..\..\src\DevSetupEngineProjection\bin\$(Platform)\$(Configuration)\**\Microsoft.Windows.DevHome.DevSetupEngine.winmd" />
   </ItemGroup>
 </Project>

--- a/HyperVExtension/test/DevSetupEngine.Test/DevSetupEngine.Test.csproj
+++ b/HyperVExtension/test/DevSetupEngine.Test/DevSetupEngine.Test.csproj
@@ -36,6 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ReferenceCopyLocalPaths Include="$(ProjectDir)..\DevSetupEngineProjection\bin\$(Platform)\$(Configuration)\**\Microsoft.Windows.DevHome.DevSetupEngine.winmd" />
+    <ReferenceCopyLocalPaths Include="$(ProjectDir)..\..\src\DevSetupEngineProjection\bin\$(Platform)\$(Configuration)\**\Microsoft.Windows.DevHome.DevSetupEngine.winmd" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION


## Summary of the pull request
Previous implementation of communication between host and guest Hyper-V machine using [Hyper-V KVP integration service](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/integration-services#hyper-v-data-exchange-service-kvp) was not deleting KVPs correctly. KVPs created on host side must be delete from host. When they are only deleted from guest side (as registry keys) they are re-created after Hyper-V VM reboot.

In addition, Hyper-V KVP integration service has a limit (undocumented) on number of KVP and after exceeding that limit no new keys can be created. KVP service API doesn't allow reading We used GUID in the key names. 

This fix changes KVP name format: instead of using GUID ("DevSetup{<GUID>}") it's now a sequential number ("DevSetup{<number>}") to make KVP names more predictable. In case we run into a situation where we have stale KVPs, some of them can be re-used (and then deleted), reducing chances of reaching max number of KVPs limit.
Under normal operation these KVPs deleted after communication with guest machine is complete or KvpSession object is disposed.

Added a new GetState request to get DevSetupAgent service state. For now, it returns a list of requests in queue. Host side won't send new requests if queue is not empty (this flow will need improvements in the future. We don't have UX for it yet)

Added a test for GetState request.

Updated current tests to use new format of KVP names.

Fixed copying of Microsoft.Windows.DevHome.DevSetupEngine.winmd into test projects output.
## References and relevant issues

## Validation steps performed
Ran tests and Hyper-V configuration flow.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
