### PR TITLE
Fix links on Dev Drive insights

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -242,7 +242,7 @@
     <comment>Optimizer dev drive description when environment variable is not set</comment>
   </data>
   <data name="PackageCachesDescription.Text" xml:space="preserve">
-    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. Visual Studio is one such application that stores a large portion of its data in the Package Cache. </value>
+    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. </value>
     <comment>Package caches description</comment>
   </data>
   <data name="PackageCachesLearnMoreLink.Text" xml:space="preserve">

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -242,8 +242,12 @@
     <comment>Optimizer dev drive description when environment variable is not set</comment>
   </data>
   <data name="PackageCachesDescription.Text" xml:space="preserve">
-    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. Visual Studio is one such application that stores a large portion of its data in the Package Cache.</value>
+    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. Visual Studio is one such application that stores a large portion of its data in the Package Cache. To learn more about configuring your package caches see </value>
     <comment>Package caches description</comment>
+  </data>
+  <data name="PackageCachesLearnMoreLink.Text" xml:space="preserve">
+    <value>Set up a Dev Drive on Windows 11 | Microsoft Learn</value>
+    <comment>Package caches hyperlink text</comment>
   </data>
   <data name="SettingsAutoSuggestBox.PlaceholderText" xml:space="preserve">
     <value>Search</value>

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -242,11 +242,11 @@
     <comment>Optimizer dev drive description when environment variable is not set</comment>
   </data>
   <data name="PackageCachesDescription.Text" xml:space="preserve">
-    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. Visual Studio is one such application that stores a large portion of its data in the Package Cache. To learn more about configuring your package caches see </value>
+    <value>A package cache is the global folder location used by an application to store files for installed software. These source files are needed when you want to update, uninstall, or repair the installed software. Visual Studio is one such application that stores a large portion of its data in the Package Cache. </value>
     <comment>Package caches description</comment>
   </data>
   <data name="PackageCachesLearnMoreLink.Text" xml:space="preserve">
-    <value>Set up a Dev Drive on Windows 11 | Microsoft Learn</value>
+    <value>Learn more</value>
     <comment>Package caches hyperlink text</comment>
   </data>
   <data name="SettingsAutoSuggestBox.PlaceholderText" xml:space="preserve">

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -92,10 +92,9 @@
                                 IsTextSelectionEnabled="True"/>
                     </Grid>
                     <ctControls:SettingsExpander.Items>
-                        <ctControls:SettingsCard Description="{Binding Path=OptimizerDevDriveDescription, Mode=OneWay}">
+                        <ctControls:SettingsCard Padding="60 10 20 15" Description="{Binding Path=OptimizerDevDriveDescription, Mode=OneWay}">
                             <Button x:Name="OptimizerDialogLauncher" Content="{x:Bind MakeTheChangeText, Mode=OneWay}" Command="{Binding OptimizeDevDriveCommand}" CommandParameter="{Binding ElementName=OptimizerDialogLauncher}"/>
                         </ctControls:SettingsCard>
-                        <ctControls:SettingsCard Header="{Binding Path=CacheToBeMoved, Mode=OneWay}" Foreground="{ThemeResource HyperlinkButtonForeground}"/>
                     </ctControls:SettingsExpander.Items>
                 </ctControls:SettingsExpander>
             </DataTemplate>
@@ -152,12 +151,12 @@
                 Style="{StaticResource CardBodyStackPanelTextBlockStyle}"
                 Text="Package Caches"
                 IsTextSelectionEnabled="True"/>
-            <TextBlock
-                Margin="0 10 0 0"
-                Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}"
-                x:Uid ="PackageCachesDescription"
-                IsTextSelectionEnabled="True"
-                TextWrapping="WrapWholeWords"/>
+            <TextBlock Margin="0 10 0 0" Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" TextWrapping="WrapWholeWords">
+                <Run x:Uid="PackageCachesDescription"/>
+                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/dev-drive/#storing-package-cache-on-dev-drive">
+                    <Run x:Uid="PackageCachesLearnMoreLink" />
+                </Hyperlink>
+            </TextBlock>
             <!--- List of DevDriveOptimizersListViewModel objects. -->
             <ListView
                 x:Name="DevDriveOptimizersList"

--- a/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/DevDriveInsightsView.xaml
@@ -153,7 +153,7 @@
                 IsTextSelectionEnabled="True"/>
             <TextBlock Margin="0 10 0 0" Style="{StaticResource CardBodyStackPanelAltTextBlockStyle}" TextWrapping="WrapWholeWords">
                 <Run x:Uid="PackageCachesDescription"/>
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/dev-drive/#storing-package-cache-on-dev-drive">
+                <Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2268089">
                     <Run x:Uid="PackageCachesLearnMoreLink" />
                 </Hyperlink>
             </TextBlock>


### PR DESCRIPTION
## Summary of the pull request
1. Remove package cache name link from Optimizer card.
2. Add Learn more link on package caches.
![Screenshot0](https://github.com/microsoft/devhome/assets/93530301/ea9eff29-29f4-4ac7-b747-bec781295b67)

Added additional padding to the Optimizer card, screenshots before and after:
![Screenshot2](https://github.com/microsoft/devhome/assets/93530301/7bf6c7c4-15ed-4bfc-839b-14b47c7ad5af)
![Screenshot](https://github.com/microsoft/devhome/assets/93530301/f13154d4-71bd-4494-89ae-4a5dbf663878)


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
