### PR TITLE
Quiet feature: Fix analytic summary layout when text scaled at 200%

### DIFF
--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/TimedQuietSession.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/TimedQuietSession.h
@@ -78,6 +78,8 @@ struct UnelevatedServerReference
 //          teardown in unelevated server (assuming DevHome is closed), releasing the cached *strong* reference
 //          to the session (elevated) -> COM triggers teardown in elevated server.
 //
+#pragma warning(push)
+#pragma warning(disable : 4324) // Avoid WRL alignment warning
 struct TimedQuietSession
 {
     TimedQuietSession(std::chrono::seconds seconds)
@@ -158,3 +160,4 @@ private:
     wil::com_ptr<ABI::DevHome::QuietBackgroundProcesses::IPerformanceRecorderEngine> m_performanceRecorderEngine;
     std::mutex m_mutex;
 };
+#pragma warning(pop)

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Strings/en-us/Resources.resw
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Strings/en-us/Resources.resw
@@ -104,10 +104,6 @@
   </data>
 
   <!-- Analytic Summary -->
-  <data name="AnalyticSummary_Title.Text" xml:space="preserve">
-    <value>Analytic Summary</value>
-    <comment>Title of the analytic summary page</comment>
-  </data>
   <data name="AnalyticSummary_Description.Text" xml:space="preserve">
     <value>Analysis of process CPU utilization while the session was in use. Calculated amount of time that the process used CPU above the designated threshold.</value>
     <comment>Desciption of the analytic summary page</comment>
@@ -131,6 +127,10 @@
   <data name="AnalyticSummary_FilterProcesses_PlaceholderText.PlaceholderText" xml:space="preserve">
     <value>Search for a process</value>
     <comment>Label for analytic summary save report button</comment>
+  </data>
+  <data name="AnalyticSummaryContentDialog.Title" xml:space="preserve">
+    <value>Analytic Summary</value>
+    <comment>Title of the analytic summary page</comment>
   </data>
   <data name="AnalyticSummaryContentDialog.PrimaryButtonText" xml:space="preserve">
     <value>Save report</value>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/AnalyticSummaryPopup.xaml
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/AnalyticSummaryPopup.xaml
@@ -12,26 +12,35 @@
     PrimaryButtonClick="SaveReportButtonClicked"
     Style="{StaticResource DefaultContentDialogStyle}">
 
-    <Grid Height="480" Width="600">
+    <!-- ContentDialog Width and Height are not properly hooked up and must be set this way -->
+    <ContentDialog.Resources>
+        <!-- MinWidth here might be useless -->
+        <x:Double x:Key="ContentDialogMinWidth">652</x:Double>
+        <x:Double x:Key="ContentDialogMaxWidth">700</x:Double>
+        <x:Double x:Key="ContentDialogMaxHeight">590</x:Double>
+        <Thickness x:Key="ContentDialogPadding">36</Thickness>
+    </ContentDialog.Resources>
+
+    <!-- I would also try removing the Width property on the Grid altogether, but if you leave it, -->
+    <!-- you probably always want it to be ContentDialogMaxWidth - 2*ContentDialogPadding -->
+    <Grid Width="628">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0">
+        <StackPanel Grid.Row="0" Spacing="24">
             <TextBlock
                 x:Uid="AnalyticSummary_Title"
                 Style="{StaticResource SubtitleTextBlockStyle}"
-                HorizontalAlignment="Left"
-                Margin="16,10,0,0" />
+                HorizontalAlignment="Left" />
             <TextBlock
                 x:Uid="AnalyticSummary_Description"
                 HorizontalAlignment="Left"
-                TextWrapping="Wrap"
-                Margin="16,10,100,0" />
+                TextWrapping="Wrap" />
 
             <!-- Filters & sorting -->
-            <Grid Margin="15 40 15 5">
+            <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
@@ -43,7 +52,7 @@
                 <ComboBox
                     Grid.Column="1"
                     x:Name="SortComboBox"
-                    Margin="5 0 5 0"
+                    Margin="5 0"
                     SelectedValue=""
                     SelectedIndex="{x:Bind ViewModel.SortComboBoxIndex, Mode=TwoWay}">
                     <ComboBoxItem x:Uid="ComboBox_SortBy_Process" Tag="Process" />
@@ -61,7 +70,7 @@
                     Grid.Column="2"
                     x:Uid="AnalyticSummary_FilterProcesses_PlaceholderText"
                     x:Name="FilterTextBox"
-                    Margin="30 0 100 0">
+                    Margin="30 0 0 0">
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="TextChanged">
                             <ic:InvokeCommandAction
@@ -73,7 +82,7 @@
             </Grid>
         </StackPanel>
 
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0 20 100 0">
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0 20 0 0">
             <local:ProcessPerformanceTableControl x:Name="processListControl" ItemsSource="{x:Bind ViewModel.ProcessDatasAd}" />
         </ScrollViewer>
     </Grid>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/AnalyticSummaryPopup.xaml
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/AnalyticSummaryPopup.xaml
@@ -17,23 +17,17 @@
         <!-- MinWidth here might be useless -->
         <x:Double x:Key="ContentDialogMinWidth">652</x:Double>
         <x:Double x:Key="ContentDialogMaxWidth">700</x:Double>
