### PR TITLE
Add Quickstart reference sample functionality, plus UX fixes (accessibility, data binding)

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1979,14 +1979,6 @@
     <value>Select an extension provider before continuing.</value>
     <comment>Guidance text to instruct user to select a Quickstart provider before continuing</comment>
   </data>
-  <data name="QuickstartPlaygroundReferenceSample.Content" xml:space="preserve">
-    <value>Reference Sample</value>
-    <comment>Button for opening the folder of the reference sample project that was given to the model for the currently-selected extension</comment>
-  </data>
-  <data name="QuickstartPlaygroundReferenceSampleTooltip.Content" xml:space="preserve">
-    <value>Location of reference sample</value>
-    <comment>Tooltip for the button to the reference sample used for generating this project</comment>
-  </data>
   <data name="QuickstartPlaygroundReferenceSamplePrefix.Text" xml:space="preserve">
     <value>Generated based on example: </value>
     <comment>Text explaining what reference sample was used for generating the project</comment>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1979,4 +1979,28 @@
     <value>Select an extension provider before continuing.</value>
     <comment>Guidance text to instruct user to select a Quickstart provider before continuing</comment>
   </data>
+  <data name="QuickstartPlaygroundReferenceSample.Content" xml:space="preserve">
+    <value>Reference Sample</value>
+    <comment>Button for opening the folder of the reference sample project that was given to the model for the currently-selected extension</comment>
+  </data>
+  <data name="QuickstartPlaygroundReferenceSampleTooltip.Content" xml:space="preserve">
+    <value>Location of reference sample</value>
+    <comment>Tooltip for the button to the reference sample used for generating this project</comment>
+  </data>
+  <data name="QuickstartPlaygroundReferenceSamplePrefix.Text" xml:space="preserve">
+    <value>Generated based on example: </value>
+    <comment>Text explaining what reference sample was used for generating the project</comment>
+  </data>
+  <data name="QuickstartPlaygroundDislikeButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Give thumbs-down feedback on the generated project</value>
+    <comment>Label for thumbs-down button for generated Quickstart projects</comment>
+  </data>
+  <data name="QuickstartPlaygroundLikeButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Give thumbs-up feedback on the generated project</value>
+    <comment>Label for thumbs-up button for generated Quickstart projects</comment>
+  </data>
+  <data name="QuickstartPlaygroundOpenInEditor.AutomationProperties.Name" xml:space="preserve">
+    <value>Open in editor</value>
+    <comment>Label for the button to launch the project host from the selected Quickstart extension</comment>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -51,8 +51,6 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     private readonly ILocalSettingsService _localSettingsService;
 
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
-
     private readonly ObservableCollection<ExplorerItem> _dataSource = new();
 
     private IQuickStartProjectGenerationOperation _quickStartProjectGenerationOperation = null!;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -17,13 +17,13 @@ using DevHome.Common.TelemetryEvents.SetupFlow.QuickstartPlayground;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.Telemetry;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Storage;
 using Windows.Storage.Pickers;
+using Windows.System;
 using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
@@ -51,7 +51,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     private readonly ILocalSettingsService _localSettingsService;
 
-    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
     private readonly ObservableCollection<ExplorerItem> _dataSource = new();
 
@@ -103,6 +103,10 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     private Uri? _termsUri = default;
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OpenReferenceSampleCommand))]
+    private Uri? _referenceSampleUri = default;
+
+    [ObservableProperty]
     private string _outputFolderRoot = Path.Combine(Path.GetTempPath(), "DevHomeQuickstart");
 
     private string _outputFolderForCurrentPrompt = string.Empty;
@@ -119,6 +123,9 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     [ObservableProperty]
     private bool _isFileViewVisible = false;
+
+    [ObservableProperty]
+    private string _generatedFileContent = string.Empty;
 
     [ObservableProperty]
     private bool _isProgressOutputVisible = false;
@@ -281,6 +288,23 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             throw new ArgumentNullException("Error creating explorer items.");
         }
 
