### PR TITLE
Changed AppDetailsPage IsXXX to a collection of readonly checkboxes

### DIFF
--- a/tools/PI/DevHome.PI/App.config
+++ b/tools/PI/DevHome.PI/App.config
@@ -34,15 +34,6 @@
         <setting name="IsProcessFilterIncludeBgTaskHost" serializeAs="String">
           <value>False</value>
         </setting>
-        <setting name="status1Source" serializeAs="String">
-          <value />
-        </setting>
-        <setting name="status2Source" serializeAs="String">
-          <value />
-        </setting>
-        <setting name="status3Source" serializeAs="String">
-          <value />
-        </setting>
         <setting name="SettingsToolPosition" serializeAs="Xml">
           <value>
             <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/tools/PI/DevHome.PI/BarWindow.xaml
+++ b/tools/PI/DevHome.PI/BarWindow.xaml
@@ -64,7 +64,7 @@
                     </ItemsPanelTemplate>
                 </GridView.ItemsPanel>
 
-                <StackPanel x:Name="AllControls" Orientation="{x:Bind BarOrientation, Mode=OneWay}" HorizontalAlignment="Center" Background="Transparent">
+                <StackPanel x:Name="AllControls" Orientation="{x:Bind BarOrientation, Mode=OneWay}" HorizontalAlignment="Center">
                     <controls:ProcessSelectionButton
                          x:Uid="ProcessChooserButton"
                          x:Name="ProcessChooserButton"

--- a/tools/PI/DevHome.PI/BarWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindow.xaml.cs
@@ -135,8 +135,6 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
         }
     }
 
-    private readonly ObservableCollection<Button> externalTools = [];
-
     private readonly WINEVENTPROC winPositionEventDelegate;
     private readonly WINEVENTPROC winFocusEventDelegate;
 
