### PR TITLE
Defining contrast color

### DIFF
--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -19,18 +19,15 @@
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <x:String x:Key="Background">/Assets/WhatsNewPage/LightTheme/Background.png</x:String>
-                    <Color x:Key="ButtonAccentBackground">#6659CA</Color>
-                    <Color x:Key="ButtonAccentForeground">#FFFFFF</Color>
                     <Color x:Key="LearnMoreForeground">#005FB8</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <x:String x:Key="Background">/Assets/WhatsNewPage/DarkTheme/Background.png</x:String>
-                    <Color x:Key="ButtonAccentBackground">#47E1DA</Color>
-                    <Color x:Key="ButtonAccentForeground">#000000</Color>
                     <Color x:Key="LearnMoreForeground">#60CDFF</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
                     <x:String x:Key="Background">/Assets/WhatsNewPage/DarkTheme/Background.png</x:String>
+                    <Color x:Key="LearnMoreForeground">#60CDFF</Color>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>


### PR DESCRIPTION
## Summary of the pull request
DevHome crashes on the "What's new" page when viewing on a high-contrast theme because `LearnMoreForeground` is not defined for HighContrast.

Fixed by defining `LearnMoreForeground` to the `HighContrast` `ResourceDictionary`

Also removed the unused `ButtonAccent` keys.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Picture!
![HighContrastHyperLink](https://github.com/microsoft/devhome/assets/2517139/c30a1b16-ec5e-478c-9db4-c67f8aca1014)
