### PR TITLE
Add a few more fixes for environments

### DIFF
--- a/common/Environments/Helpers/ComputeSystemHelpers.cs
+++ b/common/Environments/Helpers/ComputeSystemHelpers.cs
@@ -130,6 +130,17 @@ public static class ComputeSystemHelpers
         return new(navigateToExtensionsLibrary, callToActionText, callToActionHyperLinkText);
     }
 
+    /// <summary>
+    /// Safely remove all items from an observable collection.
+    /// </summary>
+    /// <remarks>
+    /// There can be random COM exceptions due to using the "Clear()" method in an observable collection. This method
+    /// is used so that we can safely clear the observable collection without throwing an exceptions. This is related
+    /// to this GitHub issue https://github.com/microsoft/microsoft-ui-xaml/issues/8684. To work around this,
+    /// this method is used to remove all items individually from the end of the collection to the beginning of the collection.
+    /// </remarks>
+    /// <typeparam name="T">Type of objects that the collection contains</typeparam>
+    /// <param name="collection">An observable collection that contains zero to N elements</param>
     public static void RemoveAllItems<T>(ObservableCollection<T> collection)
     {
         try

--- a/common/Environments/Helpers/ComputeSystemHelpers.cs
+++ b/common/Environments/Helpers/ComputeSystemHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
@@ -15,6 +16,8 @@ namespace DevHome.Common.Environments.Helpers;
 
 public static class ComputeSystemHelpers
 {
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemHelpers));
+
     public static async Task<byte[]?> GetBitmapImageArrayAsync(ComputeSystemCache computeSystem)
     {
         try
@@ -23,7 +26,7 @@ public static class ComputeSystemHelpers
 
             if ((result.Result.Status == ProviderOperationStatus.Failure) || (result.ThumbnailInBytes.Length <= 0))
             {
-                Log.Error($"Failed to get thumbnail for compute system {computeSystem}. Error: {result.Result.DiagnosticText}");
+                _log.Error($"Failed to get thumbnail for compute system {computeSystem}. Error: {result.Result.DiagnosticText}");
 
                 // No thumbnail available, return null so that the card will display the default image.
                 return null;
@@ -33,7 +36,7 @@ public static class ComputeSystemHelpers
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"Failed to get thumbnail for compute system {computeSystem}.");
+            _log.Error(ex, $"Failed to get thumbnail for compute system {computeSystem}.");
             return null;
         }
     }
@@ -48,7 +51,7 @@ public static class ComputeSystemHelpers
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Failed to get thumbnail from a byte array.");
+            _log.Error(ex, "Failed to get thumbnail from a byte array.");
             return null;
         }
     }
@@ -74,7 +77,7 @@ public static class ComputeSystemHelpers
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"Failed to get all ComputeSystemCardProperties.");
+            _log.Error(ex, $"Failed to get all ComputeSystemCardProperties.");
             return propertyList;
         }
     }
@@ -88,7 +91,7 @@ public static class ComputeSystemHelpers
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"Failed to get all properties for compute system {computeSystem}.");
+            _log.Error(ex, $"Failed to get all properties for compute system {computeSystem}.");
             return new List<CardProperty>();
         }
     }
@@ -125,5 +128,20 @@ public static class ComputeSystemHelpers
         }
 
         return new(navigateToExtensionsLibrary, callToActionText, callToActionHyperLinkText);
+    }
+
+    public static void RemoveAllItems<T>(ObservableCollection<T> collection)
+    {
+        try
+        {
+            for (var i = collection.Count - 1; i >= 0; i--)
+            {
+                collection.RemoveAt(i);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Unable to remove items from the collection");
+        }
     }
 }

--- a/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
@@ -106,10 +106,16 @@ public class DataExtractor
                 _stringResource.GetLocalized("Operations_ShutDown"), "\uE71A", computeSystem.ShutDownAsync, ComputeSystemOperations.ShutDown));
         }
 
