### PR TITLE
Add template for symbols publishing

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -76,16 +76,18 @@ extends:
             filePath: 'Build.ps1'
             arguments: -Configuration "Release" -VersionOfSDK $(VersionOfSDK) -BuildStep "sdk" -IsAzurePipelineBuild
 
-        - task: PublishSymbols@2
-          displayName: Publish Symbols
-          inputs:
-            SearchPattern: |
+        - template: ./build/templates/publish-symbolrequestprod-api.yml@self
+          parameters:
+            includePublicSymbolServer: false
+            subscription: $(symbolsubscription)
+            symbolProject: 'DevHome'
+            indexSources: false
+            symbolsArtifactName: 'DevHomeSDK'
+            symbolsVersion: '$(Build.BuildNumber)'
+            searchPattern: |
               **/bin/**/*.pdb
               **/bin/**/*.exe
               **/bin/**/*.dll
-            IndexSources: false
-            SymbolServerType: TeamServices
-            SymbolsProduct: DevHomeSDK
 
         templateContext:
           outputs:
@@ -222,6 +224,23 @@ extends:
                   Move-Item -Path $(Build.SourcesDirectory)\DevHome.${{ platform }}.${{ configuration }}.binlog -Destination $(Build.SourcesDirectory)\src\bin -Force
                 pwsh: true
 
+            - template: ./build/templates/publish-symbolrequestprod-api.yml@self
+              parameters:
+                includePublicSymbolServer: true
+                symbolProject: 'DevHome'
+                subscription: $(SymbolSubscription)
+                indexSources: true
+                symbolsArtifactName: 'DevHome_${{ platform }}_${{ configuration }}'
+                symbolsVersion: $(Build.BuildNumber)
+                searchPattern: >-
+                  $(Build.SourcesDirectory)\**\bin\**\*.pdb
+
+                  $(Build.SourcesDirectory)\**\bin\**\*.exe
+
+                  $(Build.SourcesDirectory)\**\bin\**\*.dll
+
+                  $(Build.SourcesDirectory)\**\obj\**\*.r2r.ni.pdb
+
             - task: EsrpCodeSigning@2
               inputs:
                 ConnectedServiceName: 'Xlang Code Signing'
@@ -310,21 +329,6 @@ extends:
                 testRunTitle: '$(Agent.JobName)'
                 buildPlatform: '${{ platform }}'
                 buildConfiguration: '${{ configuration }}'
-
-            - task: PublishSymbols@2
-              displayName: Publish Symbols
-              inputs:
-                SearchPattern: >-
-                  $(Build.SourcesDirectory)\**\bin\**\*.pdb
-
-                  $(Build.SourcesDirectory)\**\bin\**\*.exe
-
-                  $(Build.SourcesDirectory)\**\bin\**\*.dll
-
-                  $(Build.SourcesDirectory)\**\obj\**\*.r2r.ni.pdb
-                IndexSources: true
-                SymbolServerType: TeamServices
-                SymbolsProduct: DevHome
 
             templateContext:
               outputs:

