### PR TITLE
Allow user to trust untrusted dev drives [NEW]

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -165,11 +165,11 @@
     <value>Dev Drive volumes</value>
     <comment>Header for Dev Drive volumes list in Dev Drive insights page</comment>
   </data>
-  <data name="DevDriveTrustedText" xml:space="preserve">
+  <data name="DevDriveTrusted.Text" xml:space="preserve">
     <value>Trusted</value>
     <comment>Dev drive is trusted</comment>
   </data>
-  <data name="DevDriveUntrustedText" xml:space="preserve">
+  <data name="DevDriveUntrusted.Text" xml:space="preserve">
     <value>Untrusted</value>
     <comment>Dev drive is not trusted</comment>
   </data>
@@ -241,8 +241,8 @@
     <value>Move contents of {0} to a directory on Dev Drive such as {1} and set {2} to that chosen directory on Dev Drive</value>
     <comment>Optimizer dev drive description when environment variable is not set</comment>
   </data>
-  <data name="PackageCachesDescription" xml:space="preserve">
-    <value>A package cache is the global folder location used by application to store files for installed software. These source files are needed when you want to update, uninstall or repair the installed software. Visual Studio is one such application that stores a large portion of it's data in the Package Cache.</value>
+  <data name="PackageCachesDescription.Text" xml:space="preserve">
+    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. Visual Studio is one such application that stores a large portion of its data in the Package Cache.</value>
     <comment>Package caches description</comment>
   </data>
   <data name="SettingsAutoSuggestBox.PlaceholderText" xml:space="preserve">

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -145,6 +145,14 @@
     <value>Dev Drive insights</value>
     <comment>Header for Dev Drive insights page in the breadcrumb bar</comment>
   </data>
+  <data name="DevDriveOptimizationSuggestion" xml:space="preserve">
+    <value>Suggestion</value>
+    <comment>Dev drive optimization suggestion</comment>
+  </data>
+  <data name="DevDriveOptimized" xml:space="preserve">
+    <value>Optimized</value>
+    <comment>Dev drive optimized indicator</comment>
+  </data>
   <data name="DevDriveSizeText" xml:space="preserve">
     <value>Size - {0} {1}</value>
     <comment>Dev drive size</comment>
@@ -156,6 +164,14 @@
   <data name="DevDriveVolumesHeader.Text" xml:space="preserve">
     <value>Dev Drive volumes</value>
     <comment>Header for Dev Drive volumes list in Dev Drive insights page</comment>
+  </data>
+  <data name="DevDriveTrustedText" xml:space="preserve">
+    <value>Trusted</value>
+    <comment>Dev drive is trusted</comment>
+  </data>
+  <data name="DevDriveUntrustedText" xml:space="preserve">
+    <value>Untrusted</value>
+    <comment>Dev drive is not trusted</comment>
   </data>
   <data name="FileExplorerCard.Description" xml:space="preserve">
     <value>Adjust these settings for a more developer-friendly experience using File Explorer</value>
@@ -181,6 +197,10 @@
     <value>End Task</value>
     <comment>The header for the end task on task bar settings card</comment>
   </data>
+  <data name="MainPage_Header" xml:space="preserve">
+    <value>Windows customization</value>
+    <comment>Header for main Windows customization page in the breadcrumb bar</comment>
+  </data>
   <data name="MakeChangesText" xml:space="preserve">
     <value>Make changes</value>
     <comment>Make changes button on dialog</comment>
@@ -188,6 +208,10 @@
   <data name="MakeTheChangeText" xml:space="preserve">
     <value>Make the change</value>
     <comment>Make the change button on optimizer card</comment>
+  </data>
+  <data name="MakeTrustedText" xml:space="preserve">
+    <value>Trust</value>
+    <comment>Make dev drive trusted</comment>
   </data>
   <data name="MoreWindowsSettingsSectionDescription.Text" xml:space="preserve">
     <value>Additional settings below can be configured in the system settings app</value>
@@ -217,6 +241,10 @@
     <value>Move contents of {0} to a directory on Dev Drive such as {1} and set {2} to that chosen directory on Dev Drive</value>
     <comment>Optimizer dev drive description when environment variable is not set</comment>
   </data>
