### PR TITLE
Fix Coding style link in Contributor's Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ Alternatively,
 ### Rules
 
 - **Follow the pattern of what you already see in the code.**
-- [Coding style](style.md).
+- [Coding style](./docs/style.md).
 - Try to package new ideas/components into libraries that have nicely defined interfaces.
 - Package new ideas into classes or refactor existing ideas into a class as you extend.
 - When adding new classes/methods/changing existing code: add new unit tests or update the existing tests.


### PR DESCRIPTION
## Summary of the pull request
The link to the coding style doc navigated to a 404 page.  This change points to the style.md in the docs directory.

## References and relevant issues
N/A

## Detailed description of the pull request / Additional comments

## Validation steps performed
Verified in GitHub.dev environment that clicking on updated link properly navigates to the Coding Style guidelines doc.

## PR checklist
- [#2837] Closes #xxx
- [ ] Tests added/passed
- [X] Documentation updated

