### PR TITLE
Fix LabelGroup and "Add account" spacing

### DIFF
--- a/common/Renderers/LabelGroup.cs
+++ b/common/Renderers/LabelGroup.cs
@@ -95,6 +95,8 @@ public class LabelGroupRenderer : IAdaptiveElementRenderer
         {
             Name = LabelGroup.CustomTypeString,
             Orientation = Orientation.Horizontal,
+            HorizontalSpacing = 4,
+            VerticalSpacing = 4,
         };
 
         if (element is LabelGroup labelGroup)
@@ -108,7 +110,6 @@ public class LabelGroupRenderer : IAdaptiveElementRenderer
                 {
                     Background = GetBrushFromColor(label.Item2, 0.4),
                     Padding = new Thickness(7, 2, 7, 2),
-                    Margin = new Thickness(0, 0, 10, 0),
                 };
                 if (labelGroup.RoundedCorners)
                 {

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml
@@ -14,9 +14,7 @@
         <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Collapsed" TrueValue="Visible"/>
 
         <DataTemplate x:Key="AccountsProviderButtonTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
-            <StackPanel>
-                <Button Content="{x:Bind ProviderName}" HorizontalAlignment="Stretch" Click="AddDeveloperId_Click" Tag="{x:Bind}" />
-            </StackPanel>
+            <Button Content="{x:Bind ProviderName}" HorizontalAlignment="Stretch" Click="AddDeveloperId_Click" Tag="{x:Bind}"/>
         </DataTemplate>
 
         <DataTemplate x:Key="AccountsProviderViewTemplate" x:DataType="viewmodels:AccountsProviderViewModel">
@@ -41,12 +39,19 @@
                     <ctControls:SettingsCard.HeaderIcon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8fa;"/>
                     </ctControls:SettingsCard.HeaderIcon>
-                    <Button x:Uid="Settings_Accounts_AddAccountButton" AutomationProperties.AutomationId="AddAccountsButton" HorizontalAlignment="Right" Click="AddAccountButton_Click">
+                    <Button
+                        x:Uid="Settings_Accounts_AddAccountButton"
+                        AutomationProperties.AutomationId="AddAccountsButton"
+                        HorizontalAlignment="Right"
+                        Click="AddAccountButton_Click">
                         <Button.Resources>
                             <Flyout x:Name="AccountsProvidersFlyout" Placement="Bottom">
                                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.AccountsProviders}"
                                                ItemTemplate="{StaticResource AccountsProviderButtonTemplate}"
                                                HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                                    <ItemsRepeater.Layout>
+                                        <StackLayout Orientation="Vertical" Spacing="8" />
+                                    </ItemsRepeater.Layout>
                                 </ItemsRepeater>
                                 <Flyout.FlyoutPresenterStyle>
                                     <Style TargetType="FlyoutPresenter">


### PR DESCRIPTION
## Summary of the pull request
Fixes spacing in two places;
* Adds horizontal spacing in LabelGroups:
![image](https://github.com/microsoft/devhome/assets/47155823/89683fc4-864e-478c-bf20-87b67a61698b)

* Adds horizontal spacing between account providers:
![image](https://github.com/microsoft/devhome/assets/47155823/a8de5d23-6dce-4a4d-8f4b-7df62cf510d4)

## PR checklist
- [x] Closes #1569
- [x] Addresses (probably doesn't close) #1501