### PR TITLE
Add QuickStart Playground API surface

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -22,7 +22,7 @@ parameters:
 variables:
  # MSIXVersion's second part should always be odd to account for stub app's version
   MSIXVersion: '0.1301'
-  VersionOfSDK: '0.500'
+  VersionOfSDK: '0.600'
   solution: '**/DevHome.sln'
   appxPackageDir: 'AppxPackages'
   testOutputArtifactDir: 'TestResults'

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -9,6 +9,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DebugType>pdbonly</DebugType>
+    <!-- Remove once new CsWinRT version is available and Uri.cs is removed -->
+    <NoWarn>0436</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Uri.cs
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Uri.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Copy of https://github.com/microsoft/CsWinRT/blob/2.0.4.231013.1/src/WinRT.Runtime/Projections/Uri.cs
+// with bug fixes already in staging/AOT branch.  Remove once updated CsWinRT is available.
+
+#nullable disable
+
+using System;
+using System.Runtime.InteropServices;
+using WinRT;
+using WinRT.Interop;
+
+namespace ABI.Windows.Foundation
+{
+    [Guid("9E365E57-48B2-4160-956F-C7385120BBFC")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct IUriRuntimeClassVftbl
+    {
+        internal IInspectable.Vftbl IInspectableVftbl;
+        public IntPtr get_AbsoluteUri_0;
+        public IntPtr get_DisplayUri_1;
+        public IntPtr get_Domain_2;
+        public IntPtr get_Extension_3;
+        public IntPtr get_Fragment_4;
+        public IntPtr get_Host_5;
+        public IntPtr get_Password_6;
+        public IntPtr get_Path_7;
+        public IntPtr get_Query_8;
+        public IntPtr get_QueryParsed_9;
+        public void* _get_RawUri_10;
+        public delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int> get_RawUri_10 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)_get_RawUri_10;
+        public IntPtr get_SchemeName_11;
+        public IntPtr get_UserName_12;
+        public IntPtr get_Port_13;
+        public IntPtr get_Suspicious_14;
+        public IntPtr Equals_15;
+        public IntPtr CombineUri_16;
+    }
+}
+
+namespace ABI.System
+{
+
+    [global::WinRT.ObjectReferenceWrapper(nameof(_obj))]
+    [Guid("44A9796F-723E-4FDF-A218-033E75B0C084")]
+    internal sealed class WinRTUriRuntimeClassFactory
+    {
+        [Guid("44A9796F-723E-4FDF-A218-033E75B0C084")]
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct Vftbl
+        {
+            internal IInspectable.Vftbl IInspectableVftbl;
+            private void* _CreateUri_0;
+            public delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out IntPtr, int> CreateUri_0 => (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, out IntPtr, int>)_CreateUri_0;
+            public IntPtr _CreateWithRelativeUri;
+        }
+        public static ObjectReference<Vftbl> FromAbi(IntPtr thisPtr) => ObjectReference<Vftbl>.FromAbi(thisPtr);
+
+        public static implicit operator WinRTUriRuntimeClassFactory(IObjectReference obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
+        public static implicit operator WinRTUriRuntimeClassFactory(ObjectReference<Vftbl> obj) => (obj != null) ? new WinRTUriRuntimeClassFactory(obj) : null;
+        private readonly ObjectReference<Vftbl> _obj;
+        public IntPtr ThisPtr => _obj.ThisPtr;
+        public ObjectReference<I> AsInterface<I>() => _obj.As<I>();
+        public A As<A>() => _obj.AsType<A>();
+        public WinRTUriRuntimeClassFactory(IObjectReference obj) : this(obj.As<Vftbl>()) { }
+        public WinRTUriRuntimeClassFactory(ObjectReference<Vftbl> obj)
+        {
+            _obj = obj;
+        }
+
+        public unsafe IObjectReference CreateUri(string uri)
+        {
+            IntPtr __retval = default;
+            MarshalString.Pinnable __uri = new(uri);
+            fixed (void* ___uri = __uri)
+            {
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateUri_0(ThisPtr, MarshalString.GetAbi(ref __uri), out __retval));
+                return ObjectReference<IUnknownVftbl>.Attach(ref __retval);
+            }
+        }
+
+        public unsafe ObjectReferenceValue CreateUriForMarshaling(string uri)
+        {
+            IntPtr __retval = default;
+            MarshalString.Pinnable __uri = new(uri);
+            fixed (void* ___uri = __uri)
+            {
+                global::WinRT.ExceptionHelpers.ThrowExceptionForHR(_obj.Vftbl.CreateUri_0(ThisPtr, MarshalString.GetAbi(ref __uri), out __retval));
+                return ObjectReferenceValue.Attach(ref __retval);
+            }
+        }
+    }
+
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct Uri
+    {
+        private sealed class ActivationFactory : BaseActivationFactory
+        {
+            public ActivationFactory() : base("Windows.Foundation", "Windows.Foundation.Uri")
+            {
+            }
+
+            internal static WinRTUriRuntimeClassFactory Instance =
+                new ActivationFactory()._As<WinRTUriRuntimeClassFactory.Vftbl>();
+        }
+
+        public static IObjectReference CreateMarshaler(global::System.Uri value)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            return ActivationFactory.Instance.CreateUri(value.OriginalString);
+        }
+
+        public static ObjectReferenceValue CreateMarshaler2(global::System.Uri value)
+        {
+            if (value is null)
+            {
+                return new ObjectReferenceValue();
+            }
+
+            return ActivationFactory.Instance.CreateUriForMarshaling(value.OriginalString);
+        }
+
+        public static IntPtr GetAbi(IObjectReference m) => m?.ThisPtr ?? IntPtr.Zero;
+
+        public static global::System.Uri FromAbi(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            IntPtr rawUri = IntPtr.Zero;
+            try
+            {
+                ExceptionHelpers.ThrowExceptionForHR((**(ABI.Windows.Foundation.IUriRuntimeClassVftbl**)ptr).get_RawUri_10(ptr, &rawUri));
+                return new global::System.Uri(MarshalString.FromAbi(rawUri));
+            }
+            finally
+            {
+                MarshalString.DisposeAbi(rawUri);
+            }
+        }
+
+        public static unsafe global::System.Uri[] FromAbiArray(object box) => MarshalInterfaceHelper<global::System.Uri>.FromAbiArray(box, FromAbi);
+
+        public static unsafe void CopyManaged(global::System.Uri o, IntPtr dest)
+        {
+            *(IntPtr*)dest.ToPointer() = CreateMarshaler2(o).Detach();
+        }
+
+        public static IntPtr FromManaged(global::System.Uri value)
+        {
+            if (value is null)
+            {
+                return IntPtr.Zero;
+            }
+            return CreateMarshaler2(value).Detach();
+        }
+
+        public static unsafe MarshalInterfaceHelper<global::System.Uri>.MarshalerArray CreateMarshalerArray(global::System.Uri[] array) => MarshalInterfaceHelper<global::System.Uri>.CreateMarshalerArray2(array, (o) => CreateMarshaler2(o));
+        public static (int length, IntPtr data) GetAbiArray(object box) => MarshalInterfaceHelper<global::System.Uri>.GetAbiArray(box);
+        public static void CopyAbiArray(global::System.Uri[] array, object box) => MarshalInterfaceHelper<global::System.Uri>.CopyAbiArray(array, box, FromAbi);
+        public static (int length, IntPtr data) FromManagedArray(global::System.Uri[] array) => MarshalInterfaceHelper<global::System.Uri>.FromManagedArray(array, (o) => FromManaged(o));
+        public static void DisposeMarshalerArray(MarshalInterfaceHelper<global::System.Uri>.MarshalerArray array) => MarshalInterfaceHelper<global::System.Uri>.DisposeMarshalerArray(array);
+        public static void DisposeMarshaler(IObjectReference m) { m?.Dispose(); }
+        public static void DisposeAbi(IntPtr abi) { MarshalInspectable<object>.DisposeAbi(abi); }
+        public static void DisposeAbiArray(object box) => MarshalInterfaceHelper<global::System.Uri>.DisposeAbiArray(box);
+
+        public static string GetGuidSignature()
+        {
+            return "rc(Windows.Foundation.Uri;{9e365e57-48b2-4160-956f-c7385120bbfc})";
+        }
+    }
+}
+
+#nullable restore

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -1,6 +1,6 @@
 namespace Microsoft.Windows.DevHome.SDK
 {
-    [contractversion(5)]
+    [contractversion(6)]
     apicontract DevHomeContract {}
 
     [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 1)]
