### PR TITLE
Fix extension names in extensions page

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -144,9 +144,6 @@ Try {
         if ($extension.Attribute("Category").Value -eq "windows.appExtension") {
           $appExtension = $extension.Element($uapAppExtension)
           switch ($appExtension.Attribute("Name").Value) {
-            "com.microsoft.devhome" {
-              $appExtension.Attribute("DisplayName").Value = $newAppDisplayNameResource
-            }
             "com.microsoft.windows.widgets" {
               $appExtension.Attribute("DisplayName").Value = $newWidgetProviderDisplayName
             }
@@ -200,9 +197,6 @@ Try {
       if ($extension.Attribute("Category").Value -eq "windows.appExtension") {
         $appExtension = $extension.Element($uapAppExtension)
         switch ($appExtension.Attribute("Name").Value) {
-          "com.microsoft.devhome" {
-            $appExtension.Attribute("DisplayName").Value = "ms-resource:AppDisplayNameDev"
-          }
           "com.microsoft.windows.widgets" {
             $appExtension.Attribute("DisplayName").Value = "ms-resource:WidgetProviderDisplayNameDev"
           }


### PR DESCRIPTION
## Summary of the pull request
Extension names were getting overwritten in Canary/Release builds.  We no longer needed to update the specified fields in the appxmanifest.

## References and relevant issues
#2865 

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2865
- [ ] Tests added/passed
- [ ] Documentation updated
