### PR TITLE
Update Utilities page design to align with designer feedback

### DIFF
--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -38,7 +38,7 @@
             "assembly": "DevHome.Utilities",
             "viewFullName": "DevHome.Utilities.Views.UtilitiesMainPageView",
             "viewModelFullName": "DevHome.Utilities.ViewModels.UtilitiesMainPageViewModel",
-            "icon": "ED35"
+            "icon": "ECED"
           }
         ]
       }

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -38,7 +38,7 @@
             "assembly": "DevHome.Utilities",
             "viewFullName": "DevHome.Utilities.Views.UtilitiesMainPageView",
             "viewModelFullName": "DevHome.Utilities.ViewModels.UtilitiesMainPageViewModel",
-            "icon": "ECED"
+            "icon": "ED35"
           }
         ]
       }

--- a/tools/Utilities/src/Strings/en-us/Resources.resw
+++ b/tools/Utilities/src/Strings/en-us/Resources.resw
@@ -118,13 +118,14 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="EnvVariablesEditorUtilityDesc" xml:space="preserve">
-    <value>Create and manage variable sets with a lightweight UI.</value>
+    <value>Create and manage environment variables.</value>
   </data>
   <data name="EnvVariablesEditorUtilityTitle" xml:space="preserve">
     <value>Environment Variables Editor</value>
   </data>
   <data name="HostsFileEditorUtilityDesc" xml:space="preserve">
-    <value>Add, filter, or remove file entries in less time.</value>
+    <value>Add, filter or remove Hosts file entries.</value>
+    <comment>;Locked={"Hosts"}</comment>
   </data>
   <data name="HostsFileEditorUtilityTitle" xml:space="preserve">
     <value>Hosts File Editor</value>
@@ -144,7 +145,7 @@
     <value>Project Ironsides</value>
   </data>
   <data name="RegistryPreviewUtilityDesc" xml:space="preserve">
-    <value>Edit and visualize Windows Registry files faster.</value>
+    <value>Edit and visualize Windows Registry files.</value>
   </data>
   <data name="RegistryPreviewUtilityTitle" xml:space="preserve">
     <value>Registry Preview</value>

--- a/tools/Utilities/src/Strings/en-us/Resources.resw
+++ b/tools/Utilities/src/Strings/en-us/Resources.resw
@@ -130,6 +130,9 @@
     <value>Hosts File Editor</value>
     <comment>;Locked={"Hosts"}</comment>
   </data>
+  <data name="LaunchButton.Text" xml:space="preserve">
+    <value>Launch</value>
+  </data>
   <data name="NavigationPane.Content" xml:space="preserve">
     <value>Utilities</value>
     <comment>Utilities</comment>
@@ -145,5 +148,11 @@
   </data>
   <data name="RegistryPreviewUtilityTitle" xml:space="preserve">
     <value>Registry Preview</value>
+  </data>
+  <data name="SupportsLaunchAsAdmin.OffContent" xml:space="preserve">
+    <value>Launch as administrator</value>
+  </data>
+  <data name="SupportsLaunchAsAdmin.OnContent" xml:space="preserve">
+    <value>Launch as administrator</value>
   </data>
 </root>

--- a/tools/Utilities/src/Strings/en-us/Resources.resw
+++ b/tools/Utilities/src/Strings/en-us/Resources.resw
@@ -118,14 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="EnvVariablesEditorUtilityDesc" xml:space="preserve">
-    <value>A quick utility for managing environment variables.</value>
+    <value>Create and manage variable sets with a lightweight UI.</value>
   </data>
   <data name="EnvVariablesEditorUtilityTitle" xml:space="preserve">
     <value>Environment Variables Editor</value>
   </data>
   <data name="HostsFileEditorUtilityDesc" xml:space="preserve">
-    <value>Quick and simple utility for managing hosts file.</value>
-    <comment>;Locked={"hosts"}</comment>
+    <value>Add, filter, or remove file entries in less time.</value>
   </data>
   <data name="HostsFileEditorUtilityTitle" xml:space="preserve">
     <value>Hosts File Editor</value>
@@ -142,7 +141,7 @@
     <value>Project Ironsides</value>
   </data>
   <data name="RegistryPreviewUtilityDesc" xml:space="preserve">
-    <value>A quick little utility to visualize and edit complex Windows Registry files.</value>
+    <value>Edit and visualize Windows Registry files faster.</value>
   </data>
   <data name="RegistryPreviewUtilityTitle" xml:space="preserve">
     <value>Registry Preview</value>