@@ -286,6 +284,13 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
 
     private void WindowEx_Closed(object sender, WindowEventArgs args)
     {
+        if (LargeContentPanel is not null
+            && LargeContentPanel.Visibility == Visibility.Visible
+            && !IsMaximized)
+        {
+            CacheRestoreState();
+        }
+
         ClipboardMonitor.Instance.Stop();
         TargetAppData.Instance.ClearAppData();
 

--- a/tools/PI/DevHome.PI/Controls/ProcessSelectionButton.cs
+++ b/tools/PI/DevHome.PI/Controls/ProcessSelectionButton.cs
@@ -20,7 +20,7 @@ public class ProcessSelectionButton : Button
     {
         base.OnPointerEntered(e);
 
-        // When the mouse cursor is over the button, change to the default cursor
+        // When the mouse cursor is over the button, change to the default cursor.
         ResetCursor();
     }
 
@@ -28,7 +28,7 @@ public class ProcessSelectionButton : Button
     {
         base.OnPointerExited(e);
 
-        // When the mouse cursor leaves the button, change the cursor to the cross
+        // When the mouse cursor leaves the button, change the cursor to the cross.
         ChangeCursor();
     }
 
@@ -37,7 +37,7 @@ public class ProcessSelectionButton : Button
         base.OnPointerReleased(e);
 
         // Were we showing the select cursor?
-        if (this.ProtectedCursor == null)
+        if (ProtectedCursor == null)
         {
             return;
         }
@@ -45,9 +45,8 @@ public class ProcessSelectionButton : Button
         Process? p;
         Windows.Win32.Foundation.HWND hwnd;
 
-        // Grab the window under the cursor and attach to that process
+        // Grab the window under the cursor and attach to that process.
         WindowHelper.GetAppInfoUnderMouseCursor(out p, out hwnd);
-
         if (p != null)
         {
             TargetAppData.Instance.SetNewAppData(p, hwnd);
@@ -58,11 +57,11 @@ public class ProcessSelectionButton : Button
 
     public void ChangeCursor()
     {
-        this.ProtectedCursor = InputSystemCursor.Create(InputSystemCursorShape.Cross);
+        ProtectedCursor = InputSystemCursor.Create(InputSystemCursorShape.Cross);
     }
 
     public void ResetCursor()
     {
-        this.ProtectedCursor = null;
+        ProtectedCursor = null;
     }
 }

--- a/tools/PI/DevHome.PI/Controls/ReadOnlyCheckBox.cs
+++ b/tools/PI/DevHome.PI/Controls/ReadOnlyCheckBox.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+
+namespace DevHome.PI.Controls;
+
+public class ReadOnlyCheckBox : CheckBox
+{
+    public static readonly DependencyProperty IsReadOnlyProperty =
+        DependencyProperty.Register(
+            nameof(IsReadOnly),
+            typeof(bool),
+            typeof(ReadOnlyCheckBox),
+            new PropertyMetadata(false));
+
+    public bool IsReadOnly
+    {
+        get => (bool)GetValue(IsReadOnlyProperty);
+        set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    protected override void OnToggle()
+    {
+        if (!IsReadOnly)
+        {
+            base.OnToggle();
+        }
+    }
+
+    protected override void OnPointerPressed(PointerRoutedEventArgs e)
+    {
+        if (!IsReadOnly)
+        {
+            base.OnPointerPressed(e);
+        }
+    }
+
+    protected override void OnKeyDown(KeyRoutedEventArgs e)
+    {
+        if (!IsReadOnly)
+        {
+            base.OnKeyDown(e);
+        }
+    }
+}

--- a/tools/PI/DevHome.PI/DevHome.PI.csproj
+++ b/tools/PI/DevHome.PI/DevHome.PI.csproj
@@ -74,6 +74,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.240109" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.3" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.9" GeneratePathProperty="true"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />

--- a/tools/PI/DevHome.PI/Models/AppRuntimeInfo.cs
+++ b/tools/PI/DevHome.PI/Models/AppRuntimeInfo.cs
@@ -62,7 +62,7 @@ public partial class AppRuntimeInfo : ObservableObject
         foreach (var item in FrameworkTypes)
         {
             // Skip if already matched.
-            if (item.Status == true)
+            if (item.IsTypeSupported == true)
             {
                 continue;
             }
@@ -71,14 +71,14 @@ public partial class AppRuntimeInfo : ObservableObject
             {
                 if (moduleName.Equals(item.Determinator, StringComparison.OrdinalIgnoreCase))
                 {
-                    item.Status = true;
+                    item.IsTypeSupported = true;
                 }
             }
             else
             {
                 if (moduleName.Contains(item.Determinator, StringComparison.OrdinalIgnoreCase))
                 {
-                    item.Status = true;
+                    item.IsTypeSupported = true;
                 }
             }
         }

--- a/tools/PI/DevHome.PI/Models/AppRuntimeInfo.cs
+++ b/tools/PI/DevHome.PI/Models/AppRuntimeInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.PI.Helpers;
 using Microsoft.UI.Xaml;
@@ -28,31 +30,7 @@ public partial class AppRuntimeInfo : ObservableObject
     private bool isPackaged = false;
 
     [ObservableProperty]
-    private bool usesWpf = false;
-
-    [ObservableProperty]
-    private bool usesWinForms = false;
-
-    [ObservableProperty]
-    private bool usesMfc = false;
-
-    [ObservableProperty]
     private bool isStoreApp = false;
-
-    [ObservableProperty]
-    private bool isAvalonia = false;
-
-    [ObservableProperty]
-    private bool isMaui = false;
-
-    [ObservableProperty]
-    private bool usesWinAppSdk = false;
-
-    [ObservableProperty]
-    private bool usesWinUi = false;
-
-    [ObservableProperty]
-    private bool usesDirectX = false;
 
     [ObservableProperty]
     private bool isRunningAsAdmin = false;
@@ -62,4 +40,47 @@ public partial class AppRuntimeInfo : ObservableObject
 
     [ObservableProperty]
     private Visibility visibility = Visibility.Visible;
+
+    public ObservableCollection<FrameworkType> FrameworkTypes { get; } = [];
+
+    public AppRuntimeInfo()
+    {
+        // Note these are in alphabetical order of Name.
+        FrameworkTypes.Add(new FrameworkType("Avalonia.Base.dll", "Avalonia"));
+        FrameworkTypes.Add(new FrameworkType("DXCore.dll", "DirectX"));
+        FrameworkTypes.Add(new FrameworkType("Microsoft.Maui.dll", "Maui"));
+        FrameworkTypes.Add(new FrameworkType("MFC", "MFC", false));
+        FrameworkTypes.Add(new FrameworkType("Python.exe", "Python"));
+        FrameworkTypes.Add(new FrameworkType("Microsoft.Windows.SDK.NET.dll", "Windows App SDK"));
+        FrameworkTypes.Add(new FrameworkType("System.Windows.Forms.dll", "Windows Forms"));
+        FrameworkTypes.Add(new FrameworkType("Microsoft.WinUI.dll", "WinUI"));
+        FrameworkTypes.Add(new FrameworkType("PresentationFramework.dll", "WPF"));
+    }
+
+    public void CheckFrameworkTypes(string moduleName)
+    {
+        foreach (var item in FrameworkTypes)
+        {
+            // Skip if already matched.
+            if (item.Status == true)
+            {
+                continue;
+            }
+
+            if (item.IsExactMatch)
+            {
+                if (moduleName.Equals(item.Determinator, StringComparison.OrdinalIgnoreCase))
+                {
+                    item.Status = true;
+                }
+            }
+            else
+            {
+                if (moduleName.Contains(item.Determinator, StringComparison.OrdinalIgnoreCase))
+                {
+                    item.Status = true;
+                }
+            }
+        }
+    }
 }

--- a/tools/PI/DevHome.PI/Models/FrameworkType.cs
+++ b/tools/PI/DevHome.PI/Models/FrameworkType.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DevHome.PI.Models;
+
+public partial class FrameworkType : ObservableObject
+{
+    internal bool IsExactMatch { get; private set; } = true;
+
+    internal string Determinator
+    {
+        get; set;
+    }
+
+    public string Name
+    {
+        get; set;
+    }
+
+    [ObservableProperty]
+    private bool status;
+
+    public FrameworkType(string determinator, string name, bool isExactMatch = true)
+    {
+        Determinator = determinator;
+        Name = name;
+        IsExactMatch = isExactMatch;
+    }
+}

--- a/tools/PI/DevHome.PI/Models/FrameworkType.cs
+++ b/tools/PI/DevHome.PI/Models/FrameworkType.cs
@@ -20,7 +20,7 @@ public partial class FrameworkType : ObservableObject
     }
 
     [ObservableProperty]