+  <data name="PackageCachesDescription" xml:space="preserve">
+    <value>A package cache is the global folder location used by application to store files for installed software. These source files are needed when you want to update, uninstall or repair the installed software. Visual Studio is one such application that stores a large portion of it's data in the Package Cache.</value>
+    <comment>Package caches description</comment>
+  </data>
   <data name="SettingsAutoSuggestBox.PlaceholderText" xml:space="preserve">
     <value>Search</value>
     <comment>The placholder text for the settings auto suggest box</comment>
@@ -241,17 +269,17 @@
     <value>Show hidden and system files</value>
     <comment>The header for the show hidden and system files setting.</comment>
   </data>
-  <data name="DevDriveOptimizationSuggestion" xml:space="preserve">
-    <value>Suggestion</value>
-    <comment>Dev drive optimization suggestion</comment>
+  <data name="UntrustedDevDriveDescription" xml:space="preserve">
+    <value>Mircosoft Defender performance mode is only available for Trusted Dev Drive volumes </value>
+    <comment>The meaning of untrusted dev drives.</comment>
   </data>
-  <data name="DevDriveOptimized" xml:space="preserve">
-    <value>Optimized</value>
-    <comment>Dev drive optimized indicator</comment>
+  <data name="UntrustedDevDriveLearnMoreText" xml:space="preserve">
+    <value>Learn more.</value>
+    <comment>Learn more link for untrusted dev drives.</comment>
   </data>
-  <data name="MainPage_Header" xml:space="preserve">
-    <value>Windows customization</value>
-    <comment>Header for main Windows customization page in the breadcrumb bar</comment>
+  <data name="UntrustedDevDriveText" xml:space="preserve">
+    <value>Untrusted Dev Drive</value>
+    <comment>Untrusted Dev Drive</comment>
   </data>
   <data name="WindowsDeveloperCard.ActionIconToolTip" xml:space="preserve">
     <value>Open the Windows Settings app</value>

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -209,7 +209,7 @@
     <value>Make the change</value>
     <comment>Make the change button on optimizer card</comment>
   </data>
-  <data name="MakeTrustedText" xml:space="preserve">
+  <data name="MakeTrusted.Text" xml:space="preserve">
     <value>Trust</value>
     <comment>Make dev drive trusted</comment>
   </data>
@@ -269,17 +269,17 @@
     <value>Show hidden and system files</value>
     <comment>The header for the show hidden and system files setting.</comment>
   </data>
-  <data name="UntrustedDevDriveDescription" xml:space="preserve">
-    <value>Mircosoft Defender performance mode is only available for Trusted Dev Drive volumes </value>
+  <data name="UntrustedDevDrive.Description" xml:space="preserve">
+    <value>Microsoft Defender performance mode is only available for trusted Dev Drive volumes </value>
     <comment>The meaning of untrusted dev drives.</comment>
   </data>
-  <data name="UntrustedDevDriveLearnMoreText" xml:space="preserve">
-    <value>Learn more.</value>
-    <comment>Learn more link for untrusted dev drives.</comment>
-  </data>
-  <data name="UntrustedDevDriveText" xml:space="preserve">
+  <data name="UntrustedDevDrive.Header" xml:space="preserve">
     <value>Untrusted Dev Drive</value>
     <comment>Untrusted Dev Drive</comment>
+  </data>
+  <data name="UntrustedDevDriveLearnMoreText" xml:space="preserve">
+    <value>Learn more</value>
+    <comment>Learn more link for untrusted dev drives.</comment>
   </data>
   <data name="WindowsDeveloperCard.ActionIconToolTip" xml:space="preserve">
     <value>Open the Windows Settings app</value>

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
@@ -42,12 +42,6 @@ public partial class DevDriveCardViewModel : ObservableObject
 
     public string DevDriveTrustText { get; set; }
 
-    public string UntrustedDevDriveDescription { get; set; }
-
-    public string UntrustedDevDriveText { get; set; }
-
-    public string MakeTrustedText { get; set; }
-
     public char DriveLetter { get; set; }
 
     [RelayCommand]
