### PR TITLE
Correct styling on Environments page

### DIFF
--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -126,13 +126,13 @@
     <value>Sync</value>
     <comment>Text for the sync button on the top right side</comment>
   </data>
-  <data name="CreateEnvironmentButton.Text" xml:space="preserve">
-    <value>Create Environment</value>
+  <data name="CreateEnvironmentButton.Content" xml:space="preserve">
+    <value>+ Create environment</value>
     <comment>Text for button that will redirect the user to the Create Environment page in Dev Home</comment>
   </data>
-  <data name="Titlebar.Text" xml:space="preserve">
+  <data name="EnvironmentsHeader.Text" xml:space="preserve">
     <value>Environments</value>
-    <comment>Title text for the main landing page</comment>
+    <comment>Header text for the main landing page</comment>
   </data>
   <data name="SearchTextBox.PlaceholderText" xml:space="preserve">
     <value>Filter</value>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -255,7 +255,7 @@
                     </i:Interaction.Behaviors>
                 </ComboBox>
                 <!--  Sync button -->
-                <Button Command="{x:Bind ViewModel.SyncButtonCommand}">
+                <Button Command="{x:Bind ViewModel.SyncButtonCommand}" Margin="0 3 0 0">
                     <StackPanel Orientation="Horizontal" Padding="18 0" Spacing="8">
                         <FontIcon FontSize ="16" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
                         <TextBlock x:Uid="SyncButtonTextBlock" />

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -256,7 +256,7 @@
                 </ComboBox>
                 <!-- Sync button -->
                 <Button Command="{x:Bind ViewModel.SyncButtonCommand}" Margin="0 3 0 0">
-                    <StackPanel Orientation="Horizontal" Padding="18 0" Spacing="8">
+                    <StackPanel Orientation="Horizontal" Padding="20 0" Spacing="8">
                         <FontIcon FontSize="16" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
                         <TextBlock x:Uid="SyncButtonTextBlock" />
                     </StackPanel>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -31,7 +31,7 @@
         <Grid.Resources>
 
             <converters:EmptyCollectionToObjectConverter x:Key="EmptyCollectionVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
-            
+
             <!-- Launch Button template -->
             <DataTemplate x:Key="LaunchButton" x:DataType="vm:ComputeSystemViewModel">
                 <SplitButton
@@ -153,7 +153,7 @@
                     </Grid>
                 </Grid>
             </DataTemplate>
-            
+
             <DataTemplate x:Key="CreateComputeSystemOperationTemplate" x:DataType="vm:CreateComputeSystemOperationViewModel">
                 <Grid Style="{StaticResource HorizontalCardRootForEnvironmentsPage}">
                     <Grid.RowDefinitions>
@@ -185,85 +185,83 @@
         </Grid.Resources>
         <!-- Templates end here -->
 
-
+        <!-- Header -->
         <Grid Grid.Row="0" x:Name="TitleGrid"
-              MaxWidth="{ThemeResource MaxPageContentWidth}"  Margin="{ThemeResource HeaderMargin}">
+              MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource HeaderMargin}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" x:Uid="Titlebar" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left" x:Name="Titlebar"/>
+            <TextBlock Grid.Column="0" x:Uid="EnvironmentsHeader" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left" x:Name="EnvironmentsHeader"/>
             <Button 
                 Grid.Column="3" 
-                Style="{ThemeResource AccentButtonStyle}" 
                 HorizontalAlignment="Right"
-                Command="{x:Bind ViewModel.CreateEnvironmentButtonCommand}" >
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <FontIcon  Grid.Column="0"  Glyph="&#xE710;"/>
-                    <TextBlock Grid.Column="1" x:Uid="CreateEnvironmentButton" Margin="8 0 0 0"/>
-                </Grid>
-            </Button>
+                x:Uid="CreateEnvironmentButton"
+                Command="{x:Bind ViewModel.CreateEnvironmentButtonCommand}" />
         </Grid>
 
+        <!-- Filtering and sorting -->
         <Grid Grid.Row="1" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="10*" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