-    private bool status;
+    private bool isTypeSupported;
 
     public FrameworkType(string determinator, string name, bool isExactMatch = true)
     {

--- a/tools/PI/DevHome.PI/PIApp.xaml
+++ b/tools/PI/DevHome.PI/PIApp.xaml
@@ -25,6 +25,7 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+            
             <StackLayout x:Name="ExternalToolsHorizontalLayout" Orientation="Horizontal" />
             <StackLayout x:Name="ExternalToolsVerticalLayout" Orientation="Vertical" />
 

--- a/tools/PI/DevHome.PI/PIApp.xaml
+++ b/tools/PI/DevHome.PI/PIApp.xaml
@@ -27,6 +27,7 @@
             </Style>
             <StackLayout x:Name="ExternalToolsHorizontalLayout" Orientation="Horizontal" />
             <StackLayout x:Name="ExternalToolsVerticalLayout" Orientation="Vertical" />
+
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -78,7 +78,7 @@
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="models:FrameworkType">
                                 <local:ReadOnlyCheckBox
-                                    Content="{x:Bind Name, Mode=OneWay}" IsChecked="{x:Bind Status, Mode=OneWay}" 
+                                    Content="{x:Bind Name, Mode=OneWay}" IsChecked="{x:Bind IsTypeSupported, Mode=OneWay}" 
                                     Width="180" IsReadOnly="True"/>
                             </DataTemplate>
                         </ListView.ItemTemplate>

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -5,6 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:DevHome.PI.Models"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:local="using:DevHome.PI.Controls"
     mc:Ignorable="d">
 
     <Grid>
@@ -31,19 +34,6 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="200"/>
@@ -51,39 +41,60 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Uid="IDTextBlock"/>
                 <TextBox Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.ProcessId, Mode=OneWay}" IsReadOnly="True"/>
