### PR TITLE
Dev Home PI: Close target process Performance counters when the target process exits

### DIFF
--- a/tools/PI/DevHome.PI/Models/PerfCounters.cs
+++ b/tools/PI/DevHome.PI/Models/PerfCounters.cs
@@ -89,6 +89,10 @@ public partial class PerfCounters : ObservableObject, IDisposable
         {
             ThreadPool.QueueUserWorkItem((o) => UpdateTargetProcess(TargetAppData.Instance.TargetProcess));
         }
+        else if (e.PropertyName == nameof(TargetAppData.HasExited))
+        {
+            CloseTargetCounters();
+        }
     }
 
     private void UpdateTargetProcess(Process? process)
@@ -130,15 +134,26 @@ public partial class PerfCounters : ObservableObject, IDisposable
     private void CloseTargetCounters()
     {
         cpuCounter?.Close();
+        cpuCounter?.Dispose();
+        cpuCounter = null;
         ramCounter?.Close();
+        ramCounter?.Dispose();
+        ramCounter = null;
 
         foreach (var counter in gpuCounters ?? Enumerable.Empty<PerformanceCounter>())
         {
             counter.Close();
+            counter.Dispose();
         }
 
+        gpuCounters?.Clear();
+
         readCounter?.Close();
+        readCounter?.Dispose();
+        readCounter = null;
         writeCounter?.Close();
+        writeCounter?.Dispose();
+        writeCounter = null;
     }
 
     public static List<PerformanceCounter> GetGpuCounters(int pid)


### PR DESCRIPTION
## Detailed description of the pull request / Additional comments
Bug: Performance counters continue running after the target process has exited.
Fix: When target process HasExited property changes, close all Performance counters for the target process.

## Validation steps performed
1. Launch PI from Dev Home utilities and target to any app
2. Expand the window to see all pages
3. go to "Resource usage" page
4. Close the app that we are targeting.
5. Validate that the resource usage goes down to 0.