+        // TODO: Eventually the Dev Home UI will need to be generalized to support
+        // multiple reference samples. For now, it displays the first one returned.
+        ReferenceSampleUri = _quickStartProject.ReferenceSamples.FirstOrDefault();
+        if (ReferenceSampleUri == null)
+        {
+            _log.Error("Failed to retrieve a valid reference sample URI when setting up FileView for project");
+        }
+        else
+        {
+            _log.Information($"Using {ReferenceSampleUri.AbsoluteUri} as reference sample");
+        }
+
+        // Prepare the progress bar for the next run (this also ensures that the user doesn't see
+        // stale data from the previous run when they click generate the next time).
+        ProgressValue = 0;
+        ProgressMessage = string.Empty;
+
         IsFileViewVisible = true;
     }
 
@@ -409,6 +433,12 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             // Ensure file view isn't visible (in the case where the user has previously run a Generate command
             IsFileViewVisible = false;
 
+            // Without this, when the user generates two projects in sequence, the text box
+            // will contain any text from last-opened file in the previous project (which is
+            // confusing as this project may not have anything to do with the current one). This
+            // ensures that the file view is back to a known, clean state.
+            GeneratedFileContent = string.Empty;
+
             // Temporarily turn off the provider combobox and ensure user cannot edit the prompt for the moment
             EnableQuickstartProjectCombobox = false;
             IsPromptTextBoxReadOnly = true;
@@ -461,6 +491,25 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
         TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundLaunchProjectClicked");
         var projectHostToLaunch = projectHost ?? QuickStartProjectHosts[0];
         await Task.Run(projectHostToLaunch.Launch);
+    }
+
+    private bool EnableReferenceSample()
+    {
+        return ReferenceSampleUri != null;
+    }
+
+    [RelayCommand(CanExecute = nameof(EnableReferenceSample))]
+    private async Task OpenReferenceSample()
+    {
+        if (ReferenceSampleUri != null)
+        {
+            _log.Information("Launching reference sample for generated project");
+            await Launcher.LaunchUriAsync(ReferenceSampleUri);
+        }
+        else
+        {
+            _log.Error("User has requested to see reference sample but the URI from the extension is null.");
+        }
     }
 
     public void ProvideFeedback(bool isPositive, string feedback)
@@ -517,6 +566,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             EnableProjectButtons = false;
             IsQuickstartProjectComboboxExpanded = false;
             PromptTextBoxPlaceholder = StringResource.GetLocalized("QuickstartPlaygroundGenerationPromptPlaceholder");
+            ReferenceSampleUri = null;
 
             // Update our setting to indicate the user preference
             _localSettingsService.SaveSettingAsync("QuickstartPlaygroundSelectedProvider", ActiveQuickstartSelection.DisplayName);

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -17,7 +17,6 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
-            <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
             <converters:BoolToObjectConverter x:Key="BoolToOpacityConverter" TrueValue="1" FalseValue="0.4" />
             <x:Double x:Key="SettingsCardHeaderIconMaxSize">32</x:Double>
 
@@ -172,7 +171,7 @@
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                            AutomationProperties.AccessibilityView="Control"
                                            ActionIcon="{x:Null}" 
-                                           Visibility="{x:Bind ViewModel.EnableQuickstartPlayground, Mode=TwoWay, Converter={StaticResource BoolToVisibilityConverter}}" >
+                                           Visibility="{x:Bind ViewModel.EnableQuickstartPlayground}" >
                             <ctControls:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_QuickstartPlayground.png" />
                             </ctControls:SettingsCard.HeaderIcon>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
@@ -16,17 +16,18 @@
             <Button x:Uid="QuickstartPlaygroundSaveButton"
                     Command="{x:Bind ViewModel.SaveProjectCommand}"
                     Margin="4, 0"
-                    TabIndex="31" />
+                    TabIndex="30" />
             <Button Command="{x:Bind ViewModel.LaunchProjectHostCommand}"
                     Style="{ThemeResource AccentButtonStyle}"
                     Visibility="{x:Bind ViewModel.IsLaunchButtonVisible, Mode=OneWay}"
                     Margin="4, 0"
                     Content="{x:Bind ViewModel.LaunchButtonText, Mode=OneWay}"
