### PR TITLE
Reduce WinUIEx references 

### DIFF
--- a/common/Extensions/StackedNotificationsBehaviorExtensions.cs
+++ b/common/Extensions/StackedNotificationsBehaviorExtensions.cs
@@ -1,17 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Behaviors;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using WinUIEx;
 
 namespace DevHome.Common.Extensions;
 
@@ -25,9 +20,9 @@ public static class StackedNotificationsBehaviorExtensions
         IRelayCommand? command = null,
         string? buttonContent = null)
     {
-        var dispatcherQueue = Application.Current.GetService<WindowEx>().DispatcherQueue;
+        var dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
 
-        dispatcherQueue.EnqueueAsync(() =>
+        dispatcherQueue?.EnqueueAsync(() =>
         {
             var notificationToShow = new Notification
             {
@@ -55,9 +50,9 @@ public static class StackedNotificationsBehaviorExtensions
 
     public static void RemoveWithWindowExtension(this StackedNotificationsBehavior behavior, Notification notification)
     {
-        var dispatcherQueue = Application.Current.GetService<WindowEx>().DispatcherQueue;
+        var dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
 
-        dispatcherQueue.EnqueueAsync(() =>
+        dispatcherQueue?.EnqueueAsync(() =>
         {
             behavior.Remove(notification);
         });
@@ -65,7 +60,7 @@ public static class StackedNotificationsBehaviorExtensions
 
     public static void ClearWithWindowExtension(this StackedNotificationsBehavior behavior)
     {
-        var dispatcherQueue = Application.Current.GetService<WindowEx>().DispatcherQueue;
+        var dispatcherQueue = Application.Current.GetService<Window>().DispatcherQueue;
 
         dispatcherQueue.EnqueueAsync(() =>
         {

--- a/common/NativeMethods.txt
+++ b/common/NativeMethods.txt
@@ -13,3 +13,8 @@ SHLoadIndirectString
 StrFormatByteSizeEx
 SFBS_FLAGS
 MAX_PATH
+GetDpiForWindow
+GetWindowRect
+GetMonitorInfo
+SetWindowPos
+MonitorFromWindow

--- a/common/Services/AdaptiveCardRenderingService.cs
+++ b/common/Services/AdaptiveCardRenderingService.cs
@@ -7,10 +7,10 @@ using System.Threading.Tasks;
 using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common.Renderers;
 using DevHome.Contracts.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.Storage;
-using WinUIEx;
 
 namespace DevHome.Common.Services;
 
@@ -20,7 +20,7 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
 
     public event EventHandler RendererUpdated = (_, _) => { };
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly IThemeSelectorService _themeSelectorService;
 
@@ -30,9 +30,9 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
 
     private bool _disposedValue;
 
-    public AdaptiveCardRenderingService(WindowEx windowEx, IThemeSelectorService themeSelectorService)
+    public AdaptiveCardRenderingService(DispatcherQueue dispatcherQueue, IThemeSelectorService themeSelectorService)
     {
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _themeSelectorService = themeSelectorService;
         _themeSelectorService.ThemeChanged += OnThemeChanged;
     }
@@ -122,7 +122,7 @@ public class AdaptiveCardRenderingService : IAdaptiveCardRenderingService, IDisp
                 _log.Error(ex, "Error retrieving HostConfig");
             }
 
-            _windowEx.DispatcherQueue.TryEnqueue(() =>
+            _dispatcherQueue.TryEnqueue(() =>
             {
                 if (!string.IsNullOrEmpty(hostConfigContents))
                 {

--- a/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
+++ b/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
-using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common.DevHomeAdaptiveCards.CardModels;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using WinUIEx;
 
 namespace DevHome.Common.Views.AdaptiveCardViews;
 
@@ -22,7 +20,7 @@ public sealed partial class ContentDialogWithNonInteractiveContent : ContentDial
         this.InitializeComponent();
 
         // Since we use the renderer service to allow the card to receive theming updates, we need to ensure the UI thread is used.
-        var dispatcherQueue = Application.Current.GetService<WindowEx>().DispatcherQueue;
+        var dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
         dispatcherQueue.TryEnqueue(async () =>
         {
             Title = content.Title;

--- a/common/Windows/SecondaryWindow.cs
+++ b/common/Windows/SecondaryWindow.cs
@@ -8,23 +8,23 @@ using DevHome.Common.Services;
 using DevHome.Contracts.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Markup;
+using Windows.Graphics;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
-using WinUIEx;
 
 namespace DevHome.Common.Windows;
 
 [ContentProperty(Name = nameof(SecondaryWindowContent))]
-public class SecondaryWindow : WindowEx
+public class SecondaryWindow : WinUIEx.WindowEx
 {
     private readonly SecondaryWindowTemplate _windowTemplate;
-    private WindowEx? _primaryWindow;
+    private Window? _primaryWindow;
     private bool _useAppTheme;
     private bool _isModal;
     private bool _isTopLevel;
 
-    private WindowEx MainWindow => Application.Current.GetService<WindowEx>();
+    private Window MainWindow => Application.Current.GetService<Window>();
 
     private IThemeSelectorService ThemeSelector => Application.Current.GetService<IThemeSelectorService>();
 
@@ -149,7 +149,7 @@ public class SecondaryWindow : WindowEx
         }
     }
 
-    public WindowEx? PrimaryWindow
+    public Window? PrimaryWindow
     {
         get => _primaryWindow;
         set
@@ -195,7 +195,7 @@ public class SecondaryWindow : WindowEx
         SystemBackdrop = PrimaryWindow.SystemBackdrop;
 
         Title = AppInfo.GetAppNameLocalized();
-        this.SetIcon(AppInfo.IconPath);
+        AppWindow.SetIcon(AppInfo.IconPath);
 
         ShowInTaskbar();
     }
@@ -212,7 +212,7 @@ public class SecondaryWindow : WindowEx
     /// </summary>
     /// <remarks>
     /// <para>This method should be called after the secondary window is shown.</para>
-    /// <para>See also: <seealso cref="WindowExtensions.CenterOnScreen"/></para>
+    /// <para>See also: <seealso cref="WindowExExtensions.CenterOnScreen"/></para>
     /// </remarks>
     public void CenterOnWindow()
     {
@@ -224,22 +224,23 @@ public class SecondaryWindow : WindowEx
         {
             // Get DPI for primary widow
             const float defaultDPI = 96f;
-            var dpi = HwndExtensions.GetDpiForWindow(PrimaryWindow.GetWindowHandle()) / defaultDPI;
+            var dpi = PInvoke.GetDpiForWindow((HWND)PrimaryWindow.GetWindowHandle()) / defaultDPI;
 
             // Extract primary window dimensions
             var primaryWindowLeftOffset = PrimaryWindow.AppWindow.Position.X;
             var primaryWindowTopOffset = PrimaryWindow.AppWindow.Position.Y;
-            var primaryWindowHalfWidth = (PrimaryWindow.Width * dpi) / 2;
-            var primaryWindowHalfHeight = (PrimaryWindow.Height * dpi) / 2;
+            var primaryWindowHalfWidth = (PrimaryWindow.AppWindow.Size.Width * dpi) / 2;
+            var primaryWindowHalfHeight = (PrimaryWindow.AppWindow.Size.Height * dpi) / 2;
 
             // Derive secondary window dimensions
-            var secondaryWindowHalfWidth = (Width * dpi) / 2;
-            var secondaryWindowHalfHeight = (Height * dpi) / 2;
+            var secondaryWindowHalfWidth = (AppWindow.Size.Width * dpi) / 2;
+            var secondaryWindowHalfHeight = (AppWindow.Size.Height * dpi) / 2;
             var secondaryWindowLeftOffset = primaryWindowLeftOffset + primaryWindowHalfWidth - secondaryWindowHalfWidth;
             var secondaryWindowTopOffset = primaryWindowTopOffset + primaryWindowHalfHeight - secondaryWindowHalfHeight;
 
             // Move and resize secondary window
-            this.MoveAndResize(secondaryWindowLeftOffset, secondaryWindowTopOffset, Width, Height);
+            var newRect = new RectInt32((int)secondaryWindowLeftOffset, (int)secondaryWindowTopOffset, AppWindow.Size.Width, AppWindow.Size.Height);
+            AppWindow.MoveAndResize(newRect);
         }
     }
 

--- a/docs/tools/common/SecondaryWindow.md
+++ b/docs/tools/common/SecondaryWindow.md
@@ -14,7 +14,7 @@ Create a secondary application window that derives from `WinUIEx.WindowEx` ensur
 ## Additional methods
 | Property | Retrun type | Description |
 | -------- | -------- | -------- |
-| CenterOnWindow() | void | If the primary window is set, center the secondary window on the primary window. Otherwise, center the secondary window on the screen by calling `WinUIEx.WindowExtensions.CenterOnScreen()`. |
+| CenterOnWindow() | void | If the primary window is set, center the secondary window on the primary window. Otherwise, center the secondary window on the screen by calling `WindowExExtensions.CenterOnScreen()`. |
 
 ## Usage
 ### Example 1: Set content from XAML

--- a/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AccountsPage.xaml.cs
@@ -16,7 +16,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.Settings.Views;
 
@@ -173,7 +172,7 @@ public sealed partial class AccountsPage : Page
         }
         else if (authenticationFlow == AuthenticationExperienceKind.CustomProvider)
         {
-            var windowHandle = Application.Current.GetService<WindowEx>().GetWindowHandle();
+            var windowHandle = Application.Current.GetService<Window>().GetWindowHandle();
             var windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
             try
             {

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -26,9 +26,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 using Serilog;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace DevHome;
 
@@ -49,7 +52,7 @@ public partial class App : Application, IApp
     public T GetService<T>()
         where T : class => Host.GetService<T>();
 
-    public static WindowEx MainWindow { get; } = new MainWindow();
+    public static Window MainWindow { get; } = new MainWindow();
 
     private static string RemoveComments(string text)
     {
@@ -135,7 +138,11 @@ public partial class App : Application, IApp
 
             // Main window: Allow access to the main window
             // from anywhere in the application.
-            services.AddSingleton<WindowEx>(_ => MainWindow);
+            services.AddSingleton(_ => MainWindow);
+
+            // DispatcherQueue: Allow access to the DispatcherQueue for
+            // the main window for general purpose UI thread access.
+            services.AddSingleton(_ => MainWindow.DispatcherQueue);
 
             // Views and ViewModels
             services.AddTransient<ShellPage>();
@@ -179,13 +186,13 @@ public partial class App : Application, IApp
         _dispatcherQueue.TryEnqueue(() =>
         {
             var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(MainWindow);
-            if (Windows.Win32.PInvoke.IsIconic(new Windows.Win32.Foundation.HWND(hWnd)))
+            if (PInvoke.IsIconic(new HWND(hWnd)) && MainWindow.AppWindow.Presenter is OverlappedPresenter overlappedPresenter)
             {
-                MainWindow.Restore();
+                overlappedPresenter.Restore(true);
             }
             else
             {
-                MainWindow.SetForegroundWindow();
+                PInvoke.SetForegroundWindow(new HWND(hWnd));
             }
         });
     }

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml;
 
 namespace DevHome;
 
-public sealed partial class MainWindow : WindowEx
+public sealed partial class MainWindow : WinUIEx.WindowEx
 {
     private readonly DateTime mainWindowCreated;
 
@@ -23,7 +23,7 @@ public sealed partial class MainWindow : WindowEx
         mainWindowCreated = DateTime.UtcNow;
     }
 
-    private void MainWindow_Closed(object sender, Microsoft.UI.Xaml.WindowEventArgs args)
+    private void MainWindow_Closed(object sender, WindowEventArgs args)
     {
         Application.Current.GetService<IExtensionService>().SignalStopExtensionsAsync();
         TelemetryFactory.Get<ITelemetry>().Log("DevHome_MainWindow_Closed_Event", LogLevel.Critical, new DevHomeClosedEvent(mainWindowCreated));

--- a/src/Services/DSCFileActivationHandler.cs
+++ b/src/Services/DSCFileActivationHandler.cs
@@ -25,14 +25,14 @@ public class DSCFileActivationHandler : ActivationHandler<FileActivatedEventArgs
     private readonly INavigationService _navigationService;
     private readonly SetupFlowViewModel _setupFlowViewModel;
     private readonly SetupFlowOrchestrator _setupFlowOrchestrator;
-    private readonly WindowEx _mainWindow;
+    private readonly Window _mainWindow;
 
     public DSCFileActivationHandler(
         ISetupFlowStringResource setupFlowStringResource,
         INavigationService navigationService,
         SetupFlowOrchestrator setupFlowOrchestrator,
         SetupFlowViewModel setupFlowViewModel,
-        WindowEx mainWindow)
+        Window mainWindow)
     {
         _setupFlowStringResource = setupFlowStringResource;
         _setupFlowViewModel = setupFlowViewModel;

--- a/src/Usings.cs
+++ b/src/Usings.cs
@@ -1,4 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-global using WinUIEx;

--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
@@ -13,9 +13,9 @@ using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents;
 using DevHome.Customization.Models;
 using DevHome.Telemetry;
+using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.Storage.Pickers;
-using WinUIEx;
 
 namespace DevHome.Customization.ViewModels.DevDriveInsights;
 
@@ -94,7 +94,7 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
         };
 
         folderPicker.FileTypeFilter.Add("*");
-        WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, Microsoft.UI.Xaml.Application.Current.GetService<WindowEx>().GetWindowHandle());
+        WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, Microsoft.UI.Xaml.Application.Current.GetService<Window>().GetWindowHandle());
         var folder = await folderPicker.PickSingleFolderAsync();
 
         if (folder != null)

--- a/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/MainPageViewModel.cs
@@ -11,9 +11,8 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
-using Windows.System;
-using WinUIEx;
 
 namespace DevHome.Customization.ViewModels;
 
@@ -21,7 +20,7 @@ public partial class MainPageViewModel : ObservableObject
 {
     private INavigationService NavigationService { get; }
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     public ObservableCollection<Breadcrumb> Breadcrumbs { get; }
 
@@ -30,10 +29,10 @@ public partial class MainPageViewModel : ObservableObject
 
     public MainPageViewModel(
         INavigationService navigationService,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
         NavigationService = navigationService;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
 
         var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
         Breadcrumbs = [new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!)];
@@ -47,7 +46,7 @@ public partial class MainPageViewModel : ObservableObject
             var anyDevDrivesPresent = Application.Current.GetService<IDevDriveManager>().GetAllDevDrivesThatExistOnSystem().Any();
 
             // Update the UI thread
-            await _windowEx.DispatcherQueue.EnqueueAsync(() =>
+            await _dispatcherQueue.EnqueueAsync(() =>
             {
                 AnyDevDrivesPresent = anyDevDrivesPresent;
             });
@@ -57,7 +56,7 @@ public partial class MainPageViewModel : ObservableObject
     [RelayCommand]
     private async Task LaunchWindowsDeveloperSettings()
     {
-        await Launcher.LaunchUriAsync(new("ms-settings:developers"));
+        await Windows.System.Launcher.LaunchUriAsync(new("ms-settings:developers"));
     }
 
     [RelayCommand]

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetBoard.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetBoard.cs
@@ -5,11 +5,11 @@ using System;
 using System.Linq;
 using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
 using Windows.UI.ViewManagement;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Controls;
 
@@ -265,7 +265,7 @@ public sealed class WidgetBoard : Panel
 
     private void HandleTextScaleFactorChanged(UISettings sender, object args)
     {
-        Application.Current.GetService<WindowEx>().DispatcherQueue.EnqueueAsync(() =>
+        Application.Current.GetService<DispatcherQueue>().EnqueueAsync(() =>
         {
             _textScale = sender.TextScaleFactor;
             InvalidateMeasure();

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -15,6 +15,7 @@ using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Dashboard.Views;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
@@ -22,7 +23,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.Widgets;
 using Serilog;
 using Windows.UI.ViewManagement;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Controls;
 
@@ -94,7 +94,7 @@ public sealed partial class WidgetControl : UserControl
 
     private async void HandleTextScaleFactorChangedAsync(UISettings sender, object args)
     {
-        await Application.Current.GetService<WindowEx>().DispatcherQueue.EnqueueAsync(() =>
+        await Application.Current.GetService<DispatcherQueue>().EnqueueAsync(() =>
         {
             if (WidgetSource == null)
             {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetAdaptiveCardRenderingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetAdaptiveCardRenderingService.cs
@@ -8,10 +8,10 @@ using AdaptiveCards.Rendering.WinUI3;
 using DevHome.Common.Renderers;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.Storage;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Services;
 
@@ -21,7 +21,7 @@ public class WidgetAdaptiveCardRenderingService : IAdaptiveCardRenderingService,
 
     public event EventHandler RendererUpdated = (_, _) => { };
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly IThemeSelectorService _themeSelectorService;
 
@@ -31,9 +31,9 @@ public class WidgetAdaptiveCardRenderingService : IAdaptiveCardRenderingService,
 
     private bool _disposedValue;
 
-    public WidgetAdaptiveCardRenderingService(WindowEx windowEx, IThemeSelectorService themeSelectorService)
+    public WidgetAdaptiveCardRenderingService(DispatcherQueue dispatcherQueue, IThemeSelectorService themeSelectorService)
     {
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _themeSelectorService = themeSelectorService;
         _themeSelectorService.ThemeChanged += OnThemeChanged;
     }
@@ -118,7 +118,7 @@ public class WidgetAdaptiveCardRenderingService : IAdaptiveCardRenderingService,
                 _log.Error(ex, "Error retrieving HostConfig");
             }
 
-            _windowEx.DispatcherQueue.TryEnqueue(() =>
+            _dispatcherQueue.TryEnqueue(() =>
             {
                 if (!string.IsNullOrEmpty(hostConfigContents))
                 {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using DevHome.Dashboard.ComSafeWidgetObjects;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
 using Windows.Storage.Streams;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Services;
 
@@ -19,14 +19,14 @@ public class WidgetIconService : IWidgetIconService
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WidgetIconService));
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly ConcurrentDictionary<string, BitmapImage> _widgetLightIconCache;
     private readonly ConcurrentDictionary<string, BitmapImage> _widgetDarkIconCache;
 
-    public WidgetIconService(WindowEx windowEx)
+    public WidgetIconService(DispatcherQueue dispatcherQueue)
     {
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
 
         _widgetLightIconCache = new ConcurrentDictionary<string, BitmapImage>();
         _widgetDarkIconCache = new ConcurrentDictionary<string, BitmapImage>();
@@ -90,7 +90,7 @@ public class WidgetIconService : IWidgetIconService
         // Return the bitmap image via TaskCompletionSource. Using WCT's EnqueueAsync does not suffice here, since if
         // we're already on the thread of the DispatcherQueue then it just directly calls the function, with no async involved.
         var completionSource = new TaskCompletionSource<BitmapImage>();
-        _windowEx.DispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
             using var bitmapStream = await iconStreamRef.OpenReadAsync();
             var itemImage = new BitmapImage();

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetScreenshotService.cs
@@ -7,24 +7,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Dashboard.ComSafeWidgetObjects;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.Widgets.Hosts;
 using Windows.Storage.Streams;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Services;
 
 public class WidgetScreenshotService : IWidgetScreenshotService
 {
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly ConcurrentDictionary<string, BitmapImage> _widgetLightScreenshotCache;
     private readonly ConcurrentDictionary<string, BitmapImage> _widgetDarkScreenshotCache;
 
-    public WidgetScreenshotService(WindowEx windowEx)
+    public WidgetScreenshotService(DispatcherQueue dispatcherQueue)
     {
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
 
         _widgetLightScreenshotCache = new ConcurrentDictionary<string, BitmapImage>();
         _widgetDarkScreenshotCache = new ConcurrentDictionary<string, BitmapImage>();
@@ -76,7 +76,7 @@ public class WidgetScreenshotService : IWidgetScreenshotService
         // Return the bitmap image via TaskCompletionSource. Using WCT's EnqueueAsync does not suffice here, since if
         // we're already on the thread of the DispatcherQueue then it just directly calls the function, with no async involved.
         var completionSource = new TaskCompletionSource<BitmapImage>();
-        _windowEx.DispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
             using var bitmapStream = await iconStreamRef.OpenReadAsync();
             var itemImage = new BitmapImage();

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -12,6 +12,7 @@ using DevHome.Dashboard.ComSafeWidgetObjects;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
@@ -20,7 +21,6 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Views;
 
@@ -36,7 +36,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private readonly IWidgetHostingService _hostingService;
     private readonly IWidgetIconService _widgetIconService;
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     public AddWidgetDialog()
     {
@@ -46,7 +46,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
         this.InitializeComponent();
 
-        _windowEx = Application.Current.GetService<WindowEx>();
+        _dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
 
         RequestedTheme = Application.Current.GetService<IThemeSelectorService>().Theme;
     }
@@ -311,7 +311,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
     {
         var deletedDefinitionId = args.DefinitionId;
 
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             // If we currently have the deleted widget open, un-select it.
             if (_selectedWidget is not null &&

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -21,14 +21,13 @@ using DevHome.Dashboard.Services;
 using DevHome.Dashboard.TelemetryEvents;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Telemetry;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
-using Windows.System;
-using WinUIEx;
 
 namespace DevHome.Dashboard.Views;
 
@@ -48,7 +47,7 @@ public partial class DashboardView : ToolPage, IDisposable
 
     private readonly SemaphoreSlim _pinnedWidgetsLock = new(1, 1);
 
-    private static WindowEx _windowEx;
+    private static DispatcherQueue _dispatcherQueue;
     private readonly ILocalSettingsService _localSettingsService;
     private bool _disposedValue;
 
@@ -66,7 +65,7 @@ public partial class DashboardView : ToolPage, IDisposable
         PinnedWidgets = new ObservableCollection<WidgetViewModel>();
         PinnedWidgets.CollectionChanged += OnPinnedWidgetsCollectionChangedAsync;
 
-        _windowEx = Application.Current.GetService<WindowEx>();
+        _dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
         _localSettingsService = Application.Current.GetService<ILocalSettingsService>();
 
 #if DEBUG
@@ -458,11 +457,11 @@ public partial class DashboardView : ToolPage, IDisposable
     {
         if (Common.Helpers.RuntimeHelper.IsOnWindows11)
         {
-            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
+            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
         }
         else
         {
-            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
+            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
         }
     }
 
@@ -548,7 +547,7 @@ public partial class DashboardView : ToolPage, IDisposable
 
     private async Task ShowCreateWidgetErrorMessage()
     {
-        var mainWindow = Application.Current.GetService<WindowEx>();
+        var mainWindow = Application.Current.GetService<Window>();
         var stringResource = new StringResource("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
         await mainWindow.ShowErrorMessageDialogAsync(
             title: string.Empty,
@@ -581,7 +580,7 @@ public partial class DashboardView : ToolPage, IDisposable
                     new ReportPinnedWidgetEvent(comSafeWidgetDefinition.ProviderDefinitionId, widgetDefinitionId));
 
                 var wvm = _widgetViewModelFactory(widget, size, comSafeWidgetDefinition);
-                _windowEx.DispatcherQueue.TryEnqueue(() =>
+                _dispatcherQueue.TryEnqueue(() =>
                 {
                     try
                     {
@@ -658,7 +657,7 @@ public partial class DashboardView : ToolPage, IDisposable
             // If we're no longer allowed to have multiple instances of this widget, delete all but the first.
             if (++matchingWidgetsFound > 1 && comSafeNewDefinition.AllowMultiple == false && oldDef.AllowMultiple == true)
             {
-                _windowEx.DispatcherQueue.TryEnqueue(async () =>
+                _dispatcherQueue.TryEnqueue(async () =>
                 {
                     _log.Information($"No longer allowed to have multiple of widget {updatedDefinitionId}");
                     _log.Information($"Delete widget {widgetToUpdate.Widget.Id}");
@@ -698,7 +697,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private void WidgetCatalog_WidgetDefinitionDeleted(WidgetCatalog sender, WidgetDefinitionDeletedEventArgs args)
     {
         var definitionId = args.DefinitionId;
-        _windowEx.DispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
             _log.Information($"WidgetDefinitionDeleted {definitionId}");
             foreach (var widgetToRemove in PinnedWidgets.Where(x => x.Widget.DefinitionId == definitionId).ToList())

--- a/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
@@ -7,6 +7,7 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Services;
 using DevHome.Environments.Models;
 using DevHome.Environments.ViewModels;
+using Microsoft.UI.Dispatching;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.Environments.Helpers;
@@ -22,7 +23,7 @@ public class DataExtractor
     /// ToDo: Add a pause after each operation
     /// </summary>
     /// <param name="computeSystem">Compute system used to fill OperationsViewModel's callback function.</param>
-    public static List<OperationsViewModel> FillDotButtonOperations(ComputeSystemCache computeSystem, WinUIEx.WindowEx windowEx)
+    public static List<OperationsViewModel> FillDotButtonOperations(ComputeSystemCache computeSystem, DispatcherQueue dispatcherQueue)
     {
         var operations = new List<OperationsViewModel>();
         var supportedOperations = computeSystem.SupportedOperations.Value;
@@ -36,7 +37,7 @@ public class DataExtractor
         if (supportedOperations.HasFlag(ComputeSystemOperations.Delete))
         {
             operations.Add(new OperationsViewModel(
-                _stringResource.GetLocalized("Operations_Delete"), "\uE74D", computeSystem.DeleteAsync, ComputeSystemOperations.Delete, windowEx));
+                _stringResource.GetLocalized("Operations_Delete"), "\uE74D", computeSystem.DeleteAsync, ComputeSystemOperations.Delete, dispatcherQueue));
         }
 
         return operations;

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -7,26 +7,21 @@ using System.Collections.ObjectModel;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
-using Antlr4.Runtime.Misc;
-using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
-using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Common.TelemetryEvents.Environments;
 using DevHome.Common.TelemetryEvents.SetupFlow.Environments;
 using DevHome.Environments.Helpers;
 using DevHome.Environments.Models;
 using DevHome.Telemetry;
+using Microsoft.UI.Dispatching;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using Windows.Foundation;
-using WinUIEx;
-using WinUIEx.Messaging;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -38,7 +33,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemViewModel));
     private readonly StringResource _stringResource;
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
     private readonly IComputeSystemManager _computeSystemManager;
     private readonly ComputeSystemProvider _provider;
 
@@ -72,9 +67,9 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         ComputeSystemProvider provider,
         Func<ComputeSystemCardBase, bool> removalAction,
         string packageFullName,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _computeSystemManager = manager;
         _provider = provider;
 
@@ -128,7 +123,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         await _semaphoreSlimLock.WaitAsync();
         try
         {
-            RegisterForAllOperationMessages(DataExtractor.FillDotButtonOperations(ComputeSystem, _windowEx), DataExtractor.FillLaunchButtonOperations(ComputeSystem));
+            RegisterForAllOperationMessages(DataExtractor.FillDotButtonOperations(ComputeSystem, _dispatcherQueue), DataExtractor.FillLaunchButtonOperations(ComputeSystem));
 
             foreach (var data in await DataExtractor.FillDotButtonPinOperationsAsync(ComputeSystem))
             {
@@ -203,7 +198,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 
     public void OnComputeSystemStateChanged(ComputeSystem sender, ComputeSystemState newState)
     {
-        _windowEx.DispatcherQueue.EnqueueAsync(async () =>
+        _dispatcherQueue.EnqueueAsync(async () =>
         {
             if (sender.Id == ComputeSystem.Id.Value &&
                 sender.AssociatedProviderId.Equals(ComputeSystem.AssociatedProviderId.Value, StringComparison.OrdinalIgnoreCase))
@@ -238,7 +233,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         // We'll need to disable the card UI while the operation is in progress and handle failures.
         Task.Run(async () =>
         {
-            _windowEx.DispatcherQueue.TryEnqueue(() =>
+            _dispatcherQueue.TryEnqueue(() =>
             {
                 UiMessageToDisplay = _stringResource.GetLocalized("LaunchingEnvironmentText");
                 IsOperationInProgress = true;
@@ -265,7 +260,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
                 LogLevel.Critical,
                 new EnvironmentLaunchUserEvent(ComputeSystem.AssociatedProviderId.Value, completionStatus));
 
-            _windowEx.DispatcherQueue.TryEnqueue(() =>
+            _dispatcherQueue.TryEnqueue(() =>
             {
                 IsOperationInProgress = false;
                 UiMessageToDisplay = string.Empty;
@@ -275,7 +270,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 
     private void RemoveComputeSystem()
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             _log.Information($"Removing Compute system with Name: {ComputeSystem.DisplayName} from UI");
             _removalAction(this);
@@ -308,7 +303,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     /// <param name="message">The object that holds the data needed to capture the operationInvoked telemetry data</param>
     public void Receive(ComputeSystemOperationStartedMessage message)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             var data = message.Value;
             IsOperationInProgress = true;
@@ -329,7 +324,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     /// <param name="message">The object that holds the data needed to capture the operationInvoked telemetry data</param>
     public void Receive(ComputeSystemOperationCompletedMessage message)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             var data = message.Value;
             _log.Information($"operation '{data.ComputeSystemOperation}' completed for Compute System: {Name}");

--- a/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
@@ -3,16 +3,12 @@
 
 using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel.DataAnnotations;
-using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
 using DevHome.Common.Services;
-using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Dispatching;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -25,7 +21,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private readonly IComputeSystemManager _computeSystemManager;
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly StringResource _stringResource;
 
@@ -53,13 +49,13 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
     public CreateComputeSystemOperationViewModel(
         IComputeSystemManager computeSystemManager,
         StringResource stringResource,
-        WindowEx windowsEx,
+        DispatcherQueue dispatcherQueue,
         Func<ComputeSystemCardBase, bool> removalAction,
         Action<ComputeSystemViewModel> addComputeSystemAction,
         CreateComputeSystemOperation operation)
     {
         IsOperationInProgress = true;
-        _windowEx = windowsEx;
+        _dispatcherQueue = dispatcherQueue;
         _removalAction = removalAction;
         _addComputeSystemAction = addComputeSystemAction;
         _stringResource = stringResource;
@@ -99,7 +95,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private void UpdateStatusIfCompleted(CreateComputeSystemResult createComputeSystemResult)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             // Update the creation status
             IsOperationInProgress = false;
@@ -132,7 +128,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private void UpdateUiMessage(string operationStatus, uint percentage = 0)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             if (operationStatus == null)
             {
@@ -146,7 +142,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private void RemoveViewModelFromUI()
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             _removalAction(this);
             RemoveEventHandlers();
@@ -163,11 +159,11 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
             Operation.ProviderDetails.ComputeSystemProvider,
             _removalAction,
             Operation.ProviderDetails.ExtensionWrapper.PackageFullName,
-            _windowEx);
+            _dispatcherQueue);
 
         await newComputeSystemViewModel.InitializeCardDataAsync();
 
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             newComputeSystemViewModel.InitializeUXData();
             _addComputeSystemAction(newComputeSystemViewModel);

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -15,14 +15,10 @@ using CommunityToolkit.WinUI.Collections;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
-using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.Environments.Helpers;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.Windows.DevHome.SDK;
+using Microsoft.UI.Dispatching;
 using Serilog;
-using Windows.Foundation;
-using WinUIEx;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -35,7 +31,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
     private readonly AutoResetEvent _computeSystemLoadWait = new(false);
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly EnvironmentsExtensionsService _environmentExtensionsService;
 
@@ -95,11 +91,11 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
         INavigationService navigationService,
         IComputeSystemManager manager,
         EnvironmentsExtensionsService extensionsService,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
         _computeSystemManager = manager;
         _environmentExtensionsService = extensionsService;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _navigationService = navigationService;
 
         _stringResource = new StringResource("DevHome.Environments.pri", "DevHome.Environments/Resources");
@@ -128,7 +124,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
         // Reset the old sync timer
         _cancellationTokenSource.Cancel();
-        await _windowEx.DispatcherQueue.EnqueueAsync(() => LastSyncTime = _stringResource.GetLocalized("MomentsAgo"));
+        await _dispatcherQueue.EnqueueAsync(() => LastSyncTime = _stringResource.GetLocalized("MomentsAgo"));
 
         // We need to signal to the compute system manager that it can remove all the completed operations now that
         // we're done showing them in the view.
@@ -161,7 +157,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
         if (!token.IsCancellationRequested)
         {
-            await _windowEx.DispatcherQueue.EnqueueAsync(() => LastSyncTime = time);
+            await _dispatcherQueue.EnqueueAsync(() => LastSyncTime = time);
         }
     }
 
@@ -284,7 +280,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
             foreach (var operation in curOperations)
             {
                 // this is a new operation so we need to create a view model for it.
-                ComputeSystemCards.Insert(0, new CreateComputeSystemOperationViewModel(_computeSystemManager, _stringResource, _windowEx, RemoveComputeSystemCard, AddNewlyCreatedComputeSystem, operation));
+                ComputeSystemCards.Insert(0, new CreateComputeSystemOperationViewModel(_computeSystemManager, _stringResource, _dispatcherQueue, RemoveComputeSystemCard, AddNewlyCreatedComputeSystem, operation));
                 ComputeSystemCards.Last().ComputeSystemErrorReceived += OnComputeSystemOperationError;
                 _log.Information($"Found new create compute system operation for provider {operation.ProviderDetails.ComputeSystemProvider}, with name {operation.EnvironmentName}");
             }
@@ -319,7 +315,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
                 provider,
                 RemoveComputeSystemCard,
                 packageFullName,
-                _windowEx);
+                _dispatcherQueue);
 
             computeSystemViewModel.ComputeSystemErrorReceived += OnComputeSystemOperationError;
             computeSystemViewModels.Add(computeSystemViewModel);
@@ -330,7 +326,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
             await computeSystemModel.InitializeCardDataAsync();
         });
 
-        await _windowEx.DispatcherQueue.EnqueueAsync(() =>
+        await _dispatcherQueue.EnqueueAsync(() =>
         {
             try
             {
@@ -459,7 +455,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
             if (viewModel == null)
             {
-                _windowEx.DispatcherQueue.EnqueueAsync(() =>
+                _dispatcherQueue.EnqueueAsync(() =>
                 {
                     lock (ComputeSystemCards)
                     {

--- a/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
@@ -2,18 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Configuration.Provider;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
-using CommunityToolkit.WinUI;
 using DevHome.Common.Services;
 using DevHome.Environments.Models;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
-using Windows.Foundation;
-using WinUIEx;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -51,23 +48,27 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
 
     private Action? DevHomeAction { get; }
 
-    private WinUIEx.WindowEx? _windowEx;
+    private readonly DispatcherQueue? _dispatcherQueue;
 
-    private StringResource _stringResource = new("DevHome.Environments.pri", "DevHome.Environments/Resources");
+    private readonly Window? _mainWindow;
+
+    private readonly StringResource _stringResource = new("DevHome.Environments.pri", "DevHome.Environments/Resources");
 
     public OperationsViewModel(
         string name,
         string icon,
         Func<string, Task<ComputeSystemOperationResult>> command,
         ComputeSystemOperations computeSystemOperation,
-        WinUIEx.WindowEx? windowEx = null)
+        DispatcherQueue? dispatcherQueue = null,
+        Window? mainWindow = null)
     {
         _operationKind = OperationKind.ExtensionTask;
         Name = name;
         IconGlyph = icon;
         ExtensionTask = command;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         ComputeSystemOperation = computeSystemOperation;
+        _mainWindow = mainWindow;
     }
 
     public OperationsViewModel(
@@ -125,10 +126,10 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
                 Content = _stringResource.GetLocalized("DeleteEnviroment_Content"),
                 PrimaryButtonText = _stringResource.GetLocalized("DeleteEnviroment_ConfirmButton"),
                 SecondaryButtonText = _stringResource.GetLocalized("DeleteEnviroment_CancelButton"),
-                XamlRoot = _windowEx?.Content.XamlRoot,
+                XamlRoot = _mainWindow?.Content.XamlRoot,
             };
 
-            _windowEx?.DispatcherQueue.TryEnqueue(async () =>
+            _dispatcherQueue?.TryEnqueue(async () =>
             {
                 var result = await noWifiDialog.ShowAsync();
 

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -12,14 +12,13 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.ApplicationModel;
 using Windows.Data.Json;
 using Windows.Storage;
-using Windows.System;
-using WinUIEx;
 
 namespace DevHome.ExtensionLibrary.ViewModels;
 
@@ -30,7 +29,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     private readonly string devHomeProductId = "9N8MHTPHNGVV";
 
     private readonly IExtensionService _extensionService;
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     // All internal Dev Home extensions that should allow users to enable/disable them, should add
     // their class Ids to this set.
@@ -46,10 +45,10 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     [ObservableProperty]
     private bool _shouldShowStoreError = false;
 
-    public ExtensionLibraryViewModel(IExtensionService extensionService, WindowEx windowEx)
+    public ExtensionLibraryViewModel(IExtensionService extensionService, DispatcherQueue dispatcherQueue)
     {
         _extensionService = extensionService;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
 
         extensionService.OnExtensionsChanged -= OnExtensionsChanged;
         extensionService.OnExtensionsChanged += OnExtensionsChanged;
@@ -61,7 +60,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     [RelayCommand]
     public async Task GetUpdatesButtonAsync()
     {
-        await Launcher.LaunchUriAsync(new("ms-windows-store://downloadsandupdates"));
+        await Windows.System.Launcher.LaunchUriAsync(new("ms-windows-store://downloadsandupdates"));
     }
 
     [RelayCommand]
@@ -73,7 +72,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 
     private async void OnExtensionsChanged(object? sender, EventArgs e)
     {
-        await _windowEx.DispatcherQueue.EnqueueAsync(async () =>
+        await _dispatcherQueue.EnqueueAsync(async () =>
         {
             ShouldShowStoreError = false;
             await GetInstalledExtensionsAsync();

--- a/tools/PI/DevHome.PI/Telemetry/WindowEventGenerator.cs
+++ b/tools/PI/DevHome.PI/Telemetry/WindowEventGenerator.cs
@@ -2,18 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using DevHome.Common.Extensions;
-using DevHome.PI;
 using DevHome.PI.Helpers;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
-using Windows.Foundation;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using WinUIEx;
 
 namespace DevHome.Telemetry;
 

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/ViewModels/QuietBackgroundProcessesViewModel.cs
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/ViewModels/QuietBackgroundProcessesViewModel.cs
@@ -9,14 +9,11 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using DevHome.Common.Services;
 using DevHome.Telemetry;
-using Microsoft.UI;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Serilog;
 using Windows.Foundation.Diagnostics;
-using Windows.UI;
-using WinUIEx;
 
 namespace DevHome.QuietBackgroundProcesses.UI.ViewModels;
 
@@ -28,7 +25,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
 
     private readonly TimeSpan _zero = new(0, 0, 0);
     private readonly TimeSpan _oneSecond = new(0, 0, 1);
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
     private TimeSpan _sessionDuration;
     private QuietBackgroundProcessesSession? _session;
     private ProcessPerformanceTable? _table;
@@ -89,10 +86,10 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
 
     public QuietBackgroundProcessesViewModel(
         IExperimentationService experimentationService,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
         _experimentationService = experimentationService;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _countdownTimer = string.Empty;
         _sessionStateText = GetString("QuietBackgroundProcesses_Description");
 
@@ -149,7 +146,7 @@ public partial class QuietBackgroundProcessesViewModel : ObservableObject
             }
 
             // Update the UI thread
-            await _windowEx.DispatcherQueue.EnqueueAsync(() =>
+            await _dispatcherQueue.EnqueueAsync(() =>
             {
                 IsFeaturePresent = isFeaturePresent;
                 IsAnalyticSummaryAvailable = isAvailable;

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/AnalyticSummaryPopup.xaml.cs
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/Views/AnalyticSummaryPopup.xaml.cs
@@ -6,13 +6,12 @@ using DevHome.Common.Windows.FileDialog;
 using DevHome.QuietBackgroundProcesses.UI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using WinUIEx;
 
 namespace DevHome.QuietBackgroundProcesses.UI.Views;
 
 public sealed partial class AnalyticSummaryPopup : ContentDialog
 {
-    private readonly WindowEx _mainWindow;
+    private readonly Window _mainWindow;
 
     public AnalyticSummaryPopupViewModel ViewModel
     {
@@ -21,7 +20,7 @@ public sealed partial class AnalyticSummaryPopup : ContentDialog
 
     public AnalyticSummaryPopup(QuietBackgroundProcesses.ProcessPerformanceTable? performanceTable)
     {
-        _mainWindow = Application.Current.GetService<WindowEx>();
+        _mainWindow = Application.Current.GetService<Window>();
 
         ViewModel = new AnalyticSummaryPopupViewModel(performanceTable);
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/ConfigureTargetTask.cs
@@ -21,12 +21,12 @@ using DevHome.SetupFlow.Models.WingetConfigure;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
 using DevHome.Telemetry;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Projection::DevHome.SetupFlow.ElevatedComponent;
 using Serilog;
 using Windows.Foundation;
-using WinUIEx;
 using SDK = Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.SetupFlow.Models;
@@ -35,7 +35,7 @@ public class ConfigureTargetTask : ISetupTask
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ConfigureTargetTask));
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly ISetupFlowStringResource _stringResource;
 
@@ -100,13 +100,13 @@ public class ConfigureTargetTask : ISetupTask
         IComputeSystemManager computeSystemManager,
         ConfigurationFileBuilder configurationFileBuilder,
         SetupFlowOrchestrator setupFlowOrchestrator,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
         _stringResource = stringResource;
         _computeSystemManager = computeSystemManager;
         _configurationFileBuilder = configurationFileBuilder;
         _setupFlowOrchestrator = setupFlowOrchestrator;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _adaptiveCardRenderingService = Application.Current.GetService<AdaptiveCardRenderingService>();
     }
 
@@ -346,7 +346,7 @@ public class ConfigureTargetTask : ISetupTask
     /// </summary>
     public void RemoveAdaptiveCardPanelFromLoadingUI()
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             if (ActionCenterMessages.ExtensionAdaptiveCardPanel != null)
             {
@@ -458,7 +458,7 @@ public class ConfigureTargetTask : ISetupTask
     /// <param name="session">Adaptive card session sent by the extension when it needs a user to perform an action</param>
     public async Task CreateCorrectiveActionPanel(IExtensionAdaptiveCardSession2 session)
     {
-        await _windowEx.DispatcherQueue.EnqueueAsync(async () =>
+        await _dispatcherQueue.EnqueueAsync(async () =>
         {
             var renderer = await _adaptiveCardRenderingService.GetRendererAsync();
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/ComputeSystemViewModelFactory.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/ComputeSystemViewModelFactory.cs
@@ -7,8 +7,8 @@ using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
 using DevHome.SetupFlow.ViewModels.Environments;
+using Microsoft.UI.Dispatching;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.Common.Services;
 
@@ -22,9 +22,9 @@ public class ComputeSystemViewModelFactory
         ComputeSystemCache computeSystem,
         ComputeSystemProvider provider,
         string packageFullName,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
-        var cardViewModel = new ComputeSystemCardViewModel(computeSystem, manager, windowEx, packageFullName);
+        var cardViewModel = new ComputeSystemCardViewModel(computeSystem, manager, dispatcherQueue, packageFullName);
 
         try
         {

--- a/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/SetupTargetTaskGroup.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/TaskGroups/SetupTargetTaskGroup.cs
@@ -6,7 +6,7 @@ using DevHome.Common.Environments.Services;
 using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.ViewModels;
-using WinUIEx;
+using Microsoft.UI.Dispatching;
 
 namespace DevHome.SetupFlow.TaskGroups;
 
@@ -24,7 +24,7 @@ public class SetupTargetTaskGroup : ISetupTaskGroup
         IComputeSystemManager computeSystemManager,
         ConfigurationFileBuilder configurationFileBuilder,
         SetupFlowOrchestrator setupFlowOrchestrator,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
         _setupTargetViewModel = setupTargetViewModel;
         _setupTargetReviewViewModel = setupTargetReviewViewModel;
@@ -34,7 +34,7 @@ public class SetupTargetTaskGroup : ISetupTaskGroup
             computeSystemManager,
             configurationFileBuilder,
             setupFlowOrchestrator,
-            windowEx);
+            dispatcherQueue);
     }
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -23,12 +23,12 @@ using DevHome.SetupFlow.Views;
 using DevHome.Telemetry;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation;
-using WinUIEx;
 using static DevHome.SetupFlow.Models.Common;
 
 namespace DevHome.SetupFlow.ViewModels;
@@ -691,7 +691,7 @@ public partial class AddRepoViewModel : ObservableObject
         _addRepoDialog = addRepoDialog;
         _stringResource = stringResource;
         _host = host;
-        _dispatcherQueue = host.GetService<WindowEx>().DispatcherQueue;
+        _dispatcherQueue = host.GetService<DispatcherQueue>();
         _loginUiContent = new Frame();
         _setupFlowOrchestrator = setupFlowOrchestrator;
 
@@ -1295,7 +1295,7 @@ public partial class AddRepoViewModel : ObservableObject
         }
         else if (authenticationFlow == AuthenticationExperienceKind.CustomProvider)
         {
-            var windowHandle = _host.GetService<WindowEx>().GetWindowHandle();
+            var windowHandle = _host.GetService<Window>().GetWindowHandle();
             var windowPtr = Win32Interop.GetWindowIdFromWindow(windowHandle);
             try
             {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ConfigurationFileViewModel.cs
@@ -15,9 +15,9 @@ using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;
+using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.Storage;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -25,7 +25,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ConfigurationFileViewModel));
     private readonly IDesiredStateConfiguration _dsc;
-    private readonly WindowEx _mainWindow;
+    private readonly Window _mainWindow;
 
     public List<ConfigureTask> TaskList { get; } = new List<ConfigureTask>();
 
@@ -50,7 +50,7 @@ public partial class ConfigurationFileViewModel : SetupPageViewModelBase
     public ConfigurationFileViewModel(
         ISetupFlowStringResource stringResource,
         IDesiredStateConfiguration dsc,
-        WindowEx mainWindow,
+        Window mainWindow,
         SetupFlowOrchestrator orchestrator)
         : base(stringResource, orchestrator)
     {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/DevDriveViewModel.cs
@@ -24,11 +24,9 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.Globalization.NumberFormatting;
-using Windows.Storage.Pickers;
 using Windows.System;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -104,7 +102,7 @@ public partial class DevDriveViewModel : ObservableObject, IDevDriveWindowViewMo
     /// <summary>
     /// Gets a value indicating the window title of the Dev Drive window.
     /// </summary>
-    public string AppTitle => Application.Current.GetService<WindowEx>().Title;
+    public string AppTitle => Application.Current.GetService<Window>().Title;
 
     public DevDriveViewModel(
         ISetupFlowStringResource stringResource,

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text;
@@ -12,12 +11,10 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
-using DevHome.Common.Extensions;
-using Microsoft.UI.Xaml;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels.Environments;
 
@@ -28,7 +25,7 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemCardViewModel));
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly IComputeSystemManager _computeSystemManager;
 
@@ -64,9 +61,9 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 
     public ObservableCollection<CardProperty> ComputeSystemProperties { get; set; }
 
-    public ComputeSystemCardViewModel(ComputeSystemCache computeSystem, IComputeSystemManager manager, WindowEx windowEx, string packageFullName)
+    public ComputeSystemCardViewModel(ComputeSystemCache computeSystem, IComputeSystemManager manager, DispatcherQueue dispatcherQueue, string packageFullName)
     {
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _computeSystemManager = manager;
         ComputeSystemTitle = computeSystem.DisplayName.Value;
         ComputeSystem = computeSystem;
@@ -78,7 +75,7 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 
     public void OnComputeSystemStateChanged(ComputeSystem sender, ComputeSystemState state)
     {
-        _windowEx.DispatcherQueue.EnqueueAsync(async () =>
+        _dispatcherQueue.EnqueueAsync(async () =>
         {
             if (sender.Id == ComputeSystem.Id.Value &&
                 sender.AssociatedProviderId.Equals(ComputeSystem.AssociatedProviderId.Value, StringComparison.OrdinalIgnoreCase))

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
@@ -17,9 +17,9 @@ using DevHome.Common.Services;
 using DevHome.SetupFlow.Exceptions;
 using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels.Environments;
 
@@ -34,7 +34,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
 
     private readonly AdaptiveCardRenderingService _adaptiveCardRenderingService;
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly AdaptiveElementParserRegistration _elementRegistration = new();
 
@@ -69,14 +69,14 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
         ISetupFlowStringResource stringResource,
         SetupFlowOrchestrator orchestrator,
         SetupFlowViewModel setupFlow,
-        WindowEx windowEx,
+        DispatcherQueue dispatcherQueue,
         AdaptiveCardRenderingService renderingService)
            : base(stringResource, orchestrator)
     {
         PageTitle = stringResource.GetLocalized(StringResourceKey.ConfigureEnvironmentPageTitle);
         _setupFlowViewModel = setupFlow;
         _setupFlowViewModel.EndSetupFlow += OnEndSetupFlow;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
 
         // Register for changes to the selected provider. This will be triggered when the user selects a provider.
         // from the SelectEnvironmentProviderViewModel. This is a weak reference so that the recipient can be garbage collected.
@@ -165,7 +165,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
     /// </summary>
     public void UpdateExtensionAdaptiveCard(ComputeSystemAdaptiveCardResult adaptiveCardSessionResult)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             try
             {
@@ -221,7 +221,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
     /// </summary>
     public void OnAdaptiveCardUpdated(object sender, AdaptiveCard adaptiveCard)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             // Render the adaptive card and set the action event handler.
             _renderedAdaptiveCard = _adaptiveCardRenderer.RenderAdaptiveCard(adaptiveCard);
@@ -247,7 +247,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
     /// <param name="args">The action and user inputs from within the adaptive card</param>
     private void OnRenderedAdaptiveCardAction(object sender, AdaptiveActionEventArgs args)
     {
-        _windowEx.DispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
             IsAdaptiveCardSessionLoaded = false;
             AdaptiveCardLoadingMessage = StringResource.GetLocalized(StringResourceKey.EnvironmentCreationAdaptiveCardLoadingMessage, _curProviderDetails.ComputeSystemProvider.DisplayName);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/SelectEnvironmentProviderViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/SelectEnvironmentProviderViewModel.cs
@@ -1,25 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
-using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Behaviors;
 using DevHome.Common.Contracts.Services;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
-using DevHome.Common.Environments.Services;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.Services;
-using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels.Environments;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
@@ -10,7 +10,6 @@ using DevHome.Common.Windows.FileDialog;
 using DevHome.SetupFlow.Services;
 using Microsoft.UI.Xaml;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -131,7 +130,7 @@ public partial class FolderPickerViewModel : ObservableObject
         {
             _log.Information("Opening folder picker to select clone directory");
             using var folderPicker = new WindowOpenFolderDialog();
-            var locationToCloneTo = await folderPicker.ShowAsync(Application.Current.GetService<WindowEx>());
+            var locationToCloneTo = await folderPicker.ShowAsync(Application.Current.GetService<Window>());
             if (locationToCloneTo != null && locationToCloneTo.Path.Length > 0)
             {
                 _log.Information($"Selected '{locationToCloneTo.Path}' as location to clone to");

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/LoadingViewModel.cs
@@ -18,10 +18,10 @@ using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
 using DevHome.Telemetry;
 using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -216,7 +216,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
 
     public void AddMessage(string message, MessageSeverityKind severityKind = MessageSeverityKind.Info)
     {
-        Application.Current.GetService<WindowEx>().DispatcherQueue.TryEnqueue(() =>
+        Application.Current.GetService<DispatcherQueue>().TryEnqueue(() =>
         {
             var messageToDisplay = _host.GetService<LoadingMessageViewModel>();
             messageToDisplay.MessageToShow = message;
@@ -250,9 +250,9 @@ public partial class LoadingViewModel : SetupPageViewModelBase
 
     public void UpdateActionCenterMessage(ActionCenterMessages message, ActionMessageRequestKind requestKind)
     {
-        // ALl referenced to WindowEx and Application.Current will be removed in the future,
-        // in the loadingViewModel.
-        Application.Current.GetService<WindowEx>().DispatcherQueue.TryEnqueue(() =>
+        // All references to DispatcherQueue and Application.Current will be removed in the future,
+        // in the LoadingViewModel.
+        Application.Current.GetService<DispatcherQueue>().TryEnqueue(() =>
         {
             // We need to add/remove the message in a temporary list and then re add the items to a new collection. This is because
             // of the adaptive card panel and it receiving UI updates in the listview. There can be random crashes if we don't do this when
@@ -463,7 +463,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
     private async Task StartAllTasks(ObservableCollection<TaskInformation> tasks)
     {
         _log.Information("Starting all tasks");
-        var window = Application.Current.GetService<WindowEx>();
+        var dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
         await Task.Run(async () =>
         {
             var tasksToRunFirst = new List<TaskInformation>();
@@ -487,13 +487,13 @@ public partial class LoadingViewModel : SetupPageViewModelBase
             // Run all tasks that don't need dev drive installed.
             await Parallel.ForEachAsync(tasksToRunFirst, async (taskInformation, token) =>
             {
-                await StartTaskAndReportResult(window, taskInformation);
+                await StartTaskAndReportResult(dispatcherQueue, taskInformation);
             });
 
             // Run all the tasks that need dev drive installed.
             await Parallel.ForEachAsync(tasksToRunSecond, async (taskInformation, token) =>
             {
-                await StartTaskAndReportResult(window, taskInformation);
+                await StartTaskAndReportResult(dispatcherQueue, taskInformation);
             });
         });
 
@@ -530,17 +530,17 @@ public partial class LoadingViewModel : SetupPageViewModelBase
     /// <summary>
     /// Runs the specified task and updates the UI when the task is finished.
     /// </summary>
-    /// <param name="window">Used to get access to the dispatcher queue.</param>
+    /// <param name="dispatcherQueue">Dispatcher queue associated with the window for the task.</param>
     /// <param name="taskInformation">Information about the task to execute.  Will be modified</param>
     /// <returns>An awaitable task</returns>
-    private async Task StartTaskAndReportResult(WinUIEx.WindowEx window, TaskInformation taskInformation)
+    private async Task StartTaskAndReportResult(DispatcherQueue dispatcherQueue, TaskInformation taskInformation)
     {
         // Start the task and wait for it to complete.
         try
         {
             var loadingMessage = _host.GetService<LoadingMessageViewModel>();
             loadingMessage.MessageToShow = taskInformation.MessageToShow;
-            window.DispatcherQueue.TryEnqueue(() =>
+            dispatcherQueue.TryEnqueue(() =>
             {
                 TasksStarted++;
                 if (!Orchestrator.IsSettingUpATargetMachine)
@@ -570,7 +570,7 @@ public partial class LoadingViewModel : SetupPageViewModelBase
                 taskFinishedState = await taskInformation.TaskToExecute.Execute();
             }
 
-            window.DispatcherQueue.TryEnqueue(() =>
+            dispatcherQueue.TryEnqueue(() =>
             {
                 // Keep decrement inside TryEnqueue to enforce "locking"
                 _numberOfExecutingTasks--;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageCatalogListViewModel.cs
@@ -14,8 +14,8 @@ using DevHome.Common.Services;
 using DevHome.SetupFlow.Behaviors;
 using DevHome.SetupFlow.Services;
 using DevHome.Telemetry;
+using Microsoft.UI.Dispatching;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -25,7 +25,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
     private readonly ICatalogDataSourceLoader _catalogDataSourceLoader;
     private readonly IExtensionService _extensionService;
     private readonly PackageCatalogViewModelFactory _packageCatalogViewModelFactory;
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
     private readonly SemaphoreSlim _loadCatalogsSemaphore = new(1, 1);
 
     [ObservableProperty]
@@ -56,10 +56,10 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
         IExtensionService extensionService,
         ICatalogDataSourceLoader catalogDataSourceLoader,
         PackageCatalogViewModelFactory packageCatalogViewModelFactory,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
     {
         _extensionService = extensionService;
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _catalogDataSourceLoader = catalogDataSourceLoader;
         _packageCatalogViewModelFactory = packageCatalogViewModelFactory;
     }
@@ -172,7 +172,7 @@ public partial class PackageCatalogListViewModel : ObservableObject, IDisposable
 
     private async void OnExtensionChangedAsync(object sender, EventArgs e)
     {
-        await _windowEx.DispatcherQueue.EnqueueAsync(() => LoadCatalogsAsync());
+        await _dispatcherQueue.EnqueueAsync(() => LoadCatalogsAsync());
     }
 
     private void Dispose(bool disposing)

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -24,7 +24,6 @@ using Serilog;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.System;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -195,7 +194,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
             // TODO: Replace with WindowSaveFileDialog
             var folderPicker = new FolderPicker();
-            var hWnd = Application.Current.GetService<WindowEx>().GetWindowHandle();
+            var hWnd = Application.Current.GetService<Window>().GetWindowHandle();
             WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hWnd);
             folderPicker.FileTypeFilter.Add("*");
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs
@@ -16,8 +16,8 @@ using DevHome.SetupFlow.Models;
 using DevHome.SetupFlow.Services;
 using DevHome.SetupFlow.TaskGroups;
 using DevHome.Telemetry;
+using Microsoft.UI.Xaml;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -27,7 +27,7 @@ public partial class ReviewViewModel : SetupPageViewModelBase
 
     private readonly SetupFlowOrchestrator _setupFlowOrchestrator;
     private readonly ConfigurationFileBuilder _configFileBuilder;
-    private readonly WindowEx _mainWindow;
+    private readonly Window _mainWindow;
 
     [ObservableProperty]
     private IList<ReviewTabViewModelBase> _reviewTabs;
@@ -95,7 +95,7 @@ public partial class ReviewViewModel : SetupPageViewModelBase
         ISetupFlowStringResource stringResource,
         SetupFlowOrchestrator orchestrator,
         ConfigurationFileBuilder configFileBuilder,
-        WindowEx mainWindow)
+        Window mainWindow)
         : base(stringResource, orchestrator)
     {
         NextPageButtonText = StringResource.GetLocalized(StringResourceKey.SetUpButton);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Collections.ObjectModel;
-using System.Configuration;
-using System.Globalization;
-using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -18,10 +15,9 @@ using DevHome.Common.Environments.Services;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.Services;
-using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Dispatching;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.SetupFlow.ViewModels;
 
@@ -29,7 +25,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(SetupTargetViewModel));
 
-    private readonly WindowEx _windowEx;
+    private readonly DispatcherQueue _dispatcherQueue;
 
     private const string SortByDisplayName = "DisplayName";
 
@@ -87,7 +83,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         SetupFlowOrchestrator orchestrator,
         IComputeSystemManager computeSystemManager,
         ComputeSystemViewModelFactory computeSystemViewModelFactory,
-        WindowEx windowEx)
+        DispatcherQueue dispatcherQueue)
         : base(stringResource, orchestrator)
     {
         // Setup initial state for page.
@@ -111,7 +107,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
         // Add AdvancedCollectionView to make filtering and sorting the list of ComputeSystemsListViewModels easier.
         ComputeSystemsCollectionView = new AdvancedCollectionView(_computeSystemViewModelList, true);
 
-        _windowEx = windowEx;
+        _dispatcherQueue = dispatcherQueue;
         _computeSystemViewModelFactory = computeSystemViewModelFactory;
         ComputeSystemManagerObj = computeSystemManager;
         _setupFlowViewModel = setupFlowModel;
@@ -410,7 +406,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
             }
         });
 
-        await _windowEx.DispatcherQueue.EnqueueAsync(async () =>
+        await _dispatcherQueue.EnqueueAsync(async () =>
         {
             foreach (var computeSystem in curListViewModel.ComputeSystems)
             {
@@ -426,7 +422,7 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
                     computeSystem,
                     curListViewModel.Provider,
                     packageFullName,
-                    _windowEx);
+                    _dispatcherQueue);
 
                 // Don't show environments that aren't in a state to configure
                 if (!ShouldShowCard(card.CardState))

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
@@ -27,8 +27,8 @@ public sealed partial class SummaryView : UserControl, IRecipient<NewAdaptiveCar
         if (sender is HyperlinkButton hyperlinkButton && hyperlinkButton.Tag is PackageViewModel package)
         {
             var window = new InstallationNotesWindow(package.PackageTitle, package.InstallationNotes);
-            window.Activate();
             window.CenterOnWindow();
+            window.Activate();
         }
     }
 

--- a/tools/Utilities/EnvVariablesUtility/EnvironmentVariablesAppMainWindow.xaml.cs
+++ b/tools/Utilities/EnvVariablesUtility/EnvironmentVariablesAppMainWindow.xaml.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.EnvironmentVariables.TelemetryEvents;
 using DevHome.EnvironmentVariables.Win32;
@@ -14,11 +15,10 @@ using EnvironmentVariablesUILib.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.EnvironmentVariables;
 
-public sealed partial class EnvironmentVariablesMainWindow : WindowEx
+public sealed partial class EnvironmentVariablesMainWindow : WinUIEx.WindowEx
 {
     private EnvironmentVariablesMainPage EnvVariablesUtilityMainPage { get; }
 

--- a/tools/Utilities/EnvVariablesUtility/Helpers/NativeMethods.cs
+++ b/tools/Utilities/EnvVariablesUtility/Helpers/NativeMethods.cs
@@ -12,12 +12,6 @@ public static class NativeMethods
 
     internal delegate IntPtr WinProc(IntPtr hWnd, WindowMessage msg, IntPtr wParam, IntPtr lParam);
 
-    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-    internal static extern int SendNotifyMessage(IntPtr hWnd, WindowMessage msg, IntPtr wParam, IntPtr lParam);
-
-    [DllImport("User32.dll")]
-    internal static extern int GetDpiForWindow(IntPtr hwnd);
-
     [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
     internal static extern int SetWindowLong32(IntPtr hWnd, WindowLongIndexFlags nIndex, WinProc newProc);
 

--- a/tools/Utilities/HostsUtility/HostsFileEditorMainWindow.xaml.cs
+++ b/tools/Utilities/HostsUtility/HostsFileEditorMainWindow.xaml.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using DevHome.Common.Services;
-using DevHome.HostsFileEditor.Helpers;
 using DevHome.HostsFileEditor.TelemetryEvents;
 using DevHome.Telemetry;
 using HostsUILib.Helpers;
@@ -12,11 +11,10 @@ using HostsUILib.Views;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.HostsFileEditor;
 
-public sealed partial class HostsFileEditorMainWindow : WindowEx
+public sealed partial class HostsFileEditorMainWindow : WinUIEx.WindowEx
 {
     private HostsMainPage HostsNugetMainPage { get; }
 

--- a/tools/Utilities/HostsUtility/Views/HostsFileEditorSettingsWindow.xaml.cs
+++ b/tools/Utilities/HostsUtility/Views/HostsFileEditorSettingsWindow.xaml.cs
@@ -5,11 +5,10 @@ using System;
 using System.IO;
 using DevHome.Common.Services;
 using DevHome.HostsFileEditor.ViewModels;
-using WinUIEx;
 
 namespace DevHome.HostsFileEditor.Views;
 
-public sealed partial class HostsFileEditorSettingsWindow : WindowEx
+public sealed partial class HostsFileEditorSettingsWindow : WinUIEx.WindowEx
 {
     public HostsFileEditorSettingsViewModel ViewModel { get; }
 

--- a/tools/Utilities/RegPreviewUtility/RegistryPreviewMainWindow.xaml.cs
+++ b/tools/Utilities/RegPreviewUtility/RegistryPreviewMainWindow.xaml.cs
@@ -10,11 +10,10 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using RegistryPreviewUILib;
 using Serilog;
-using WinUIEx;
 
 namespace DevHome.RegistryPreview;
 
-public sealed partial class RegistryPreviewMainWindow : WindowEx
+public sealed partial class RegistryPreviewMainWindow : WinUIEx.WindowEx
 {
     private string AppName { get; set; }
 


### PR DESCRIPTION
## Summary of the pull request
WinUIEx is primarily used in Dev Home for easy handling of MinWidth and MinHeight of main and secondary windows and for remembering window placement of the main window across launches (PersistenceId). As WinUI improves these dependencies will be unnecessary and this dependency can eventually be removed since the intention of WinUIEx is to highlight gaps in WinUI rather than replace or extend it.

Most of the usage of WinUIEx in Dev Home is actually using the WindowEx to get access to the DispatcherQueue to queue work on the UI thread. We don't actually need to expose the WindowEx for that since the Microsoft.UI.Xaml.Window has that itself. In fact, most consumers don't even care about the Window so we can easily just register the DispatcherQueue itself to avoid overexposure of the Window and callers can be more explicit. We should in the longer-term reconsider access to the Dispatcher and why so many components need the UI thread... I suspect a lot of this can be further simplified. The goal of this PR is to just reduce the scope of the dependencies. 

I also took the liberty of cleaning up some references that were unused as I found them when removing the using WinUIEx statements as well.

The two convenience methods from WinUIEx that were used GetWindowHandle and CenterOnScreen were pulled into WindowExExtensions (didn't rename for easier change tracking, we can rename this to WindowExtensions when fully removing WinUIEx down the road.)
 
PI coming in brings quite a few new dependencies on WinUIEx but nothing insurmountable. These similar principals should apply to that project as well but given the churn there I did not make many changes to anything in that project.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
I've going through the testing scenarios checklist and ensured that secondary windows as well as PI is unaffected. 

## PR checklist
- [ ] Closes #2928 
- [ ] Tests added/passed
- [ ] Documentation updated
