### PR TITLE
Update pinning operation and delete operation for HyperV

### DIFF
--- a/common/Environments/Models/ComputeSystemCache.cs
+++ b/common/Environments/Models/ComputeSystemCache.cs
@@ -235,8 +235,18 @@ public class ComputeSystemCache
     public async Task FetchDataAsync()
     {
         _ = await GetStateAsync();
-        _ = SupportedOperations.Value;
-        _ = await GetIsPinnedToStartMenuAsync();
+        var supportedOperations = SupportedOperations?.Value ?? ComputeSystemOperations.None;
+
+        if (supportedOperations.HasFlag(ComputeSystemOperations.PinToStartMenu))
+        {
+            _ = await GetIsPinnedToStartMenuAsync();
+        }
+
+        if (supportedOperations.HasFlag(ComputeSystemOperations.PinToTaskbar))
+        {
+           _ = await GetIsPinnedToTaskbarAsync();
+        }
+
         _ = await GetComputeSystemThumbnailAsync(string.Empty);
         _ = await GetComputeSystemPropertiesAsync(string.Empty);
     }

--- a/extensions/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
@@ -367,8 +367,23 @@ public class HyperVManager : IHyperVManager, IDisposable
                 return false;
             }
 
-            var virtualMachine = _hyperVVirtualMachineFactory(vmObject);
-            return virtualMachine.IsDeleted;
+            var psObjectHelper = new PsObjectHelper(vmObject);
+
+            // Check if the Hyper-V virtual machine object returned to use has its IsDeleted status set to true
+            if (psObjectHelper.MemberNameToValue<bool>("IsDeleted"))
+            {
+                return true;
+            }
+
+            // Unfortunately sometimes the IsDeleted property can be set to false and dynamically
+            // update to true later on. There is no documentation for the Hyper-V objects, or best practices for the Hyper-V PowerShell
+            // cmdlets, so we will do an additional check by attempting to get the VM with the Get-VM cmdlet. If there are no results
+            // we can say the VM has been deleted.
+            result = _powerShellService.Execute(GetVMCommandLineStatement(vmId), PipeType.None);
+            _log.Information($"Attempted second try of deletion check with result message: {result.CommandOutputErrorMessage}");
+
+            // If the VM does not exist then there should be no PsObjects in the list.
+            return result.PsObjects.FirstOrDefault() == null;
         }
         finally
         {

--- a/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Services;
+using DevHome.Environments.Models;
 using DevHome.Environments.ViewModels;
 using Microsoft.Windows.DevHome.SDK;
 
@@ -41,47 +42,53 @@ public class DataExtractor
         return operations;
     }
 
-    public static async Task<List<OperationsViewModel>> FillDotButtonPinOperationsAsync(ComputeSystemCache computeSystem)
+    public static async Task<List<PinOperationData>> FillDotButtonPinOperationsAsync(ComputeSystemCache computeSystem)
     {
         var supportedOperations = computeSystem.SupportedOperations.Value;
-        var operations = new List<OperationsViewModel>();
+        var operationData = new List<PinOperationData>();
         if (supportedOperations.HasFlag(ComputeSystemOperations.PinToTaskbar))
         {
             var pinResultTaskbar = await computeSystem.GetIsPinnedToTaskbarAsync();
+            OperationsViewModel? operation = null;
             if (pinResultTaskbar.Result.Status == ProviderOperationStatus.Success)
             {
                 if (pinResultTaskbar.IsPinned)
                 {
                     var itemText = _stringResource.GetLocalized("UnpinFromTaskbarButtonContextMenuItem");
-                    operations.Add(new OperationsViewModel(itemText, "\uE77A", computeSystem.UnpinFromTaskbarAsync, ComputeSystemOperations.PinToTaskbar, "Unpin"));
+                    operation = new OperationsViewModel(itemText, "\uE77A", computeSystem.UnpinFromTaskbarAsync, ComputeSystemOperations.PinToTaskbar, "Unpin");
                 }
                 else
                 {
                     var itemText = _stringResource.GetLocalized("PinToTaskbarButtonContextMenuItem");
-                    operations.Add(new OperationsViewModel(itemText, "\uE718", computeSystem.PinToTaskbarAsync, ComputeSystemOperations.PinToTaskbar, "Pin"));
+                    operation = new OperationsViewModel(itemText, "\uE718", computeSystem.PinToTaskbarAsync, ComputeSystemOperations.PinToTaskbar, "Pin");
                 }
             }
+
+            operationData.Add(new(operation, pinResultTaskbar));
         }
 
         if (supportedOperations.HasFlag(ComputeSystemOperations.PinToStartMenu))
         {
             var pinResultStartMenu = await computeSystem.GetIsPinnedToStartMenuAsync();
+            OperationsViewModel? operation = null;
             if (pinResultStartMenu.Result.Status == ProviderOperationStatus.Success)
             {
                 if (pinResultStartMenu.IsPinned)
                 {
                     var itemText = _stringResource.GetLocalized("UnpinFromStartButtonContextMenuItem");
-                    operations.Add(new OperationsViewModel(itemText, "\uE77A", computeSystem.UnpinFromStartMenuAsync, ComputeSystemOperations.PinToStartMenu, "Unpin"));
+                    operation = new OperationsViewModel(itemText, "\uE77A", computeSystem.UnpinFromStartMenuAsync, ComputeSystemOperations.PinToStartMenu, "Unpin");
                 }
                 else
                 {
                     var itemText = _stringResource.GetLocalized("PinToStartButtonContextMenuItem");
-                    operations.Add(new OperationsViewModel(itemText, "\uE718", computeSystem.PinToStartMenuAsync, ComputeSystemOperations.PinToStartMenu, "Pin"));
+                    operation = new OperationsViewModel(itemText, "\uE718", computeSystem.PinToStartMenuAsync, ComputeSystemOperations.PinToStartMenu, "Pin");
                 }
             }
+
+            operationData.Add(new(operation, pinResultStartMenu));
         }
 
-        return operations;
+        return operationData;
     }
 
     /// <summary>