+        if (supportedOperations.HasFlag(ComputeSystemOperations.Save))
+        {
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Save"), "\uE74E", computeSystem.SaveAsync, ComputeSystemOperations.Save));
+        }
+
         if (supportedOperations.HasFlag(ComputeSystemOperations.CreateSnapshot))
         {
             operations.Add(new OperationsViewModel(
-                _stringResource.GetLocalized("Operations_CreateSnapshot"), "\uE7C1", computeSystem.CreateSnapshotAsync, ComputeSystemOperations.CreateSnapshot));
+                _stringResource.GetLocalized("Operations_CreateCheckpoint"), "\uE7C1", computeSystem.CreateSnapshotAsync, ComputeSystemOperations.CreateSnapshot));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.RevertSnapshot))
@@ -134,12 +140,6 @@ public class DataExtractor
         {
             operations.Add(new OperationsViewModel(
                 _stringResource.GetLocalized("Operations_Terminate"), "\uEE95", computeSystem.TerminateAsync, ComputeSystemOperations.Terminate));
-        }
-
-        if (supportedOperations.HasFlag(ComputeSystemOperations.Save))
-        {
-            operations.Add(new OperationsViewModel(
-                _stringResource.GetLocalized("Operations_Save"), "\uE74E", computeSystem.SaveAsync, ComputeSystemOperations.Save));
         }
 
         return operations;