--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -27,7 +27,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Description = stringResource.GetLocalized("HostsFileEditorUtilityDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2271355",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\HostsUILib", "Hosts.ico"),
-                LaunchAsAdminVisibility = Microsoft.UI.Xaml.Visibility.Visible,
+                SupportsLaunchAsAdmin = Microsoft.UI.Xaml.Visibility.Visible,
             },
             new(Path.Combine(appExAliasAbsFolderPath, "DevHome.RegistryPreviewApp.exe"))
             {
@@ -35,7 +35,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Description = stringResource.GetLocalized("RegistryPreviewUtilityDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2270966",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\RegistryPreview", "RegistryPreview.ico"),
-                LaunchAsAdminVisibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+                SupportsLaunchAsAdmin = Microsoft.UI.Xaml.Visibility.Collapsed,
             },
             new(Path.Combine(appExAliasAbsFolderPath, "DevHome.EnvironmentVariablesApp.exe"))
             {
@@ -43,7 +43,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Description = stringResource.GetLocalized("EnvVariablesEditorUtilityDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2270894",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\EnvironmentVariables", "EnvironmentVariables.ico"),
-                LaunchAsAdminVisibility = Microsoft.UI.Xaml.Visibility.Visible,
+                SupportsLaunchAsAdmin = Microsoft.UI.Xaml.Visibility.Visible,
             },
             new(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}\\devhome.pi.exe"), experimentationService, "ProjectIronsidesExperiment")
             {

--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -27,6 +27,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Description = stringResource.GetLocalized("HostsFileEditorUtilityDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2271355",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\HostsUILib", "Hosts.ico"),
+                LaunchAsAdminVisibility = Microsoft.UI.Xaml.Visibility.Visible,
             },
             new(Path.Combine(appExAliasAbsFolderPath, "DevHome.RegistryPreviewApp.exe"))
             {
@@ -34,6 +35,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Description = stringResource.GetLocalized("RegistryPreviewUtilityDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2270966",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\RegistryPreview", "RegistryPreview.ico"),
+                LaunchAsAdminVisibility = Microsoft.UI.Xaml.Visibility.Collapsed,
             },
             new(Path.Combine(appExAliasAbsFolderPath, "DevHome.EnvironmentVariablesApp.exe"))
             {
@@ -41,6 +43,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Description = stringResource.GetLocalized("EnvVariablesEditorUtilityDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2270894",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\EnvironmentVariables", "EnvironmentVariables.ico"),
+                LaunchAsAdminVisibility = Microsoft.UI.Xaml.Visibility.Visible,
             },
             new(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}\\devhome.pi.exe"), experimentationService, "ProjectIronsidesExperiment")
             {

--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -25,21 +25,21 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
             {
                 Title = stringResource.GetLocalized("HostsFileEditorUtilityTitle"),
                 Description = stringResource.GetLocalized("HostsFileEditorUtilityDesc"),
-                NavigateUri = "https://aka.ms/PowerToysOverview_HostsFileEditor",
+                NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2271355",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\HostsUILib", "Hosts.ico"),
             },
             new(Path.Combine(appExAliasAbsFolderPath, "DevHome.RegistryPreviewApp.exe"))
             {
                 Title = stringResource.GetLocalized("RegistryPreviewUtilityTitle"),
                 Description = stringResource.GetLocalized("RegistryPreviewUtilityDesc"),
-                NavigateUri = "https://aka.ms/PowerToysOverview_RegistryPreview",
+                NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2270966",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\RegistryPreview", "RegistryPreview.ico"),
             },
             new(Path.Combine(appExAliasAbsFolderPath, "DevHome.EnvironmentVariablesApp.exe"))
             {
                 Title = stringResource.GetLocalized("EnvVariablesEditorUtilityTitle"),
                 Description = stringResource.GetLocalized("EnvVariablesEditorUtilityDesc"),
-                NavigateUri = "https://aka.ms/PowerToysOverview_EnvironmentVariables",
+                NavigateUri = "https://go.microsoft.com/fwlink/?Linkid=2270894",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\EnvironmentVariables", "EnvironmentVariables.ico"),
             },
             new(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}\\devhome.pi.exe"), experimentationService, "ProjectIronsidesExperiment")

--- a/tools/Utilities/src/ViewModels/UtilityViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilityViewModel.cs
@@ -21,7 +21,7 @@ public class UtilityViewModel : INotifyPropertyChanged
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(UtilityViewModel));
     private readonly IExperimentationService? experimentationService;
     private readonly string? experimentalFeature;
-    private readonly string exeName;
+    private readonly string _exeName;
 #nullable disable
 
     public bool Visible
@@ -76,7 +76,7 @@ public class UtilityViewModel : INotifyPropertyChanged
 #nullable enable
     public UtilityViewModel(string exeName, IExperimentationService? experimentationService = null, string? experimentalFeature = null)
     {
-        this.exeName = exeName;
+        this._exeName = exeName;
         this.experimentationService = experimentationService;
         this.experimentalFeature = experimentalFeature;
         LaunchCommand = new RelayCommand(Launch);
@@ -86,12 +86,12 @@ public class UtilityViewModel : INotifyPropertyChanged
 
     private void Launch()
     {
-        _log.Information("Launching {ExeName}, as admin: {RunAsAdmin}", exeName, launchAsAdmin);
+        _log.Information($"Launching {_exeName}, as admin: {launchAsAdmin}");
 
         // We need to start the process with ShellExecute to run elevated
         var processStartInfo = new ProcessStartInfo
         {
-            FileName = exeName,
+            FileName = _exeName,
             UseShellExecute = true,
 
             Verb = launchAsAdmin ? "runas" : "open",
@@ -108,7 +108,7 @@ public class UtilityViewModel : INotifyPropertyChanged
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to start process {ExeName}", exeName);
+            _log.Error(ex, "Failed to start process {ExeName}", _exeName);
         }
 
         TelemetryFactory.Get<DevHome.Telemetry.ITelemetry>().Log("Utilities_UtilitiesLaunchEvent", LogLevel.Critical, new UtilitiesLaunchEvent(Title, launchAsAdmin), null);

--- a/tools/Utilities/src/ViewModels/UtilityViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilityViewModel.cs
@@ -62,7 +62,7 @@ public partial class UtilityViewModel : ObservableObject
         this.experimentationService = experimentationService;
         this.experimentalFeature = experimentalFeature;
         LaunchCommand = new RelayCommand(Launch);
-        _log.Information("UtilityViewModel created for Title: {Title}, exe: {ExeName}", Title, exeName);
+        _log.Information($"UtilityViewModel created for Title: {Title}, exe: {exeName}");
     }
 #nullable disable
 
@@ -84,13 +84,13 @@ public partial class UtilityViewModel : ObservableObject
             var process = Process.Start(processStartInfo);
             if (process is null)
             {
-                _log.Error("Failed to start process {ExeName}", exeName);
+                _log.Error($"Failed to start process {_exeName}");
                 throw new InvalidOperationException("Failed to start process");
             }
         }
         catch (Exception ex)
         {
-            _log.Error(ex, "Failed to start process {ExeName}", _exeName);
+            _log.Error(ex, $"Failed to start process {_exeName}");
         }
 
         TelemetryFactory.Get<DevHome.Telemetry.ITelemetry>().Log("Utilities_UtilitiesLaunchEvent", LogLevel.Critical, new UtilitiesLaunchEvent(Title, LaunchAsAdmin), null);

--- a/tools/Utilities/src/ViewModels/UtilityViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilityViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Services;
 using DevHome.Telemetry;
@@ -14,7 +15,7 @@ using Serilog;
 
 namespace DevHome.Utilities.ViewModels;
 
-public class UtilityViewModel : INotifyPropertyChanged
+public partial class UtilityViewModel : ObservableObject
 {
 #nullable enable
 
@@ -39,8 +40,6 @@ public class UtilityViewModel : INotifyPropertyChanged
         }
     }
 
-    private bool launchAsAdmin;
-
     public string Title { get; set; }
 
     public string Description { get; set; }
@@ -51,27 +50,10 @@ public class UtilityViewModel : INotifyPropertyChanged
 
     public ICommand LaunchCommand { get; set; }
 
-    public Visibility LaunchAsAdminVisibility { get; set; }
+    public Visibility SupportsLaunchAsAdmin { get; set; }
 
-    public bool LaunchAsAdmin
-    {
-        get => launchAsAdmin;
-
-        set
-        {
-            if (launchAsAdmin != value)
-            {
-                launchAsAdmin = value;
-            }
-        }
-    }
-
-    public event PropertyChangedEventHandler PropertyChanged;
-
-    protected virtual void OnPropertyChanged(string propertyName)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-    }
+    [ObservableProperty]
+    private bool _launchAsAdmin;
 
 #nullable enable
     public UtilityViewModel(string exeName, IExperimentationService? experimentationService = null, string? experimentalFeature = null)
@@ -86,7 +68,7 @@ public class UtilityViewModel : INotifyPropertyChanged
 
     private void Launch()
     {
-        _log.Information($"Launching {_exeName}, as admin: {launchAsAdmin}");
+        _log.Information($"Launching {_exeName}, as admin: {LaunchAsAdmin}");
 
         // We need to start the process with ShellExecute to run elevated
         var processStartInfo = new ProcessStartInfo
@@ -94,7 +76,7 @@ public class UtilityViewModel : INotifyPropertyChanged
             FileName = _exeName,
             UseShellExecute = true,
 
-            Verb = launchAsAdmin ? "runas" : "open",
+            Verb = LaunchAsAdmin ? "runas" : "open",
         };
 
         try
@@ -111,6 +93,6 @@ public class UtilityViewModel : INotifyPropertyChanged
             _log.Error(ex, "Failed to start process {ExeName}", _exeName);
         }
 
