### PR TITLE
Add error handling for QuickStart Playground

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1979,4 +1979,12 @@
     <value>Select an extension provider before continuing.</value>
     <comment>Guidance text to instruct user to select a Quickstart provider before continuing</comment>
   </data>
+  <data name="QuickstartPlaygroundGenerationFailed.Text" xml:space="preserve">
+    <value>Something went wrong, we weren't able to generate the content for this prompt.</value>
+    <comment>Error message shown when we failed to generate the project.</comment>
+  </data>
+  <data name="QuickstartPlaygroundGenerationFailedDetails" xml:space="preserve">
+    <value>Error: {0}</value>
+    <comment>Locked={"{0}"} Error message with additional details in {0} shown when we failed to generate the project.</comment>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/QuickstartStyles.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/QuickstartStyles.xaml
@@ -13,6 +13,7 @@
     <Style x:Key="ErrorIconStyle" TargetType="Image">
         <Setter Property="Height" Value="16px" />
         <Setter Property="Width" Value="16px" />
+        <Setter Property="Margin" Value="2,2,2,2" />
         <Setter Property="Source" Value="{ThemeResource ErrorIcon}" />
     </Style>
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/QuickstartStyles.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/QuickstartStyles.xaml
@@ -10,4 +10,18 @@
         <Setter Property="Width" Value="Auto" />
         <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     </Style>
+    <Style x:Key="ErrorIconStyle" TargetType="Image">
+        <Setter Property="Height" Value="16px" />
+        <Setter Property="Width" Value="16px" />
+        <Setter Property="Source" Value="{ThemeResource ErrorIcon}" />
+    </Style>
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <x:String x:Key="ErrorIcon">ms-appx:///DevHome.SetupFlow/Assets/LightError.png</x:String>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <x:String x:Key="ErrorIcon">ms-appx:///DevHome.SetupFlow/Assets/DarkError.png</x:String>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -127,6 +127,12 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     private bool _isPromptTextBoxReadOnly = false;
 
     [ObservableProperty]
+    private bool _isErrorViewVisible = false;
+
+    [ObservableProperty]
+    private string _errorMessage = string.Empty;
+
+    [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(GenerateCodespaceCommand))]
     private bool _areDependenciesPresent = false;
 
@@ -408,10 +414,12 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
             // Ensure file view isn't visible (in the case where the user has previously run a Generate command
             IsFileViewVisible = false;
+            IsErrorViewVisible = false;
 
             // Temporarily turn off the provider combobox and ensure user cannot edit the prompt for the moment
             EnableQuickstartProjectCombobox = false;
             IsPromptTextBoxReadOnly = true;
+            EnableProjectButtons = false;
 
             IProgress<QuickStartProjectProgress> progress = new Progress<QuickStartProjectProgress>(UpdateProgress);
 
@@ -430,7 +438,8 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             }
             else
             {
-                // TODO handle error scenario
+                IsErrorViewVisible = true;
+                ErrorMessage = StringResource.GetLocalized("QuickstartPlaygroundGenerationFailedDetails", _quickStartProject.Result.DisplayMessage);
                 TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateFailed", LogLevel.Critical, new ProjectGenerationErrorInfo(_quickStartProject.Result.DisplayMessage, _quickStartProject.Result.ExtendedError, _quickStartProject.Result.DiagnosticText));
             }
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -523,6 +523,15 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
             _log.Information("Completed setup work for extension selection");
         }
+        else
+        {
+            _log.Information("Reset extension selection");
+
+            ShowExamplePrompts = false;
+            ShowPrivacyAndTermsLink = false;
+            IsLaunchButtonVisible = false;
+            ConfigureForProviderSelection();
+        }
     }
 }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
@@ -65,7 +65,7 @@
                             <TextBlock x:Uid="QuickstartPlaygroundPromptHeader"
                                        Grid.Column="0"
                                        VerticalAlignment="Center"
-                                       TextWrapping="Wrap"
+                                       TextWrapping="WrapWholeWords"
                                        Margin="10"/>
                             <ctcontrols:WrapPanel Grid.Column="1" 
                                         Orientation="Horizontal"
@@ -186,7 +186,7 @@
                                Margin="10"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center"
-                               TextWrapping="Wrap"/>
+                               TextWrapping="WrapWholeWords"/>
                         <ProgressBar AutomationProperties.LabeledBy="{Binding ElementName=ProgressStatus}"
                                  Grid.Column="1"
                                  Margin="30"
@@ -225,8 +225,8 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center">
                     <Image Style="{StaticResource ErrorIconStyle}"/>
-                    <TextBlock x:Uid="QuickstartPlaygroundGenerationFailed" TextWrapping="Wrap" />
-                    <TextBlock Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" TextWrapping="Wrap" />
+                    <TextBlock x:Uid="QuickstartPlaygroundGenerationFailed" TextWrapping="WrapWholeWords" />
+                    <TextBlock Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" TextWrapping="WrapWholeWords" />
                 </StackPanel>
             </Grid>
 
@@ -377,7 +377,7 @@
                            FontFamily="{StaticResource CascadiaMonoFontFamily}"
                            Margin="20"
                            IsTextSelectionEnabled="True"
-                           TextWrapping="Wrap"
+                           TextWrapping="WrapWholeWords"
                            IsTabStop="True"
                            TabIndex="23">
                         </TextBlock>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
@@ -220,6 +220,16 @@
             </Grid>
 
             <!--Bottom half of UI-->
+            <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.IsErrorViewVisible, Mode=OneWay}">
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                    <Image Style="{StaticResource ErrorIconStyle}"/>
+                    <TextBlock x:Uid="QuickstartPlaygroundGenerationFailed" TextWrapping="Wrap" />
+                    <TextBlock Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" TextWrapping="Wrap" />
+                </StackPanel>
+            </Grid>
+
             <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.IsFileViewVisible, Mode=OneWay}">
                 <Grid>
                     <Grid.RowDefinitions>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
@@ -140,6 +140,10 @@ public sealed partial class QuickstartPlaygroundView : UserControl
             DispatcherQueue.TryEnqueue(() =>
             {
                 _adaptiveCardContentDialog?.Hide();
+                if (data.Result.Status == ProviderOperationStatus.Failure)
+                {
+                    ViewModel.ActiveQuickstartSelection = null;
+                }
             });
         }
     }
@@ -182,9 +186,11 @@ public sealed partial class QuickstartPlaygroundView : UserControl
 
     public async Task ShowExtensionInitializationUI()
     {
-        ArgumentNullException.ThrowIfNull(ViewModel.ActiveQuickstartSelection);
-        var adaptiveCardSessionResult = ViewModel.ActiveQuickstartSelection.CreateAdaptiveCardSessionForExtensionInitialization();
-        await ShowAdaptiveCardOnContentDialog(adaptiveCardSessionResult);
+        if (ViewModel.ActiveQuickstartSelection is not null)
+        {
+            var adaptiveCardSessionResult = ViewModel.ActiveQuickstartSelection.CreateAdaptiveCardSessionForExtensionInitialization();
+            await ShowAdaptiveCardOnContentDialog(adaptiveCardSessionResult);
+        }
     }
 
     public async Task ShowProgressAdaptiveCard()


### PR DESCRIPTION
## Summary of the pull request

- Added an error window for any errors during project generation
- Made the cancel button during extension initialization go back to the extension selection rather than continuing.

## References and relevant issues

## Detailed description of the pull request / Additional comments

![image](https://github.com/microsoft/devhome/assets/1691134/765ae3ce-0f29-4224-a5da-d7927f5becca)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
