### PR TITLE
Set focus to ContentDialogWithNonInteractiveContent on launch.

### DIFF
--- a/common/DevHomeAdaptiveCards/CardModels/DevHomeLaunchContentDialogButton.cs
+++ b/common/DevHomeAdaptiveCards/CardModels/DevHomeLaunchContentDialogButton.cs
@@ -58,6 +58,11 @@ public partial class DevHomeLaunchContentDialogButton : IDevHomeSettingsCardNonS
 
         var dialog = new ContentDialogWithNonInteractiveContent(dialogContent);
 
+        // The dialog's content and XAMLRoot is set on the DispatcherQueue.
+        // This results in a race condition and the result is focus is not moved
+        // to the content dialog.  Wait a bit.
+        await Task.Delay(100);
+
         dialog.XamlRoot = senderObj.XamlRoot;
 
         await dialog.ShowAsync();

--- a/common/DevHomeAdaptiveCards/CardModels/DevHomeLaunchContentDialogButton.cs
+++ b/common/DevHomeAdaptiveCards/CardModels/DevHomeLaunchContentDialogButton.cs
@@ -9,7 +9,6 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.DevHomeAdaptiveCards.CardInterfaces;
 using DevHome.Common.Views.AdaptiveCardViews;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Windows.Data.Json;
 
 namespace DevHome.Common.DevHomeAdaptiveCards.CardModels;

--- a/common/DevHomeAdaptiveCards/CardModels/DevHomeLaunchContentDialogButton.cs
+++ b/common/DevHomeAdaptiveCards/CardModels/DevHomeLaunchContentDialogButton.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using DevHome.Common.DevHomeAdaptiveCards.CardInterfaces;
 using DevHome.Common.Views.AdaptiveCardViews;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Windows.Data.Json;
 
 namespace DevHome.Common.DevHomeAdaptiveCards.CardModels;
@@ -57,11 +58,6 @@ public partial class DevHomeLaunchContentDialogButton : IDevHomeSettingsCardNonS
         }
 
         var dialog = new ContentDialogWithNonInteractiveContent(dialogContent);
-
-        // The dialog's content and XAMLRoot is set on the DispatcherQueue.
-        // This results in a race condition and the result is focus is not moved
-        // to the content dialog.  Wait a bit.
-        await Task.Delay(100);
 
         dialog.XamlRoot = senderObj.XamlRoot;
 

--- a/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
+++ b/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
@@ -31,6 +31,7 @@ public sealed partial class ContentDialogWithNonInteractiveContent : ContentDial
             var card = renderer.RenderAdaptiveCardFromJsonString(content.ContentDialogInternalAdaptiveCardJson?.Stringify() ?? string.Empty);
             Content = card.FrameworkElement;
             SecondaryButtonText = content.SecondaryButtonText;
+            this.Focus(FocusState.Programmatic);
         });
     }
 }

--- a/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
+++ b/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
-using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common.DevHomeAdaptiveCards.CardModels;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;


### PR DESCRIPTION
## Summary of the pull request
The ContentDialogWithNonInteractiveContent is set up on the UI thread.  This is causing a race-condition and the result is focus is not moved to the dialog.

I set the focus manually.  Works with mouse and keyboard.

## References and relevant issues

https://task.ms/50382877

## Detailed description of the pull request / Additional comments

## Validation steps performed
Went to Hyper-V page and launched the content dialogs with the keyboard.


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