--- a/tools/Environments/DevHome.Environments/Models/PinOperationData.cs
+++ b/tools/Environments/DevHome.Environments/Models/PinOperationData.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHome.Environments.ViewModels;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace DevHome.Environments.Models;
+
+public class PinOperationData
+{
+    public OperationsViewModel? ViewModel { get; }
+
+    public bool WasPinnedStatusSuccessful { get; }
+
+    public string? PinnedStatusDisplayMessage { get; }
+
+    public string? PinnedStatusDiagnosticText { get; }
+
+    public PinOperationData(OperationsViewModel? viewModel, ComputeSystemPinnedResult pinnedResult)
+    {
+        ViewModel = viewModel;
+        WasPinnedStatusSuccessful = pinnedResult.Result.Status == ProviderOperationStatus.Success;
+        PinnedStatusDisplayMessage = pinnedResult.Result.DisplayMessage;
+        PinnedStatusDiagnosticText = pinnedResult.Result.DiagnosticText;
+    }
+}

--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -158,7 +158,7 @@
     <comment>Text for the revert checkpoint button that will revert a virtual machines checkpoint to its previous checkpoint.</comment>
   </data>
   <data name="ShutdownButtonContextMenuItem" xml:space="preserve">
-    <value>Shutdown</value>
+    <value>Shut down</value>
     <comment>Text for shutdown button in the context menu that will shutdown the virtual machines operating system.</comment>
   </data>
   <data name="StartButtonContextMenuItem" xml:space="preserve">
@@ -318,7 +318,7 @@
     <comment>Text for the start operation shown for the environment.</comment>
   </data>
   <data name="Operations_Shutdown" xml:space="preserve">
-    <value>Shutdown</value>
+    <value>Shut down</value>
     <comment>Text for the shutdown operation shown for the environment.</comment>
   </data>
   <data name="Operations_Terminate" xml:space="preserve">

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -157,8 +157,18 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     private async Task RefreshOperationDataAsync()
     {
         ComputeSystem.ResetSupportedOperations();
-        ComputeSystem.ResetPinnedToStartMenu();
-        ComputeSystem.ResetPinnedToTaskbar();
+        var supportedOperations = ComputeSystem.SupportedOperations?.Value ?? ComputeSystemOperations.None;
+
+        if (supportedOperations.HasFlag(ComputeSystemOperations.PinToStartMenu))
+        {
+            ComputeSystem.ResetPinnedToStartMenu();
+        }
+
+        if (supportedOperations.HasFlag(ComputeSystemOperations.PinToTaskbar))
+        {
+            ComputeSystem.ResetPinnedToTaskbar();
+        }
+
         ComputeSystem.ResetComputeSystemProperties();
         await InitializeOperationDataAsync();
     }

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -55,7 +55,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     public string PackageFullName { get; set; }
 
     private readonly Func<ComputeSystemCardBase, bool> _removalAction;
