### PR TITLE
Fix foreground issues with Dev Environment pinning.

### DIFF
--- a/common/NativeMethods.txt
+++ b/common/NativeMethods.txt
@@ -1,4 +1,5 @@
-﻿EnableWindow
+﻿AllowSetForegroundWindow
+EnableWindow
 CoCreateInstance
 FileOpenDialog
 FileSaveDialog


### PR DESCRIPTION
## Summary of the pull request
Fix foreground issues with Dev Environment pinning.

## References and relevant issues

## Detailed description of the pull request / Additional comments
There is currently an issue with all DevHome extensions that run in their own process, where foreground rights are not transferred to the extension process.  This leads to UI issues obviously.  But in the specific case of Dev Environment Start Menu and Taskbar pinning, it blocks the entire feature from working.  This is because the Shell APIs for Start Menu and Taskbar pinning require the caller to be in the foreground, and if it isn't the Shell APIs fail.

There is currently work going on to fix this foreground issue for all DevHome extensions in a proper way, but this work won't be done in time for Build.  The pinning features are required for Build, so I have to put in this temporary fix.  The fix is to search for the specific extension process involved in this pinning by name (DevHomeAzureExtension), and directly call AllowSetForegroundWindow via its PID.

## Validation steps performed
Made sure pinning worked and that other options within Dev Environments (launch, start, stop, etc.) still work.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
