### PR TITLE
Add AddCreateButton and AddCreateHyperlinkButton

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -14,6 +14,7 @@
     <None Remove="Environments\CustomControls\CardHeader.xaml" />
     <None Remove="Environments\Styles\HorizontalCardStyles.xaml" />
     <None Remove="Environments\Templates\EnvironmentsTemplates.xaml" />
+    <None Remove="Views\AddCreateButton.xaml" />
     <None Remove="Views\Banner.xaml" />
     <None Remove="Views\CloseButton.xaml" />
     <None Remove="Views\HyperlinkTextBlock.xaml" />
@@ -75,6 +76,9 @@
     </Page>
     <Page Update="Views\Banner.xaml">
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\AddCreateButton.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
     <Page Update="Views\CloseButton.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -15,6 +15,7 @@
     <None Remove="Environments\Styles\HorizontalCardStyles.xaml" />
     <None Remove="Environments\Templates\EnvironmentsTemplates.xaml" />
     <None Remove="Views\AddCreateButton.xaml" />
+    <None Remove="Views\AddCreateHyperlinkButton.xaml" />
     <None Remove="Views\Banner.xaml" />
     <None Remove="Views\CloseButton.xaml" />
     <None Remove="Views\HyperlinkTextBlock.xaml" />
@@ -73,6 +74,10 @@
     </Page>
     <Page Update="Environments\Templates\EnvironmentsTemplates.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+    <Page Update="Views\AddCreateHyperlinkButton.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+      <SubType>Designer</SubType>
     </Page>
     <Page Update="Views\Banner.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/common/Environments/Models/EnvironmentsCallToActionData.cs
+++ b/common/Environments/Models/EnvironmentsCallToActionData.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace DevHome.Common.Environments.Models;
 
 public class EnvironmentsCallToActionData

--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -305,16 +305,16 @@
     <value>+ Create new environment</value>
     <comment>Text for a hyperlink button that will redirect user to the create environment page</comment>
   </data>
-	<data name="NoEnvironmentsButExtensionsInstalledCallToAction" xml:space="preserve">
+  <data name="NoEnvironmentsButExtensionsInstalledCallToAction" xml:space="preserve">
     <value>No environments added yet</value>
     <comment>Text for when the environment page in Dev Home is empty</comment>
   </data>
-	<data name="NoEnvironmentsAndExtensionsNotInstalledCallToAction" xml:space="preserve">
+  <data name="NoEnvironmentsAndExtensionsNotInstalledCallToAction" xml:space="preserve">
     <value>Install an extension that supports environments and refresh the page</value>
     <comment>Text for when the environment page in Dev Home is empty and no extensions are installed that support environments</comment>
   </data>
   <data name="NoEnvironmentsAndExtensionsNotInstalledButton" xml:space="preserve">
-    <value>+ Go to extensions library</value>
+    <value>Go to extensions library</value>
     <comment>Text for when the environment page in Dev Home is empty and the user has no extensions installed that support environments</comment>
   </data>
 </root>

--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -302,7 +302,7 @@
     <comment>Generic name text for the card header for an environment that is being created in Dev Homes environment page</comment>
   </data>
   <data name="NoEnvironmentsButExtensionsInstalledButton" xml:space="preserve">
-    <value>+ Create new environment</value>
+    <value>Create new environment</value>
     <comment>Text for a hyperlink button that will redirect user to the create environment page</comment>
   </data>
   <data name="NoEnvironmentsButExtensionsInstalledCallToAction" xml:space="preserve">

--- a/common/Views/AddCreateButton.xaml
+++ b/common/Views/AddCreateButton.xaml
@@ -1,0 +1,14 @@
+<Button
+    x:Class="DevHome.Common.Views.AddCreateButton"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Style="{StaticResource DefaultButtonStyle}">
+
+    <StackPanel Orientation="Horizontal" Spacing="12">
+        <FontIcon FontSize="16" Glyph="&#xE710;" />
+        <TextBlock
+               FontSize="{ThemeResource BodyTextBlockFontSize}"
+               AutomationProperties.AccessibilityView="Raw"
+               Text="{x:Bind Content}" />
+    </StackPanel>
+</Button>