@@ -94,9 +88,6 @@ public partial class DevDriveCardViewModel : ObservableObject
         DevDriveFreeSizeText = stringResource.GetLocalized("DevDriveFreeSizeText", DevDriveFreeSize, DevDriveUnitOfMeasure);
         IsDevDriveTrusted = devDrive.IsDevDriveTrusted;
         DevDriveTrustText = IsDevDriveTrusted ? stringResource.GetLocalized("DevDriveTrustedText") : stringResource.GetLocalized("DevDriveUntrustedText");
-        UntrustedDevDriveDescription = stringResource.GetLocalized("UntrustedDevDriveDescription");
-        UntrustedDevDriveText = stringResource.GetLocalized("UntrustedDevDriveText");
-        MakeTrustedText = stringResource.GetLocalized("MakeTrustedText");
         DriveLetter = devDrive.DriveLetter;
     }
 }

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
@@ -40,8 +40,6 @@ public partial class DevDriveCardViewModel : ObservableObject
 
     public bool IsDevDriveTrusted { get; set; }
 
-    public string DevDriveTrustText { get; set; }
-
     public char DriveLetter { get; set; }
 
     [RelayCommand]
@@ -87,7 +85,6 @@ public partial class DevDriveCardViewModel : ObservableObject
         DevDriveUsedSizeText = stringResource.GetLocalized("DevDriveUsedSizeText", DevDriveUsedSize, DevDriveUnitOfMeasure);
         DevDriveFreeSizeText = stringResource.GetLocalized("DevDriveFreeSizeText", DevDriveFreeSize, DevDriveUnitOfMeasure);
         IsDevDriveTrusted = devDrive.IsDevDriveTrusted;
-        DevDriveTrustText = IsDevDriveTrusted ? stringResource.GetLocalized("DevDriveTrustedText") : stringResource.GetLocalized("DevDriveUntrustedText");
         DriveLetter = devDrive.DriveLetter;
     }
 }

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/DevDriveCardViewModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Extensions;
@@ -42,16 +43,18 @@ public partial class DevDriveCardViewModel : ObservableObject
 
     public char DriveLetter { get; set; }
 
+    private const string Fsutil = "fsutil.exe";
+
     [RelayCommand]
     private void MakeDevDriveTrusted()
     {
         // Launch a UAC prompt
         var startInfo = new ProcessStartInfo();
         startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-        startInfo.FileName = Environment.SystemDirectory + "\\fsutil.exe";
+        startInfo.FileName = Path.Join(Environment.SystemDirectory, Fsutil);
 
         // Run the fstutil cmd to trust the dev drive
-        startInfo.Arguments = "devdrv trust /f " + DriveLetter + ":";
+        startInfo.Arguments = $"devdrv trust /f {DriveLetter}:";
         startInfo.UseShellExecute = true;
         startInfo.Verb = "runas";
 

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -32,6 +32,9 @@ public partial class DevDriveInsightsViewModel : ObservableObject
     private readonly OptimizeDevDriveDialogViewModelFactory _optimizeDevDriveDialogViewModelFactory;
 
     [ObservableProperty]
+    private string _packageCachesDescription;
+
+    [ObservableProperty]
     private bool _shouldShowCollectionView;
 
     [ObservableProperty]
@@ -76,6 +79,7 @@ public partial class DevDriveInsightsViewModel : ObservableObject
             new(stringResource.GetLocalized("DevDriveInsights_Header"), typeof(DevDriveInsightsViewModel).FullName!)
         ];
 
+        _packageCachesDescription = new(stringResource.GetLocalized("PackageCachesDescription"));
         _optimizeDevDriveDialogViewModelFactory = optimizeDevDriveDialogViewModelFactory;
         DevDriveManagerObj = devDriveManager;
     }

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsightsViewModel.cs
@@ -32,9 +32,6 @@ public partial class DevDriveInsightsViewModel : ObservableObject
     private readonly OptimizeDevDriveDialogViewModelFactory _optimizeDevDriveDialogViewModelFactory;
 
     [ObservableProperty]
-    private string _packageCachesDescription;
-
-    [ObservableProperty]
     private bool _shouldShowCollectionView;
 
     [ObservableProperty]
@@ -79,7 +76,6 @@ public partial class DevDriveInsightsViewModel : ObservableObject
             new(stringResource.GetLocalized("DevDriveInsights_Header"), typeof(DevDriveInsightsViewModel).FullName!)
         ];
 
