### PR TITLE
Quiet mode: Add process performance metrics telemetry

### DIFF
--- a/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
+++ b/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
@@ -84,7 +84,7 @@ public:
             PCWSTR, packageFullName,
             int, sampleCount,
             double, maxPercent,
-            double, standardDeviation,
+            uint32_t, samplesAboveThreshold,
             double, sigma4Deviation,
             int, totalCpuTimeInMicroseconds);
     END_ACTIVITY_CLASS();

--- a/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
+++ b/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
@@ -17,23 +17,75 @@ class DevHomeTelemetryProvider : public wil::TraceLoggingProvider
 
 public:
 
+    // Activity for quiet session
     BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS_WITH_LEVEL(
         QuietBackgroundProcesses_ElevatedServer_Session,
         PDT_ProductAndServicePerformance,
         WINEVENT_LEVEL_CRITICAL);
 
-        DEFINE_ACTIVITY_START(uint64_t expectedDuration)
+        DEFINE_ACTIVITY_START(bool isPlacebo, uint64_t expectedDuration)
         {
             TraceLoggingClassWriteStart(
                 QuietBackgroundProcesses_ElevatedServer_Session,
-                TraceLoggingValue(expectedDuration, "ExpectedDuration"));
+                TraceLoggingValue(isPlacebo, "isPlacebo"),
+                TraceLoggingValue(expectedDuration, "expectedDuration"));
         }
         DEFINE_ACTIVITY_STOP(bool manuallyStopped, uint64_t actualDuration)
         {
             TraceLoggingClassWriteStop(
                 QuietBackgroundProcesses_ElevatedServer_Session,
-                TraceLoggingValue(manuallyStopped, "ManuallyStopped"),
-                TraceLoggingValue(actualDuration, "ActualDuration"));
+                TraceLoggingValue(manuallyStopped, "manuallyStopped"),
+                TraceLoggingValue(actualDuration, "actualDuration"));
         }
+    END_ACTIVITY_CLASS();
+
+
+    // Activity for process metrics
+    BEGIN_COMPLIANT_MEASURES_ACTIVITY_CLASS_WITH_LEVEL(
+        QuietBackgroundProcesses_PerformanceMetrics,
+        PDT_ProductAndServicePerformance,
+        WINEVENT_LEVEL_CRITICAL);
+
+        DEFINE_ACTIVITY_START(uint32_t quietSessionVersion, uint64_t samplingPeriodInMs, uint64_t totalCpuUsageInMicroseconds)
+        {
+            TraceLoggingClassWriteStart(QuietBackgroundProcesses_PerformanceMetrics,
+                TraceLoggingValue(quietSessionVersion, "quietSessionVersion"),
+                TraceLoggingValue(samplingPeriodInMs, "samplingPeriodInMs"),
+                TraceLoggingValue(totalCpuUsageInMicroseconds, "totalCpuUsageInMicroseconds")
+            );
+        }
+
+        DEFINE_TRACELOGGING_EVENT_PARAM4(
+            ComputerInfo,
+            DWORD, processorCount,
+            PCWSTR, processor,
+            PCWSTR, motherboard,
+            DWORD, ram);
+
+        DEFINE_TRACELOGGING_EVENT_PARAM10(
+            SessionCategoryMetrics,
+            int, numProcesses_unknown,
+            int, numProcesses_user,
+            int, numProcesses_system,
+            int, numProcesses_developer,
+            int, numProcesses_background,
+            int, totalCpuTimesByCategory_unknown,
+            int, totalCpuTimesByCategory_user,
+            int, totalCpuTimesByCategory_system,
+            int, totalCpuTimesByCategory_developer,
+            int, totalCpuTimesByCategory_background);
+
+        DEFINE_TRACELOGGING_EVENT_PARAM10(
+            ProcessInfo,
+            int, reason,
+            bool, isInSystem32,
+            PCWSTR, processName,
+            uint32_t, category,
+            PCWSTR, packageFullName,
+            int, sampleCount,
+            double, maxPercent,
+            double, sigma4,
+            double, percent,
+            int, totalCpuTimeInMicroseconds);
     END_ACTIVITY_CLASS();
 };

--- a/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
+++ b/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
@@ -84,8 +84,8 @@ public:
             PCWSTR, packageFullName,
             int, sampleCount,
             double, maxPercent,
-            double, sigma4,
-            double, percent,
+            double, standardDeviation,
+            double, sigma4Deviation,
             int, totalCpuTimeInMicroseconds);
     END_ACTIVITY_CLASS();
 };

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.cpp
@@ -207,7 +207,7 @@ void UploadPerformanceDataTelemetry(std::chrono::milliseconds samplingPeriod, co
 
             item.sampleCount,
             item.maxPercent,
-            standardDeviation,
+            item.samplesAboveThreshold,
             sigma4Deviation,
             item.totalCpuTimeInMicroseconds);
     }

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.cpp
@@ -4,10 +4,16 @@
 #include <pch.h>
 
 #include <fstream>