--- a/common/Views/AddCreateButton.xaml
+++ b/common/Views/AddCreateButton.xaml
@@ -2,13 +2,13 @@
     x:Class="DevHome.Common.Views.AddCreateButton"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Style="{StaticResource DefaultButtonStyle}">
+    Style="{StaticResource DefaultButtonStyle}"
+    AutomationProperties.Name="{x:Bind Content}">
 
     <StackPanel Orientation="Horizontal" Spacing="12">
         <FontIcon FontSize="16" Glyph="&#xE710;" />
         <TextBlock
                FontSize="{ThemeResource BodyTextBlockFontSize}"
-               AutomationProperties.AccessibilityView="Raw"
                Text="{x:Bind Content}" />
     </StackPanel>
 </Button>

--- a/common/Views/AddCreateButton.xaml.cs
+++ b/common/Views/AddCreateButton.xaml.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Common.Views;
+
+/// <summary>
+/// A button whose content is a + icon and a string. Used for creating new items.
+/// </summary>
+public sealed partial class AddCreateButton : Button
+{
+    /// <summary>
+    /// Gets or Sets the Content to display on the Button alongside the icon.
+    /// </summary>
+    public new string Content
+    {
+        get => (string)GetValue(ContentProperty);
+        set => SetValue(ContentProperty, value);
+    }
+
+    public AddCreateButton()
+    {
+        this.InitializeComponent();
+    }
+
+    public static readonly new DependencyProperty ContentProperty = DependencyProperty.Register(nameof(Content), typeof(string), typeof(Button), new PropertyMetadata(string.Empty));
+}

--- a/common/Views/AddCreateHyperlinkButton.xaml
+++ b/common/Views/AddCreateHyperlinkButton.xaml
@@ -1,0 +1,14 @@
+<HyperlinkButton
+    x:Class="DevHome.Common.Views.AddCreateHyperlinkButton"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Style="{StaticResource DefaultHyperlinkButtonStyle}"
+    AutomationProperties.Name="{x:Bind Content}">
+
+    <StackPanel Orientation="Horizontal" Spacing="12">
+        <FontIcon FontSize="16" Glyph="&#xE710;" />
+        <TextBlock
+               FontSize="{ThemeResource BodyTextBlockFontSize}"
+               Text="{x:Bind Content}" />
+    </StackPanel>
+</HyperlinkButton>

--- a/common/Views/AddCreateHyperlinkButton.xaml.cs
+++ b/common/Views/AddCreateHyperlinkButton.xaml.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Common.Views;
+
+/// <summary>
+/// A HyperlinkButton whose content is a + icon and a string. Used for creating new items.
+/// </summary>
+public sealed partial class AddCreateHyperlinkButton : HyperlinkButton
+{
+    /// <summary>
+    /// Gets or Sets the Content to display on the Button alongside the icon.
+    /// </summary>
+    public new string Content
+    {
+        get => (string)GetValue(ContentProperty);
+        set => SetValue(ContentProperty, value);
+    }
+
+    public AddCreateHyperlinkButton()
+    {
+        this.InitializeComponent();
+    }
+
+    public static readonly new DependencyProperty ContentProperty = DependencyProperty.Register(nameof(Content), typeof(string), typeof(HyperlinkButton), new PropertyMetadata(string.Empty));
+}

--- a/docs/tools/common/AddCreateButton.md
+++ b/docs/tools/common/AddCreateButton.md
@@ -1,0 +1,12 @@
+# AddCreateButton
+Create a button with a + symbol and the given text content. Used for buttons that add or create something.
+
+## Usage
+### Example
+#### HelloWorldDialog.xaml
+```xml
+  <views:AddCreateButton
+      AutomationProperties.AutomationId="AddRepositoriesButton"
+      x:Uid="MainPage_RepoReview_AddRepository"
+      Command="{x:Bind AddRepoCommand}" />
+```