-        _packageCachesDescription = new(stringResource.GetLocalized("PackageCachesDescription"));
         _optimizeDevDriveDialogViewModelFactory = optimizeDevDriveDialogViewModelFactory;
         DevDriveManagerObj = devDriveManager;
     }

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -25,7 +25,7 @@
                 <StackPanel Orientation="Vertical">
                     <ctControls:SettingsCard Header="{Binding DevDriveLabel, Mode=OneWay}" Visibility="{Binding Path=IsDevDriveTrusted, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <ctControls:SettingsCard.Description>
-                            <TextBlock Text="{Binding Path=DevDriveTrustText, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
+                            <TextBlock x:Uid="DevDriveTrusted" Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
                         </ctControls:SettingsCard.Description>
                         <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon Glyph="&#xEDA2;" FontSize="25" FontFamily="{ThemeResource AmcFluentIcons}"/>
@@ -46,8 +46,8 @@
                     </ctControls:SettingsCard>
                     <ctControls:SettingsExpander IsExpanded="False" Header="{Binding DevDriveLabel, Mode=OneWay}" Visibility="{Binding Path=IsDevDriveTrusted, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" >
                         <ctControls:SettingsExpander.Description>
-                            <TextBlock Text="{Binding Path=DevDriveTrustText, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorCautionBrush}" />
-                        </ctControls:SettingsExpander.Description>
+                            <TextBlock x:Uid="DevDriveUntrusted" Foreground="{ThemeResource SystemFillColorCautionBrush}" />
+                        </ctControls:SettingsExpander.Description>   
                         <ctControls:SettingsExpander.HeaderIcon>
                             <FontIcon Glyph="&#xEDA2;" FontSize="25" FontFamily="{ThemeResource AmcFluentIcons}"/>
                         </ctControls:SettingsExpander.HeaderIcon>
@@ -156,7 +156,7 @@
             <TextBlock
                 Margin="0 20 0 -10"
                 Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}"
-                Text="{x:Bind ViewModel.PackageCachesDescription, Mode=OneWay}"
+                x:Uid ="PackageCachesDescription"
                 IsTextSelectionEnabled="True"
                 TextWrapping="WrapWholeWords"/>
             <!--- List of DevDriveOptimizersListViewModel objects. -->

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -7,6 +7,8 @@
     xmlns:devViewModels="using:DevHome.Customization.ViewModels.DevDriveInsights"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     mc:Ignorable="d"
     Loaded="UserControl_Loaded">
     <UserControl.Resources>
@@ -15,12 +17,23 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.Common/Environments/Templates/EnvironmentsTemplates.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <converters:BoolToVisibilityConverter x:Key="CollapsedWhenTrueBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+
             <!--- Template for dev drive horizontal cards on the dev insights page. -->
             <DataTemplate x:Key="HorizontalCardForDevDriveInsightsPage" x:DataType="devViewModels:DevDriveCardViewModel">
-                <ctControls:SettingsCard Header="{Binding DevDriveLabel, Mode=OneWay}">
-                    <ctControls:SettingsCard.HeaderIcon>
+                <ctControls:SettingsExpander IsExpanded="False" Header="{Binding DevDriveLabel, Mode=OneWay}" >
+                    <ctControls:SettingsExpander.Description>
+                        <TextBlock Text="{Binding Path=DevDriveTrustText, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorCautionBrush}">
+                            <i:Interaction.Behaviors>
+                                <ic:DataTriggerBehavior Binding="{x:Bind IsDevDriveTrusted}" Value="True">
+                                    <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorSuccessBrush}"/>
+                                </ic:DataTriggerBehavior>
+                            </i:Interaction.Behaviors>
+                        </TextBlock>
+                    </ctControls:SettingsExpander.Description>   
+                    <ctControls:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xEDA2;" FontSize="25" FontFamily="{ThemeResource AmcFluentIcons}"/>
-                    </ctControls:SettingsCard.HeaderIcon>
+                    </ctControls:SettingsExpander.HeaderIcon>
                     <Grid Grid.Column="2">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -34,7 +47,19 @@
                             <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{x:Bind DevDriveFreeSizeText, Mode=OneWay}" />
                         </Grid>
                     </Grid>
