### PR TITLE
Fix Quitckstart Extension Provider ComboBox UI

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
@@ -57,7 +57,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <StackPanel Orientation="Vertical" Grid.Row="0">
-                        <Grid>
+                        <Grid Margin="0, 0, 0, 30">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="1*"/>
                                 <ColumnDefinition Width="1*"/>


### PR DESCRIPTION
## Summary of the pull request
Fix overlap of UI components

## References and relevant issues

## Detailed description of the pull request / Additional comments
When there are no extension providers available, the UI overlaps with other content, so added a margin to the Grid component

## Validation steps performed
Before:
![before](https://github.com/microsoft/devhome/assets/169488102/8b5d4b03-4f7e-4adb-a90a-6317066e8fc3)


After:
<img width="913" alt="after" src="https://github.com/microsoft/devhome/assets/169488102/78f01cf7-1809-4efc-b39d-93b50d9ae981">

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