-                <TextBlock Grid.Row="1" x:Uid="BasePriorityTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="1" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.BasePriority, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="2" x:Uid="PriorityClassTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.PriorityClass, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="3" x:Uid="MainModuleTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.MainModuleFileName, Mode=OneWay}" IsReadOnly="True" TextWrapping="Wrap" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="4" x:Uid="BinaryTypeTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="4" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.BinaryType, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="5" x:Uid="MSIXPackagedTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="5" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsPackaged, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="6" x:Uid="UsesWPFTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="6" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.UsesWpf, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="7" x:Uid="UsesWinFormsTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="7" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.UsesWinForms, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="8" x:Uid="UsesMFCTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="8" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.UsesMfc, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="9" x:Uid="MicrosoftStoreAppTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="9" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsStoreApp, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="10" x:Uid="IsAvaloniaTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="10" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsAvalonia, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="11" x:Uid="IsMauiTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="11" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsMaui, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="12" x:Uid="UsesWinAppSdkTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="12" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.UsesWinAppSdk, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="13" x:Uid="UsesWinUiTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="13" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.UsesWinUi, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="14" x:Uid="UsesDirectXTextBlock" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBox Grid.Row="14" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.UsesDirectX, Mode=OneWay}" IsReadOnly="True" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}"/>
-                <TextBlock Grid.Row="15" x:Uid="IsRunningAsSystemTextBlock"/>
-                <TextBox Grid.Row="15" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsSystem, Mode=OneWay}" IsReadOnly="True"/>
-                <TextBlock Grid.Row="16" x:Uid="IsRunningAsAdminTextBlock"/>
-                <TextBox Grid.Row="16" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsAdmin, Mode=OneWay}" IsReadOnly="True"/>
-                <Button Grid.Row="17" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
+                
+                <!-- These fields can't be reported if we get an exception accessing them,
+                for example if the target app is running elevated but PI is not. -->
+                <Grid Grid.Row="1" Grid.ColumnSpan="2" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="200"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock x:Uid="BasePriorityTextBlock"/>
+                    <TextBox Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.BasePriority, Mode=OneWay}" IsReadOnly="True" />
+                    <TextBlock Grid.Row="1" x:Uid="PriorityClassTextBlock" />
+                    <TextBox Grid.Row="1" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.PriorityClass, Mode=OneWay}" IsReadOnly="True" />
+                    <TextBlock Grid.Row="2" x:Uid="MainModuleTextBlock" />
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.MainModuleFileName, Mode=OneWay}" IsReadOnly="True" TextWrapping="Wrap" />
+                    <TextBlock Grid.Row="3" x:Uid="BinaryTypeTextBlock" />
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.BinaryType, Mode=OneWay}" IsReadOnly="True" />
+                    <TextBlock Grid.Row="4" x:Uid="MSIXPackagedTextBlock" />
+                    <TextBox Grid.Row="4" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsPackaged, Mode=OneWay}" IsReadOnly="True" />
+                    <TextBlock Grid.Row="5" x:Uid="MicrosoftStoreAppTextBlock" />
+                    <TextBox Grid.Row="5" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsStoreApp, Mode=OneWay}" IsReadOnly="True" />
+
+                    <TextBlock Grid.Row="6" x:Uid="FrameworkTypesTextBlock" />
+                    <ListView 
+                        Grid.Row="6" Grid.Column="1" IsItemClickEnabled="False"
+                        ItemsSource="{x:Bind ViewModel.AppInfo.FrameworkTypes, Mode=OneWay}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="models:FrameworkType">
+                                <local:ReadOnlyCheckBox
+                                    Content="{x:Bind Name, Mode=OneWay}" IsChecked="{x:Bind Status, Mode=OneWay}" 
+                                    Width="180" IsReadOnly="True"/>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <controls:WrapPanel/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ListView>
+                </Grid>
+                
+                <TextBlock Grid.Row="2" x:Uid="IsRunningAsSystemTextBlock"/>
+                <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsSystem, Mode=OneWay}" IsReadOnly="True"/>
+                <TextBlock Grid.Row="3" x:Uid="IsRunningAsAdminTextBlock"/>
+                <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsAdmin, Mode=OneWay}" IsReadOnly="True"/>
+                <Button Grid.Row="4" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
             </Grid>
         </ScrollViewer>
     </Grid>

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml.cs
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using DevHome.Common.Extensions;
-using DevHome.PI;
 using DevHome.PI.Telemetry;
 using DevHome.PI.ViewModels;
 using Microsoft.UI.Xaml;

--- a/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
@@ -8,7 +8,6 @@
     xmlns:models="using:DevHome.PI.Models"
     mc:Ignorable="d">
 
-
     <Grid>
         <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsList}">
             <ItemsControl.ItemTemplate>
@@ -17,7 +16,7 @@
                         <Expander.Header>
                             <TextBlock Text="{x:Bind Title}"/>
                         </Expander.Header>
-                        <RichTextBlock TextWrapping="Wrap" Margin="12,0,12,0">
+                        <RichTextBlock TextWrapping="Wrap" Margin="12,0,12,0" HorizontalAlignment="Left">
                             <Paragraph>
                                 <Run Text="{x:Bind Description}"/>
                             </Paragraph>

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:diagnostics="using:System.Diagnostics"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 
     <Grid>
@@ -25,8 +26,10 @@
         <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="220"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
