### PR TITLE
fix how we update the properties in environments page after an operation

### DIFF
--- a/common/Environments/Helpers/ComputeSystemHelpers.cs
+++ b/common/Environments/Helpers/ComputeSystemHelpers.cs
@@ -155,7 +155,7 @@ public static class ComputeSystemHelpers
                 collectionToUpdate.RemoveAt(i);
             }
 
-            for (var i = listWithUpdates.Count - 1; i >= 0; i--)
+            for (var i = 0; i < listWithUpdates.Count; i++)
             {
                 collectionToUpdate.Add(listWithUpdates[i]);
             }

--- a/common/Environments/Helpers/ComputeSystemHelpers.cs
+++ b/common/Environments/Helpers/ComputeSystemHelpers.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using DevHome.Common.Environments.Models;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.VisualBasic;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 
@@ -131,7 +132,7 @@ public static class ComputeSystemHelpers
     }
 
     /// <summary>
-    /// Safely remove all items from an observable collection.
+    /// Safely removes all items from an observable collection and replaces them with new items.
     /// </summary>
     /// <remarks>
     /// There can be random COM exceptions due to using the "Clear()" method in an observable collection. This method
@@ -140,19 +141,32 @@ public static class ComputeSystemHelpers
     /// this method is used to remove all items individually from the end of the collection to the beginning of the collection.
     /// </remarks>
     /// <typeparam name="T">Type of objects that the collection contains</typeparam>
-    /// <param name="collection">An observable collection that contains zero to N elements</param>
-    public static void RemoveAllItems<T>(ObservableCollection<T> collection)
+    /// <param name="collectionToUpdate">An observable collection that contains zero to N elements that will have its contents replaced</param>
+    /// <param name="listWithUpdates">A list that contains zero to N elements whose elements will be added to collectionToUpdate</param>
+    /// <returns>
+    /// True only if we successfully replaced all items in the collection. False otherwise.
+    /// </returns>
+    public static bool RemoveAllItemsAnReplace<T>(ObservableCollection<T> collectionToUpdate, List<T> listWithUpdates)
     {
         try
         {
-            for (var i = collection.Count - 1; i >= 0; i--)
+            for (var i = collectionToUpdate.Count - 1; i >= 0; i--)
             {
-                collection.RemoveAt(i);
+                collectionToUpdate.RemoveAt(i);
             }
+
+            for (var i = listWithUpdates.Count - 1; i >= 0; i--)
+            {
+                collectionToUpdate.Add(listWithUpdates[i]);
+            }
+
+            return true;
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Unable to remove items from the collection");
         }
+
+        return false;
     }
 }

--- a/common/Environments/Helpers/ComputeSystemHelpers.cs
+++ b/common/Environments/Helpers/ComputeSystemHelpers.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using DevHome.Common.Environments.Models;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.VisualBasic;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 
@@ -87,8 +86,8 @@ public static class ComputeSystemHelpers
     {
         try
         {
-            var curentProperties = await computeSystem.GetComputeSystemPropertiesAsync(string.Empty);
-            return GetComputeSystemCardProperties(curentProperties, packageFullName);
+            var currentProperties = await computeSystem.GetComputeSystemPropertiesAsync(string.Empty);
+            return GetComputeSystemCardProperties(currentProperties, packageFullName);
         }
         catch (Exception ex)
         {
@@ -146,7 +145,7 @@ public static class ComputeSystemHelpers
     /// <returns>
     /// True only if we successfully replaced all items in the collection. False otherwise.
     /// </returns>
-    public static bool RemoveAllItemsAnReplace<T>(ObservableCollection<T> collectionToUpdate, List<T> listWithUpdates)
+    public static bool RemoveAllItemsAndReplace<T>(ObservableCollection<T> collectionToUpdate, List<T> listWithUpdates)
     {
         try
         {

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -193,11 +193,9 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         }
 
         var properties = await ComputeSystemHelpers.GetComputeSystemCardPropertiesAsync(ComputeSystem!, PackageFullName);
-
-        ComputeSystemHelpers.RemoveAllItems(Properties);
-        foreach (var property in properties)
+        if (!ComputeSystemHelpers.RemoveAllItemsAnReplace(Properties, properties))
         {
-            Properties.Add(property);
+            Properties = new(properties);
         }
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -193,7 +193,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         }
 
         var properties = await ComputeSystemHelpers.GetComputeSystemCardPropertiesAsync(ComputeSystem!, PackageFullName);
-        if (!ComputeSystemHelpers.RemoveAllItemsAnReplace(Properties, properties))
+        if (!ComputeSystemHelpers.RemoveAllItemsAndReplace(Properties, properties))
         {
             Properties = new(properties);
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -102,10 +102,9 @@ public partial class ComputeSystemCardViewModel : ObservableObject
         var properties = await ComputeSystemHelpers.GetComputeSystemCardPropertiesAsync(ComputeSystem, _packageFullName);
         lock (_lock)
         {
-            ComputeSystemHelpers.RemoveAllItems(ComputeSystemProperties);
-            foreach (var property in properties)
+            if (!ComputeSystemHelpers.RemoveAllItemsAnReplace(ComputeSystemProperties, properties))
             {
-                ComputeSystemProperties.Add(property);
+                ComputeSystemProperties = new(properties);
             }
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -102,7 +102,7 @@ public partial class ComputeSystemCardViewModel : ObservableObject
         var properties = await ComputeSystemHelpers.GetComputeSystemCardPropertiesAsync(ComputeSystem, _packageFullName);
         lock (_lock)
         {
-            if (!ComputeSystemHelpers.RemoveAllItemsAnReplace(ComputeSystemProperties, properties))
+            if (!ComputeSystemHelpers.RemoveAllItemsAndReplace(ComputeSystemProperties, properties))
             {
                 ComputeSystemProperties = new(properties);
             }


### PR DESCRIPTION
## Summary of the pull request
This issue doesn't happen often but it is still an issue that can crash Dev Home which I observed. See: #2947 

I explained the issue in point 1 in this PR: https://github.com/microsoft/devhome/pull/2892

Basically, when you perform any action in the environments page, e.g Starting/Stopping the properties are updated because they may have changed as a result of the operation. In the issue I how the exception that can happen when we attempt to remove the old items from the observable collection. But because we go on add items to the collection afterwards we get an exception. As a minimal change I'm moving the loop that add new items to the observable collection to the try/catch. And then if there is an exception create a new observable collection with the new items. This will least allow the user to see the updated properties. 

In the future I'd like to investigate why the observable collection is throwing but for build we can do this work around

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #2947 
- [ ] Tests added/passed
- [ ] Documentation updated
