### PR TITLE
Add DevDriveInsufficientDiskSpaceEvent

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
+using DevHome.SetupFlow.Common.TelemetryEvents;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.TaskGroups;
 using DevHome.SetupFlow.Utilities;
@@ -274,7 +275,7 @@ public class DevDriveManager : IDevDriveManager
                 TelemetryFactory.Get<ITelemetry>().Log(
                                               "DevDrive_Insufficient_DiskSpace",
                                               LogLevel.Critical,
-                                              new EmptyEvent());
+                                              new DevDriveInsufficientDiskSpaceEvent());
                 validationSuccessful = false;
             }
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/TelemetryEvents/DevDriveInsufficientDiskspaceEvent.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TelemetryEvents/DevDriveInsufficientDiskspaceEvent.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.SetupFlow.Common.TelemetryEvents;
+
+[EventData]
+internal sealed class DevDriveInsufficientDiskSpaceEvent : EventBase
+{
+    public DevDriveInsufficientDiskSpaceEvent()
+    {
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+}


### PR DESCRIPTION
## Summary of the pull request
Adds the DevDriveInsufficientDiskSpaceEvent instead of EmptyEvent, which had the wrong privacy tagging.

## References and relevant issues
Internal data bug.

## Detailed description of the pull request / Additional comments
Adds the DevDriveInsufficientDiskSpaceEvent with PSP tagging, and changed the disk space error to use this event.

## Validation steps performed
Build

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