-        <x:Double x:Key="ContentDialogMaxHeight">590</x:Double>
+        <x:Double x:Key="ContentDialogMaxHeight">650</x:Double>
         <Thickness x:Key="ContentDialogPadding">36</Thickness>
     </ContentDialog.Resources>
 
-    <!-- I would also try removing the Width property on the Grid altogether, but if you leave it, -->
-    <!-- you probably always want it to be ContentDialogMaxWidth - 2*ContentDialogPadding -->
-    <Grid Width="628">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Spacing="24">
-            <TextBlock
-                x:Uid="AnalyticSummary_Title"
-                Style="{StaticResource SubtitleTextBlockStyle}"
-                HorizontalAlignment="Left" />
+        <StackPanel Grid.Row="0" Spacing="36">
             <TextBlock
                 x:Uid="AnalyticSummary_Description"
                 HorizontalAlignment="Left"

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/ProcessPerformanceTableControl.xaml
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/ProcessPerformanceTableControl.xaml
@@ -29,13 +29,13 @@
             <ListView.Header>
                 <Grid ColumnSpacing="0">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="40"/>
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="180" />
-                        <ColumnDefinition Width="130" />
-                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     
                     <Border Grid.Column="0" Style="{StaticResource BorderStyle}">
@@ -61,6 +61,7 @@
                             VerticalAlignment="Center"
                             HorizontalAlignment="Left"
                             HorizontalTextAlignment="Left"
+                            TextWrapping="WrapWholeWords"
                             TextTrimming="CharacterEllipsis" />
                     </Border>
                 </Grid>
@@ -70,9 +71,9 @@
                 <DataTemplate x:DataType="local:ProcessData">
                     <Grid ColumnSpacing="5">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="180" />
-                            <ColumnDefinition Width="130" />
-                            <ColumnDefinition Width="200" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
                         <Border Grid.Column="0" Style="{StaticResource BorderStyle}" BorderThickness="0, 0, 1, 0">

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/ProcessPerformanceTableControl.xaml
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/ProcessPerformanceTableControl.xaml
@@ -25,23 +25,24 @@
             HorizontalContentAlignment="Stretch"
             Margin="0"
             Padding="0"
-            ui:ListViewExtensions.AlternateColor="{StaticResource CardBackgroundFillColorDefaultBrush}">
+            ui:ListViewExtensions.AlternateColor="{StaticResource SubtleFillColorSecondaryBrush}">
             <ListView.Header>
                 <Grid ColumnSpacing="0">
                     <Grid.RowDefinitions>
-                        <RowDefinition />
+                        <RowDefinition MinHeight="35" />
                     </Grid.RowDefinitions>
                     
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="2*" />
                     </Grid.ColumnDefinitions>
                     
                     <Border Grid.Column="0" Style="{StaticResource BorderStyle}">
                         <TextBlock
                             x:Uid="ProcessPerformanceTableControl_Heading_Process"
-                            Padding="20 0 0 0"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Padding="25 0 0 0"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Left"
                             HorizontalTextAlignment="Left" />
@@ -49,7 +50,8 @@
                     <Border Grid.Column="1" Style="{StaticResource BorderStyle}">
                         <TextBlock
                             x:Uid="ProcessPerformanceTableControl_Heading_ProcessType"
-                            Margin="40 0 0 0"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Margin="20 0 0 0"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Left"
                             HorizontalTextAlignment="Left" />
@@ -57,7 +59,8 @@
                     <Border Grid.Column="2" Grid.ColumnSpan="2" Style="{StaticResource BorderStyle}">
                         <TextBlock
                             x:Uid="ProcessPerformanceTableControl_Heading_CpuAboveThreshold"
-                            Margin="40 0 0 0"
+                            Style="{StaticResource BodyStrongTextBlockStyle}"
+                            Margin="20 0 0 0"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Left"
                             HorizontalTextAlignment="Left"
@@ -71,9 +74,9 @@
                 <DataTemplate x:DataType="local:ProcessData">
                     <Grid ColumnSpacing="5">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="2*" />
                         </Grid.ColumnDefinitions>
 
                         <Border Grid.Column="0" Style="{StaticResource BorderStyle}" BorderThickness="0, 0, 1, 0">


### PR DESCRIPTION
## Summary of the pull request
Apply **krschau**'s fixes to analytic summary layout when text scaled at 200%
  * Setting <ContentDialog.Resources>
  * No elements should be cut-off
  * Removed spurious custom margins.

Use 'title' attribute of ContentDialog.

Also suppress harmless WRL warning.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

<img width="925" alt="png" src="https://github.com/microsoft/devhome/assets/6415764/65e414d9-36d0-465f-8d0c-991269f56d48">