-                </ctControls:SettingsCard>
+                    <ctControls:SettingsExpander.Items>
+                        <ctControls:SettingsCard Visibility="{Binding Path=IsDevDriveTrusted, Mode=OneWay, Converter={StaticResource CollapsedWhenTrueBoolToVisibilityConverter}}" Header="{Binding Path=UntrustedDevDriveText, Mode=OneWay}" Description="{Binding Path=UntrustedDevDriveDescription, Mode=OneWay}">
+                            <Button x:Name="UACLauncher" Command="{Binding MakeDevDriveTrustedCommand}" Width="120">
+                                <Button.Content>
+                                    <TextBlock>
+                                        <Run Text="&#xEA18;" FontSize="10" FontFamily="Segoe MDL2 Assets" />
+                                        <Run Text="{x:Bind MakeTrustedText, Mode=OneWay}" />
+                                    </TextBlock>
+                                </Button.Content>
+                            </Button>
+                        </ctControls:SettingsCard>
+                    </ctControls:SettingsExpander.Items>
+                </ctControls:SettingsExpander>
             </DataTemplate>
 
 
@@ -105,6 +130,17 @@
                 IsMultiSelectCheckBoxEnabled="False"
                 HorizontalContentAlignment="Stretch">
             </ListView>
+            <TextBlock
+                Margin="0 20 0 -10"
+                Style="{StaticResource CardBodyStackPanelTextBlockStyle}"
+                Text="Package Caches"
+                IsTextSelectionEnabled="True"/>
+            <TextBlock
+                Margin="0 20 0 -10"
+                Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}"
+                Text="{x:Bind ViewModel.PackageCachesDescription, Mode=OneWay}"
+                IsTextSelectionEnabled="True"
+                TextWrapping="WrapWholeWords"/>
             <!--- List of DevDriveOptimizersListViewModel objects. -->
             <ListView
                 x:Name="DevDriveOptimizersList"
@@ -114,7 +150,7 @@
                 ItemsSource="{x:Bind ViewModel.DevDriveOptimizerCardCollection, Mode=OneWay}"
                 SelectionMode="None"
                 ItemTemplate="{StaticResource HorizontalCardForDevDriveOptimizerInsightsPage}"
-                Margin="0 0 0 -30"
+                Margin="0 0 0 -10"
                 IsMultiSelectCheckBoxEnabled="False">
             </ListView>
             <!--- List of DevDriveOptimizedsListViewModel objects. -->

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -37,11 +37,11 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
-                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 115 5" Text="{Binding Path=DevDriveSizeText, Mode=OneWay}" />
+                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 115 5" Text="{x:Bind Path=DevDriveSizeText, Mode=OneWay}" />
                             <ProgressBar Grid.Row="1" Width="200" Value="{x:Bind DevDriveFillPercentage, Mode=OneWay}" HorizontalAlignment="Right" />
                             <Grid Grid.Row="2">
-                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 120 0" Text="{Binding Path=DevDriveUsedSizeText, Mode=OneWay}" />
-                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{Binding Path=DevDriveFreeSizeText, Mode=OneWay}" />
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 120 0" Text="{x:Bind Path=DevDriveUsedSizeText, Mode=OneWay}" />
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{x:Bind Path=DevDriveFreeSizeText, Mode=OneWay}" />
                             </Grid>
                         </Grid>
                     </ctControls:SettingsCard>
@@ -58,11 +58,11 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
-                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 115 5" Text="{Binding Path=DevDriveSizeText, Mode=OneWay}" />
+                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 115 5" Text="{x:Bind Path=DevDriveSizeText, Mode=OneWay}" />
                             <ProgressBar Grid.Row="1" Width="200" Value="{x:Bind DevDriveFillPercentage, Mode=OneWay}" HorizontalAlignment="Right" />
                             <Grid Grid.Row="2">
