### PR TITLE
Fix Hyper-V extension locating Adaptive card json files and assets in the templates directory

### DIFF
--- a/HyperVExtension/src/HyperVExtension/Helpers/DevSetupAgentDeploymentHelper.cs
+++ b/HyperVExtension/src/HyperVExtension/Helpers/DevSetupAgentDeploymentHelper.cs
@@ -6,6 +6,7 @@ using System.Security;
 using System.Text;
 using HyperVExtension.Exceptions;
 using HyperVExtension.Services;
+using Windows.ApplicationModel;
 
 namespace HyperVExtension.Helpers;
 
@@ -128,7 +129,7 @@ public class DevSetupAgentDeploymentHelper
 
     private static string LoadScript()
     {
-        var path = Path.Combine(AppContext.BaseDirectory, "HyperVExtension", "Scripts", "DevSetupAgent.ps1");
+        var path = Path.Combine(Package.Current.EffectivePath, "HyperVExtension", "Scripts", "DevSetupAgent.ps1");
         return File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
     }
 }

--- a/HyperVExtension/src/HyperVExtension/Models/VMGalleryCreationAdaptiveCardSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/VMGalleryCreationAdaptiveCardSession.cs
@@ -12,6 +12,7 @@ using HyperVExtension.Models.VirtualMachineCreation;
 using HyperVExtension.Models.VMGalleryJsonToClasses;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using Windows.ApplicationModel;
 using Windows.Foundation;
 using Windows.Storage;
 using Windows.Storage.Streams;
@@ -28,9 +29,9 @@ public class VMGalleryCreationAdaptiveCardSession : IExtensionAdaptiveCardSessio
 {
     private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(VMGalleryCreationAdaptiveCardSession));
 
-    private readonly string _pathToInitialCreationFormTemplate = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", "InitialVMGalleryCreationForm.json");
+    private readonly string _pathToInitialCreationFormTemplate = Path.Combine(Package.Current.EffectivePath, @"HyperVExtension\Templates\", "InitialVMGalleryCreationForm.json");
 
-    private readonly string _pathToReviewFormTemplate = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", "ReviewFormForVMGallery.json");
+    private readonly string _pathToReviewFormTemplate = Path.Combine(Package.Current.EffectivePath, @"HyperVExtension\Templates\", "ReviewFormForVMGallery.json");
 
     private readonly string _adaptiveCardNextButtonId = "DevHomeMachineConfigurationNextButton";
 

--- a/HyperVExtension/src/HyperVExtension/Models/VmCredentialAdaptiveCardSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/VmCredentialAdaptiveCardSession.cs
@@ -13,6 +13,7 @@ using HyperVExtension.Helpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using Windows.ApplicationModel;
 using Windows.Foundation;
 
 namespace HyperVExtension.Models;
@@ -204,14 +205,14 @@ public sealed class VmCredentialAdaptiveCardSession : IExtensionAdaptiveCardSess
             return _template;
         }
 
-        var path = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", "VmCredentialAdaptiveCardTemplate.json");
+        var path = Path.Combine(Package.Current.EffectivePath, @"HyperVExtension\Templates\", "VmCredentialAdaptiveCardTemplate.json");
         _template = File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
         return _template;
     }
 
     private static string ConvertIconToDataString(string fileName)
     {
-        var path = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", fileName);
+        var path = Path.Combine(Package.Current.EffectivePath, @"HyperVExtension\Templates\", fileName);
         var imageData = Convert.ToBase64String(File.ReadAllBytes(path.ToString()));
         return imageData;
     }

--- a/HyperVExtension/src/HyperVExtension/Models/WaitForLoginAdaptiveCardSession.cs
+++ b/HyperVExtension/src/HyperVExtension/Models/WaitForLoginAdaptiveCardSession.cs
@@ -11,6 +11,7 @@ using HyperVExtension.Helpers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using Windows.ApplicationModel;
 using Windows.Foundation;
 
 namespace HyperVExtension.Models;
@@ -191,14 +192,14 @@ public sealed class WaitForLoginAdaptiveCardSession : IExtensionAdaptiveCardSess
             return _template;
         }
 
-        var path = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", "WaitForLoginAdaptiveCardTemplate.json");
+        var path = Path.Combine(Package.Current.EffectivePath, @"HyperVExtension\Templates\", "WaitForLoginAdaptiveCardTemplate.json");
         _template = File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
         return _template;
     }
 
     private static string ConvertIconToDataString(string fileName)
     {
-        var path = Path.Combine(AppContext.BaseDirectory, @"HyperVExtension\Templates\", fileName);
+        var path = Path.Combine(Package.Current.EffectivePath, @"HyperVExtension\Templates\", fileName);
         var imageData = Convert.ToBase64String(File.ReadAllBytes(path.ToString()));
         return imageData;
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
@@ -189,7 +189,12 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
 
                 // Initialize the adaptive card session with the extension adaptive card template and data with an initial
                 // call to IExtensionAdaptiveCard.Update.
-                _extensionAdaptiveCardSession.Initialize(_extensionAdaptiveCard);
+                var result = _extensionAdaptiveCardSession.Initialize(_extensionAdaptiveCard);
+                if (result.Status == ProviderOperationStatus.Failure)
+                {
+                    _log.Error(result.ExtendedError, $"Extension failed to generate adaptive card. DisplayMsg: {result.DisplayMessage}, DiagnosticMsg: {result.DiagnosticText}");
+                    SessionErrorMessage = result.DisplayMessage;
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary of the pull request
looks like after this change: https://github.com/microsoft/devhome/pull/2729/files, the Hyper-V extension is longer able to locate the files located in: https://github.com/microsoft/devhome/tree/edbe3a7ec396ac56ffc93df89acfe98ae48ed698/HyperVExtension/src/HyperVExtension/Templates 

This is because we were using `AppContext.BaseDirectory `. Now that the packaging structure has changed we need to change these to use `Package.Current.EffectivePath`. Just like this PR: https://github.com/microsoft/devhome/pull/2767

- From this I noticed that I don't check the result of initiatializing the adaptive card from Dev Home. This led to the extension rightfully sending Dev Home a failed result but Dev Home never updating the UI with this information. So the progress ring spins and says its waiting for the extension to send its adaptive card indefinitely. I fixed this by checking for the `ProviderOperationResult` sent back from the extension for failure.

Video showing creation now working and not spinning indefinitely after fix:
 

https://github.com/microsoft/devhome/assets/105318831/2f7ebf70-cb05-4c2b-8491-a94d5f3863c7




## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