-        TelemetryFactory.Get<DevHome.Telemetry.ITelemetry>().Log("Utilities_UtilitiesLaunchEvent", LogLevel.Critical, new UtilitiesLaunchEvent(Title, launchAsAdmin), null);
+        TelemetryFactory.Get<DevHome.Telemetry.ITelemetry>().Log("Utilities_UtilitiesLaunchEvent", LogLevel.Critical, new UtilitiesLaunchEvent(Title, LaunchAsAdmin), null);
     }
 }

--- a/tools/Utilities/src/Views/UtilityView.xaml
+++ b/tools/Utilities/src/Views/UtilityView.xaml
@@ -60,12 +60,11 @@
             </StackPanel>
         </ScrollViewer>
 
-        <SplitButton
+        <ToggleSwitch
+            x:Uid="SupportsLaunchAsAdmin"
             Grid.Row="2"
             IsOn="{x:Bind ViewModel.LaunchAsAdmin, Mode=TwoWay}"
-            Visibility="{x:Bind ViewModel.LaunchAsAdminVisibility, Mode=OneWay}"
-            OnContent="Launch as administrator"
-            OffContent="Launch as administrator"
+            Visibility="{x:Bind ViewModel.SupportsLaunchAsAdmin, Mode=OneWay}"
             Margin="15 0 0 5"/>
 
         <Button
