### PR TITLE
Replace toggle split button with two separate buttons in DSC page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1050,11 +1050,11 @@
   </data>
   <data name="SetUpAsAdmin.Content" xml:space="preserve">
     <value>Set up as admin</value>
-    <comment>Text shown on a split button for setting up configuration as admin</comment>
+    <comment>Text shown on a button for setting up configuration as admin</comment>
   </data>
-  <data name="SetUpAsNonAdmin.Text" xml:space="preserve">
+  <data name="SetUpAsNonAdmin.Content" xml:space="preserve">
     <value>Set up as non-admin</value>
-    <comment>Text shown on a split button for setting up configuration as non-admin</comment>
+    <comment>Text shown on a button for setting up configuration as non-admin</comment>
   </data>
   <data name="SummaryPageAppsDownloadedCount" xml:space="preserve">
     <value>Applications installed</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
@@ -23,22 +23,10 @@
             IsChecked="{x:Bind ViewModel.ReadAndAgree, Mode=TwoWay}"/>
     </setupFlowBehaviors:SetupFlowNavigationBehavior.ContentTemplate>
     <setupFlowBehaviors:SetupFlowNavigationBehavior.NextTemplate>
-        <ToggleSplitButton
-            x:Name="SetUpButton"
-            IsEnabled="{x:Bind ViewModel.ReadAndAgree, Mode=OneWay}"
-            IsEnabledChanged="SetUpButton_IsEnabledChanged"
-            IsCheckedChanged="SetUpButton_IsCheckedChanged"
-            Command="{x:Bind ViewModel.ConfigureAsAdminCommand, Mode=OneWay}"
-            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SetUpAsAdmin">
-            <SplitButton.Flyout>
-                <MenuFlyout>
-                    <MenuFlyoutItem
-                        x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SetUpAsNonAdmin"
-                        Command="{x:Bind ViewModel.ConfigureAsNonAdminCommand}">
-                    </MenuFlyoutItem>
-                </MenuFlyout>
-            </SplitButton.Flyout>
-        </ToggleSplitButton>
+        <StackPanel Orientation="Horizontal" Spacing="4">
+            <Button x:Uid="SetUpAsNonAdmin" Command="{x:Bind ViewModel.ConfigureAsNonAdminCommand}"/>
+            <Button x:Uid="SetUpAsAdmin" Command="{x:Bind ViewModel.ConfigureAsAdminCommand}"/>
+        </StackPanel>
     </setupFlowBehaviors:SetupFlowNavigationBehavior.NextTemplate>
 
     <UserControl.Resources>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
@@ -23,7 +23,12 @@
             IsChecked="{x:Bind ViewModel.ReadAndAgree, Mode=TwoWay}"/>
     </setupFlowBehaviors:SetupFlowNavigationBehavior.ContentTemplate>
     <setupFlowBehaviors:SetupFlowNavigationBehavior.NextTemplate>
-        <StackPanel Orientation="Horizontal" Spacing="4">
+        <StackPanel Orientation="Horizontal">
+            <StackPanel.Resources>
+                <Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+                    <Setter Property="Margin" Value="6,0" />
+                </Style>
+            </StackPanel.Resources>
             <Button x:Uid="SetUpAsNonAdmin" Command="{x:Bind ViewModel.ConfigureAsNonAdminCommand}"/>
             <Button x:Uid="SetUpAsAdmin" Command="{x:Bind ViewModel.ConfigureAsAdminCommand}"/>
         </StackPanel>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml.cs
@@ -18,19 +18,6 @@ public sealed partial class ConfigurationFileView : UserControl
         this.InitializeComponent();
     }
 
-    private void SetUpButton_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
-    {
-        // Align the checked state with the enabled state.
-        SetUpButton.IsChecked = SetUpButton.IsEnabled;
-    }
-
-    private void SetUpButton_IsCheckedChanged(ToggleSplitButton sender, ToggleSplitButtonIsCheckedChangedEventArgs args)
-    {
-        // When the toggle button is invoked, its state is changed.
-        // Always mark the toggle button as checked to ensure it visually looks toggled ON.
-        SetUpButton.IsChecked = true;
-    }
-
     private async void Dependency_Click(Hyperlink sender, HyperlinkClickEventArgs args)
     {
         var textBlock = sender?.ContentStart?.VisualParent as TextBlock;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupFlowPage.xaml
@@ -102,12 +102,12 @@
                             <HyperlinkButton
                                 AutomationProperties.AutomationControlType="Button"
                                 Command="{x:Bind ViewModel.CancelCommand, Mode=OneWay}"
-                                MinWidth="120" Margin="4,0"
+                                MinWidth="120" Margin="6,0"
                                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Cancel"
                                 Visibility="{x:Bind ViewModel.Orchestrator.ShouldShowDoneButton, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"/>
                             <Button
                                 Command="{x:Bind ViewModel.CancelCommand, Mode=OneWay}"
-                                MinWidth="120" Margin="4,0"
+                                MinWidth="120" Margin="6,0"
                                 x:Uid="ms-resource:///DevHome.SetupFlow/Resources/DoneButton"
                                 Visibility="{x:Bind ViewModel.Orchestrator.ShouldShowDoneButton, Mode=OneWay}"/>
                         </Grid>
@@ -115,7 +115,7 @@
                     <setupFlowBehaviors:SetupFlowNavigationBehavior.DefaultPreviousTemplate>
                         <Button
                             Command="{x:Bind ViewModel.Orchestrator.GoToPreviousPageCommand, Mode=OneWay}"
-                            MinWidth="120" Margin="4,0"
+                            MinWidth="120" Margin="6,0"
                             Visibility="{x:Bind ViewModel.Orchestrator.HasPreviousPage, Mode=OneWay}"
                             x:Uid="ms-resource:///DevHome.SetupFlow/Resources/Previous" />
                     </setupFlowBehaviors:SetupFlowNavigationBehavior.DefaultPreviousTemplate>
@@ -126,7 +126,7 @@
                             <Button
                                 Command="{x:Bind ViewModel.Orchestrator.GoToNextPageCommand, Mode=OneWay}"
                                 Style="{StaticResource AccentButtonStyle}"
-                                MinWidth="120" Margin="4,0"
+                                MinWidth="120" Margin="6,0"
                                 Content="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonText, Mode=OneWay}"
                                 ToolTipService.ToolTip="{x:Bind ViewModel.Orchestrator.CurrentPageViewModel.NextPageButtonToolTipText, Mode=OneWay}" />
                         </Grid>


### PR DESCRIPTION
## Summary of the pull request
- Replace toggle split button with two separate buttons in DSC page
- Margin 4 to 6px per design

### Before
![image](https://github.com/microsoft/devhome/assets/104940545/d3b728f4-b4c1-4c45-bc1d-b377cbbdc9bb)

### After
![image](https://github.com/microsoft/devhome/assets/104940545/a28332dd-e936-4353-bba5-6e8edacda95c)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2739
- [ ] Tests added/passed
- [ ] Documentation updated
