### PR TITLE
Fix to have only one PI instance at any point in time

### DIFF
--- a/tools/PI/DevHome.PI/Program.cs
+++ b/tools/PI/DevHome.PI/Program.cs
@@ -47,8 +47,8 @@ public static class Program
             .ReadFrom.Configuration(configuration)
             .CreateLogger();
 
-        var stopEvent = new EventWaitHandle(false, EventResetMode.ManualReset, $"DevHomePI - {Environment.ProcessId}");
-        var stopEventThread = new Thread(() =>
+        var stopEvent = new EventWaitHandle(false, EventResetMode.ManualReset, $"DevHomePI-{Environment.ProcessId}");
+        ThreadPool.QueueUserWorkItem((o) =>
         {
             var waitResult = stopEvent.WaitOne();
 
@@ -58,7 +58,6 @@ public static class Program
                 primaryWindow.Close();
             });
         });
-        stopEventThread.Start();
 
         try
         {
@@ -81,8 +80,6 @@ public static class Program
                 });
             }
 
-            stopEvent.Set();
-            stopEventThread.Join();
             stopEvent.Close();
             stopEvent.Dispose();
         }
@@ -132,7 +129,7 @@ public static class Program
                     if (appInstance.Key.Equals(MainInstanceKey, StringComparison.OrdinalIgnoreCase))
                     {
                         isUnElevatedInstancePresent = true;
-                        var stopAppInstance = new EventWaitHandle(false, EventResetMode.ManualReset, $"DevHomePI - {appInstance.ProcessId}");
+                        var stopAppInstance = new EventWaitHandle(false, EventResetMode.ManualReset, $"DevHomePI-{appInstance.ProcessId}");
                         stopAppInstance.Set();
                     }
                 }


### PR DESCRIPTION
## Summary of the pull request
If PI is running elevated, and a user starts PI unelevated, we would have 2 instances of PI running. 
To fix this, when an elevated PI instance is running, redirect all activation calls to the elevated PI instance.

## Validation steps performed
1. Run PI unelevated
2. Change target app to task manager
3. This shows a button to run PI as admin
4. Click on the button and wait for PI to run as admin
5. From unelevated powershell run PI and confirmed that the activation is redirected to the elevated PI instance.