-#include <vector>
+#include <numeric>
 #include <span>
 #include <string>
+#include <vector>
 
+#include <wil/resource.h>
+#include <wil/result_macros.h>
+#include <wil/win32_helpers.h>
+
+#include "DevHomeTelemetryProvider.h"
 #include "PerformanceRecorderEngine.h"
 #include "Helpers.h"
 
@@ -43,4 +49,168 @@ std::vector<ProcessPerformanceSummary> ReadPerformanceDataFromDisk(_In_ PCWSTR p
 
     file.close();
     return data;
+}
+
+struct ComputerInformation
+{
+    DWORD processorCount;
+    std::wstring processor;
+    std::wstring motherboard;
+    DWORDLONG ram;
+};
+
+// Get computer information
+ComputerInformation GetComputerInformation()
+{
+    ComputerInformation computerInfo;
+
+    // Get processor information
+    SYSTEM_INFO systemInfo = { 0 };
+    GetSystemInfo(&systemInfo);
+    computerInfo.processorCount = systemInfo.dwNumberOfProcessors;
+
+    // Get processor make and model using win32 apis
+    wil::unique_hkey hKey;
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        wchar_t processorName[256] = { 0 };
+        DWORD processorNameSize = sizeof(processorName);
+        if (RegQueryValueEx(hKey.get(), L"ProcessorNameString", nullptr, nullptr, reinterpret_cast<BYTE*>(processorName), &processorNameSize) == ERROR_SUCCESS)
+        {
+            computerInfo.processor = processorName;
+        }
+    }
+
+    // Get motherboard make and model using win32 apis
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\BIOS", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        wchar_t biosName[256] = { 0 };
+        DWORD biosNameSize = sizeof(biosName);
+        if (RegQueryValueEx(hKey.get(), L"BaseBoardProduct", nullptr, nullptr, reinterpret_cast<BYTE*>(biosName), &biosNameSize) == ERROR_SUCCESS)
+        {
+            computerInfo.motherboard = biosName;
+        }
+    }
+
+    // Get ram amount using GlobalMemoryStatusEx
+    MEMORYSTATUSEX memoryStatus = { 0 };
+    memoryStatus.dwLength = sizeof(memoryStatus);
+    if (GlobalMemoryStatusEx(&memoryStatus))
+    {
+        computerInfo.ram = memoryStatus.ullTotalPhys / 1024 / 1024;
+    }
+
+    return computerInfo;
+}
+
+void UploadPerformanceDataTelemetry(std::chrono::milliseconds samplingPeriod, const std::span<ProcessPerformanceSummary>& data)
+{
+    using namespace std::chrono_literals;
+
+    enum class UploadReason
+    {
+        None,
+        MaxPercent,
+        Sigma4,
+        AveragePercent,
+        SearchIndexer,
+    };
+
+    struct UploadItem
+    {
+        UploadReason reason;
+        ProcessPerformanceSummary data;
+    };
+
+    constexpr auto c_quietSessionVersion = 1;
+
+    // Calculate total cpu time usage for all processes
+    std::chrono::microseconds totalCpuUsageInMicroseconds = std::accumulate(data.begin(), data.end(), 0us, [](std::chrono::microseconds total, const ProcessPerformanceSummary& item) {
+        return total + std::chrono::microseconds(item.totalCpuTimeInMicroseconds);
+    });
+
+    // Begin metrics activity
+    auto activity = DevHomeTelemetryProvider::QuietBackgroundProcesses_PerformanceMetrics::Start(
+        c_quietSessionVersion,
+        samplingPeriod.count(),
+        totalCpuUsageInMicroseconds.count());
+
+    // Upload computer information
+    auto computerInformation = GetComputerInformation();
+    activity.ComputerInfo(
+        computerInformation.processorCount,
+        computerInformation.processor.c_str(),
+        computerInformation.motherboard.c_str(),
+        computerInformation.ram);
+
+    // Calculate the totalCpuTimeInMicroseconds items aggregated by item.category
+    std::vector<uint64_t> numProcesses(5);
+    std::vector<uint64_t> totalCpuTimesByCategory(5);
+    for (const auto& item : data)
+    {
+        numProcesses[item.category]++;
+        totalCpuTimesByCategory[item.category] += item.totalCpuTimeInMicroseconds;
+    }
+
+    // Upload category metrics
+    activity.SessionCategoryMetrics(
+        numProcesses[0],
+        numProcesses[1],
+        numProcesses[2],
+        numProcesses[3],
+        numProcesses[4],
+        totalCpuTimesByCategory[0],
+        totalCpuTimesByCategory[1],
+        totalCpuTimesByCategory[2],
+        totalCpuTimesByCategory[3],
+        totalCpuTimesByCategory[4]);
+
+    // Choose process information to upload
+    std::vector<UploadItem> itemsToUpload;
+    for (const auto& item : data)
+    {
+        if (item.maxPercent >= 20.0)
+        {
+            // Add item to list to upload
+            itemsToUpload.emplace_back(UploadReason::MaxPercent, item);
+        }
+        else if (std::sqrt(std::sqrt(item.sigma4Cumulative / item.sampleCount)) >= 4.0)
+        {
+            // Add item to list to upload
+            itemsToUpload.emplace_back(UploadReason::Sigma4, item);
+        }
+        else if (item.percentCumulative / item.sampleCount >= 1.0)
+        {
+            // Add item to list to upload
+            itemsToUpload.emplace_back(UploadReason::AveragePercent, item);
+        }
+        else if (wil::compare_string_ordinal(item.name, L"SearchIndexer.exe", true) == 0)
+        {
+            // Add item to list to upload
+            itemsToUpload.emplace_back(UploadReason::SearchIndexer, item);
+        }
+    }
+
+    // Get system32 path
+    wchar_t system32Path[MAX_PATH];
+    GetSystemDirectory(system32Path, ARRAYSIZE(system32Path));
+
+    // Upload process information
+    for (const auto& itemToUpload : itemsToUpload)
+    {
+        activity.ProcessInfo(
+            itemToUpload.reason,
+            wil::compare_string_ordinal(itemToUpload.data.path, system32Path, true) == 0,
+            itemToUpload.data.name,
+            itemToUpload.data.category,
+            itemToUpload.data.packageFullName,
+
+            itemToUpload.data.sampleCount,
+            itemToUpload.data.maxPercent,
+            std::sqrt(std::sqrt(itemToUpload.data.sigma4Cumulative / itemToUpload.data.sampleCount)),
+            itemToUpload.data.percentCumulative / itemToUpload.data.sampleCount,
+            itemToUpload.data.totalCpuTimeInMicroseconds);
+    }
+
+    activity.Stop();
 }

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.h
@@ -41,3 +41,6 @@ wil::com_ptr<ABI::DevHome::QuietBackgroundProcesses::IPerformanceRecorderEngine>
 // Read/write the performance data to/from disk
 void WritePerformanceDataToDisk(_In_ PCWSTR path, const std::span<ProcessPerformanceSummary>& data);
 std::vector<ProcessPerformanceSummary> ReadPerformanceDataFromDisk(_In_ PCWSTR path);
