### PR TITLE
Removing comment about checking for WinRT version via contract number.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow.Common/Extensions/WinRTObjectExtensions.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/Extensions/WinRTObjectExtensions.cs
@@ -14,9 +14,6 @@ public static class WinRTObjectExtensions
         TOutput defaultValue)
         where TProjectedClass : IWinRTObject
     {
-        // TODO Use API contract version to check if member is available
-        // https://github.com/microsoft/devhome/issues/625
-        // Modify the signature to take the current and min version
         try
         {
             return getValueFunc(projectedClassInstance);


### PR DESCRIPTION
## Summary of the pull request
TODO was originally added to think about a generic solution.

DevHome did not come across a scenario where a generic solution to check for WiNGet versions was needed.

Removing the comment and the associated bug.
## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #625
- [ ] Tests added/passed
- [ ] Documentation updated