+            
             <ListView x:Name="ModulesListView" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.ModuleList, Mode=OneWay}"
                       SelectedIndex="{x:Bind ViewModel.SelectedModuleIndex, Mode=TwoWay}">
                 <ListView.ItemTemplate>
@@ -38,7 +41,11 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-            <ScrollViewer Grid.Column="1" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
+
+            <controls:GridSplitter 
+                Grid.Column="1" ResizeBehavior="BasedOnAlignment" ResizeDirection="Auto" PointerPressed="GridSplitter_PointerPressed"/>
+
+            <ScrollViewer Grid.Column="2" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
                 <StackPanel x:Name="ModuleDetailsPanel" Margin="8,0,0,0">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                         <TextBlock Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).ModuleName, Mode=OneWay}"
@@ -58,6 +65,7 @@
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>
+            
         </Grid>
     </Grid>
 </Page>

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml.cs
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using DevHome.Common.Extensions;
-using DevHome.PI;
 using DevHome.PI.Telemetry;
 using DevHome.PI.ViewModels;
 using Microsoft.UI.Xaml;
@@ -25,5 +24,10 @@ public sealed partial class ModulesPage : Page
     {
         base.OnNavigatedTo(e);
         Application.Current.GetService<TelemetryReporter>().SwitchTo(Feature.LoadedModule);
+    }
+
+    private void GridSplitter_PointerPressed(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        e.Handled = true;
     }
 }

