### PR TITLE
Make focus rect on Add widget button fully visible

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -55,7 +55,8 @@
         <Grid Grid.Row="0"
               MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left"/>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,22">
+            <!-- Include small upper margin so focus rect is fully visible -->
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,2,0,22">
                 <Button x:Name="AddWidgetButton"
                         x:Uid="AddWidget"
                         HorizontalAlignment="Right"


### PR DESCRIPTION
## Summary of the pull request
Fixes accessibility bug where focus rect wasn't fully visible by giving the button a 2 px upper margin. At some point, after some work to move logic from the View to the ViewModel, we'll use the NavigationView's header rather than building it here, so include a comment so we make sure this is still fixed after that change.

Old:
![image](https://github.com/microsoft/devhome/assets/47155823/e19e7f14-73e9-44e4-9e04-aa6fe9e01429)

New:
![image](https://github.com/microsoft/devhome/assets/47155823/5605f313-9f0d-44e7-b938-25101429d9b3)

## References and relevant issues
https://task.ms/50154033
