### PR TITLE
Fixing buildType entry for Quickstart Playground experimental feature

### DIFF
--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -81,7 +81,7 @@
           "visible": true
         },
         {
-          "buildType": "release",
+          "buildType": "stable",
           "enabledByDefault": false,
           "visible": true
         }


### PR DESCRIPTION
## Summary of the pull request
This fixes the buildType NavConfig.jsonc entry for the Quickstart Playground experimental feature. 

## References and relevant issues
#2878 

## Detailed description of the pull request / Additional comments
The documentation describes the supported values: https://github.com/microsoft/devhome/blob/main/docs/tools/ExperimentalFeatures.md

Beyond the scope of this fix: it'd be interesting to think about whether Dev Home could / should do any validation of the .jsonc file to ensure that values like this fall into the expected range. Noting that here for now, can file an issue if it seems righteous. 

Thanks to @jaholme for noticing this issue!

## Validation steps performed
I verified that the solution still builds and runs as expected. 

## PR checklist
- [ ] Closes #2878 
- [ ] Tests added/passed
- [ ] Documentation updated