-                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 120 0" Text="{Binding Path=DevDriveUsedSizeText, Mode=OneWay}" />
-                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{Binding Path=DevDriveFreeSizeText, Mode=OneWay}" />
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 120 0" Text="{x:Bind Path=DevDriveUsedSizeText, Mode=OneWay}" />
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{x:Bind Path=DevDriveFreeSizeText, Mode=OneWay}" />
                             </Grid>
                         </Grid>
                         <ctControls:SettingsExpander.Items>

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -19,6 +19,7 @@
 
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
             <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+            <converters:CollectionVisibilityConverter x:Key="CollectionHideWhenEmpty" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
 
             <!--- Template for dev drive horizontal cards on the dev insights page. -->
             <DataTemplate x:Key="HorizontalCardForDevDriveInsightsPage" x:DataType="devViewModels:DevDriveCardViewModel">
@@ -85,8 +86,8 @@
             <DataTemplate x:Key="HorizontalCardForDevDriveOptimizerInsightsPage" x:DataType="devViewModels:DevDriveOptimizerCardViewModel">
                 <ctControls:SettingsExpander IsExpanded="True" Header="{Binding CacheToBeMoved, Mode=OneWay}" Margin="0 0 0 5">
                     <Grid HorizontalAlignment="Right">
-                        <FontIcon HorizontalAlignment="Left" Margin="-10" Glyph="&#xE946;" FontSize="12" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
-                        <TextBlock HorizontalAlignment="Left" Margin="5 5 5 5"
+                        <FontIcon HorizontalAlignment="Left" Glyph="&#xE946;" FontSize="12" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+                        <TextBlock HorizontalAlignment="Left" Margin="15 5 5 5"
                                 Foreground="{ThemeResource SystemFillColorAttentionBrush}"                                   
                                 Text="{x:Bind DevDriveOptimizationSuggestion, Mode=OneWay}"
                                 IsTextSelectionEnabled="True"/>
@@ -132,7 +133,7 @@
         <StackPanel Spacing="1">
             <TextBlock
                 x:Uid="DevDriveVolumesHeader"
-                Margin="0 20 0 -10"
+                Margin="0 20 0 0"
                 Style="{StaticResource CardBodyStackPanelTextBlockStyle}"
                 IsTextSelectionEnabled="True"/>
             <!--- List of DevDrivesListViewModel objects. -->
@@ -144,17 +145,16 @@
                 ItemsSource="{x:Bind ViewModel.DevDriveCardCollection, Mode=OneWay}"
                 SelectionMode="None"
                 ItemTemplate="{StaticResource HorizontalCardForDevDriveInsightsPage}"
-                Margin="0 0 0 10"
                 IsMultiSelectCheckBoxEnabled="False"
                 HorizontalContentAlignment="Stretch">
             </ListView>
             <TextBlock
-                Margin="0 20 0 -10"
+                Margin="0 20 0 0"
                 Style="{StaticResource CardBodyStackPanelTextBlockStyle}"
                 Text="Package Caches"
                 IsTextSelectionEnabled="True"/>
             <TextBlock
-                Margin="0 20 0 -10"
+                Margin="0 10 0 0"
                 Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}"
                 x:Uid ="PackageCachesDescription"
                 IsTextSelectionEnabled="True"
@@ -166,9 +166,9 @@
                 HeaderTemplate="{StaticResource DevDriveContainerHeaderTemplate}"
                 DataContext="{Binding}"
                 ItemsSource="{x:Bind ViewModel.DevDriveOptimizerCardCollection, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.DevDriveOptimizerCardCollection, Mode=OneWay, Converter={StaticResource CollectionHideWhenEmpty}}"
                 SelectionMode="None"
                 ItemTemplate="{StaticResource HorizontalCardForDevDriveOptimizerInsightsPage}"
-                Margin="0 0 0 -10"
                 IsMultiSelectCheckBoxEnabled="False">
             </ListView>
             <!--- List of DevDriveOptimizedsListViewModel objects. -->

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -17,49 +17,67 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.Common/Environments/Templates/EnvironmentsTemplates.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <converters:BoolToVisibilityConverter x:Key="CollapsedWhenTrueBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
+            <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
 
             <!--- Template for dev drive horizontal cards on the dev insights page. -->
             <DataTemplate x:Key="HorizontalCardForDevDriveInsightsPage" x:DataType="devViewModels:DevDriveCardViewModel">
