### PR TITLE
Use absolute alias path to launch utilities

### DIFF
--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Services;
+using Windows.ApplicationModel;
 
 namespace DevHome.Utilities.ViewModels;
 
@@ -15,25 +16,26 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
 
     public UtilitiesMainPageViewModel()
     {
+        var appExAliasAbsFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}");
         var stringResource = new StringResource("DevHome.Utilities.pri", "DevHome.Utilities/Resources");
 
         Utilities = new ObservableCollection<UtilityViewModel>
         {
-            new("DevHome.HostsFileEditorApp.exe")
+            new(Path.Combine(appExAliasAbsFolderPath, "DevHome.HostsFileEditorApp.exe"))
             {
                 Title = stringResource.GetLocalized("HostsFileEditorUtilityTitle"),
                 Description = stringResource.GetLocalized("HostsFileEditorUtilityDesc"),
                 NavigateUri = "https://aka.ms/PowerToysOverview_HostsFileEditor",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\HostsUILib", "Hosts.ico"),
             },
-            new("DevHome.RegistryPreviewApp.exe")
+            new(Path.Combine(appExAliasAbsFolderPath, "DevHome.RegistryPreviewApp.exe"))
             {
                 Title = stringResource.GetLocalized("RegistryPreviewUtilityTitle"),
                 Description = stringResource.GetLocalized("RegistryPreviewUtilityDesc"),
                 NavigateUri = "https://aka.ms/PowerToysOverview_RegistryPreview",
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\RegistryPreview", "RegistryPreview.ico"),
             },
-            new("DevHome.EnvironmentVariablesApp.exe")
+            new(Path.Combine(appExAliasAbsFolderPath, "DevHome.EnvironmentVariablesApp.exe"))
             {
                 Title = stringResource.GetLocalized("EnvVariablesEditorUtilityTitle"),
                 Description = stringResource.GetLocalized("EnvVariablesEditorUtilityDesc"),

--- a/tools/Utilities/src/ViewModels/UtilityViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilityViewModel.cs
@@ -68,11 +68,18 @@ public class UtilityViewModel : INotifyPropertyChanged
             Verb = runAsAdmin ? "runas" : "open",
         };
 
-        var process = Process.Start(processStartInfo);
-        if (process is null)
+        try
         {
-            _log.Error("Failed to start process {ExeName}", exeName);
-            throw new InvalidOperationException("Failed to start process");
+            var process = Process.Start(processStartInfo);
+            if (process is null)
+            {
+                _log.Error("Failed to start process {ExeName}", exeName);
+                throw new InvalidOperationException("Failed to start process");
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to start process {ExeName}", exeName);
         }
 
         TelemetryFactory.Get<DevHome.Telemetry.ITelemetry>().Log("Utilities_UtilitiesLaunchEvent", LogLevel.Critical, new UtilitiesLaunchEvent(Title, runAsAdmin), null);


### PR DESCRIPTION
## Summary of the pull request
AppExecutionAlias can be disabled from the Settings. This would remove exe entry from %locaappdata%\Microsoft\WindowsApps folder. Entry in %locaappdata%\Microsoft\WindowsApps\<package> still exists. Hence this PR switches to using that path. However, launch as admin still fails with this approach due to OS bug. 

This change also wraps Process.Start in try-catch to prevent DevHome from crashing.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2890
- [ ] Tests added/passed
- [ ] Documentation updated