--- a/docs/tools/common/Readme.md
+++ b/docs/tools/common/Readme.md
@@ -6,6 +6,7 @@ List of common controls that are generic, customizable and reusable from all pag
 - [Secondary window](./SecondaryWindow.md)
 
 ## Controls
+- [AddCreateButton](./AddCreateButtonmd)
 - [CloseButton](./CloseButton.md)
 - [ExperimentControl](./ExperimentControl.md)
 

--- a/docs/tools/common/Readme.md
+++ b/docs/tools/common/Readme.md
@@ -6,7 +6,7 @@ List of common controls that are generic, customizable and reusable from all pag
 - [Secondary window](./SecondaryWindow.md)
 
 ## Controls
-- [AddCreateButton](./AddCreateButtonmd)
+- [AddCreateButton](./AddCreateButton.md)
 - [CloseButton](./CloseButton.md)
 - [ExperimentControl](./ExperimentControl.md)
 

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddWidget.Content" xml:space="preserve">
-    <value>+ Add widget</value>
-    <comment>Label for "Add widget" button"</comment>
+    <value>Add widget</value>
+    <comment>Label for "Add widget" button</comment>
   </data>
   <data name="DashboardBanner.Title" xml:space="preserve">
     <value>Monitor your projects using widgets</value>

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -186,7 +186,7 @@
     <comment>Message shown when no widgets have been added to the Dashboard</comment>
   </data>
   <data name="AddFirstWidgetLink.Content" xml:space="preserve">
-    <value>+ Add new widget</value>
+    <value>Add new widget</value>
     <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't added any widgets.</comment>
   </data>
   <data name="RestartDevHomeMessage.Text" xml:space="preserve">

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -57,11 +57,12 @@
             <TextBlock x:Uid="DashboardPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left"/>
             <!-- Include small upper margin so focus rect is fully visible -->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,2,0,22">
-                <Button x:Name="AddWidgetButton"
-                        x:Uid="AddWidget"
-                        HorizontalAlignment="Right"
-                        Command="{x:Bind AddWidgetClickCommand}"
-                        IsEnabled="{x:Bind ViewModel.HasWidgetService, Mode=OneWay}"/>
+                <commonviews:AddCreateButton
+                    x:Name="AddWidgetButton"
+                    x:Uid="AddWidget"
+                    HorizontalAlignment="Right"
+                    Command="{x:Bind AddWidgetClickCommand}"
+                    IsEnabled="{x:Bind ViewModel.HasWidgetService, Mode=OneWay}"/>
             </StackPanel>
         </Grid>
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -128,7 +128,7 @@
                 <StackPanel x:Name="NoWidgetsStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0"
                             Visibility="{x:Bind ViewModel.GetNoWidgetMessageVisibility(views:DashboardView.PinnedWidgets.Count, ViewModel.IsLoading), Mode=OneWay}">
                     <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
-                    <HyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center" Command="{x:Bind AddWidgetClickCommand}" />
+                    <commonviews:AddCreateHyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center" Command="{x:Bind AddWidgetClickCommand}" />
                 </StackPanel>
 
                 <!-- Widget messages -->

--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -185,8 +185,8 @@
     <value>Sync</value>
     <comment>Text for the sync button on the top right side</comment>
   </data>
-  <data name="CreateEnvironmentButton.Text" xml:space="preserve">
-    <value>+ Create environment</value>
+  <data name="CreateEnvironmentButton.Content" xml:space="preserve">
+    <value>Create environment</value>
     <comment>Text for button that will redirect the user to the Create Environment page in Dev Home</comment>
   </data>
   <data name="EnvironmentsHeader.Text" xml:space="preserve">
@@ -343,8 +343,8 @@
     <value>The extension failed to perform the requested operation for an unknown reason. Check the extensions logs for more information.</value>
     <comment>Text to tell the user Dev Home the extension failed to perform the operation send by the extension</comment>
   </data>
