### PR TITLE
Index EXEs\DLLs in addition to PDBs

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -79,7 +79,10 @@ extends:
         - task: PublishSymbols@2
           displayName: Publish Symbols
           inputs:
-            SearchPattern: '**/bin/**/*.pdb'
+            SearchPattern: |
+              **/bin/**/*.pdb
+              **/bin/**/*.exe
+              **/bin/**/*.dll
             IndexSources: false
             SymbolServerType: TeamServices
             SymbolsProduct: DevHomeSDK
@@ -313,6 +316,10 @@ extends:
               inputs:
                 SearchPattern: >-
                   $(Build.SourcesDirectory)\**\bin\**\*.pdb
+
+                  $(Build.SourcesDirectory)\**\bin\**\*.exe
+
+                  $(Build.SourcesDirectory)\**\bin\**\*.dll
 
                   $(Build.SourcesDirectory)\**\obj\**\*.r2r.ni.pdb
                 IndexSources: true


### PR DESCRIPTION
## Summary of the pull request
Indexing EXEs/DLLs results in better call stacks in crash dumps when exceptions are present.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Running full build.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