@@ -74,8 +73,7 @@
             Command="{x:Bind ViewModel.LaunchCommand}">
 
             <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Launch" Margin="0 0 5 0" />
-                <FontIcon Glyph="&#xE8A7;" FontSize="12" />
+                <TextBlock x:Uid="LaunchButton" />
             </StackPanel>
         </Button>
 

--- a/tools/Utilities/src/Views/UtilityView.xaml
+++ b/tools/Utilities/src/Views/UtilityView.xaml
@@ -22,13 +22,15 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Image
             Grid.Row="0"
             Source="{x:Bind ViewModel.ImageSource}"
-            HorizontalAlignment="Stretch"
+            HorizontalAlignment="Left"
             VerticalAlignment="Top"
+            Margin="15 5 0 0"
             Width="64"
             Height="64"/>
 
@@ -60,27 +62,22 @@
 
         <SplitButton
             Grid.Row="2"
-            HorizontalAlignment="Center"
+            IsOn="{x:Bind ViewModel.LaunchAsAdmin, Mode=TwoWay}"
+            Visibility="{x:Bind ViewModel.LaunchAsAdminVisibility, Mode=OneWay}"
+            OnContent="Launch as administrator"
+            OffContent="Launch as administrator"
+            Margin="15 0 0 5"/>
+
+        <Button
+            Grid.Row="3"
+            Margin="15 5 0 0"
             Command="{x:Bind ViewModel.LaunchCommand}">
 
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Launch" Margin="0 0 5 0" />
                 <FontIcon Glyph="&#xE8A7;" FontSize="12" />
             </StackPanel>
-
-            <SplitButton.Flyout>
-                <MenuFlyout>
-                    <MenuFlyoutItem
-                        Text="Launch as Admin"
-                        Command="{x:Bind ViewModel.LaunchAsAdminCommand}">
-
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xE7EF;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                </MenuFlyout>
-            </SplitButton.Flyout>
-        </SplitButton>
+        </Button>
 
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary of the pull request
This PR updates design of utilities page to remove the split button and add a toggle for admin launch. This change also updates descriptions to strings written by the content writer and links to go links instead of aka.ms. 

![image](https://github.com/microsoft/devhome/assets/47045043/29acfb55-f9c3-4660-a282-269d9e977306)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually validated

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
