### PR TITLE
Fixing the path and a resource.

### DIFF
--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -297,7 +297,7 @@
     <value>An unexpected error occured while attempting to create your new environment</value>
     <comment>Error text for when there was an unexpected error that we could not handle within Dev Home.</comment>
   </data>
-  <data name="GenericEnvironmentName" xml:space="preserve">
+  <data name="EnvironmentGenericName" xml:space="preserve">
     <value>New Environment</value>
     <comment>Generic name text for the card header for an environment that is being created in Dev Homes environment page</comment>
   </data>

--- a/extensions/HyperVExtension/src/HyperVExtension/Constants.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Constants.cs
@@ -24,4 +24,6 @@ internal sealed class Constants
 #endif
 
     public const string ExtensionIconInternal = "ms-appx:///HyperVExtension/Assets/hyper-v-provider-icon.png";
+
+    public const string HyperVTemplatesSubPath = @"HyperVExtension\Templates";
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/VMGalleryCreationAdaptiveCardSession.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/VMGalleryCreationAdaptiveCardSession.cs
@@ -29,9 +29,9 @@ public class VMGalleryCreationAdaptiveCardSession : IExtensionAdaptiveCardSessio
 {
     private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(VMGalleryCreationAdaptiveCardSession));
 
-    private readonly string _pathToInitialCreationFormTemplate = Path.Combine(Package.Current.EffectivePath, @"extensions\HyperVExtension\Templates\", "InitialVMGalleryCreationForm.json");
+    private readonly string _pathToInitialCreationFormTemplate = Path.Combine(Package.Current.EffectivePath, Constants.HyperVTemplatesSubPath, "InitialVMGalleryCreationForm.json");
 
-    private readonly string _pathToReviewFormTemplate = Path.Combine(Package.Current.EffectivePath, @"extensions\HyperVExtension\Templates\", "ReviewFormForVMGallery.json");
+    private readonly string _pathToReviewFormTemplate = Path.Combine(Package.Current.EffectivePath, Constants.HyperVTemplatesSubPath, "ReviewFormForVMGallery.json");
 
     private readonly string _adaptiveCardNextButtonId = "DevHomeMachineConfigurationNextButton";
 

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/VmCredentialAdaptiveCardSession.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/VmCredentialAdaptiveCardSession.cs
@@ -205,14 +205,14 @@ public sealed class VmCredentialAdaptiveCardSession : IExtensionAdaptiveCardSess
             return _template;
         }
 
-        var path = Path.Combine(Package.Current.EffectivePath, @"extensions\HyperVExtension\Templates\", "VmCredentialAdaptiveCardTemplate.json");
+        var path = Path.Combine(Package.Current.EffectivePath, Constants.HyperVTemplatesSubPath, "VmCredentialAdaptiveCardTemplate.json");
         _template = File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
         return _template;
     }
 
     private static string ConvertIconToDataString(string fileName)
     {
-        var path = Path.Combine(Package.Current.EffectivePath, @"extensions\HyperVExtension\Templates\", fileName);
+        var path = Path.Combine(Package.Current.EffectivePath, Constants.HyperVTemplatesSubPath, fileName);
         var imageData = Convert.ToBase64String(File.ReadAllBytes(path.ToString()));
         return imageData;
     }

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/WaitForLoginAdaptiveCardSession.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/WaitForLoginAdaptiveCardSession.cs
@@ -192,14 +192,14 @@ public sealed class WaitForLoginAdaptiveCardSession : IExtensionAdaptiveCardSess
             return _template;
         }
 
-        var path = Path.Combine(Package.Current.EffectivePath, @"extensions\HyperVExtension\Templates\", "WaitForLoginAdaptiveCardTemplate.json");
+        var path = Path.Combine(Package.Current.EffectivePath, Constants.HyperVTemplatesSubPath, "WaitForLoginAdaptiveCardTemplate.json");
         _template = File.ReadAllText(path, Encoding.Default) ?? throw new FileNotFoundException(path);
         return _template;
     }
 
     private static string ConvertIconToDataString(string fileName)
     {
-        var path = Path.Combine(AppContext.BaseDirectory, @"extensions\extensions\HyperVExtension\Templates\", fileName);
+        var path = Path.Combine(AppContext.BaseDirectory, Constants.HyperVTemplatesSubPath, fileName);
         var imageData = Convert.ToBase64String(File.ReadAllBytes(path.ToString()));
         return imageData;
     }


### PR DESCRIPTION
## Summary of the pull request
DevHome was looking for a resource that does not exist.  Changed the resource name.

HyperV assumed that path to the templates had an "extension" part.  It did not.  Removed "extension" and made the remaining path a constant.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