-                <ctControls:SettingsExpander IsExpanded="False" Header="{Binding DevDriveLabel, Mode=OneWay}" >
-                    <ctControls:SettingsExpander.Description>
-                        <TextBlock Text="{Binding Path=DevDriveTrustText, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorCautionBrush}">
-                            <i:Interaction.Behaviors>
-                                <ic:DataTriggerBehavior Binding="{x:Bind IsDevDriveTrusted}" Value="True">
-                                    <ic:ChangePropertyAction PropertyName="Foreground" Value="{ThemeResource SystemFillColorSuccessBrush}"/>
-                                </ic:DataTriggerBehavior>
-                            </i:Interaction.Behaviors>
-                        </TextBlock>
-                    </ctControls:SettingsExpander.Description>   
-                    <ctControls:SettingsExpander.HeaderIcon>
-                        <FontIcon Glyph="&#xEDA2;" FontSize="25" FontFamily="{ThemeResource AmcFluentIcons}"/>
-                    </ctControls:SettingsExpander.HeaderIcon>
-                    <Grid Grid.Column="2">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" Margin="0 0 115 5" Text="{Binding Path=DevDriveSizeText, Mode=OneWay}" />
-                        <ProgressBar Grid.Row="1" Width="300" Value="{x:Bind DevDriveFillPercentage, Mode=OneWay}" HorizontalAlignment="Right" />
-                        <Grid Grid.Row="2">
-                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" Margin="0 0 120 0" Text="{x:Bind DevDriveUsedSizeText, Mode=OneWay}" />
-                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{x:Bind DevDriveFreeSizeText, Mode=OneWay}" />
+                <StackPanel Orientation="Vertical">
+                    <ctControls:SettingsCard Header="{Binding DevDriveLabel, Mode=OneWay}" Visibility="{Binding Path=IsDevDriveTrusted, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <ctControls:SettingsCard.Description>
+                            <TextBlock Text="{Binding Path=DevDriveTrustText, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorSuccessBrush}"/>
+                        </ctControls:SettingsCard.Description>
+                        <ctControls:SettingsCard.HeaderIcon>
+                            <FontIcon Glyph="&#xEDA2;" FontSize="25" FontFamily="{ThemeResource AmcFluentIcons}"/>
+                        </ctControls:SettingsCard.HeaderIcon>
+                        <Grid Grid.Column="2">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 115 5" Text="{Binding Path=DevDriveSizeText, Mode=OneWay}" />
+                            <ProgressBar Grid.Row="1" Width="200" Value="{x:Bind DevDriveFillPercentage, Mode=OneWay}" HorizontalAlignment="Right" />
+                            <Grid Grid.Row="2">
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 120 0" Text="{Binding Path=DevDriveUsedSizeText, Mode=OneWay}" />
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{Binding Path=DevDriveFreeSizeText, Mode=OneWay}" />
+                            </Grid>
                         </Grid>