-  <data name="GoToExtensionsLibrary.Text" xml:space="preserve">
-    <value>+ Go to extensions library</value>
+  <data name="GoToExtensionsLibrary.Content" xml:space="preserve">
+    <value>Go to extensions library</value>
     <comment>Text for when the environment page in Dev Home is empty and the user has no extensions installed that support environments</comment>
   </data>
 </root>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -13,6 +13,7 @@
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:winUIBehaviors="using:CommunityToolkit.WinUI.Behaviors"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:views="using:DevHome.Common.Views"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     Loaded="OnLoaded">
     <pg:ToolPage.Resources>
@@ -196,23 +197,18 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0" x:Uid="EnvironmentsHeader" Style="{ThemeResource SubtitleTextBlockStyle}" HorizontalAlignment="Left" x:Name="EnvironmentsHeader"/>
-            <Button 
-                Grid.Column="3" 
+            <views:AddCreateButton
+                Grid.Column="3"
+                Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                 HorizontalAlignment="Right"
-                Command="{x:Bind ViewModel.CallToActionInvokeButtonCommand}" >
-                <Grid>
-                    <TextBlock 
-                        Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
-                        Grid.Column="1" 
-                        x:Uid="CreateEnvironmentButton" 
-                        Margin="3 0 0 0"  />
-                    <TextBlock 
-                        Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay}"
-                        Grid.Column="1" 
-                        x:Uid="GoToExtensionsLibrary" 
-                        Margin="3 0 0 0"  />
-               </Grid>
-            </Button>
+                x:Uid="CreateEnvironmentButton"
+                Command="{x:Bind ViewModel.CallToActionInvokeButtonCommand}" />
+            <Button
+                Grid.Column="3"
+                Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay}"
+                HorizontalAlignment="Right"
+                x:Uid="GoToExtensionsLibrary"
+                Command="{x:Bind ViewModel.CallToActionInvokeButtonCommand}" />
         </Grid>
 
         <!-- Filtering and sorting -->

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -318,12 +318,18 @@
                         HorizontalAlignment="Center" 
                         TextWrapping="WrapWholeWords" 
                         HorizontalTextAlignment="Center" />
+                    <views:AddCreateHyperlinkButton 
+                        Grid.Column="3" 
+                        HorizontalAlignment="Center"
+                        Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
+                        Content="{x:Bind ViewModel.CallToActionHyperLinkButtonText, Mode=OneWay}"
+                        Command="{x:Bind ViewModel.CallToActionInvokeButtonCommand}" />
                     <HyperlinkButton 
                         Grid.Column="3" 
                         HorizontalAlignment="Center"
+                        Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay}"
                         Content="{x:Bind ViewModel.CallToActionHyperLinkButtonText, Mode=OneWay}"
                         Command="{x:Bind ViewModel.CallToActionInvokeButtonCommand}" />
-
                 </StackPanel>
             </Grid>
         </ScrollViewer>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -762,7 +762,7 @@
     <comment>Description for the repo review page</comment>
   </data>
   <data name="MainPage_RepoReview_AddRepository.Content" xml:space="preserve">
-    <value>+ Add repository</value>
+    <value>Add repository</value>
     <comment>Add repository button text</comment>
   </data>
   <data name="ReposConfigPageTitle" xml:space="preserve">

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -834,7 +834,7 @@
     <comment>Shown when no repos are selected when the user gets to the repo page</comment>
   </data>
   <data name="RepoReview_NoReposSelectedLink.Content" xml:space="preserve">
-    <value>+ Add repository</value>
+    <value>Add repository</value>
     <comment>The hyperlink to bring the user to the repo clone dialog.  Shows if the user hasn't selected any repos to clone.</comment>
   </data>
   <data name="EditClonePathDialog.Title" xml:space="preserve">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -177,18 +177,21 @@
             </ListView>
             <Grid
                 Grid.Row="1"
-                x:Name="NoRepositoryGrid" Visibility="{x:Bind ViewModel.RepoReviewItems, Mode=OneWay, Converter={StaticResource CollectionShowWhenEmpty}}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                x:Name="NoRepositoryGrid"
+                Visibility="{x:Bind ViewModel.RepoReviewItems, Mode=OneWay, Converter={StaticResource CollectionShowWhenEmpty}}"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
                 <Grid.RowDefinitions>
