### PR TITLE
Fix event tags for a couple of the methods provided by the Telemetry class

### DIFF
--- a/telemetry/DevHome.Telemetry/Telemetry.cs
+++ b/telemetry/DevHome.Telemetry/Telemetry.cs
@@ -154,7 +154,7 @@ internal sealed class Telemetry : ITelemetry
                 innerMessage,
                 innerStackTrace = innerStackTrace.ToString(),
                 message = this.ReplaceSensitiveStrings(e.Message),
-                PartA_PrivTags = PartA_PrivTags.ProductAndServiceUsage,
+                PartA_PrivTags = PartA_PrivTags.ProductAndServicePerformance,
             },
             relatedActivityId,
             isError: true);
@@ -175,7 +175,7 @@ internal sealed class Telemetry : ITelemetry
             {
                 eventName,
                 timeTakenMilliseconds,
-                PartA_PrivTags = PartA_PrivTags.ProductAndServiceUsage,
+                PartA_PrivTags = PartA_PrivTags.ProductAndServicePerformance,
             },
             relatedActivityId,
             isError: false);

--- a/telemetry/DevHome.Telemetry/Telemetry.cs
+++ b/telemetry/DevHome.Telemetry/Telemetry.cs
@@ -154,6 +154,7 @@ internal sealed class Telemetry : ITelemetry
                 innerMessage,
                 innerStackTrace = innerStackTrace.ToString(),
                 message = this.ReplaceSensitiveStrings(e.Message),
+                PartA_PrivTags = PartA_PrivTags.ProductAndServiceUsage,
             },
             relatedActivityId,
             isError: true);
@@ -174,6 +175,7 @@ internal sealed class Telemetry : ITelemetry
             {
                 eventName,
                 timeTakenMilliseconds,
+                PartA_PrivTags = PartA_PrivTags.ProductAndServiceUsage,
             },
             relatedActivityId,
             isError: false);


### PR DESCRIPTION
## Summary of the pull request
The tags are missing from the Exception (and TimeTaken) logging helper methods in the Telemetry class. This change includes those entries in the data payload.

## References and relevant issues

## Detailed description of the pull request / Additional comments
I was looking through the class and noticed this, so I made the surgical fix for it. _Theoretically_, these events should be rewritten to follow the format we are trying to use for events now (e.g., as separate classes); that was a more involved change than I had time for due in part to the Exception class's use of additional internal methods... I figured that this is still a step in the right direction.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