-                    </Grid>
-                    <ctControls:SettingsExpander.Items>
-                        <ctControls:SettingsCard Visibility="{Binding Path=IsDevDriveTrusted, Mode=OneWay, Converter={StaticResource CollapsedWhenTrueBoolToVisibilityConverter}}" Header="{Binding Path=UntrustedDevDriveText, Mode=OneWay}" Description="{Binding Path=UntrustedDevDriveDescription, Mode=OneWay}">
-                            <Button x:Name="UACLauncher" Command="{Binding MakeDevDriveTrustedCommand}" Width="120">
-                                <Button.Content>
-                                    <TextBlock>
-                                        <Run Text="&#xEA18;" FontSize="10" FontFamily="Segoe MDL2 Assets" />
-                                        <Run Text="{x:Bind MakeTrustedText, Mode=OneWay}" />
-                                    </TextBlock>
-                                </Button.Content>
-                            </Button>
-                        </ctControls:SettingsCard>
-                    </ctControls:SettingsExpander.Items>
-                </ctControls:SettingsExpander>
+                    </ctControls:SettingsCard>
+                    <ctControls:SettingsExpander IsExpanded="False" Header="{Binding DevDriveLabel, Mode=OneWay}" Visibility="{Binding Path=IsDevDriveTrusted, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" >
+                        <ctControls:SettingsExpander.Description>
+                            <TextBlock Text="{Binding Path=DevDriveTrustText, Mode=OneWay}" Foreground="{ThemeResource SystemFillColorCautionBrush}" />
+                        </ctControls:SettingsExpander.Description>
+                        <ctControls:SettingsExpander.HeaderIcon>
+                            <FontIcon Glyph="&#xEDA2;" FontSize="25" FontFamily="{ThemeResource AmcFluentIcons}"/>
+                        </ctControls:SettingsExpander.HeaderIcon>
+                        <Grid Grid.Column="2">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"  />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 115 5" Text="{Binding Path=DevDriveSizeText, Mode=OneWay}" />
+                            <ProgressBar Grid.Row="1" Width="200" Value="{x:Bind DevDriveFillPercentage, Mode=OneWay}" HorizontalAlignment="Right" />
+                            <Grid Grid.Row="2">
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Margin="0 0 120 0" Text="{Binding Path=DevDriveUsedSizeText, Mode=OneWay}" />
+                                <TextBlock Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" HorizontalAlignment="Right" Text="{Binding Path=DevDriveFreeSizeText, Mode=OneWay}" />
+                            </Grid>
+                        </Grid>
+                        <ctControls:SettingsExpander.Items>
+                            <ctControls:SettingsCard x:Uid="UntrustedDevDrive">
+                                <Button x:Name="UACLauncher" Command="{Binding MakeDevDriveTrustedCommand}" MinWidth="120">
+                                    <Button.Content>
+                                        <TextBlock>
+                                            <Run Text="&#xEA18;" FontSize="10" FontFamily="Segoe MDL2 Assets" />
+                                            <Run x:Uid="MakeTrusted" />
+                                        </TextBlock>
+                                    </Button.Content>
+                                </Button>
+                            </ctControls:SettingsCard>
+                        </ctControls:SettingsExpander.Items>
+                    </ctControls:SettingsExpander>
+                </StackPanel>
             </DataTemplate>
 
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/DevDrive.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/DevDrive.cs
@@ -146,4 +146,9 @@ public class DevDrive : IDevDrive
     {
         get;
     }
+
+    public bool IsDevDriveTrusted
+    {
+        get; set;
+    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/IDevDrive.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/IDevDrive.cs
@@ -121,4 +121,12 @@ public interface IDevDrive
     }
 
     ByteUnit DriveUnitOfMeasure { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether gets if the dev drive is trusted or not.
+    /// </summary>
+    public bool IsDevDriveTrusted
+    {
+        get;
+    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/DevDriveManager.cs
@@ -47,6 +47,10 @@ public class DevDriveManager : IDevDriveManager
     // https://github.com/microsoft/devhome/issues/634
     private readonly uint _devDriveVolumeStateFlag = 0x00002000;
 
+    // Query flag for persistent state info of the volume, the presence of this flag will let us know
+    // its a trusted Dev drive.
+    private readonly uint _devDriveVolumeStateTrustedFlag = 0x00004000;
+
     /// <summary>
     /// Set that holds Dev Drives that have been created through the Dev Drive manager.
     /// </summary>
@@ -192,7 +196,7 @@ public class DevDriveManager : IDevDriveManager
                 uint outputSize;
                 var volumeInfo = new FILE_FS_PERSISTENT_VOLUME_INFORMATION { };
                 var inputVolumeInfo = new FILE_FS_PERSISTENT_VOLUME_INFORMATION { };
-                inputVolumeInfo.FlagMask = _devDriveVolumeStateFlag;
+                inputVolumeInfo.FlagMask = _devDriveVolumeStateFlag | _devDriveVolumeStateTrustedFlag;
                 inputVolumeInfo.Version = 1;
 
                 SafeFileHandle volumeFileHandle = PInvoke.CreateFile(
@@ -240,6 +244,7 @@ public class DevDriveManager : IDevDriveManager
                             DriveLocation = string.Empty,
                             DriveLabel = volumeLabel,
                             State = DevDriveState.ExistsOnSystem,
+                            IsDevDriveTrusted = (volumeInfo.VolumeFlags & _devDriveVolumeStateTrustedFlag) > 0,
                         };
 
                         devDrives.Add(newDevDrive);


### PR DESCRIPTION
## Summary of the pull request
Microsoft Defender performance mode is only available on trusted dev drives. Here we launch a UAC prompt and allow user to trust untrusted dev drives to get the most optimized perf out of their dev drives.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