-                    <RowDefinition/>
-                    <RowDefinition/>
+                    <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
-                <TextBlock Grid.Row="0" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelected"/>
-                <HyperlinkButton
+                <TextBlock Grid.Row="0" x:Uid="RepoReview_NoReposSelected" />
+                <views:AddCreateHyperlinkButton
                     Grid.Row="1"
-                    AutomationProperties.AutomationId="AddRepoHyperLinkButton"
+                    AutomationProperties.AutomationId="AddRepoHyperlinkButton"
                     HorizontalAlignment="Center"
                     Command="{x:Bind AddRepoCommand}"
-                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/RepoReview_NoReposSelectedLink" />
+                    x:Uid="RepoReview_NoReposSelectedLink" />
             </Grid>
         </Grid>
     </setupControls:SetupShell>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -9,6 +9,7 @@
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:setupControls="using:DevHome.SetupFlow.Controls"
     xmlns:models="using:DevHome.SetupFlow.Models"
+    xmlns:views="using:DevHome.Common.Views"
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -37,9 +38,9 @@
             Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}"
             Foreground="{ThemeResource TextFillColorSecondary}">
         <setupControls:SetupShell.Header>
-            <Button
+            <views:AddCreateButton
                 AutomationProperties.AutomationId="AddRepositoriesButton"
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_RepoReview_AddRepository"
+                x:Uid="MainPage_RepoReview_AddRepository"
                 Command="{x:Bind AddRepoCommand}" />
         </setupControls:SetupShell.Header>
         <Grid x:Name="RepoConfigGrid" RowSpacing="10">

--- a/uitest/Pages/RepoConfigPage.cs
+++ b/uitest/Pages/RepoConfigPage.cs
@@ -9,7 +9,7 @@ public class RepoConfigPage : ApplicationPage
 {
     private WindowsElement AddRepoButton => Driver.FindElementByName("AddRepositoriesButton");
 
-    public WindowsElement AddRepoHyperLinkButton => Driver.FindElementByAccessibilityId("AddRepoHyperLinkButton");
+    public WindowsElement AddRepoHyperlinkButton => Driver.FindElementByAccessibilityId("AddRepoHyperlinkButton");
 
     public RepoConfigPage(WindowsDriver<WindowsElement> driver)
         : base(driver)

--- a/uitest/RepoConfigPageUiTests.cs
+++ b/uitest/RepoConfigPageUiTests.cs
@@ -16,6 +16,6 @@ public class RepoConfigPageUiTests : DevHomeTestBase
         var repoConfigPage = machineConfigurationPage.GoToRepoPage();
 
         // This button will be displayed when no repos are selected.
-        Assert.IsTrue(repoConfigPage.AddRepoHyperLinkButton.Displayed);
+        Assert.IsTrue(repoConfigPage.AddRepoHyperlinkButton.Displayed);
     }
 }


### PR DESCRIPTION
## Summary of the pull request
In three places (so far) we need a button with the + symbol (glyph E710) and button text. Instead of getting the formatting right in each place, create a new AddCreateButton and AddCreateHyperlinkButton that can be used as easily as a regular button or HyperlinkButton.

Currently used for "Add widget", "Add repository", and "Create environment".

The corresponding HyperlinkButtons should also have this formatting with the glyph instead of a + character, but the Environments page does not create this HyperlinkButton directly in Xaml, so it is a more complicated change.

![image](https://github.com/microsoft/devhome/assets/47155823/3c97c796-96af-4753-aea9-b8bcfd282536)

![image](https://github.com/microsoft/devhome/assets/47155823/10df3eb3-43f5-455a-9fd6-c6633fcfbd1d)

## Validation steps performed
Tested all three pages visually and with Narrator.

## PR checklist
- [x] Closes #2855
- [ ] Tests added/passed
- [x] Documentation updated
