### PR TITLE
Add a warning about possible elevation UAC dialogs on target device during its configuration.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1501,7 +1501,7 @@
     <comment>The operating system version of the compute system.</comment>
   </data>
   <data name="SetupTargetReviewPageDefaultInfoBarMessage" xml:space="preserve">
-    <value>Proceeding with the next step may result in the target machine being rebooted and logging in may be required.</value>
+    <value>Proceeding with the next step may result in the target machine being rebooted and logging in may be required. App installers may show Windows UAC prompts that will require your attention.</value>
     <comment>Message that explicitly tells the user that if they proceed we may reboot their machine and they may need to log back in.</comment>
   </data>
   <data name="SetupTargetReviewPageDefaultInfoBarTitle" xml:space="preserve">
@@ -1509,7 +1509,7 @@
     <comment>Title for info bar that will warn users that proceeding with the setup may result in the restart and re-login of the targeted remote machine or virtual machine.</comment>
   </data>
   <data name="SetupTargetReviewPageHyperVInfoBarMessage" xml:space="preserve">
-    <value>The next step may require you to reboot and sign in again. The Dev Home's DevSetupAgent service will be installed for setup of a Hyper-V virtual machine</value>
+    <value>The next step may require you to reboot and sign in again. The Dev Home's DevSetupAgent service will be installed for setup of a Hyper-V virtual machine. App installers may show Windows UAC prompts that will require your attention.</value>
     <comment>{Locked="DevSetupAgent"} Message that explicitly tells the user that if they proceed we may reboot their machine and they may need to log back in.</comment>
   </data>
   <data name="SetupTargetUnknownStatus" xml:space="preserve">

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1501,7 +1501,7 @@
     <comment>The operating system version of the compute system.</comment>
   </data>
   <data name="SetupTargetReviewPageDefaultInfoBarMessage" xml:space="preserve">
-    <value>Proceeding with the next step may result in the target machine being rebooted and logging in may be required. App installers may show Windows UAC prompts that will require your attention.</value>
+    <value>Proceeding with the set up may result in the environment being rebooted and log in may be required. App installation may show Windows UAC prompts in the environment that will require your attention.</value>
     <comment>Message that explicitly tells the user that if they proceed we may reboot their machine and they may need to log back in.</comment>
   </data>
   <data name="SetupTargetReviewPageDefaultInfoBarTitle" xml:space="preserve">
@@ -1509,7 +1509,7 @@
     <comment>Title for info bar that will warn users that proceeding with the setup may result in the restart and re-login of the targeted remote machine or virtual machine.</comment>
   </data>
   <data name="SetupTargetReviewPageHyperVInfoBarMessage" xml:space="preserve">
-    <value>The next step may require you to reboot and sign in again. The Dev Home's DevSetupAgent service will be installed for setup of a Hyper-V virtual machine. App installers may show Windows UAC prompts that will require your attention.</value>
+    <value>Proceeding with the set up may result in the environment being rebooted and log in may be required. Dev Home's DevSetupAgent service will be installed to configure a Hyper-V virtual machine. App installation may show Windows UAC prompts in the environment that will require your attention.</value>
     <comment>{Locked="DevSetupAgent"} Message that explicitly tells the user that if they proceed we may reboot their machine and they may need to log back in.</comment>
   </data>
   <data name="SetupTargetUnknownStatus" xml:space="preserve">


### PR DESCRIPTION
## Summary of the pull request
Currently we don't have a way to detect UAC dialog on a remote device during device configuration (and notify Dev Home).
This PR adds a warning to let users know that there could be a UAC prompt. Exact wording is subject to PM/content writes and can be changed later.
 
![Screenshot 2024-05-09 221452](https://github.com/microsoft/devhome/assets/51001703/cbbc6840-d663-44ef-9ba0-bdc715b8478a)

## References and relevant issues
[Users do not have visibility into UAC prompts thrown inside the environment during configuration](#2710)


## PR checklist
- [ ] Closes #2710 
- [ ] Tests added/passed
- [ ] Documentation updated