-                    TabIndex="30"/>
+                    TabIndex="31"/>
             <DropDownButton x:Uid="QuickstartPlaygroundLaunchDropDownButton"
                     Visibility="{x:Bind ViewModel.IsLaunchDropDownVisible, Mode=OneWay}"
                     Style="{ThemeResource AccentButtonStyle}"
-                    Margin="4, 0">
+                    Margin="4, 0"
+                    TabIndex="32">
                 <DropDownButton.Flyout>
                     <MenuFlyout x:Name="DropDownButtonFlyout" />
                 </DropDownButton.Flyout>
@@ -227,92 +228,105 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="8" HorizontalAlignment="Left">
-                        <TextBlock x:Uid="QuickstartPlaygroundGenerationOutputLabel"
-                                   Margin="2, 20, 20, 20"/>
-                        <StackPanel Orientation="Horizontal" Margin="8" HorizontalAlignment="Right">
-                            <Button x:Name="positiveFeedbackButton"
-                                    AutomationProperties.LabeledBy="{Binding ElementName=PositiveFeedbackToolTip}"
-                                    Margin="4,0"
-                                    VerticalAlignment="Bottom"
-                                    TabIndex="20">
-                                <FontIcon Glyph="👍" FontFamily="Segoe Fluent" />
-                                <Button.Flyout>
-                                    <Flyout x:Name="positiveFeedbackFlyout" Closed="PositiveFeedbackFlyout_Closed">
-                                        <StackPanel>
-                                            <FontIcon Glyph="👍" FontFamily="Segoe Fluent"/>
-                                            <TextBlock x:Uid="QuickstartPlaygroundFeedbackHeader"
-                                                       x:Name="posProvideAddtionalFeedbackText"
-                                                       Style="{ThemeResource BaseTextBlockStyle}"
-                                                       Visibility="{x:Bind ViewModel.PositivesGroupOne, Mode=OneWay}"/>
-                                            <TextBox x:Uid="QuickstartPlaygroundPositiveFeedbackPromptPlaceholder"
-                                                     Margin="4"
-                                                     x:Name="positiveFeedbackTextBox"
-                                                     TextWrapping="Wrap"
-                                                     Visibility="{x:Bind ViewModel.PositivesGroupOne, Mode=OneWay}" />
-                                            <Button x:Uid="QuickstartPlaygroundSubmitFeedback"
-                                                    x:Name="posSubmitFeedbackButton"
-                                                    Click="PositiveFeedbackConfirmation_Click"
-                                                    HorizontalAlignment="Right"
-                                                    Visibility="{x:Bind ViewModel.PositivesGroupOne, Mode=OneWay}"/>
-                                            <TextBlock x:Uid="QuickstartPlaygroundFeedbackSubmitted"
-                                                       x:Name="posFeedbackSuccessText"
-                                                       Style="{ThemeResource BaseTextBlockStyle}"
-                                                       Visibility="{x:Bind ViewModel.PositivesGroupTwo, Mode=OneWay}"/>
-                                            <Button x:Uid="CloseButton"
-                                                    x:Name="posCloseFlyoutButton"
-                                                    Click="PosCloseFlyout_Click"
-                                                    HorizontalAlignment="Right"
-                                                    Visibility="{x:Bind ViewModel.PositivesGroupTwo, Mode=OneWay}"/>
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                                <ToolTipService.ToolTip>
-                                    <ToolTip x:Name="PositiveFeedbackToolTip" x:Uid="QuickstartPlaygroundFeedbackLikeTooltip"/>
-                                </ToolTipService.ToolTip>
-                            </Button>
-                            <Button x:Name="negativeFeedbackButton"
-                                    AutomationProperties.LabeledBy="{Binding ElementName=NegativeFeedbackToolTip}"
-                                    Margin="4,0"
-                                    VerticalAlignment="Bottom"
-                                    TabIndex="21">
-                                <FontIcon Glyph="👎" FontFamily="Segoe Fluent" />
-                                <Button.Flyout>
-                                    <Flyout x:Name="negativeFeedbackFlyout" Closed="NegativeFeedbackFlyout_Closed">
-                                        <StackPanel>
-                                            <FontIcon Glyph="👎" FontFamily="Segoe Fluent"/>
-                                            <TextBlock x:Uid="QuickstartPlaygroundFeedbackHeader"
-                                                       x:Name="negProvideAddtionalFeedbackText"
-                                                       Style="{ThemeResource BaseTextBlockStyle}"
-                                                       Visibility="{x:Bind ViewModel.NegativesGroupOne, Mode=OneWay}"/>
-                                            <TextBox x:Uid="QuickstartPlaygroundNegativeFeedbackPromptPlaceholder"
-                                                     x:Name="negativeFeedbackTextBox"
-                                                     Margin="4"
-                                                     TextWrapping="Wrap"
-                                                     Visibility="{x:Bind ViewModel.NegativesGroupOne, Mode=OneWay}"/>
-                                            <Button x:Uid="QuickstartPlaygroundSubmitFeedback"
-                                                    x:Name="negSubmitFeedbackButton"
-                                                    Click="NegativeFeedbackConfirmation_Click"
-                                                    HorizontalAlignment="Right"
-                                                    Visibility="{x:Bind ViewModel.NegativesGroupOne, Mode=OneWay}"/>
-                                            <TextBlock x:Uid="QuickstartPlaygroundFeedbackSubmitted"
-                                                       x:Name="negFeedbackSuccessText"
-                                                       Style="{ThemeResource BaseTextBlockStyle}"
-                                                       Visibility="{x:Bind ViewModel.NegativesGroupTwo, Mode=OneWay}"/>
-                                            <Button x:Uid="CloseButton"
-                                                    x:Name="negCloseFlyoutButton"
-                                                    Click="NegCloseFlyout_Click"
-                                                    HorizontalAlignment="Right"
-                                                    Visibility="{x:Bind ViewModel.NegativesGroupTwo, Mode=OneWay}"/>
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                                <ToolTipService.ToolTip>
-                                    <ToolTip x:Name="NegativeFeedbackToolTip"  x:Uid="QuickstartPlaygroundFeedbackDislikeTooltip"/>
-                                </ToolTipService.ToolTip>
-                            </Button>
+                    <Grid Grid.Row="1" HorizontalAlignment="Stretch">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="8" HorizontalAlignment="Left">
+                            <TextBlock x:Uid="QuickstartPlaygroundGenerationOutputLabel"
+                                       Margin="2, 20, 20, 20"/>
+                            <StackPanel Orientation="Horizontal" Margin="8" HorizontalAlignment="Right">
+                                <Button x:Name="positiveFeedbackButton"
+                                        x:Uid="QuickstartPlaygroundLikeButton"
+                                        Margin="4,0"
+                                        VerticalAlignment="Bottom"
+                                        TabIndex="20">
+                                    <FontIcon Glyph="👍" FontFamily="Segoe Fluent" />
+                                    <Button.Flyout>
+                                        <Flyout x:Name="positiveFeedbackFlyout" Closed="PositiveFeedbackFlyout_Closed">
+                                            <StackPanel>
+                                                <FontIcon Glyph="👍" FontFamily="Segoe Fluent"/>
+                                                <TextBlock x:Uid="QuickstartPlaygroundFeedbackHeader"
+                                                           x:Name="posProvideAddtionalFeedbackText"
+                                                           Style="{ThemeResource BaseTextBlockStyle}"
+                                                           Visibility="{x:Bind ViewModel.PositivesGroupOne, Mode=OneWay}"/>
+                                                <TextBox x:Uid="QuickstartPlaygroundPositiveFeedbackPromptPlaceholder"
+                                                         Margin="4"
+                                                         x:Name="positiveFeedbackTextBox"
+                                                         TextWrapping="Wrap"
+                                                         Visibility="{x:Bind ViewModel.PositivesGroupOne, Mode=OneWay}" />
+                                                <Button x:Uid="QuickstartPlaygroundSubmitFeedback"
+                                                        x:Name="posSubmitFeedbackButton"
+                                                        Click="PositiveFeedbackConfirmation_Click"
+                                                        HorizontalAlignment="Right"
+                                                        Visibility="{x:Bind ViewModel.PositivesGroupOne, Mode=OneWay}"/>
+                                                <TextBlock x:Uid="QuickstartPlaygroundFeedbackSubmitted"
+                                                           x:Name="posFeedbackSuccessText"
+                                                           Style="{ThemeResource BaseTextBlockStyle}"
+                                                           Visibility="{x:Bind ViewModel.PositivesGroupTwo, Mode=OneWay}"/>
+                                                <Button x:Uid="CloseButton"
+                                                        x:Name="posCloseFlyoutButton"
+                                                        Click="PosCloseFlyout_Click"
+                                                        HorizontalAlignment="Right"
+                                                        Visibility="{x:Bind ViewModel.PositivesGroupTwo, Mode=OneWay}"/>
+                                            </StackPanel>
+                                        </Flyout>
+                                    </Button.Flyout>
+                                    <ToolTipService.ToolTip>
+                                        <ToolTip x:Name="PositiveFeedbackToolTip" x:Uid="QuickstartPlaygroundFeedbackLikeTooltip"/>
+                                    </ToolTipService.ToolTip>
+                                </Button>
+                                <Button x:Name="negativeFeedbackButton"
+                                        x:Uid="QuickstartPlaygroundDislikeButton"
+                                        Margin="4,0"
+                                        VerticalAlignment="Bottom"
+                                        TabIndex="21">
+                                    <FontIcon Glyph="👎" FontFamily="Segoe Fluent" />
+                                    <Button.Flyout>
+                                        <Flyout x:Name="negativeFeedbackFlyout" Closed="NegativeFeedbackFlyout_Closed">
+                                            <StackPanel>
+                                                <FontIcon Glyph="👎" FontFamily="Segoe Fluent"/>
+                                                <TextBlock x:Uid="QuickstartPlaygroundFeedbackHeader"
+                                                           x:Name="negProvideAddtionalFeedbackText"
+                                                           Style="{ThemeResource BaseTextBlockStyle}"
+                                                           Visibility="{x:Bind ViewModel.NegativesGroupOne, Mode=OneWay}"/>
+                                                <TextBox x:Uid="QuickstartPlaygroundNegativeFeedbackPromptPlaceholder"
+                                                         x:Name="negativeFeedbackTextBox"
+                                                         Margin="4"
+                                                         TextWrapping="Wrap"
+                                                         Visibility="{x:Bind ViewModel.NegativesGroupOne, Mode=OneWay}"/>
+                                                <Button x:Uid="QuickstartPlaygroundSubmitFeedback"
+                                                        x:Name="negSubmitFeedbackButton"
+                                                        Click="NegativeFeedbackConfirmation_Click"
+                                                        HorizontalAlignment="Right"
+                                                        Visibility="{x:Bind ViewModel.NegativesGroupOne, Mode=OneWay}"/>
+                                                <TextBlock x:Uid="QuickstartPlaygroundFeedbackSubmitted"
+                                                           x:Name="negFeedbackSuccessText"
+                                                           Style="{ThemeResource BaseTextBlockStyle}"
+                                                           Visibility="{x:Bind ViewModel.NegativesGroupTwo, Mode=OneWay}"/>
+                                                <Button x:Uid="CloseButton"
+                                                        x:Name="negCloseFlyoutButton"
+                                                        Click="NegCloseFlyout_Click"
+                                                        HorizontalAlignment="Right"
+                                                        Visibility="{x:Bind ViewModel.NegativesGroupTwo, Mode=OneWay}"/>
+                                            </StackPanel>
+                                        </Flyout>
+                                    </Button.Flyout>
+                                    <ToolTipService.ToolTip>
+                                        <ToolTip x:Name="NegativeFeedbackToolTip" x:Uid="QuickstartPlaygroundFeedbackDislikeTooltip"/>
+                                    </ToolTipService.ToolTip>
+                                </Button>
+                            </StackPanel>
                         </StackPanel>
