### PR TITLE
Fix path issues attributed to switching to WAP Project

### DIFF
--- a/Packaging/Package.appxmanifest
+++ b/Packaging/Package.appxmanifest
@@ -76,21 +76,21 @@
         </uap:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="HyperVExtensionServer.exe" Arguments="-RegisterProcessAsComServer" DisplayName="HyperVExtensionServer">
+            <com:ExeServer Executable="DevHome\HyperVExtensionServer.exe" Arguments="-RegisterProcessAsComServer" DisplayName="HyperVExtensionServer">
               <com:Class Id="F8B26528-976A-488C-9B40-7198FB425C9E" DisplayName="HyperVExtensionServer" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="CoreWidgetProvider">
+            <com:ExeServer Executable="DevHome\CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="CoreWidgetProvider">
               <com:Class Id="F8B2DBB9-3687-4C6E-99B2-B92C82905937" DisplayName="CoreWidgetProvider" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Core Extension">
+            <com:ExeServer Executable="DevHome\CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Core Extension">
               <com:Class Id="426A52D6-8007-4894-A946-CF80F39507F1" DisplayName="Core Extension" />
             </com:ExeServer>
           </com:ComServer>

--- a/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
@@ -5,7 +5,9 @@ using System.Text;
 using System.Text.Json.Nodes;
 using CoreWidgetProvider.Helpers;
 using CoreWidgetProvider.Widgets.Enums;
+using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.Windows.Widgets.Providers;
+using Windows.ApplicationModel;
 
 namespace CoreWidgetProvider.Widgets;
 
@@ -131,7 +133,7 @@ internal abstract class CoreWidget : WidgetImpl
 
         try
         {
-            var path = Path.Combine(AppContext.BaseDirectory, GetTemplatePath(page));
+            var path = Path.Combine(Package.Current.EffectivePath, GetTemplatePath(page));
             var template = File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
             template = Resources.ReplaceIdentifers(template, Resources.GetWidgetResourceIdentifiers(), Log);
             Log.Debug($"Caching template for {page}");

--- a/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Text.Json.Nodes;
 using CoreWidgetProvider.Helpers;
 using CoreWidgetProvider.Widgets.Enums;
-using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.Windows.Widgets.Providers;
 using Windows.ApplicationModel;
 


### PR DESCRIPTION
## Summary of the pull request
WAP Project implicitly puts executables in a top-level DevHome directory within the package.

## References and relevant issues

## Detailed description of the pull request / Additional comments
Appxmanifest entries need to be correctly prepended with the path DevHome\....
The core widget provider code made the assumption that its assembly location was at the root of the package which is no longer the case. Updated the code to load from the package's effectivepath location.
## Validation steps performed
1. Hyper-V extension now loads and shows local devices.
2. Can add new Core widgets. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