--- a/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
+++ b/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
@@ -133,42 +133,6 @@ namespace DevHome.PI.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string status1Source {
-            get {
-                return ((string)(this["status1Source"]));
-            }
-            set {
-                this["status1Source"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string status2Source {
-            get {
-                return ((string)(this["status2Source"]));
-            }
-            set {
-                this["status2Source"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string status3Source {
-            get {
-                return ((string)(this["status3Source"]));
-            }
-            set {
-                this["status3Source"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
 <ArrayOfString xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
   <string>50</string>

--- a/tools/PI/DevHome.PI/Properties/Settings.settings
+++ b/tools/PI/DevHome.PI/Properties/Settings.settings
@@ -29,15 +29,6 @@
     <Setting Name="IsProcessFilterIncludeBgTaskHost" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="status1Source" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
-    <Setting Name="status2Source" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
-    <Setting Name="status3Source" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
     <Setting Name="SettingsToolPosition" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
 &lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -209,18 +209,6 @@
     <value>MSIX packaged</value>
     <comment>This refers to whether the application is using MSIX packaging technology.</comment>
   </data>
-  <data name="UsesWPFTextBlock.Text" xml:space="preserve">
-    <value>Uses WPF</value>
-    <comment>This refers to whether the application is using Windows Presentation Framework (WPF) technology.</comment>
-  </data>
-  <data name="UsesWinFormsTextBlock.Text" xml:space="preserve">
-    <value>Uses Windows Forms</value>
-    <comment>This refers to whether the application is using Windows Forms technology.</comment>
-  </data>
-  <data name="UsesMFCTextBlock.Text" xml:space="preserve">
-    <value>Uses MFC</value>
-    <comment>This refers to whether the application is using Microsoft Foundation Class (MFC) technology.</comment>
-  </data>
   <data name="MicrosoftStoreAppTextBlock.Text" xml:space="preserve">
     <value>Microsoft Store app</value>
     <comment>This refers to whether the application was acquired via the Microsoft Store.</comment>
@@ -537,18 +525,6 @@
     <value>Code</value>
     <comment>This refers to a short hand for an error code representation of the contents of the clipboard.</comment>
   </data>
-  <data name="IsAvaloniaTextBlock.Text" xml:space="preserve">
-    <value>Is Avalonia</value>
-    <comment>This refers to whether the application is using the Avalonia framework</comment>
-  </data>
-  <data name="IsMauiTextBlock.Text" xml:space="preserve">
-    <value>Is Maui</value>
-    <comment>This refers to whether the application is using the Maui framework</comment>
-  </data>
-  <data name="UsesDirectXTextBlock.Text" xml:space="preserve">
-    <value>Uses DirectX</value>
-    <comment>This refers to whether the application is using DirectX</comment>
-  </data>
   <data name="IsRunningAsAdminTextBlock.Text" xml:space="preserve">
     <value>Is running as Admin</value>
     <comment>This refers to whether the application is running as admin</comment>
@@ -560,14 +536,6 @@
   <data name="RunElevatedButton.Content" xml:space="preserve">
     <value>Run PI as Admin to get more data</value>
     <comment>When the user clicks this button we relaunch PI as admin to get more app details</comment>
-  </data>
-  <data name="UsesWinAppSdkTextBlock.Text" xml:space="preserve">
-    <value>Uses Windows App SDK</value>
-    <comment>This refers to whether the application is using the Windows App SDK</comment>
-  </data>
-  <data name="UsesWinUiTextBlock.Text" xml:space="preserve">
-    <value>Uses WinUI</value>
-    <comment>This refers to whether the application is using WinUI</comment>
   </data>
   <data name="InsightsButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Go to the key insights</value>
@@ -776,5 +744,9 @@
   <data name="GenericInsightDescription" xml:space="preserve">
     <value>Error {0}: {1}</value>
     <comment>Locked={"{0}", "{1}"} A description to help a user that is dealing with non-specific error situation. {0} is the error name. {1} is the error description.</comment>
+  </data>
+  <data name="FrameworkTypesTextBlock.Text" xml:space="preserve">
+    <value>Framework types</value>
+    <comment>This refers to the set of application frameworks this application uses.</comment>
   </data>
 </root>

--- a/tools/PI/DevHome.PI/ViewModels/AppDetailsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/AppDetailsPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -63,51 +62,15 @@ public partial class AppDetailsPageViewModel : ObservableObject
                     {
                         AppInfo.MainModuleFileName = targetProcess.MainModule.FileName;
                         uint binaryTypeValue;
+
+                        // TODO GetBinaryType only distinguishes x86 from x64. It doesn't allow for ARM or ARM64.
                         PInvoke.GetBinaryType(AppInfo.MainModuleFileName, out binaryTypeValue);
                         AppInfo.BinaryType = (WindowHelper.BinaryType)binaryTypeValue;
                     }
 
                     foreach (ProcessModule module in targetProcess.Modules)
                     {
-                        if (module.ModuleName.Equals("PresentationFramework.dll", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.UsesWpf = true;
-                        }
-
-                        if (module.ModuleName.Equals("System.Windows.Forms.dll", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.UsesWinForms = true;
-                        }
-
-                        if (module.ModuleName.Contains("mfc", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.UsesMfc = true;
-                        }
-
-                        if (module.ModuleName.Contains("Avalonia", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.IsAvalonia = true;
-                        }
-
-                        if (module.ModuleName.Contains("Microsoft.Maui", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.IsMaui = true;
-                        }
-
-                        if (module.ModuleName.Contains("Microsoft.Windows.SDK.NET", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.UsesWinAppSdk = true;
-                        }
-
-                        if (module.ModuleName.Contains("Microsoft.WinUI", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.UsesWinUi = true;
-                        }
-
-                        if (module.ModuleName.Contains("dxcore", StringComparison.OrdinalIgnoreCase))
-                        {
-                            AppInfo.UsesDirectX = true;
-                        }
+                        AppInfo.CheckFrameworkTypes(module.ModuleName);
                     }
 
                     AppInfo.IsStoreApp = PInvoke.IsImmersiveProcess(targetProcess.SafeHandle);

--- a/tools/PI/DevHome.PI/ViewModels/ModulesPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ModulesPageViewModel.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.Helpers;
@@ -55,7 +57,11 @@ public partial class ModulesPageViewModel : ObservableObject
             {
                 if (!process.HasExited)
                 {
-                    foreach (ProcessModule module in targetProcess.Modules)
+                    // Sort the list based on the module name.
+                    var moduleList = targetProcess.Modules.Cast<ProcessModule>().ToList();
+                    moduleList = [.. moduleList.OrderBy(module => module.ModuleName)];
+
+                    foreach (var module in moduleList)
                     {
                         ModuleList.Add(module);
                     }


### PR DESCRIPTION
As part of this, created a new FrameworkTypes model, and AppRuntimeInfo now has an ObservableCollection of these. This should make it easier to add new framework types later (I added Python). In the UI, each item is represented by a readonly CheckBox in a WrapPanel, so that they flow when the window is sized. Standard CheckBox doesn't support readonly, so I added a custom ReadOnlyCheckBox control.

Also simplified the visibility of the problem fields in the AppDetailsPage - these are all now within a grid, so we only have to set visibility on the grid instead of on each field (should also improve perf very slightly).

Sorted the module list by name. Added a GridSplitter to the Modules page, so that the user can size the width of the list.

Also, when the user closes the Bar window, we save the expanded size to user settings (if not maximized).

Deleted some redundant fields and strings.