-    private bool disposedValue;
+    private bool _disposedValue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ComputeSystemViewModel"/> class.
@@ -405,14 +405,14 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 
     protected virtual void Dispose(bool disposing)
     {
-        if (!disposedValue)
+        if (!_disposedValue)
         {
             if (disposing)
             {
                 _semaphoreSlimLock.Release();
             }
 
-            disposedValue = true;
+            _disposedValue = true;
         }
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -418,7 +418,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         {
             if (disposing)
             {
-                _semaphoreSlimLock.Release();
+                _semaphoreSlimLock.Dispose();
             }
 
             _disposedValue = true;

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -27,7 +27,6 @@ using Serilog;
 using Windows.Foundation;
 using WinUIEx;
 using WinUIEx.Messaging;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace DevHome.Environments.ViewModels;
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -136,7 +136,8 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
                 if ((!data.WasPinnedStatusSuccessful) || (data.ViewModel == null))
                 {
                     // TODO: pinned status for dev box for example fails often. So we'll log it and not show notifications so we don't overload the user with
-                    // redundant notifications until the feature is fixed.
+                    // failure notifications until the feature is fixed. We simply do not show the pinned icons in these cases since we don't know which ones
+                    // to show.
                     _log.Error($"Pinned status check failed: for '{Name}': {data?.PinnedStatusDisplayMessage}. DiagnosticText: {data?.PinnedStatusDiagnosticText}");
                     continue;
                 }

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -332,7 +332,7 @@
             </Grid>
         </ScrollViewer>
         <Grid Grid.Row="3" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
-            <InfoBar MaxWidth="480"
+            <InfoBar MaxWidth="600"
                 Margin="24"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Bottom">


### PR DESCRIPTION
## Summary of the pull request

**Note: secondary PR in Azure extension:**  https://github.com/microsoft/DevHomeAzureExtension/pull/182

This PR does two things, it updates how we reset the pinned/unpinned status in the Environments page and updates how we check if a Hyper-V VM has been deleted.

When a compute system provider performs an operation in the environments page, they first send dev home an updated State. E.g `Saving`. Then when the operation is done an updated state event is sent e.g `Saved`. Both time we update the operations in the menu flyout as the supported operations can change based on the state. Before this change when Pinning/Unpinning was performed, no telemetry and no updates to the operations were performed. 

Unlike regular operations the pinning operations are asynchronous as we first need to check the status of whether the environment is pinned or not. If its pinned we will show the "Unpin" operations in the menu flyout, and if its not pinned we will show the "Pin" operations in the menu flyout. Due to this asynchronous call we need to lock the method so there is not a race between updating the operations for the initial "Saving" state and updating them when it changes to "Saved". So I added a semphore lock to prevent this.

I also slight tweaked how we check if a Hyper-V VM is deleted by adding another check as sometimes the powershell object may say its not deleted but it actually was. Causing us to show the wrong UI in Dev Home

Other small updates:

- Shutdown resource value named "Shutdown" instead of "Shut down". Missed in my last PR so updated here
- widen the infobar as it was cutting off some error messages
- Added a class to hold the pinning operation and the results of the `GetIsPinnedToTaskbarAsync` and `GetIsPinnedToStartMenuAsync` operations so in the future we can show the user the errors in the UI when the Windows app code is more stable.

Videos

Showing Pinning:

https://github.com/microsoft/devhome/assets/105318831/cf424578-62b2-4c28-ab9a-af0ebe93399f

Showing Deleting Hyper-V VM:


https://github.com/microsoft/devhome/assets/105318831/7d2bcaf6-aa00-4093-aa37-7f8982bb6deb



## References and relevant issues

## Detailed description of the pull request / Additional comments
**Note: Due to the asynchrous calls for GetPinStatusAsync, when the operation to pin/upin the dev box is completed, the pin/pinned operations don't reset until GetPinStatusAsync is complete so there is a small delay when the operations update. We can work on trying to optimize this reset in a future PR. What happens is if the user clicks the menu flyout immediately after pinning it will close as it updates with the new items. You can see it happen in this video:
**

https://github.com/microsoft/devhome/assets/105318831/05187da8-d467-46a1-88cf-0e356ccfaa8a


## Validation steps performed

## PR checklist
- [x] Closes #2877
- [ ] Tests added/passed
- [ ] Documentation updated
