### PR TITLE
Fix utility card layout

### DIFF
--- a/tools/Utilities/src/Views/UtilityView.xaml
+++ b/tools/Utilities/src/Views/UtilityView.xaml
@@ -5,9 +5,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-    xmlns:ui="using:CommunityToolkit.WinUI"
-    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
-    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d" 
     d:DesignHeight="300" d:DesignWidth="300">
 
@@ -22,7 +19,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
@@ -36,7 +33,7 @@
 
         <ScrollViewer
             Grid.Row="1"
-            Padding="15 10 15 0">
+            Padding="15 10 15 8">
 
             <StackPanel>
                 <TextBlock

--- a/tools/Utilities/src/Views/UtilityView.xaml
+++ b/tools/Utilities/src/Views/UtilityView.xaml
@@ -41,21 +41,19 @@
                     Style="{ThemeResource BodyTextStyle}"
                     Text="{x:Bind ViewModel.Title}" />
 
-                <StackPanel Orientation="Vertical" Margin="0 16 0 0">
-                    <TextBlock
-                        Margin="0 0 0 5"
-                        TextWrapping="Wrap"
-                        VerticalAlignment="Top"
-                        TextTrimming="WordEllipsis"
-                        Text="{x:Bind ViewModel.Description}"/>
+                <TextBlock
+                    Margin="0 16 0 5"
+                    TextWrapping="Wrap"
+                    VerticalAlignment="Top"
+                    TextTrimming="WordEllipsis"
+                    Text="{x:Bind ViewModel.Description}"/>
 
-                    <HyperlinkButton
-                        Content="Learn More"
-                        NavigateUri="{x:Bind ViewModel.NavigateUri}"
-                        VerticalAlignment="Top"
-                        Padding="0 0 0 15"
-                        HorizontalAlignment="Left"/>
-                </StackPanel>
+                <HyperlinkButton
+                    Content="Learn More"
+                    NavigateUri="{x:Bind ViewModel.NavigateUri}"
+                    VerticalAlignment="Top"
+                    Padding="0 0 0 0"
+                    HorizontalAlignment="Left"/>
             </StackPanel>
         </ScrollViewer>
 


### PR DESCRIPTION
## Summary of the pull request
Fixes two bugs:
* Launch buttons were being pushed off the bottom of the card when the card was too narrow to fit all content (#2864)
* Launch buttons were too high when card was wide enough to fit all content (#2860)

By changing the middle row height to *, the middle section will take up all the space it can, but not more.
Also added a small padding at the bottom of the ScrollViewer so text doesn't butt up against the button. Removed padding from bottom of HyperlinkButton, since the large bottom looked strange. Removed unnecessary StackPanel.
![image](https://github.com/microsoft/devhome/assets/47155823/7d2bb090-7b4a-405d-8b0d-df50b341ea90)
![image](https://github.com/microsoft/devhome/assets/47155823/8778c2e3-4f20-493e-b916-24e4362ba2f6)


## PR checklist
- [ ] Closes #2860
- [ ] Closes #2864
- [ ] Tests added/passed
- [ ] Documentation updated