@@ -20,6 +20,10 @@ namespace Microsoft.Windows.DevHome.SDK
         // an object that implements the IComputeSystemProvider interface.
         [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 2)]
         ComputeSystem = 4,
+
+        [experimental]
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+        QuickStartProject = 5,
     };
 
     // Definitions for exceptions.
@@ -1424,4 +1428,216 @@ namespace Microsoft.Windows.DevHome.SDK
     };
 
     // End FileExplorerSourceControlIntegration APIs
+
+    // Beginning of QuickStartProject APIs
+
+    // Used to indicate an application such as an IDE which can be used to launch the generated quick start project.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    interface IQuickStartProjectHost
+    {
+        // Name of the QuickStart project host that shows up on the UI.
+        String DisplayName
+        {
+            get;
+        };
+
+        // Uri for icon to represent the QuickStart project host.
+        // This is currently not shown anywhere but can be shown
+        // in the future such as on the UI alongside the display name.
+        // This Uri path needs to be located in a resource.pri file
+        // and be in the format of the ms-resource:// schema.
+        // E.g "ms-resource://Contoso.Extension/Files/Extension/Assets/icon.png"
+        // It is also recommended to be 16x16px for best appearance
+        // when displayed within the button for launching the project host.
+        Windows.Foundation.Uri Icon
+        {
+            get;
+        };
+        
+        // Launches the project host for the quick start project that it was created for.
+        ProviderOperationResult Launch();
+    }
+
+    // Used by the extension to get any feedback provided by the user on the generated project.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    interface IQuickStartProjectResultFeedbackHandler
+    {
+        // Handler to get any feedback provided to Dev Home by the user on the generated project.
+        ProviderOperationResult ProvideFeedback(Boolean isPositive, String feedback);
+    }
+
+    // Used by the extension to provide information on the generated quickstart project.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    runtimeclass QuickStartProjectResult
+    {
+        // Used when generating the project was successful.
+        QuickStartProjectResult(IQuickStartProjectHost[] projectHosts, Windows.Foundation.Uri[] referenceSamples);
+
+        // Used when generating the quickstart project was unsuccessful.
+        // The extension can provide Dev Home with an error message to be displayed in the UI by providing
+        // a non-empty value for the displayMessage. diagnosticText can be used to send non-localized error
+        // information back to Dev Home.
+        QuickStartProjectResult(HRESULT e, String displayMessage, String diagnosticText);
+
+        // Used when generating the project was successful and
+        // the extension would like to be get any feedback
+        // provided by the user on it.
+        static QuickStartProjectResult CreateWithFeedbackHandler(IQuickStartProjectHost[] projectHosts, Windows.Foundation.Uri[] referenceSamples, IQuickStartProjectResultFeedbackHandler feedbackHandler);
+
+        // The array of hosts that support launching the project.
+        IQuickStartProjectHost[] ProjectHosts
+        {
+            get;
+        };
+
+        // The result of the operation. This contains the ProviderOperationStatus enum value that tells Dev Home
+        // whether the result was successful or failed. It is created based on the constructor that was used.
+        ProviderOperationResult Result
+        {
+            get;
+        };
+
+        // Used to provide to Dev Home the references / samples that were used
+        // by the AI in the extension or by the extension itself to generate
+        // the quick start project.  Dev Home shows this to the user as the
+        // references that this project was generated based on.
+        Windows.Foundation.Uri[] ReferenceSamples
+        {
+            get;
+        };
+
+        // Used to provide Dev Home a way to pass feedback back to the
+        // extension if the user provides one on the generated project.
+        IQuickStartProjectResultFeedbackHandler FeedbackHandler
+        {
+            get;
+        };
+    }
+
+    // Passed back to Dev Home to provide the progress in generating a quick start project.
+    // This is used by Dev Home to show progress to the user while the project is being generated.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    struct QuickStartProjectProgress
+    {
+        // Allows extensions to provide intermediary status for the operation e.g "Generating project".
+        String DisplayStatus;
+
+        // Allows extensions to provide progress for the operation.
+        // Value should be in the range of 0 through 1.0.
+        Double Progress;
+    };
+
+    // The result object returned to Dev Home when it calls one of the IQuickStartProjectProvider
+    // CreateAdaptiveCard methods.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    runtimeclass QuickStartProjectAdaptiveCardResult
+    {
+        // Used when retrieving the adaptive card session was successful.
+        QuickStartProjectAdaptiveCardResult(IExtensionAdaptiveCardSession2 adaptiveCardSession);
+
+        // Used when retrieving the adaptive card session was unsuccessful.
+        // The extension can provide Dev Home with an error message to be displayed in the UI by providing
+        // a non-empty value for the displayMessage. diagnosticText can be used to send non-localized error
+        // information back to Dev Home.
+        QuickStartProjectAdaptiveCardResult(HRESULT e, String displayMessage, String diagnosticText);
+
+        // The adaptive card session object.
+        IExtensionAdaptiveCardSession2 AdaptiveCardSession
+        {
+            get;
+        };
+
+        // The result of the operation. This contains the ProviderOperationStatus enum value that tells Dev Home
+        // whether the result was successful or failed. It is created based on the constructor that was used.
+        ProviderOperationResult Result
+        {
+            get;
+        };
+    }
+
+    // Extensions implement this and is provided to Dev Home when CreateProjectGenerationOperation is called.
+    // This allows to have an async operation can be started but also additional context reported back to Dev Home
+    // as progress is being made such as a detailed log out output through the adaptive card session.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    interface IQuickStartProjectGenerationOperation
+    {
+        // Adaptive card session that can be provided by the extension to supplement
+        // the progress shown by Dev Home.  This can be used where the extension
+        // may want to provide more progress information such as build output.
+        // Extension may return null if they don't want to show any custom progress
+        // other than the one based on Status and Progress.  If one is
+        // provided when a progress is reported, it would be shown in a ScrollViewer
+        // on the Dev Home UI scrolled to the bottom as if it is some form of log output.
+        IExtensionAdaptiveCardSession2 AdaptiveCardSession
+        {
+            get;
+        };
+
+        // Starts the operation which generates a project based on a given prompt by the user in the
+        // given output folder. The generated content in the output folder can be anything that is needed
+        // for the project based on the technology it uses.  Dev Home just displays the generated content
+        // in a file viewer.
+        Windows.Foundation.IAsyncOperationWithProgress<QuickStartProjectResult, QuickStartProjectProgress> GenerateAsync();
+    }
+
+    // Extensions can implement this provider to provide a way to
+    // create a project based on a prompt as part of the Dev Home 
+    // quick start project feature.
+    [experimental]
+    [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
+    interface IQuickStartProjectProvider
+    {
+        // Name of the QuickStart project provider that shows up on the UI.
+        String DisplayName
+        {
+            get;
+        };
+
+        // Used to provide the URI to the terms of service for the extension
+        // and its AI endpoint.  This is shown on the Dev Home UI as a link
+        // and should be able to be protocol launched into the browser.
+        Windows.Foundation.Uri TermsOfServiceUri
+        {
+            get;
+        };
+
+        // Used to provide the URI to the privacy statement for the extension
+        // and its AI endpoint.  This is shown on the Dev Home UI as a link
+        // and should be able to be protocol launched into the browser.
+        Windows.Foundation.Uri PrivacyPolicyUri
+        {
+            get;
+        };
+
+        // Used to provide the sample prompts to guide the user on what types of 
+        // things they can generate with the extension. This is shown on the 
+        // Dev Home UI.
+        String[] SamplePrompts
+        {
+            get;
+        };
+
+        // Adaptive card UI flow that can be provided by the extension to initialize or
+        // setup anything required by it such as to install any dependencies
+        // it needs or to setup its AI endpoint.  In addition, to showing the user the dependencies,
+        // this flow can be used to install them through OnAction in the adaptive card session.
+        // Extension may return null if there is nothing to do here.
+        // This is called when the user selects in the extension provider that they want to use
+        // this extension to generate the project.
+        QuickStartProjectAdaptiveCardResult CreateAdaptiveCardSessionForExtensionInitialization();
+
+        // Creates an operation which allows to generate a project based on a given prompt by the
+        // user in the given output folder.  The generated content in the output folder can be anything that
+        // is needed for the project based on the technology it uses.  Dev Home just displays the generated content
+        // in a file viewer.
+        IQuickStartProjectGenerationOperation CreateProjectGenerationOperation(String prompt, Windows.Storage.StorageFolder outputFolder);
+    }
+
+    // End of QuickStartProject APIs
 }

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.vcxproj
@@ -227,6 +227,8 @@
     <ClInclude Include="OpenConfigurationSetResult.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ProviderOperationResult.h" />
