### PR TITLE
Adding tooltips to NavigationViewItems on AddWidget dialog

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -107,6 +107,8 @@ public sealed partial class AddWidgetDialog : ContentDialog
                     Content = providerDef.DisplayName,
                 };
 
+                navItem.SetValue(ToolTipService.ToolTipProperty, providerDef.DisplayName);
+
                 foreach (var widgetDef in comSafeWidgetDefinitions)
                 {
                     if (widgetDef.ProviderDefinitionId.Equals(providerDef.Id, StringComparison.Ordinal))
@@ -121,6 +123,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
                         };
                         subItem.SetValue(AutomationProperties.AutomationIdProperty, $"NavViewItem_{widgetDef.Id}");
                         subItem.SetValue(AutomationProperties.NameProperty, widgetDef.DisplayTitle);
+                        subItem.SetValue(ToolTipService.ToolTipProperty, widgetDef.DisplayTitle);
 
                         navItem.MenuItems.Add(subItem);
                     }


### PR DESCRIPTION
## Summary of the pull request
This PR adds tooltips to the menu items in the `AddWidgetDialog` page.

![image](https://github.com/microsoft/devhome/assets/13912953/9e7aafbd-d7db-4728-846e-ed4263ec2326)

## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/49360580
https://dev.azure.com/microsoft/OS/_workitems/edit/50153016
## Detailed description of the pull request / Additional comments
If the string have too many characters, the text will be clipped on the `NavigtationViewItem` on the `AddWidgetDialog` page. This can also happen when the user needs to scale up the size of the text to 200% for example. Limiting the size of the strings is also problematic because of changes on the size due to localization to other languages.

This issue also appears externally from Dev Home, on the Windows 11 start menu for example. And the way they worked around this is adding tooltips that can fully show the intended string.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