--- a/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
@@ -28,7 +28,8 @@ public class DataExtractor
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.Restart))
         {
-            operations.Add(new OperationsViewModel("Restart", "\uE777", computeSystem.RestartAsync, ComputeSystemOperations.Restart));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Restart"), "\uE777", computeSystem.RestartAsync, ComputeSystemOperations.Restart));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.Delete))
@@ -95,37 +96,50 @@ public class DataExtractor
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.Start))
         {
-            operations.Add(new OperationsViewModel("Start", "\uE768", computeSystem.StartAsync, ComputeSystemOperations.Start));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Start"), "\uE768", computeSystem.StartAsync, ComputeSystemOperations.Start));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.ShutDown))
         {
-            operations.Add(new OperationsViewModel("Stop", "\uE71A", computeSystem.ShutDownAsync, ComputeSystemOperations.ShutDown));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_ShutDown"), "\uE71A", computeSystem.ShutDownAsync, ComputeSystemOperations.ShutDown));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.CreateSnapshot))
         {
-            operations.Add(new OperationsViewModel("Checkpoint", "\uE7C1", computeSystem.CreateSnapshotAsync, ComputeSystemOperations.CreateSnapshot));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_CreateSnapshot"), "\uE7C1", computeSystem.CreateSnapshotAsync, ComputeSystemOperations.CreateSnapshot));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.RevertSnapshot))
         {
-            operations.Add(new OperationsViewModel("Revert", "\uE7A7", computeSystem.RevertSnapshotAsync, ComputeSystemOperations.RevertSnapshot));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_RevertCheckpoint"), "\uE7A7", computeSystem.RevertSnapshotAsync, ComputeSystemOperations.RevertSnapshot));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.Pause))
         {
-            operations.Add(new OperationsViewModel("Pause", "\uE769", computeSystem.PauseAsync, ComputeSystemOperations.Pause));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Pause"), "\uE769", computeSystem.PauseAsync, ComputeSystemOperations.Pause));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.Resume))
         {
-            operations.Add(new OperationsViewModel("Resume", "\uE768", computeSystem.ResumeAsync, ComputeSystemOperations.Resume));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Resume"), "\uE768", computeSystem.ResumeAsync, ComputeSystemOperations.Resume));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.Terminate))
         {
-            operations.Add(new OperationsViewModel("Terminate", "\uEE95", computeSystem.TerminateAsync, ComputeSystemOperations.Terminate));
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Terminate"), "\uEE95", computeSystem.TerminateAsync, ComputeSystemOperations.Terminate));
+        }
+
+        if (supportedOperations.HasFlag(ComputeSystemOperations.Save))
+        {
+            operations.Add(new OperationsViewModel(
+                _stringResource.GetLocalized("Operations_Save"), "\uE74E", computeSystem.SaveAsync, ComputeSystemOperations.Save));
         }
 
         return operations;

--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -289,7 +289,7 @@
     <value>Do you want to delete your environment?</value>
     <comment>Text for the title of the delete environment confirmation popup.</comment>
   </data>
-  <data name="Operations_Checkpoint" xml:space="preserve">
+  <data name="Operations_CreateCheckpoint" xml:space="preserve">
     <value>Checkpoint</value>
     <comment>Text for the creating the checkpoint operation shown for the environment.</comment>
   </data>
@@ -309,7 +309,7 @@
     <value>Resume</value>
     <comment>Text for the resume operation shown for the environment.</comment>
   </data>
-  <data name="Operations_Revert" xml:space="preserve">
+  <data name="Operations_RevertCheckpoint" xml:space="preserve">
     <value>Revert</value>
     <comment>Text for the revert operation shown for the environment.</comment>
   </data>
@@ -317,12 +317,16 @@
     <value>Start</value>
     <comment>Text for the start operation shown for the environment.</comment>
   </data>
-  <data name="Operations_Stop" xml:space="preserve">
-    <value>Stop</value>
-    <comment>Text for the stop operation shown for the environment.</comment>
+  <data name="Operations_Shutdown" xml:space="preserve">
+    <value>Shutdown</value>
+    <comment>Text for the shutdown operation shown for the environment.</comment>
   </data>
   <data name="Operations_Terminate" xml:space="preserve">
-    <value>Terminate</value>
+    <value>Turn off</value>
+    <comment>Text for the terminate operation shown for the environment.</comment>
+  </data>
+  <data name="Operations_Save" xml:space="preserve">
+    <value>Save</value>
     <comment>Text for the terminate operation shown for the environment.</comment>
   </data>
   <data name="LaunchingEnvironmentText" xml:space="preserve">

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Environments.Models;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.DevHome.SDK;
+using Windows.Foundation;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -22,6 +23,8 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
     public DateTime LastConnected { get; protected set; } = DateTime.Now;
 
     public bool IsCreateComputeSystemOperation { get; protected set; }
+
+    public event TypedEventHandler<ComputeSystemCardBase, string>? ComputeSystemErrorReceived;
 
     // Will hold the supported actions that the user can perform on in the UI. E.g Remove button
     public ObservableCollection<OperationsViewModel> DotOperations { get; protected set; } = new();
@@ -54,5 +57,14 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
     public override string ToString()
     {
         return $"{Name} {AlternativeName}";
+    }
+
+    /// <summary>
+    /// Common way to send error message to UI for classes that implement ComputeSystemCardBase
+    /// </summary>
+    /// <param name="errorMessage">Error message to send to the user</param>
+    public virtual void OnErrorReceived(string errorMessage)
+    {
+        ComputeSystemErrorReceived?.Invoke(this, errorMessage);
     }
 }

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -44,8 +44,6 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 
     public ComputeSystemCache ComputeSystem { get; protected set; }
 
-    public event TypedEventHandler<ComputeSystemViewModel, string>? ComputeSystemErrorFound;
-
     // Launch button operations
     public ObservableCollection<OperationsViewModel> LaunchOperations { get; set; } = new();
 
@@ -165,7 +163,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         var properties = await ComputeSystemHelpers.GetComputeSystemCardPropertiesAsync(ComputeSystem!, PackageFullName);
         lock (_lock)
         {
-            Properties.Clear();
+            ComputeSystemHelpers.RemoveAllItems(Properties);
             foreach (var property in properties)
             {
                 Properties.Add(property);
@@ -177,7 +175,8 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     {
         _windowEx.DispatcherQueue.EnqueueAsync(async () =>
         {
-            if (sender.Id == ComputeSystem.Id.Value)
+            if (sender.Id == ComputeSystem.Id.Value &&
+                sender.AssociatedProviderId.Equals(ComputeSystem.AssociatedProviderId.Value, StringComparison.OrdinalIgnoreCase))
             {
                 State = newState;
                 StateColor = ComputeSystemHelpers.GetColorBasedOnState(newState);
@@ -269,7 +268,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         }
 
         // Show the error notification to tell the user the operation failed
-        ComputeSystemErrorFound?.Invoke(this, errorMessage);
+        OnErrorReceived(errorMessage);
     }
 
     /// <summary>

--- a/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
@@ -110,7 +110,9 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
             }
             else
             {
-                UpdateUiMessage(_stringResource.GetLocalized("FailureMessageForCreateComputeSystem", createComputeSystemResult.Result.DisplayMessage));
+                // Reset text in UI card and show the error notification info bar to tell the user the operation failed
+                UpdateUiMessage(string.Empty);
+                OnErrorReceived(_stringResource.GetLocalized("FailureMessageForCreateComputeSystem", createComputeSystemResult.Result.DisplayMessage));
                 State = ComputeSystemState.Unknown;
                 StateColor = CardStateColor.Failure;
             }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -80,7 +80,8 @@ public partial class ComputeSystemCardViewModel : ObservableObject
     {
         _windowEx.DispatcherQueue.EnqueueAsync(async () =>
         {
-            if (sender.Id == ComputeSystem.Id.Value)
+            if (sender.Id == ComputeSystem.Id.Value &&
+                sender.AssociatedProviderId.Equals(ComputeSystem.AssociatedProviderId.Value, StringComparison.OrdinalIgnoreCase))
             {
                 CardState = state;
                 StateColor = ComputeSystemHelpers.GetColorBasedOnState(state);
@@ -101,7 +102,7 @@ public partial class ComputeSystemCardViewModel : ObservableObject
         var properties = await ComputeSystemHelpers.GetComputeSystemCardPropertiesAsync(ComputeSystem, _packageFullName);
         lock (_lock)
         {
-            ComputeSystemProperties.Clear();
+            ComputeSystemHelpers.RemoveAllItems(ComputeSystemProperties);
             foreach (var property in properties)
             {
                 ComputeSystemProperties.Add(property);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetReviewViewModel.cs
@@ -40,9 +40,6 @@ public partial class SetupTargetReviewViewModel : ReviewTabViewModelBase
     [ObservableProperty]
     private string _osName;
 
-    [ObservableProperty]
-    private bool _wasOsNameRetrieved;
-
     public SetupTargetReviewViewModel(ISetupFlowStringResource stringResource, IComputeSystemManager computeSystemManager)
     {
         _stringResource = stringResource;
@@ -66,31 +63,28 @@ public partial class SetupTargetReviewViewModel : ReviewTabViewModelBase
     private async Task SetOsNameAsync()
     {
         var computeSystem = _computeSystemManager.ComputeSystemSetupItem.ComputeSystemToSetup;
-        ComputeSystemProperties ??= await computeSystem?.GetComputeSystemPropertiesAsync(string.Empty);
+        ComputeSystemProperties = await computeSystem?.GetComputeSystemPropertiesAsync(string.Empty);
+        OsName = null;
 
         if (ComputeSystemProperties == null)
         {
             return;
         }
 
+        var osName = string.Empty;
         foreach (var property in ComputeSystemProperties)
         {
             var lowerCasePropertyName = property.Name.ToLowerInvariant();
             if (_osPropertyNameValues.Contains(lowerCasePropertyName))
             {
-                OsName = property.Value as string;
+                osName = property.Value as string;
                 break;
             }
         }
 
-        if (!string.IsNullOrEmpty(OsName))
+        if (!string.IsNullOrEmpty(osName))
         {
-            WasOsNameRetrieved = true;
-        }
-        else
-        {
-            WasOsNameRetrieved = false;
-            OsName = _stringResource.GetLocalized(StringResourceKey.SetupTargetUnknownStatus);
+            OsName = osName;
         }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
@@ -427,6 +427,13 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
                     curListViewModel.Provider,
                     packageFullName,
                     _windowEx);
+
+                // Don't show environments that aren't in a state to configure
+                if (!ShouldShowCard(card.CardState))
+                {
+                    continue;
+                }
+
                 curListViewModel.ComputeSystemCardCollection.Add(card);
                 curListViewModel.CardSelectionChanged += OnListSelectionChanged;
             }
@@ -488,5 +495,18 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         }
 
         Orchestrator.NavigateToOutsideFlow(KnownPageKeys.SetupFlow, "startCreationFlow");
+    }
+
+    private bool ShouldShowCard(ComputeSystemState state)
+    {
+        switch (state)
+        {
+            case ComputeSystemState.Creating:
+            case ComputeSystemState.Deleting:
+            case ComputeSystemState.Deleted:
+                return false;
+            default:
+                return true;
+        }
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetReviewView.xaml
@@ -11,6 +11,7 @@
     Loaded="UserControl_Loaded">
     <UserControl.Resources>
         <converters:BoolToVisibilityConverter x:Key="NegatedBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
+        <converters:EmptyObjectToObjectConverter x:Key="EmptyObjectToObjectConverter" NotEmptyValue="Visible" EmptyValue="Collapsed"/>
     </UserControl.Resources>
 
     <Grid>
@@ -83,6 +84,7 @@
                             Grid.Column="2"
                             Margin="0 0 5 0"
                             x:Uid="SetupTargetReviewPageComputeSystemVersion"
+                            Visibility="{x:Bind ViewModel.OsName, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Style="{StaticResource BodyTextBlockStyle}"
                             IsTextSelectionEnabled="True"/>
@@ -90,17 +92,8 @@
                             Grid.Row="1"
                             Grid.Column="2"
                             Margin="0 0 5 0"
-                            Text="{x:Bind ViewModel.OsName}"
-                            Visibility="{x:Bind ViewModel.WasOsNameRetrieved}"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Style="{StaticResource BodyTextBlockStyle}"
-                            IsTextSelectionEnabled="True"/>
-                        <TextBlock
-                            Grid.Row="1"
-                            Grid.Column="2"
-                            Margin="0 0 5 0"
-                            Visibility="{x:Bind ViewModel.WasOsNameRetrieved, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                             Text="{x:Bind ViewModel.OsName, Mode=OneWay}"
+                            Visibility="{x:Bind ViewModel.OsName, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Style="{StaticResource BodyTextBlockStyle}"
                             IsTextSelectionEnabled="True"/>


### PR DESCRIPTION
## Summary of the pull request
After testing environments more for any random crashes or things that may have been missed before release I found the following:

1. If you repeatedly perform operations on multiple environments, there can be a random COM exception due to using the "Clear()" method in the observable collection that we hold properties in here: https://github.com/microsoft/devhome/blob/f88a26c19865a73b2bd81b86bdd3fca9cd07a81a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs#L168 this can happen randomly and upon looking online there are people who have ran into the same issue when using the clear method. Found an issue related to this https://github.com/microsoft/microsoft-ui-xaml/issues/8684. To work around this, I found that removing the properties from the end of the collection to the beginning  throws no exception no matter how many operations I attempt. Interestingly I found other places online like in WPF that also have issues with clearing directly: https://stackoverflow.com/questions/47347273/clear-observablecollection-throws-exception. So I updated this in the two place we use it.
2. Updated the logging context in ComputeSystemHelpers so its name shows up in the logs.
3. Noticed that the operation names that appear in the menu flyouts in the environments pages were localized but we werent using them from the resource file. Updated the `DataExtractor` to use them
4. Noticed we were missing the `Save` operation in the `DataExtractor` so I added it in
5. Noticed in the Set up environments flow we were showing "Version: Unknown" when the user gets to the review page for environments where we don't know the operating system. For these we shouldn't show any version. We should only show the version if we know it. So updated the `SetupTargetReviewView` to only show the version when an operating system property from the environment exists
6. Noticed we still showed environments that were being created and deleted in the set up environments page so added a method to check for these so we don't show them as they won't be in a configurable state.

Video of me performing multiple operations with no crashes in environments page, also shows save button:

https://github.com/microsoft/devhome/assets/105318831/8284ea2b-f072-4cc7-aae9-e0b4249be3ce

Showing version not showing up when the environment does not have the operating system as a property:

https://github.com/microsoft/devhome/assets/105318831/04cda3b7-35dd-4f12-b641-336c88c20a8b

Showing me creating a Dev Box which shows up in the environments page and now does not show up in set up environments page:

https://github.com/microsoft/devhome/assets/105318831/84215a24-a4f1-4ef3-9f3b-a0cc875d18e0




## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
