### PR TITLE
[Hyper-V Extension] Support new 'securityContext' attribute in WinGet YAML.

### DIFF
--- a/HyperVExtension/src/DevSetupEngine/PackageVersionExtensions.cs
+++ b/HyperVExtension/src/DevSetupEngine/PackageVersionExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Windows.ApplicationModel;
+
+namespace HyperVExtension.DevSetupEngine;
+
+public static class PackageVersionExtensions
+{
+    public static bool LessThan(this PackageVersion version, ushort major, ushort minor, ushort build, ushort revision)
+    {
+        return LessThan(version, new PackageVersion(major, minor, build, revision));
+    }
+
+    public static bool LessThan(this PackageVersion version, PackageVersion other)
+    {
+        if (version.Major > other.Major)
+        {
+            return false;
+        }
+        else if (version.Major < other.Major)
+        {
+            return true;
+        }
+
+        if (version.Minor > other.Minor)
+        {
+            return false;
+        }
+        else if (version.Minor < other.Minor)
+        {
+            return true;
+        }
+
+        if (version.Build > other.Build)
+        {
+            return false;
+        }
+        else if (version.Build < other.Build)
+        {
+            return true;
+        }
+
+        if (version.Revision >= other.Revision)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Contracts/InstallPackageTaskArguments.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Contracts/InstallPackageTaskArguments.cs
@@ -42,6 +42,11 @@ public class InstallPackageTaskArguments : ITaskArguments
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether elevation is required to install the package.
+    /// </summary>
+    public bool IsElevationRequired { get; set; }
+
+    /// <summary>
     /// Try to read and parse argument list into an object.
     /// </summary>
     /// <param name="argumentList">Argument list</param>

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/InstallPackageTask.cs
@@ -123,6 +123,7 @@ public class InstallPackageTask : ISetupTask
             PackageId = _package.Id,
             CatalogName = _package.CatalogName,
             Version = _installVersion,
+            IsElevationRequired = _package.IsElevationRequired,
         };
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/WingetConfigure/WingGetConfigDirectives.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/WingetConfigure/WingGetConfigDirectives.cs
@@ -9,9 +9,20 @@ namespace DevHome.SetupFlow.Models.WingetConfigure;
 /// </summary>
 public class WingGetConfigDirectives
 {
+    public const string SecurityContextCurrent = "current";
+    public const string SecurityContextElevated = "elevated";
+
     public string Description { get; set; }
 
     public bool AllowPrerelease { get; set; }
 
     public string Module { get; set; }
+
+    /// <summary>
+    /// Gets or sets SecurityContext required by the app installer.
+    /// SecurityContext can be "current" or "elevated".
+    /// If set to "elevated", the WinGet will request elevation and will run app installer from
+    /// an elevated process.
+    /// </summary>
+    public string SecurityContext { get; set; } = SecurityContextCurrent;
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/ConfigurationFileBuilder.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/ConfigurationFileBuilder.cs
@@ -180,12 +180,18 @@ public class ConfigurationFileBuilder
     {
         var arguments = task.GetArguments();
         var id = arguments.PackageId;
+        var securityContext = WingGetConfigDirectives.SecurityContextCurrent;
 
         if (configurationFileKind == ConfigurationFileKind.SetupTarget)
         {
             // WinGet configure uses the Id property to uniquely identify a resource and also to display the resource status in the UI.
             // So we add a description to the Id to make it more readable in the UI. These do not need to be localized.
             id = $"{arguments.PackageId}{PackageNameSeparator}{task.PackageName}";
+
+            if (arguments.IsElevationRequired)
+            {
+                securityContext = WingGetConfigDirectives.SecurityContextElevated;
+            }
         }
 
         return new WinGetConfigResource()
@@ -196,6 +202,7 @@ public class ConfigurationFileBuilder
             {
                 AllowPrerelease = true,
                 Description = $"Installing {arguments.PackageId}",
+                SecurityContext = securityContext,
             },
             Settings = new WinGetDscSettings()
             {


### PR DESCRIPTION

## Summary of the pull request

New version of AppInstaller will support "securityContext" attribute that can tell AppInstaller to show elevation prompt and install apps from an elevated context. So, there would be one elevation prompt for all packages in YAML that need elevated context.

This version of AppInstaller is not publicly released yet, but we can make changes on Dev Home side. "securityContext" is ignored by the current versions of AppInstaller.

"securityContext" can be set to "current" to "elevated"

Example of configuration YAML with "securityContext"
```
# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
properties:
  resources:
  - resource: Microsoft.WinGet.DSC/WinGetPackagew
    directives:
      description: Installing Notepad++.Notepad++
      allowPrerelease: true
      securityContext: elevated
    settings:
      id: "Notepad++.Notepad++"
      source: winget
    id: Notepad++.Notepad++ | Notepad++
  configurationVersion: 0.2.0
```

This change does not affect local configuration flow.

## Validation steps performed
Tested with private build of AppInstaller package.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