-                    </StackPanel>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="8" HorizontalAlignment="Right">
+                            <TextBlock x:Uid="QuickstartPlaygroundReferenceSamplePrefix" VerticalAlignment="Center"/>
+                            <TextBlock xmlns:ui="using:CommunityToolkit.WinUI" VerticalAlignment="Center" Margin="5" >
+                                    <Hyperlink ui:HyperlinkExtensions.Command="{x:Bind ViewModel.OpenReferenceSampleCommand}"
+                                               ui:HyperlinkExtensions.CommandParameter="{Binding}">[1]</Hyperlink>
+                            </TextBlock>
+                        </StackPanel>
+                    </Grid>
                     <Grid x:Name="FileView" 
                           Grid.Row="2" 
                           BorderBrush="{ThemeResource TextControlElevationBorderBrush}" 
@@ -355,21 +369,22 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <TreeView x:Name="FolderHierarchy"
-                          Grid.Column="0" 
-                          Height="Auto" 
-                          Margin="20" 
-                          ItemsSource="{x:Bind ViewModel.DataSource, Mode=OneWay}" 
-                          ItemTemplateSelector="{StaticResource ExplorerItemTemplateSelector}" 
-                          ItemInvoked="FolderHierarchy_ItemInvoked"
-                          TabIndex="22"/>
+                                  Grid.Column="0" 
+                                  Height="Auto" 
+                                  Margin="20" 
+                                  ItemsSource="{x:Bind ViewModel.DataSource, Mode=OneWay}" 
+                                  ItemTemplateSelector="{StaticResource ExplorerItemTemplateSelector}" 
+                                  ItemInvoked="FolderHierarchy_ItemInvoked"
+                                  TabIndex="23"/>
                         <TextBlock x:Name="GeneratedFileContent"
