### PR TITLE
Fix *.deps.json files not being automatically deployed when using WAP Project in release mode

### DIFF
--- a/Packaging/Packaging.wapproj
+++ b/Packaging/Packaging.wapproj
@@ -97,6 +97,10 @@
     <None Remove="..\src\Styles\WindowTitleBar_ThemeResources.xaml" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Workaround WAP Project not deploying dependent project's *.deps.json into the final location -->
+    <ContentWithTargetPath Include="..\src\bin\$(Platform)\$(Configuration)\**\win-$(Platform)\*.deps.json" TargetPath="DevHome\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
     <PRIResource Include="..\src\Strings\en-us\Resources.resw" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
WAP Project was not deploying executables <assemblyname>.deps.json which is required by the .net runtime to be able to look up dependencies when in release mode.

## References and relevant issues

## Detailed description of the pull request / Additional comments
Manually copy the *.deps.json files as content in the WAP Project to ensure that they end up in the MSIX payload.

## Validation steps performed
.\build.ps1 -configuration "release"
Validated that the corewidgetsprovider.exe is able to launch without raising any exceptions.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