+    <ClInclude Include="QuickStartProjectAdaptiveCardResult.h" />
+    <ClInclude Include="QuickStartProjectResult.h" />
     <ClInclude Include="RepositoriesResult.h" />
     <ClInclude Include="RepositoriesSearchResult.h" />
     <ClInclude Include="RepositoryResult.h" />
@@ -264,6 +266,8 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="ProviderOperationResult.cpp" />
+    <ClCompile Include="QuickStartProjectAdaptiveCardResult.cpp" />
+    <ClCompile Include="QuickStartProjectResult.cpp" />
     <ClCompile Include="RepositoriesResult.cpp" />
     <ClCompile Include="RepositoriesSearchResult.cpp" />
     <ClCompile Include="RepositoryResult.cpp" />

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectAdaptiveCardResult.cpp
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectAdaptiveCardResult.cpp
@@ -1,0 +1,28 @@
+#include "pch.h"
+#include "QuickStartProjectAdaptiveCardResult.h"
+#include "QuickStartProjectAdaptiveCardResult.g.cpp"
+
+namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
+{
+    QuickStartProjectAdaptiveCardResult::QuickStartProjectAdaptiveCardResult(winrt::Microsoft::Windows::DevHome::SDK::IExtensionAdaptiveCardSession2 const& adaptiveCardSession) :
+        m_adaptiveCardSession(adaptiveCardSession),
+        m_result(ProviderOperationStatus::Success, S_OK, hstring{}, hstring{})
+    {
+    }
+
+    QuickStartProjectAdaptiveCardResult::QuickStartProjectAdaptiveCardResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText) :
+        m_adaptiveCardSession(nullptr),
+        m_result(ProviderOperationStatus::Failure, e, displayMessage, diagnosticText)
+    {
+    }
+
+    winrt::Microsoft::Windows::DevHome::SDK::IExtensionAdaptiveCardSession2 QuickStartProjectAdaptiveCardResult::AdaptiveCardSession()
+    {
+        return m_adaptiveCardSession;
+    }
+
+    winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult QuickStartProjectAdaptiveCardResult::Result()
+    {
+        return m_result;
+    }
+}

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectAdaptiveCardResult.h
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectAdaptiveCardResult.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "QuickStartProjectAdaptiveCardResult.g.h"
+
+namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
+{
+    struct QuickStartProjectAdaptiveCardResult : QuickStartProjectAdaptiveCardResultT<QuickStartProjectAdaptiveCardResult>
+    {
+        QuickStartProjectAdaptiveCardResult(winrt::Microsoft::Windows::DevHome::SDK::IExtensionAdaptiveCardSession2 const& adaptiveCardSession);
+        QuickStartProjectAdaptiveCardResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
+        winrt::Microsoft::Windows::DevHome::SDK::IExtensionAdaptiveCardSession2 AdaptiveCardSession();
+        winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult Result();
+
+    private:
+        IExtensionAdaptiveCardSession2 m_adaptiveCardSession;
+        ProviderOperationResult m_result;
+    };
+}
+namespace winrt::Microsoft::Windows::DevHome::SDK::factory_implementation
+{
+    struct QuickStartProjectAdaptiveCardResult : QuickStartProjectAdaptiveCardResultT<QuickStartProjectAdaptiveCardResult, implementation::QuickStartProjectAdaptiveCardResult>
+    {
+    };
+}

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectResult.cpp
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectResult.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "QuickStartProjectResult.h"
+#include "QuickStartProjectResult.g.cpp"
+
+namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
+{
+    QuickStartProjectResult::QuickStartProjectResult(
+        array_view<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost const> projectHosts,
+        array_view<winrt::Windows::Foundation::Uri const> referenceSamples) :
+        m_projectHosts(projectHosts.begin(), projectHosts.end()),
+        m_referenceSamples(referenceSamples.begin(), referenceSamples.end()),
+        m_result(ProviderOperationStatus::Success, S_OK, hstring(), hstring()),
+        m_feedbackHandler(nullptr)
+    {
+    }
+
+    QuickStartProjectResult::QuickStartProjectResult(
+        array_view<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost const> projectHosts,
+        array_view<winrt::Windows::Foundation::Uri const> referenceSamples,
+        winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler const& feedbackHandler) :
+        m_projectHosts(projectHosts.begin(), projectHosts.end()),
+        m_referenceSamples(referenceSamples.begin(), referenceSamples.end()),
+        m_result(ProviderOperationStatus::Success, S_OK, hstring(), hstring()),
+        m_feedbackHandler(feedbackHandler)
+    {
+    }
+
+    QuickStartProjectResult::QuickStartProjectResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText) :
+        m_projectHosts(std::vector<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost>{}),
+        m_referenceSamples(std::vector<winrt::Windows::Foundation::Uri>{}),
+		m_result(ProviderOperationStatus::Failure, e, displayMessage, diagnosticText),
+        m_feedbackHandler(nullptr)
+    {
+    }
+
+    winrt::Microsoft::Windows::DevHome::SDK::QuickStartProjectResult QuickStartProjectResult::CreateWithFeedbackHandler(
+        array_view<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost const> projectHosts,
+        array_view<winrt::Windows::Foundation::Uri const> referenceSamples,
+        winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler const& feedbackHandler)
+    {
+        return make<QuickStartProjectResult>(projectHosts, referenceSamples, feedbackHandler);
+    }
+
+    com_array<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost> QuickStartProjectResult::ProjectHosts()
+    {
+        return com_array<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost>(m_projectHosts.begin(), m_projectHosts.end());
+    }
+
+    winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult QuickStartProjectResult::Result()
+    {
+        return m_result;
+    }
+
+    com_array<winrt::Windows::Foundation::Uri> QuickStartProjectResult::ReferenceSamples()
+    {
+        return com_array<winrt::Windows::Foundation::Uri>(m_referenceSamples.begin(), m_referenceSamples.end());
+    }
+
+    winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler QuickStartProjectResult::FeedbackHandler()
+    {
+        return m_feedbackHandler;
+    }
+}

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectResult.h
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/QuickStartProjectResult.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include "QuickStartProjectResult.g.h"
+
+namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
+{
+    struct QuickStartProjectResult : QuickStartProjectResultT<QuickStartProjectResult>
+    {
+        QuickStartProjectResult(
+            array_view<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost const> projectHosts,
+            array_view<winrt::Windows::Foundation::Uri const> referenceSamples);
+
+        QuickStartProjectResult(
+            array_view<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost const> projectHosts,
+            array_view<winrt::Windows::Foundation::Uri const> referenceSamples,
+            winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler const& feedbackHandler);
+
+        QuickStartProjectResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
+
+        static winrt::Microsoft::Windows::DevHome::SDK::QuickStartProjectResult CreateWithFeedbackHandler(
+            array_view<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost const> projectHosts,
+            array_view<winrt::Windows::Foundation::Uri const> referenceSamples,
+            winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler const& feedbackHandler);
+
+        com_array<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost> ProjectHosts();
+        winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult Result();
+        com_array<winrt::Windows::Foundation::Uri> ReferenceSamples();
+        winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler FeedbackHandler();
+
+        private:
+            std::vector<winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectHost> m_projectHosts;
+			winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult m_result;
+            std::vector<winrt::Windows::Foundation::Uri> m_referenceSamples;
+			winrt::Microsoft::Windows::DevHome::SDK::IQuickStartProjectResultFeedbackHandler m_feedbackHandler;
+    };
+}
+namespace winrt::Microsoft::Windows::DevHome::SDK::factory_implementation
+{
+    struct QuickStartProjectResult : QuickStartProjectResultT<QuickStartProjectResult, implementation::QuickStartProjectResult>
+    {
+    };
+}


### PR DESCRIPTION
## Summary of the pull request

This adds the QuickStart Playground API surface to the Dev Home SDK.

## References and relevant issues

https://task.ms/48702956

## Detailed description of the pull request / Additional comments

The following types are added:
- IQuickStartProjectProvider
- IQuickStartProjectGenerationOperation
- QuickStartProjectAdaptiveCardResult
- QuickStartProjectProgress
- QuickStartProjectResult
- IQuickStartProjectResultFeedbackHandler
- IQuickStartProjectHost

Incremented the Dev Home contract version to 6.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
