### PR TITLE
fix crashing due to null exception in compute system cache

### DIFF
--- a/common/Environments/Models/ComputeSystemCache.cs
+++ b/common/Environments/Models/ComputeSystemCache.cs
@@ -229,8 +229,8 @@ public class ComputeSystemCache
         builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem name: {DisplayName} ");
         builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem SupplementalDisplayName: {SupplementalDisplayName} ");
         builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem associated Provider Id : {AssociatedProviderId} ");
-        builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem associated developerId LoginId: {AssociatedDeveloperId?.Value.LoginId} ");
-        builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem associated developerId Url: {AssociatedDeveloperId?.Value.Url} ");
+        builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem associated developerId LoginId: {AssociatedDeveloperId?.Value?.LoginId} ");
+        builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem associated developerId Url: {AssociatedDeveloperId?.Value?.Url} ");
 
         var supportedOperations = EnumHelper.SupportedOperationsToString<ComputeSystemOperations>(SupportedOperations.Value);
         builder.AppendLine(CultureInfo.InvariantCulture, $"ComputeSystem supported operations : {string.Join(",", supportedOperations)} ");


### PR DESCRIPTION
## Summary of the pull request
This PR fixes a crashing issue where we look at the lazy loaded value of a DeveloperID without a null check on the value.

Video of me invoking each operation without crashing Dev Home:

https://github.com/microsoft/devhome/assets/105318831/16967397-a1f4-463d-8e17-2be99f70df66


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Confirmed all hyper-v operations do not crash dev home.
Note: Once #2861 is fixed the state of the card should be updated correctly

## PR checklist
- [x] Closes #2867
- [ ] Tests added/passed
- [ ] Documentation updated