-                           Grid.Column="1"
-                           FontFamily="{StaticResource CascadiaMonoFontFamily}"
-                           Margin="20"
-                           IsTextSelectionEnabled="True"
-                           TextWrapping="Wrap"
-                           IsTabStop="True"
-                           TabIndex="23">
+                                   Text="{x:Bind ViewModel.GeneratedFileContent, Mode=OneWay}"
+                                   Grid.Column="1"
+                                   FontFamily="{StaticResource CascadiaMonoFontFamily}"
+                                   Margin="20"
+                                   IsTextSelectionEnabled="True"
+                                   TextWrapping="Wrap"
+                                   IsTabStop="True"
+                                   TabIndex="24">
                         </TextBlock>
                     </Grid>
                 </Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
@@ -67,14 +67,14 @@ public sealed partial class QuickstartPlaygroundView : UserControl
         {
             if (item.Type == ExplorerItem.ExplorerItemType.Folder)
             {
-                GeneratedFileContent.Text = string.Empty;
+                ViewModel.GeneratedFileContent = string.Empty;
             }
             else
             {
                 // TODO: should theoretically do this more efficiently instead of re-reading the file
                 if (item.FullPath != null)
                 {
-                    GeneratedFileContent.Text = File.ReadAllText(item.FullPath);
+                    ViewModel.GeneratedFileContent = File.ReadAllText(item.FullPath);
                 }
             }
         }


