### PR TITLE
Fix issue where dropdown buttons for launching project host pointed to stale projects

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -434,9 +434,16 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
             TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateButtonClicked", LogLevel.Critical, new GenerateButtonClicked(userPrompt));
 
-            // Ensure file view isn't visible (in the case where the user has previously run a Generate command
+            // Ensure file view isn't visible (in the case where the user has previously run a Generate command)
             IsFileViewVisible = false;
             IsErrorViewVisible = false;
+
+            // Ensure that the launch buttons are in their default state. This is important for scenarios where
+            // the extension has more than one project host and the user is doing multiple generate attempts in sequence.
+            // It makes sure that the code in the code-behind for populating the dropdown button gets re-run to pick up
+            // the new project host objects.
+            IsLaunchButtonVisible = true;
+            IsLaunchDropDownVisible = false;
 
             // Without this, when the user generates two projects in sequence, the text box
             // will contain any text from last-opened file in the previous project (which is


### PR DESCRIPTION
## Summary of the pull request
This change fixes a bug in scenarios where, when a user has multiple project hosts installed (Visual Studio Code and Visual Studio Code Insiders in the case of our implementation), the launch buttons would not open the most-recently-generated project and instead always attempt to open the first one.

## References and relevant issues
#2917 

## Detailed description of the pull request / Additional comments
If an extension supports multiple project hosts, Quickstart Playground shows a DropdownButton for allowing the user to choose which of those hosts they would like to use for launching their generated project. We noticed that if a user happens to have multiple project hosts installed, then on the second and onward generation attempt in the same session, the launch buttons would not open the most recently generated project. Rather, they would attempt to open the very first project (which would have been cleaned up by that point). 

There is code that runs in a property changed handler for associating the entries in the dropdown with specific project host objects. It's triggered by a boolean observable property that controls the visibility on the dropdown button. This code doesn't get invoked on the second generation attempt because it was already set to true from the first attempt. So, the entries in the list never get refreshed. The fix is to ensure that in the command for generating the project, we reset that property first. We can't change just that property on its own because otherwise there would be a gap in the UI from the button being hidden, so we ensure that the single-host button (which is the default) is visible (it won't be enabled though). After the generation completes, the dropdown button will be restored, enabled, and point to the right projects. 

## Validation steps performed
I verified that on a system with multiple project hosts installed, the user can run multiple sequential project generation attempts and that the launch buttons will correctly invoke the latest-generated project each time. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
