### PR TITLE
Fix test script to unblock build

### DIFF
--- a/Test.ps1
+++ b/Test.ps1
@@ -142,7 +142,9 @@ try {
                     "tools\$tool\*UITest\bin\$platform\$configuration\net8.0-windows10.0.22621.0\*.UITest.dll"
                 )
 
-                & $vstestPath $vstestArgs
+                if (Get-ChildItem "tools\$tool\*UnitTest\bin\$platform\$configuration\net8.0-windows10.0.22621.0\*.UnitTest.dll") {
+                    & $vstestPath $vstestArgs
+                }
                 # TODO: UI tests are currently disabled in the pipeline until signing is solved
                 if ($RunUITests) {
                     & $vstestPath $winAppTestArgs


### PR DESCRIPTION
## Summary of the pull request
Utilities tool just got added but has no unittests.  Alphabetically, "Utilities" is the last tool and the script is returning "Exit 1" since no tests are found.  Solution is to verify there is a unittest dll before attempting to run the test.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