--- a/build/templates/publish-symbolrequestprod-api.yml
+++ b/build/templates/publish-symbolrequestprod-api.yml
@@ -1,0 +1,89 @@
+parameters:
+  - name: includePublicSymbolServer
+    type: boolean
+    default: false
+  - name: symbolsFolder
+    type: string
+    default: '$(Build.SourcesDirectory)/bin'
+  - name: searchPattern
+    type: string
+    default: '**/*.pdb'
+  - name: jobName
+    type: string
+    default: PublishSymbols
+  - name: indexSources
+    type: boolean
+    default: true
+  - name: symbolExpiryTime
+    type: string
+    default: 36530 # This is the default from PublishSymbols@2
+  - name: symbolsArtifactName
+    type: string
+    default: ''
+  - name: symbolsVersion
+    type: string
+    default: ''
+  - name: symbolProject
+    type: string
+  - name: subscription
+    type: string
+
+steps:
+  - powershell: |-
+      Get-PackageProvider -Name NuGet -ForceBootstrap
+      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
+    displayName: Install Azure Module Dependencies
+
+  # Transit the Azure token from the Service Connection into a secret variable for the rest of the pipeline to use.
+  - task: AzurePowerShell@5
+    displayName: Generate an Azure Token
+    inputs:
+      azureSubscription: ${{ parameters.subscription }}
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      ScriptType: InlineScript
+      Inline: |-
+        $AzToken = (Get-AzAccessToken -ResourceUrl api://30471ccf-0966-45b9-a979-065dbedb24c1).Token
+        Write-Host "##vso[task.setvariable variable=SymbolAccessToken;issecret=true]$AzToken"
+
+  - task: PublishSymbols@2
+    displayName: Publish Symbols (to current Azure DevOps tenant)
+    continueOnError: True
+    inputs:
+      SearchPattern: ${{ parameters.searchPattern }}
+      IndexSources: ${{ parameters.indexSources }}
+      DetailedLog: true
+      SymbolsMaximumWaitTime: 30
+      SymbolServerType: 'TeamServices'
+      SymbolsProduct: 'Dev Home Symbols'
+      SymbolsVersion: ${{ parameters.symbolsVersion }}
+      SymbolsArtifactName: '${{ parameters.symbolsArtifactName }}_${{ parameters.symbolsVersion }}'
+      SymbolExpirationInDays: ${{ parameters.symbolExpiryTime }}
+    env:
+      LIB: $(Build.SourcesDirectory)
+
+  - pwsh: |-
+      # Prepare the defaults for IRM
+      $PSDefaultParameterValues['Invoke-RestMethod:Headers'] = @{ Authorization = "Bearer $(SymbolAccessToken)" }
+      $PSDefaultParameterValues['Invoke-RestMethod:ContentType'] = "application/json"
+      $PSDefaultParameterValues['Invoke-RestMethod:Method'] = "POST"
+
+      $BaseUri = "https://symbolrequestprod.trafficmanager.net/projects/${{ parameters.symbolProject }}/requests"
+
+      # Prepare the request
+      $expiration = (Get-Date).Add([TimeSpan]::FromDays(${{ parameters.symbolExpiryTime }}))
+      $createRequestBody = @{
+        requestName = "${{ parameters.symbolsArtifactName }}_${{ parameters.symbolsVersion }}";
+        expirationTime = $expiration.ToString();
+      }
+      Write-Host "##[debug]Starting request $($createRequestBody.requestName) with expiration date of $($createRequestBody.expirationTime)"
+      Invoke-RestMethod -Uri "$BaseUri" -Body ($createRequestBody | ConvertTo-Json -Compress) -Verbose
+
+      # Request symbol publication
+      $publishRequestBody = @{
+        publishToInternalServer = $true;
+        publishToPublicServer = $${{ parameters.includePublicSymbolServer }};
+      }
+      Write-Host "##[debug]Submitting request $($createRequestBody.requestName) ($($publishRequestBody | ConvertTo-Json -Compress))"
+      Invoke-RestMethod -Uri "$BaseUri/$($createRequestBody.requestName)" -Body ($publishRequestBody | ConvertTo-Json -Compress) -Verbose
+    displayName: Publish Symbols using internal REST API

--- a/build/templates/publish-symbolrequestprod-api.yml
+++ b/build/templates/publish-symbolrequestprod-api.yml
@@ -55,7 +55,7 @@ steps:
       DetailedLog: true
       SymbolsMaximumWaitTime: 30
       SymbolServerType: 'TeamServices'
-      SymbolsProduct: 'Dev Home Symbols'
+      SymbolsProduct: 'DevHome'
       SymbolsVersion: ${{ parameters.symbolsVersion }}
       SymbolsArtifactName: '${{ parameters.symbolsArtifactName }}_${{ parameters.symbolsVersion }}'
       SymbolExpirationInDays: ${{ parameters.symbolExpiryTime }}


### PR DESCRIPTION
## Summary of the pull request
Moves symbol publishing into a template that facilitates re-use for publishing to internal/external symbol servers

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Full internal build.  Checked using symchk and the public symbol server to validate that the symbols were available.

## PR checklist
- [x] Closes #2813 
- [ ] Tests added/passed
- [ ] Documentation updated