-                <!-- Search field -->
-                <AutoSuggestBox Grid.Column="0" x:Uid="SearchTextBox" x:Name="SearchTextBox" Width="250" HorizontalAlignment="Left">
+            <!-- Search field -->
+            <AutoSuggestBox Grid.Column="0" x:Uid="SearchTextBox" x:Name="SearchTextBox" Width="250" HorizontalAlignment="Left">
+                <i:Interaction.Behaviors>
+                    <ic:EventTriggerBehavior EventName="TextChanged">
+                        <ic:InvokeCommandAction
+                        Command="{x:Bind ViewModel.SearchHandlerCommand, Mode=OneWay}"
+                        CommandParameter="{Binding Text, ElementName=SearchTextBox}"/>
+                    </ic:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </AutoSuggestBox>
+            <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="16">
+                <!-- Provider field -->
+                <TextBlock x:Uid="ProviderTextBlock" VerticalAlignment="Center" />
+                <ComboBox x:Uid="ProviderSelectionComboBox"
+                          x:Name="ProviderSelectionComboBox"
+                          Margin="0 3 0 0"
+                          MinWidth="180"
+                          ItemsSource="{x:Bind ViewModel.Providers, Mode=OneWay}" 
+                          SelectedIndex="{x:Bind ViewModel.SelectedProviderIndex, Mode=TwoWay}">
                     <i:Interaction.Behaviors>
-                        <ic:EventTriggerBehavior EventName="TextChanged">
+                        <ic:EventTriggerBehavior EventName="SelectionChanged">
                             <ic:InvokeCommandAction
-                            Command="{x:Bind ViewModel.SearchHandlerCommand, Mode=OneWay}"
-                            CommandParameter="{Binding Text, ElementName=SearchTextBox}"/>
+                                Command="{x:Bind ViewModel.ProviderHandlerCommand}"
+                                CommandParameter="{Binding SelectedIndex, ElementName=ProviderSelectionComboBox, Mode=OneWay}" />
                         </ic:EventTriggerBehavior>
                     </i:Interaction.Behaviors>
-                </AutoSuggestBox>
-                <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right">
-                    <!-- Provider field -->
-                    <TextBlock x:Uid="ProviderTextBlock" VerticalAlignment="Center" Margin="50 0 5 0"/>
-                    <ComboBox x:Uid="ProviderSelectionComboBox" x:Name="ProviderSelectionComboBox" Margin="0 3 5 0"
-                        ItemsSource="{x:Bind ViewModel.Providers, Mode=OneWay}" 
-                        SelectedIndex="{x:Bind ViewModel.SelectedProviderIndex, Mode=TwoWay}">
-                        <i:Interaction.Behaviors>
-                            <ic:EventTriggerBehavior EventName="SelectionChanged">
-                            <ic:InvokeCommandAction
-                                    Command="{x:Bind ViewModel.ProviderHandlerCommand}"
-                                    CommandParameter="{Binding SelectedIndex, ElementName=ProviderSelectionComboBox, Mode=OneWay}" />
-                        </ic:EventTriggerBehavior>
-                        </i:Interaction.Behaviors>
-                    </ComboBox>
-                    <!-- Sort field -->
-                    <TextBlock x:Uid="SortByTextBlock" VerticalAlignment="Center" Margin="10 0 5 0"/>
-                    <ComboBox x:Uid="SortSelectionComboBox" x:Name="SortSelectionComboBox" Margin="0 3 13 0"
+                </ComboBox>
+                <!-- Sort field -->
+                <TextBlock x:Uid="SortByTextBlock" VerticalAlignment="Center" />
+                <ComboBox x:Uid="SortSelectionComboBox"
+                          x:Name="SortSelectionComboBox"
+                          Margin="0 3 0 0"
+                          MinWidth="236"
                           SelectedIndex="{x:Bind ViewModel.SelectedSortIndex, Mode=TwoWay}">
