### PR TITLE
Keep dialog open and display error to user on non dev drive location input

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -130,7 +130,7 @@
     <comment>Choose directory on dev drive</comment>
   </data>
   <data name="ChosenDirectoryNotOnDevDriveErrorText" xml:space="preserve">
-    <value>Chosen folder is not in a Dev Drive location</value>
+    <value>Selected directory must be on a Dev Drive</value>
     <comment>Chosen directory not on dev drive</comment>
   </data>
   <data name="DevDriveFreeSizeText" xml:space="preserve">

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -124,11 +124,15 @@
   <data name="ChooseDirectory.PlaceholderText" xml:space="preserve">
     <value>Choose a directory</value>
     <comment>Choose directory</comment>
-</data>
+  </data>
   <data name="ChooseDirectoryPromptText" xml:space="preserve">
     <value>Choose directory on Dev Drive...</value>
     <comment>Choose directory on dev drive</comment>
-  </data>  
+  </data>
+  <data name="ChosenDirectoryNotOnDevDriveErrorText" xml:space="preserve">
+    <value>Chosen folder is not in a Dev Drive location</value>
+    <comment>Chosen directory not on dev drive</comment>
+  </data>
   <data name="DevDriveFreeSizeText" xml:space="preserve">
     <value>{0} {1} free</value>
     <comment>Dev drive size free</comment>

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
@@ -46,6 +46,15 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
     [ObservableProperty]
     private string _directoryPathTextBox;
 
+    [ObservableProperty]
+    private bool _isPrimaryButtonEnabled;
+
+    [ObservableProperty]
+    private string _errorMessage;
+
+    [ObservableProperty]
+    private bool _isNotDevDrive;
+
     public OptimizeDevDriveDialogViewModel(
         string existingCacheLocation,
         string environmentVariableToBeSet,
@@ -61,6 +70,9 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
         ExistingCacheLocation = existingCacheLocation;
         EnvironmentVariableToBeSet = environmentVariableToBeSet;
         OptimizeDevDriveDialogDescription = stringResource.GetLocalized("OptimizeDevDriveDialogDescription/Text", ExistingCacheLocation, EnvironmentVariableToBeSet);
+        IsPrimaryButtonEnabled = false;
+        ErrorMessage = string.Empty;
+        IsNotDevDrive = false;
     }
 
     [RelayCommand]
@@ -86,6 +98,18 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
         if (folder != null)
         {
             DirectoryPathTextBox = folder.Path;
+            if (ChosenDirectoryInDevDrive(DirectoryPathTextBox))
+            {
+                IsPrimaryButtonEnabled = true;
+                IsNotDevDrive = false;
+            }
+            else
+            {
+                IsPrimaryButtonEnabled = false;
+                IsNotDevDrive = true;
+                var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
+                ErrorMessage = stringResource.GetLocalized("ChosenDirectoryNotOnDevDriveErrorText");
+            }
         }
     }
 
@@ -225,8 +249,6 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
 
         if (!string.IsNullOrEmpty(directoryPath))
         {
-            // Handle the selected folder
-            // TODO: If chosen folder not a dev drive location, currently we no-op and log the error. Instead we should display the error.
             if (ChosenDirectoryInDevDrive(directoryPath))
             {
                 if (MoveDirectory(ExistingCacheLocation, directoryPath))

--- a/tools/Customization/DevHome.Customization/Views/OptimizeDevDriveDialog.xaml
+++ b/tools/Customization/DevHome.Customization/Views/OptimizeDevDriveDialog.xaml
@@ -30,7 +30,7 @@
         <TextBlock Margin="0 10 0 0" TextWrapping="Wrap" Text="{x:Bind ViewModel.ExampleDevDriveLocation, Mode=OneWay}"/>
         <Grid Visibility="{x:Bind ViewModel.IsNotDevDrive, Mode=OneWay}" Margin="0 10 0 0">
             <FontIcon HorizontalAlignment="Left" Glyph="&#xE946;" FontSize="12" FontFamily="{StaticResource SymbolThemeFontFamily}" Foreground="{ThemeResource SystemFillColorCautionBrush}" />
-            <TextBlock Margin="20 0 0 0" TextWrapping="Wrap" Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" FontSize="12" Foreground="{ThemeResource SystemFillColorCautionBrush}"/>
+            <TextBlock Margin="20 0 0 0" TextWrapping="WrapWholeWords" Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" FontSize="12" Foreground="{ThemeResource SystemFillColorCautionBrush}"/>
         </Grid>
     </StackPanel>
 </ContentDialog>

--- a/tools/Customization/DevHome.Customization/Views/OptimizeDevDriveDialog.xaml
+++ b/tools/Customization/DevHome.Customization/Views/OptimizeDevDriveDialog.xaml
@@ -14,6 +14,7 @@
     Style="{StaticResource DefaultContentDialogStyle}"
     Title="{x:Bind ViewModel.ChooseDirectoryPromptText}"
     PrimaryButtonText="{x:Bind ViewModel.MakeChangesText}"
+    IsPrimaryButtonEnabled="{x:Bind ViewModel.IsPrimaryButtonEnabled, Mode=OneWay}"
     PrimaryButtonCommand="{x:Bind ViewModel.DirectoryInputConfirmedCommand}"
     SecondaryButtonText="Cancel">
     <StackPanel>
@@ -27,5 +28,9 @@
             <Button HorizontalAlignment="Right" Margin="10 0 0 0" Grid.Column="1" x:Uid="BrowseButton" Command="{x:Bind ViewModel.BrowseButtonClickCommand}"/>
         </Grid>
         <TextBlock Margin="0 10 0 0" TextWrapping="Wrap" Text="{x:Bind ViewModel.ExampleDevDriveLocation, Mode=OneWay}"/>
+        <Grid Visibility="{x:Bind ViewModel.IsNotDevDrive, Mode=OneWay}" Margin="0 10 0 0">
+            <FontIcon HorizontalAlignment="Left" Glyph="&#xE946;" FontSize="12" FontFamily="{StaticResource SymbolThemeFontFamily}" Foreground="{ThemeResource SystemFillColorCautionBrush}" />
+            <TextBlock Margin="20 0 0 0" TextWrapping="Wrap" Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" FontSize="12" Foreground="{ThemeResource SystemFillColorCautionBrush}"/>
+        </Grid>
     </StackPanel>
 </ContentDialog>


### PR DESCRIPTION
## Summary of the pull request
When user clicks "Make changes" to move a cache, it launches a dialog. The dialog has a textbox for the user to browse and input a directory. Currently if the directory is not on a dev drive, we do no op, log the error and the dialog closes without showing any message to the user.
This PR fixes that and keeps the dialog open with the "Make Change" button disabled till user browses and enters a dev drive location or clicks cancel.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2684
- [ ] Tests added/passed
- [ ] Documentation updated