### PR DESCRIPTION
## Summary of the pull request
This change adds functionality to the new Quickstart Playground feature to allow implementing extensions to show the user any reference data that went into producing the project. 

## References and relevant issues

## Detailed description of the pull request / Additional comments
In the Quickstart Playground experimental feature, this change exposes a button that the user can click on in the user interface to view the sample directory corresponding to the closest "match" for the user's input prompt (there are supporting changes being made on the Azure extension side that pair with this change). It also includes the supporting scaffolding in the ViewModel to enable this.

As part of this change, we also fix an issue with the View retaining stale data (i.e., progress bar state and last-opened file) from the prior project generation attempt.

This change also addresses some accessibility issues:

* Added a WrapPanel for ensuring the sample prompts aren't truncated when the window is made smaller horizontally.
* Added labels for the feedback buttons
* Added labels for the Open in Visual Studio Code button
* Making the TextBlock with the generated file content a tab stop

## Validation steps performed
I manually ran through the new behavior and verified that I could view the reference sample (the explorer window below was opened via the link under the Generate button). 

![image](https://github.com/microsoft/devhome/assets/8368026/c345114d-251b-4f55-aa10-66556fee12ee)

I ran Narrator and Accessibility Insights cleanly, and visually verified the behavior of the controls that are now wrapping. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