-                        <ComboBoxItem x:Uid="SortByName"/>
-                        <ComboBoxItem x:Uid="SortByNameDesc"/>
-                        <ComboBoxItem x:Uid="SortByAltName"/>
-                        <ComboBoxItem x:Uid="SortByAltNameDesc"/>
-                        <ComboBoxItem x:Uid="SortByLastConnected"/>
-                        <i:Interaction.Behaviors>
-                            <ic:EventTriggerBehavior EventName="SelectionChanged">
-                                <ic:InvokeCommandAction Command="{x:Bind ViewModel.SortHandlerCommand}"/>
-                            </ic:EventTriggerBehavior>
-                        </i:Interaction.Behaviors>
-                    </ComboBox>
-                    <!--  'Sync' button -->
-                    <Button Padding="40 5 30 8" Command="{x:Bind ViewModel.SyncButtonCommand}" Margin="0 3 0 0">
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
-                            <TextBlock x:Uid="SyncButtonTextBlock" Margin="8 0 0 0"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
+                    <ComboBoxItem x:Uid="SortByName"/>
+                    <ComboBoxItem x:Uid="SortByNameDesc"/>
+                    <ComboBoxItem x:Uid="SortByAltName"/>
+                    <ComboBoxItem x:Uid="SortByAltNameDesc"/>
+                    <ComboBoxItem x:Uid="SortByLastConnected"/>
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="SelectionChanged">
+                            <ic:InvokeCommandAction Command="{x:Bind ViewModel.SortHandlerCommand}"/>
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                </ComboBox>
+                <!--  Sync button -->
+                <Button Command="{x:Bind ViewModel.SyncButtonCommand}">
+                    <StackPanel Orientation="Horizontal" Padding="18 0" Spacing="8">
+                        <FontIcon FontSize ="16" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
+                        <TextBlock x:Uid="SyncButtonTextBlock" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
         </Grid>
 
         <!-- Last synced text block-->
@@ -280,7 +278,8 @@
         </Grid>
 
         <!-- Per VM/Compute System card -->
-        <ScrollViewer Grid.Row="3" Style="{StaticResource EnvironmentScrollViewerStyle}" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+        <ScrollViewer Grid.Row="3" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}"
+                      Style="{StaticResource EnvironmentScrollViewerStyle}">
             <StackPanel>
                 <ListView
                     MaxWidth="{ThemeResource MaxPageContentWidth}"

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -254,10 +254,10 @@
                         </ic:EventTriggerBehavior>
                     </i:Interaction.Behaviors>
                 </ComboBox>
-                <!--  Sync button -->
+                <!-- Sync button -->
                 <Button Command="{x:Bind ViewModel.SyncButtonCommand}" Margin="0 3 0 0">
                     <StackPanel Orientation="Horizontal" Padding="18 0" Spacing="8">
-                        <FontIcon FontSize ="16" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
+                        <FontIcon FontSize="16" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
                         <TextBlock x:Uid="SyncButtonTextBlock" />
                     </StackPanel>
                 </Button>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml.cs
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class LandingPage : ToolPage
 
         TitleGrid.Children.Add(onlyLocalButton);
 
-        var column = Grid.GetColumn(Titlebar);
+        var column = Grid.GetColumn(EnvironmentsHeader);
         Grid.SetColumn(onlyLocalButton, column + 1);
     }
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -7,6 +7,14 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Helpers\**" />
+    <Content Remove="Helpers\**" />
+    <EmbeddedResource Remove="Helpers\**" />
+    <None Remove="Helpers\**" />
+    <Page Remove="Helpers\**" />
+    <PRIResource Remove="Helpers\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Remove="Views\ExtensionLibraryView.xaml" />
@@ -32,7 +40,6 @@
 
   <ItemGroup>
     <Folder Include="Assets\" />
-    <Folder Include="Helpers\" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1821,7 +1821,7 @@
     <comment>Title for create environment review page</comment>
   </data>
   <data name="CreateEnvironmentButtonText" xml:space="preserve">
-    <value>Create Environment</value>
+    <value>Create environment</value>
   </data>
   <data name="EnvironmentCreationError" xml:space="preserve">
     <value>There was an error starting the creation operation</value>


### PR DESCRIPTION
## Summary of the pull request
Change environments header to reflect design spec
* "Create Environment" button changed to sentence case, default (not accent) style, using + character and not the icon.
* "Sync" button icon should be 16px.
* Widened "Sort" ComboBox to fit the widest option (in English) by default
* Changed some variable names from Titlebar to Header, since the title bar is a different part of Dev Home
* Fixed whitespace in xaml file (suggest reviewing PR with whitespace hidden)
* Corrected and simplified spacing and padding
* Removed an empty folder from the ExtensionLibrary project

Design spec:
![image](https://github.com/microsoft/devhome/assets/47155823/49b3cb1a-21a0-4cc0-a88a-effae8032298)

Updated Dev Home:
![image](https://github.com/microsoft/devhome/assets/47155823/661d407e-8bac-4c5d-9baf-65007e9cb135)

The + icon matches other instances in Dev Home. They will all be updated in #2855

## PR checklist
- [ ] Closes #2847
- [ ] Tests added/passed
- [ ] Documentation updated
