### PR TITLE
Update BreadcrumbBar ThemeDictionaries

### DIFF
--- a/src/Styles/BreadcrumbBar.xaml
+++ b/src/Styles/BreadcrumbBar.xaml
@@ -23,6 +23,29 @@
             <BreadcrumbBar
                     x:Name="BreadcrumbBar"
                     ItemsSource="{Binding Breadcrumbs}">
+                <BreadcrumbBar.Resources>
+                    <!-- Setting BreadcrumbBarNormalForegroundBrush outside of DataTemplate results in the value not being used inside the DataTemplate. -->
+                    <!-- In order for DataTemplate to use the correct brushes, they must be set this way. -->
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Light">
+                                <Color x:Key="TextFillColorSecondary">#9E000000</Color>
+                                <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource TextFillColorSecondary}" />
+                                <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Dark">
+                                <Color x:Key="TextFillColorSecondary">#C5FFFFFF</Color>
+                                <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource TextFillColorSecondary}" />
+                                <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Color x:Key="TextFillColorSecondary">#FF0000</Color>
+                                <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource TextFillColorSecondary}" />
+                                <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </BreadcrumbBar.Resources>
                 <i:Interaction.Behaviors>
                     <behaviors:BreadcrumbNavigationBehavior />
                 </i:Interaction.Behaviors>


### PR DESCRIPTION
## Summary of the pull request
When we moved the BreadcrumbBar headers into a reusable DataTemplate, it stopped picking up the custom ThemeResource for the item brushes and only used the default. This change creates ThemeDictionaries for the BreadcrumbBar inside the DataTemplate so it uses the correct brushes.

Trying to just use the ThemeResource without recreating it would cause a runtime error. Using a StaticResource without setting the underlying color for different themes resulted in the color not updating when DH theme was updated.
![image](https://github.com/microsoft/devhome/assets/47155823/4f9fdf3b-c5bf-4f58-b670-3e516e6cf93c)
![image](https://github.com/microsoft/devhome/assets/47155823/902028ee-5708-406d-b860-fa65288515dc)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #2699
