### PR TITLE
Fix previously selected environment's adaptive card from showing up in UI in creation flow

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
@@ -107,6 +107,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
     public void Receive(CreationProviderChangedMessage message)
     {
         _upcomingProviderDetails = message.Value;
+        ResetAdaptiveCardConfiguration();
     }
 
     private void OnEndSetupFlow(object sender, EventArgs e)


### PR DESCRIPTION
## Summary of the pull request
When the user goes into Machine configuration > Create environment and select a provider and clicks next, that providers creation adaptive card shows up in the UI.

When the user clicks the previous button and selects another provider and clicks next, the previous providers adaptive card flow sometimes lingers on the page before the currently selected providers adaptive card flow shows up in the UI. 

To fix this, we now clear the adaptive card information when the user changes providers.

I only managed to repro this once but did not take a video so will show video that was put in the GitHub issue to show what could happen before this change:
![creation gif issue](https://github.com/microsoft/devhome/assets/105318831/309b5099-069c-47c1-98be-eb434ac66a7d)

Now here is me going back and forth between the Hyper-V and Dev Box providers showing both providers adaptive cards get cleared from the UI


https://github.com/microsoft/devhome/assets/105318831/04f4d366-c2c1-4850-9b98-4b8007a080a2

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #2779
- [ ] Tests added/passed
- [ ] Documentation updated
