### PR TITLE
Dev Home PI: Close the settings window when the Bar Window is closed

### DIFF
--- a/tools/PI/DevHome.PI/BarWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindow.xaml.cs
@@ -288,6 +288,7 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
     {
         ClipboardMonitor.Instance.Stop();
         TargetAppData.Instance.ClearAppData();
+        ExpandedViewControl.CloseSettings();
 
         if (positionEventHook != IntPtr.Zero)
         {

--- a/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml.cs
@@ -8,13 +8,13 @@ using DevHome.PI.SettingsUi;
 using DevHome.PI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using WinUIEx;
 
 namespace DevHome.PI.Controls;
 
 public sealed partial class ExpandedViewControl : UserControl
 {
     private readonly ExpandedViewControlViewModel viewModel = new();
+    private SettingsToolWindow? settingsTool;
 
     public ExpandedViewControl()
     {
@@ -34,7 +34,12 @@ public sealed partial class ExpandedViewControl : UserControl
 
     private void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
-        SettingsToolWindow settingsTool = new(Settings.Default.SettingsToolPosition);
-        settingsTool.Show();
+        settingsTool = new(Settings.Default.SettingsToolPosition);
+        settingsTool.Activate();
+    }
+
+    public void CloseSettings()
+    {
+        settingsTool?.Close();
     }
 }


### PR DESCRIPTION
## Summary of the pull request
SettingsToolWindow is not closed when the user closes the bar window currently. Added a fix to call SettingsToolWindow.Close when the barwindow is closed.

## Validation steps performed
1. Launch DevHome.PI from Utilities
2. Click on Expand button
3. Click on Settings icon at the bottom right
4. Go back to bar window
5. Click on close icon on the top right
6. Verified that the settings window closes along with bar window