+
+// Upload the performance data to the telemetry service
+void UploadPerformanceDataTelemetry(std::chrono::milliseconds samplingPeriod, const std::span<ProcessPerformanceSummary>& data);

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/PerformanceRecorderEngineWinrt.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/PerformanceRecorderEngineWinrt.cpp
@@ -302,7 +302,6 @@ namespace ABI::DevHome::QuietBackgroundProcesses
                 // Upload the performance data telemetry
                 try
                 {
-                    bool manuallyStopped = result != nullptr;
                     UploadPerformanceDataTelemetry(samplingPeriod, data);
                 }
                 CATCH_LOG();

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietBackgroundProcessesSession.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/QuietBackgroundProcessesSession.cpp
@@ -58,11 +58,14 @@ namespace ABI::DevHome::QuietBackgroundProcesses
                 duration = std::chrono::seconds(durationOverride.value());
             }
 
+            // Let's make the quiet window a placebo 5 percent of the time
+            bool placebo = (rand() % 100) < 5;
+
             // Start timer
-            g_activeTimer.reset(new TimedQuietSession(duration));
+            g_activeTimer.reset(new TimedQuietSession(placebo, duration));
 
             // Return duration for showing countdown
-            *result = g_activeTimer->TimeLeftInSeconds();
+            *result = g_activeTimer->TimeLeftInSeconds().count();
             return S_OK;
         }
         CATCH_RETURN()
@@ -102,7 +105,7 @@ namespace ABI::DevHome::QuietBackgroundProcesses
             *value = 0;
             if (g_activeTimer)
             {
-                *value = g_activeTimer->TimeLeftInSeconds();
+                *value = g_activeTimer->TimeLeftInSeconds().count();
             }
             return S_OK;
         }

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Timer.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Timer.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "pch.h"
-
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -19,6 +17,8 @@
 #if _DEBUG || NDEBUG
 #define TRACK_SECONDS_LEFT
 #endif
+
+using namespace std::chrono_literals;
 
 class Timer
 {
@@ -58,24 +58,24 @@ public:
         m_cancelCondition.notify_one();
     }
 
-    int64_t TimeLeftInSeconds()
+    std::chrono::seconds TimeLeftInSeconds()
     {
         auto lock = std::scoped_lock(m_mutex);
         if (m_cancelled)
         {
-            return 0;
+            return 0s;
         }
 
         auto secondsLeft = CalculateSecondsLeft();
-        return std::max(secondsLeft, 0ll);
+        return std::max(secondsLeft, 0s);
     }
 
 private:
-    int64_t CalculateSecondsLeft()
+    std::chrono::seconds CalculateSecondsLeft()
     {
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - m_startTime);
-        auto secondsLeft = m_duration.count() - elapsed.count();
+        auto secondsLeft = m_duration - elapsed;
 #ifdef TRACK_SECONDS_LEFT
         m_secondsLeft = secondsLeft;
 #endif
@@ -111,6 +111,6 @@ private:
     std::function<void()> m_callback;
 
 #ifdef TRACK_SECONDS_LEFT
-    int64_t m_secondsLeft = -1;
+    std::chrono::seconds m_secondsLeft = std::chrono::seconds::max();
 #endif
 };

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.PerformanceRecorderEngine/PerformanceRecorderEngine.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.PerformanceRecorderEngine/PerformanceRecorderEngine.cpp
@@ -338,7 +338,10 @@ ProcessPerformanceInfo MakeProcessPerformanceInfo(DWORD processId)
 
     auto path = std::filesystem::path(processPathString.value_or(L""));
 
-    FILETIME createTime{}, exitTime{}, kernelTime{}, userTime{};
+    FILETIME createTime{};
+    FILETIME exitTime{};
+    FILETIME kernelTime{};
+    FILETIME userTime{};
     if (process)
     {
         THROW_IF_WIN32_BOOL_FALSE(GetProcessTimes(process.get(), &createTime, &exitTime, &kernelTime, &userTime));

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.PerformanceRecorderEngine/PerformanceRecorderEngine.h
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.PerformanceRecorderEngine/PerformanceRecorderEngine.h
@@ -33,7 +33,7 @@ struct ProcessPerformanceSummary
 
 extern "C" __declspec(dllexport) HRESULT StartMonitoringProcessUtilization(uint32_t periodInMs, void** context) noexcept;
 extern "C" __declspec(dllexport) HRESULT StopMonitoringProcessUtilization(void* context) noexcept;
-extern "C" __declspec(dllexport) HRESULT GetMonitoringProcessUtilization(void* context, ProcessPerformanceSummary** ppSummaries, size_t* summaryCount) noexcept;
+extern "C" __declspec(dllexport) HRESULT GetMonitoringProcessUtilization(void* context, std::chrono::milliseconds* samplingPeriodInMs, ProcessPerformanceSummary** ppSummaries, size_t* summaryCount) noexcept;
 extern "C" __declspec(dllexport) HRESULT DeleteMonitoringProcessUtilization(void* context) noexcept;
 
 using unique_process_utilization_monitoring_thread = wil::unique_any<void*, decltype(&::DeleteMonitoringProcessUtilization), ::DeleteMonitoringProcessUtilization>;

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/ViewModels/AnalyticSummaryPopupViewModel.cs
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/ViewModels/AnalyticSummaryPopupViewModel.cs
@@ -161,6 +161,8 @@ public partial class AnalyticSummaryPopupViewModel : ObservableObject
 
     public void SaveReport(string filePath)
     {
+        TelemetryFactory.Get<ITelemetry>().Log("QuietBackgroundProcesses_AnalyticSummary_Save", LogLevel.Info, new QuietBackgroundProcessesEvent());
+
         // Save the report to a .csv
         using (StreamWriter writer = new StreamWriter(filePath))
         {


### PR DESCRIPTION

# Telemetry collected:
## Computer Information:
- Gather information about the computer's hardware, including the processor count, processor type, motherboard, and RAM size.
## Session Category Metrics:
- Report aggregate process metrics by category.
## Process Information:
### Selects specific processes to upload based on certain criteria:
- Processes with a maximum CPU usage percentage greater than or equal to 20%.
- Processes with a standard deviation (sigma) of CPU usage exceeding a certain threshold.
- Processes with an average CPU usage percentage exceeding 1%.
- The SearchIndexer process.
For each selected process, the code uploads information such as process name, category, sample count, maximum CPU percentage, sigma, average CPU percentage, and total CPU time.

# Other:
* Always record metrics to disk (even when DevHome is open)
* Quiet session is now a placebo 5% of the time
* Fixed harmless (but expensive) exception (ACCESS DENIED) when attempting to get CPU time for CSRSS.exe every sampling
* Added telemetry event for saving the Analytic Summary

<img width="1623" alt="tmp" src="https://github.com/microsoft/devhome/assets/6415764/27572fbb-be2e-4bc6-ae43-1b72696bce02">
