### PR TITLE
Enable adding external tools to the External Tools menu

### DIFF
--- a/tools/PI/DevHome.PI/BarWindow.xaml
+++ b/tools/PI/DevHome.PI/BarWindow.xaml
@@ -90,29 +90,16 @@
                         <TextBlock Text="&#xe8a1;"/>
                     </Button>
 
-                    <!-- TODO When we add a tool, we should add it to the ExternalToolsMenu. -->
-                    <Button
-                         x:Name="ExternalToolsButton"
-                         x:Uid="ExternalToolsButton"
-                         HorizontalAlignment="Center">
-                         <Button.ContextFlyout>
-                             <MenuFlyout x:Name="ExternalToolsMenu">
-                             <!-- Menuitems for each external tool will be added below. -->
-                             </MenuFlyout>
-                        </Button.ContextFlyout>
-                        <TextBlock Text="&#xEC7A;"/>
-                    </Button>
-
-                    <ItemsRepeater
-                        x:Name="ExternalToolsRepeater"
-                        ItemsSource="{x:Bind helpers:ExternalToolsHelper.Instance.ExternalTools, Mode=OneWay}"
-                        Layout="{StaticResource ExternalToolsHorizontalLayout}">
-                        <ItemsRepeater.ContextFlyout>
+                    <!-- External tools -->
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel.ContextFlyout>
+                            <!-- TODO Re-enable this when we have Click handler implementation.-->
                             <MenuFlyout x:Name="ToolContextMenu">
                                 <MenuFlyoutItem
                                     x:Uid="UnPinMenuItem"
                                     x:Name="UnPinMenuItem"
-                                    Click="UnPinMenuItem_Click">
+                                    Click="UnPinMenuItem_Click"
+                                    IsEnabled="False">
                                     <MenuFlyoutItem.Icon>
                                         <FontIcon Glyph="&#xE77A;"/>
                                     </MenuFlyoutItem.Icon>
@@ -126,19 +113,38 @@
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                             </MenuFlyout>
-                        </ItemsRepeater.ContextFlyout>
+                        </StackPanel.ContextFlyout>
 
-                        <DataTemplate x:DataType="helpers:ExternalTool">
-                            <Button
-                                Click="ExternalToolButton_Click"
-                                HorizontalAlignment="Center" Width="45" Height="45"
-                                ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}"
-                                Tag="{x:Bind}"
-                                PointerPressed="ExternalToolButton_PointerPressed">
-                                <Image Source="{x:Bind ToolIcon, Mode=OneWay}"/>
-                            </Button>
-                        </DataTemplate>
-                    </ItemsRepeater>
+                        <Button
+                             x:Name="ManageExternalToolsButton"
+                             x:Uid="ManageExternalToolsButton"
+                             HorizontalAlignment="Center"
+                            Click="ManageExternalToolsButton_Click">
+                            <Button.ContextFlyout>
+                                <MenuFlyout x:Name="ExternalToolsMenu">
+                                    <!-- We can't databind to MenuFlyout, so we'll add a MenuFlyoutItem
+                                    for each external tool in codebehind here. -->
+                                </MenuFlyout>
+                            </Button.ContextFlyout>
+                            <TextBlock Text="&#xEC7A;"/>
+                        </Button>
+
+                        <ItemsRepeater
+                            x:Name="ExternalToolsRepeater"
+                            ItemsSource="{x:Bind helpers:ExternalToolsHelper.Instance.ExternalTools, Mode=OneWay}"
+                            Layout="{StaticResource ExternalToolsHorizontalLayout}">
+                            <DataTemplate x:DataType="helpers:ExternalTool">
+                                <Button
+                                    Click="ExternalToolButton_Click"
+                                    HorizontalAlignment="Center" Width="45" Height="45"
+                                    ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}"
+                                    Tag="{x:Bind}"
+                                    PointerPressed="ExternalToolButton_PointerPressed">
+                                    <Image Source="{x:Bind ToolIcon, Mode=OneWay}"/>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsRepeater>
+                    </StackPanel>
                 </StackPanel>
             </GridView>
 

--- a/tools/PI/DevHome.PI/BarWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindow.xaml.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -13,9 +13,9 @@ using DevHome.PI.Controls;
 using DevHome.PI.Helpers;
 using DevHome.PI.Models;
 using DevHome.PI.Properties;
+using DevHome.PI.SettingsUi;
 using DevHome.PI.Telemetry;
 using DevHome.PI.ViewModels;
-using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -139,9 +139,12 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
     private readonly WINEVENTPROC winFocusEventDelegate;
 
     private Button? selectedExternalToolButton;
+    private MenuFlyoutItem? selectedExternalToolMenuItem;
 
     private HWINEVENTHOOK positionEventHook;
     private HWINEVENTHOOK focusEventHook;
+
+    private INotifyCollectionChanged? externalTools;
 
     internal static HWND ThisHwnd { get; private set; }
 
@@ -205,14 +208,13 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
             PerfCounters.Instance.Start();
         }
 
-        ExternalToolsHelper.Instance.Init();
+        InitializeExternalTools();
 
         // Apply the user's chosen theme setting.
         ThemeName t = ThemeName.Themes.First(t => t.Name == settings.CurrentTheme);
         SetRequestedTheme(t.Theme);
 
-        // Calculate the DPI scale. We'll also recalculate later,
-        // in case the user changes the display settings.
+        // Calculate the DPI scale.
         var dpiWindow = HwndExtensions.GetDpiForWindow(ThisHwnd);
         dpiScale = dpiWindow / 96.0;
 
@@ -226,6 +228,166 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
 
         // Show the window after it has been positioned and configured.
         this.Show();
+    }
+
+    private void InitializeExternalTools()
+    {
+        ExternalToolsHelper.Instance.Init();
+
+        foreach (var item in ExternalToolsHelper.Instance.ExternalTools)
+        {
+            CreateMenuItemFromTool(item);
+        }
+
+        // We have to cast to INotifyCollectionChanged explicitly because the CollectionChanged
+        // event in ReadOnlyObservableCollection is protected.
+        externalTools = ExternalToolsHelper.Instance.ExternalTools;
+        externalTools.CollectionChanged += ExternalTools_CollectionChanged;
+    }
+
+    private void ExternalTools_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems is not null)
+        {
+            foreach (ExternalTool item in e.NewItems)
+            {
+                CreateMenuItemFromTool(item);
+            }
+        }
+        else if (e.Action == NotifyCollectionChangedAction.Remove && e.OldItems is not null)
+        {
+            foreach (ExternalTool item in e.OldItems)
+            {
+                var menuItem = ExternalToolsMenu.Items.FirstOrDefault(i => ((ExternalTool)i.Tag).ID == item.ID);
+                if (menuItem is not null)
+                {
+                    ExternalToolsMenu.Items.Remove(menuItem);
+                }
+            }
+        }
+    }
+
+    private void CreateMenuItemFromTool(ExternalTool item)
+    {
+        var imageIcon = new ImageIcon
+        {
+            Source = item.ToolIcon,
+        };
+
+        var menuItem = new MenuFlyoutItem
+        {
+            Text = item.Name,
+            Tag = item,
+            Icon = item.MenuIcon,
+        };
+        menuItem.Click += ExternalToolMenuItem_Click;
+        menuItem.RightTapped += MenuItem_RightTapped;
+        ExternalToolsMenu.Items.Add(menuItem);
+
+        // You can't databind to MenuFlyoutItem, and the ExternalTool icon image is generated asynchronously,
+        // so we'll handle the PropertyChanged event in code, so we can update the icon when it gets set.
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/1087
+        item.PropertyChanged += ExternalToolItem_PropertyChanged;
+    }
+
+    private void ExternalToolItem_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is ExternalTool item && e.PropertyName == nameof(ExternalTool.MenuIcon))
+        {
+            var menuItem = (MenuFlyoutItem?)ExternalToolsMenu.Items.FirstOrDefault(i => ((ExternalTool)i.Tag).ID == item.ID);
+            if (menuItem is not null)
+            {
+                menuItem.Icon = item.MenuIcon;
+            }
+        }
+    }
+
+    private void ManageExternalToolsButton_Click(object sender, RoutedEventArgs e)
+    {
+        SettingsToolWindow settingsTool = new(Settings.Default.SettingsToolPosition, SettingsPage.AdditionalTools);
+        settingsTool.Show();
+    }
+
+    private void MenuItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
+    {
+        var menuItem = sender as MenuFlyoutItem;
+        if (menuItem is not null)
+        {
+            selectedExternalToolMenuItem = menuItem;
+            ToolContextMenu.ShowAt(menuItem, e.GetPosition(menuItem));
+        }
+    }
+
+    private void ExternalToolMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem clickedMenuItem)
+        {
+            if (clickedMenuItem.Tag is ExternalTool tool)
+            {
+                InvokeTool(tool, TargetAppData.Instance.TargetProcess?.Id, TargetAppData.Instance.HWnd);
+            }
+        }
+    }
+
+    private void ExternalToolButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button clickedButton)
+        {
+            if (clickedButton.Tag is ExternalTool tool)
+            {
+                InvokeTool(tool, TargetAppData.Instance.TargetProcess?.Id, TargetAppData.Instance.HWnd);
+            }
+        }
+    }
+
+    private void InvokeTool(ExternalTool tool, int? id, HWND hWnd)
+    {
+        var process = tool.Invoke(id, hWnd);
+        if (process is null)
+        {
+            // A ContentDialog only renders in the space its parent occupies. Since the parent is a narrow
+            // bar, the dialog doesn't have enough space to render. So, we'll use MessageBox to display errors.
+            PInvoke.MessageBox(
+                ThisHwnd,
+                string.Format(CultureInfo.CurrentCulture, errorMessageText, tool.Executable),
+                errorTitleText,
+                MESSAGEBOX_STYLE.MB_ICONERROR);
+        }
+    }
+
+    private void ExternalToolButton_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        selectedExternalToolButton = (Button)sender;
+    }
+
+    private void UnPinMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        // TODO Unpin the tool from the bar, but don't remove it from the collection,
+        // so it stays registered, and it stays in the ExternalTools menu.
+        if (selectedExternalToolButton is not null)
+        {
+        }
+        else if (selectedExternalToolMenuItem is not null)
+        {
+        }
+    }
+
+    private void UnregisterMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (selectedExternalToolButton is not null)
+        {
+            if (selectedExternalToolButton.Tag is ExternalTool tool)
+            {
+                ExternalToolsHelper.Instance.RemoveExternalTool(tool);
+            }
+        }
+        else if (selectedExternalToolMenuItem is not null)
+        {
+            if (selectedExternalToolMenuItem.Tag is ExternalTool tool)
+            {
+                ExternalToolsHelper.Instance.RemoveExternalTool(tool);
+            }
+        }
     }
 
     private void SetDefaultPosition()
@@ -260,28 +422,6 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
         restoreState.Width = settingSize.Width;
     }
 
-    private void ExternalToolButton_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is Button clickedButton)
-        {
-            if (clickedButton.Tag is ExternalTool tool)
-            {
-                var process = tool.Invoke(TargetAppData.Instance.TargetProcess?.Id, TargetAppData.Instance.HWnd);
-
-                if (process == null)
-                {
-                    // It appears ContentDialogs only render in the space it's parent occupies. Since the parent is a narrow
-                    // bar, the dialog doesn't have enough space to render. So, we'll use MessageBox to display errors.
-                    PInvoke.MessageBox(
-                        ThisHwnd,
-                        string.Format(CultureInfo.CurrentCulture, errorMessageText, tool.Executable),
-                        errorTitleText,
-                        MESSAGEBOX_STYLE.MB_ICONERROR);
-                }
-            }
-        }
-    }
-
     private void WindowEx_Closed(object sender, WindowEventArgs args)
     {
         if (LargeContentPanel is not null
@@ -293,7 +433,11 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
 
         ClipboardMonitor.Instance.Stop();
         TargetAppData.Instance.ClearAppData();
-        ExpandedViewControl.CloseSettings();
+
+        foreach (var window in OpenChildWindows)
+        {
+            window.Close();
+        }
 
         if (positionEventHook != IntPtr.Zero)
         {
@@ -319,27 +463,6 @@ public partial class BarWindow : WindowEx, INotifyPropertyChanged
             else
             {
                 ClipboardMonitor.Instance.Stop();
-            }
-        }
-    }
-
-    private void ExternalToolButton_PointerPressed(object sender, PointerRoutedEventArgs e)
-    {
-        selectedExternalToolButton = (Button)sender;
-    }
-
-    private void UnPinMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        // TODO Implement unpinning a tool from the bar, assuming we continue with the pinning feature.
-    }
-
-    private void UnregisterMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        if (selectedExternalToolButton is not null)
-        {
-            if (selectedExternalToolButton.Tag is ExternalTool tool)
-            {
-                ExternalToolsHelper.Instance.RemoveExternalTool(tool);
             }
         }
     }

--- a/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml.cs
@@ -14,7 +14,6 @@ namespace DevHome.PI.Controls;
 public sealed partial class ExpandedViewControl : UserControl
 {
     private readonly ExpandedViewControlViewModel viewModel = new();
-    private SettingsToolWindow? settingsTool;
 
     public ExpandedViewControl()
     {
@@ -34,12 +33,7 @@ public sealed partial class ExpandedViewControl : UserControl
 
     private void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
-        settingsTool = new(Settings.Default.SettingsToolPosition);
+        SettingsToolWindow settingsTool = new(Settings.Default.SettingsToolPosition, null);
         settingsTool.Activate();
-    }
-
-    public void CloseSettings()
-    {
-        settingsTool?.Close();
     }
 }

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -281,6 +281,14 @@ public class WindowHelper
         }
     }
 
+    public static async Task<SoftwareBitmapSource> GetWinUI3BitmapSourceFromGdiBitmap(Bitmap bmp)
+    {
+        var softwareBitmap = GetSoftwareBitmapFromGdiBitmap(bmp);
+        var source = new SoftwareBitmapSource();
+        await source.SetBitmapAsync(softwareBitmap);
+        return source;
+    }
+
     public static SoftwareBitmap? GetSoftwareBitmapFromExecutable(string executable)
     {
         SoftwareBitmap? softwareBitmap = null;

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -9,11 +9,15 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Devices.Display;
 using Windows.Devices.Enumeration;
 using Windows.Graphics;
+using Windows.Graphics.Imaging;
+using Windows.Storage;
+using Windows.Storage.Streams;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
@@ -277,29 +281,65 @@ public class WindowHelper
         }
     }
 
-    public static async Task<SoftwareBitmapSource> GetWinUI3BitmapSourceFromGdiBitmap(System.Drawing.Bitmap bmp)
+    public static SoftwareBitmap? GetSoftwareBitmapFromExecutable(string executable)
     {
-        // get pixels as an array of bytes
+        SoftwareBitmap? softwareBitmap = null;
+        var toolIcon = Icon.ExtractAssociatedIcon(executable);
+
+        // Fall back to Windows default app icon.
+        toolIcon ??= Icon.FromHandle(LoadDefaultAppIcon());
+
+        if (toolIcon is not null)
+        {
+            softwareBitmap = GetSoftwareBitmapFromGdiBitmap(toolIcon.ToBitmap());
+        }
+
+        return softwareBitmap;
+    }
+
+    public static SoftwareBitmap GetSoftwareBitmapFromGdiBitmap(Bitmap bmp)
+    {
+        // Get pixels as an array of bytes.
         var data = bmp.LockBits(
-            new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height),
+            new Rectangle(0, 0, bmp.Width, bmp.Height),
             System.Drawing.Imaging.ImageLockMode.ReadOnly,
             bmp.PixelFormat);
         var bytes = new byte[data.Stride * data.Height];
         Marshal.Copy(data.Scan0, bytes, 0, bytes.Length);
         bmp.UnlockBits(data);
 
-        // get WinRT SoftwareBitmap
-        var softwareBitmap = new Windows.Graphics.Imaging.SoftwareBitmap(
-            Windows.Graphics.Imaging.BitmapPixelFormat.Bgra8,
+        // Get WinRT SoftwareBitmap.
+        var softwareBitmap = new SoftwareBitmap(
+            BitmapPixelFormat.Bgra8,
             bmp.Width,
             bmp.Height,
-            Windows.Graphics.Imaging.BitmapAlphaMode.Premultiplied);
+            BitmapAlphaMode.Premultiplied);
         softwareBitmap.CopyFromBuffer(bytes.AsBuffer());
 
-        // build WinUI3 SoftwareBitmapSource
-        var source = new SoftwareBitmapSource();
-        await source.SetBitmapAsync(softwareBitmap);
-        return source;
+        return softwareBitmap;
+    }
+
+    public static async Task<SoftwareBitmapSource> GetSoftwareBitmapSourceFromSoftwareBitmap(SoftwareBitmap softwareBitmap)
+    {
+        var softwareBitmapSource = new SoftwareBitmapSource();
+        await softwareBitmapSource.SetBitmapAsync(softwareBitmap);
+        return softwareBitmapSource;
+    }
+
+    public static async Task<Uri> SaveSoftwareBitmapToTempFile(SoftwareBitmap softwareBitmap)
+    {
+        var tempFolder = ApplicationData.Current.TemporaryFolder;
+        var tempFile = await tempFolder.CreateFileAsync(
+            Guid.NewGuid().ToString() + ".png", CreationCollisionOption.ReplaceExisting);
+
+        using (var stream = await tempFile.OpenAsync(FileAccessMode.ReadWrite))
+        {
+            var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
+            encoder.SetSoftwareBitmap(softwareBitmap);
+            await encoder.FlushAsync();
+        }
+
+        return new Uri(tempFile.Path);
     }
 
     internal static unsafe uint GetProcessIdFromWindow(HWND hWnd)

--- a/tools/PI/DevHome.PI/Models/NavLink.cs
+++ b/tools/PI/DevHome.PI/Models/NavLink.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using DevHome.PI.SettingsUi;
 
 namespace DevHome.PI.Models;
 
@@ -11,12 +12,31 @@ public class NavLink
 
     public string ContentText { get; internal set; }
 
+    public NavLink(string icon, string title)
+    {
+        IconText = icon;
+        ContentText = title;
+    }
+}
+
+public class PageNavLink : NavLink
+{
     public Type? PageViewModel { get; internal set; }
 
-    public NavLink(string i, string c, Type? pageViewModel)
+    public PageNavLink(string icon, string title, Type? pageViewModel)
+        : base(icon, title)
     {
-        IconText = i;
-        ContentText = c;
         PageViewModel = pageViewModel;
+    }
+}
+
+public class SettingsNavLink : NavLink
+{
+    public SettingsPage? SettingsPage { get; internal set; }
+
+    public SettingsNavLink(string icon, string title, SettingsPage? settingsPage)
+        : base(icon, title)
+    {
+        SettingsPage = settingsPage;
     }
 }

--- a/tools/PI/DevHome.PI/Models/TargetAppData.cs
+++ b/tools/PI/DevHome.PI/Models/TargetAppData.cs
@@ -88,15 +88,18 @@ public partial class TargetAppData : ObservableObject
                 bitmap = GetAppIcon((HWND)process.MainWindowHandle);
             }
 
-            SoftwareBitmap? softwareBitmap = null;
             if (bitmap is null && process.MainModule is not null)
             {
-                softwareBitmap = GetSoftwareBitmapFromExecutable(process.MainModule.FileName);
+                // Failing that, try and get the icon from the exe
+                bitmap = System.Drawing.Icon.ExtractAssociatedIcon(process.MainModule.FileName)?.ToBitmap();
             }
 
-            if (softwareBitmap is not null)
+            // Failing that, grab the default app icon
+            bitmap ??= System.Drawing.Icon.FromHandle(LoadDefaultAppIcon()).ToBitmap();
+
+            if (bitmap is not null)
             {
-                Icon = await GetSoftwareBitmapSourceFromSoftwareBitmap(softwareBitmap);
+                Icon = await GetWinUI3BitmapSourceFromGdiBitmap(bitmap);
             }
             else
             {

--- a/tools/PI/DevHome.PI/Models/TargetAppData.cs
+++ b/tools/PI/DevHome.PI/Models/TargetAppData.cs
@@ -10,13 +10,14 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.PI.Helpers;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Win32.SafeHandles;
+using Windows.Graphics.Imaging;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using static DevHome.PI.Helpers.WindowHelper;
 
 namespace DevHome.PI.Models;
 
-public partial class TargetAppData : ObservableObject, INotifyPropertyChanged
+public partial class TargetAppData : ObservableObject
 {
     public static readonly TargetAppData Instance = new();
 
@@ -87,18 +88,15 @@ public partial class TargetAppData : ObservableObject, INotifyPropertyChanged
                 bitmap = GetAppIcon((HWND)process.MainWindowHandle);
             }
 
+            SoftwareBitmap? softwareBitmap = null;
             if (bitmap is null && process.MainModule is not null)
             {
-                // Failing that, try and get the icon from the exe
-                bitmap = System.Drawing.Icon.ExtractAssociatedIcon(process.MainModule.FileName)?.ToBitmap();
+                softwareBitmap = GetSoftwareBitmapFromExecutable(process.MainModule.FileName);
             }
 
-            // Failing that, grab the default app icon
-            bitmap ??= System.Drawing.Icon.FromHandle(LoadDefaultAppIcon()).ToBitmap();
-
-            if (bitmap is not null)
+            if (softwareBitmap is not null)
             {
-                Icon = await WindowHelper.GetWinUI3BitmapSourceFromGdiBitmap(bitmap);
+                Icon = await GetSoftwareBitmapSourceFromSoftwareBitmap(softwareBitmap);
             }
             else
             {

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -94,7 +94,11 @@
                 <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsSystem, Mode=OneWay}" IsReadOnly="True"/>
                 <TextBlock Grid.Row="3" x:Uid="IsRunningAsAdminTextBlock"/>
                 <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsAdmin, Mode=OneWay}" IsReadOnly="True"/>
-                <Button Grid.Row="4" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
+                
+                <Button 
+                    Grid.Row="4" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Margin="0,8,0,0"
+                    Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" 
+                    Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
             </Grid>
         </ScrollViewer>
     </Grid>

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
@@ -52,14 +52,14 @@
                                    FontSize="24" FontWeight="Bold"/>
                     </StackPanel>
                     <StackPanel>
-                        <TextBlock x:Uid="FileVersionInfoTextBlock" FontSize="20" />
+                        <TextBlock x:Uid="FileVersionInfoTextBlock" FontSize="18" />
                         <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).FileVersionInfo, Mode=OneWay}"
                                  FontFamily="Consolas" TextWrapping="Wrap" IsReadOnly="True"/>
-                        <!-- TODO In WinUI we get access denied on BaseAddress and EntryPointAddress-->
-                        <!--<TextBlock Text="Base address" FontSize="18" Margin="0,6,0,0"/>
+
+                        <TextBlock x:Uid="BaseAddressTextBlock" FontSize="18" Margin="0,6,0,0"/>
                         <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).BaseAddress, Mode=OneWay}" IsReadOnly="True"/>
-                        <TextBlock Text="Entrypoint address" FontSize="18" Margin="0,6,0,0"/>
-                        <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).EntryPointAddress, Mode=OneWay}" IsReadOnly="True"/>-->
+                        <TextBlock x:Uid="EntrypointAddressTextBlock" FontSize="18" Margin="0,6,0,0"/>
+                        <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).EntryPointAddress, Mode=OneWay}" IsReadOnly="True"/>                        
                         <TextBlock x:Uid="MemorySizeTextBlock" FontSize="18" Margin="0,6,0,0"/>
                         <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).ModuleMemorySize, Mode=OneWay}" IsReadOnly="True"/>
                     </StackPanel>

--- a/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
+++ b/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
@@ -62,18 +62,6 @@ namespace DevHome.PI.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool IsProcessFilterIncludeEdge {
-            get {
-                return ((bool)(this["IsProcessFilterIncludeEdge"]));
-            }
-            set {
-                this["IsProcessFilterIncludeEdge"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool IsProcessFilterIncludeWebview {
             get {
                 return ((bool)(this["IsProcessFilterIncludeWebview"]));

--- a/tools/PI/DevHome.PI/SettingsUi/SettingsToolWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/SettingsUi/SettingsToolWindow.xaml.cs
@@ -11,13 +11,20 @@ using DevHome.PI.Helpers;
 using DevHome.PI.Models;
 using DevHome.PI.Properties;
 using DevHome.PI.ToolWindows;
-using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI;
 
 namespace DevHome.PI.SettingsUi;
+
+public enum SettingsPage
+{
+    UserProfile,
+    AdditionalTools,
+    AdvancedSettings,
+    About,
+}
 
 public sealed partial class SettingsToolWindow : ToolWindow
 {
@@ -26,15 +33,15 @@ public sealed partial class SettingsToolWindow : ToolWindow
     private readonly string advancedSettingsTabName = CommonHelper.GetLocalizedString("AdvancedSettingsTabName");
     private readonly string aboutTabName = CommonHelper.GetLocalizedString("AboutTabName");
 
-    public List<NavLink> Links { get; set; } = [];
+    public List<SettingsNavLink> Links { get; set; } = [];
 
-    public SettingsToolWindow(StringCollection pos)
+    public SettingsToolWindow(StringCollection pos, SettingsPage? page)
         : base(pos)
     {
-        Links.Add(new NavLink("\uE716", userProfileTabName, null));
-        Links.Add(new NavLink("\uEC7A", additionalToolsTabName, null));
-        Links.Add(new NavLink("\uE90F", advancedSettingsTabName, null));
-        Links.Add(new NavLink("\uE946", aboutTabName, null));
+        Links.Add(new SettingsNavLink("\uE716", userProfileTabName, SettingsPage.UserProfile));
+        Links.Add(new SettingsNavLink("\uEC7A", additionalToolsTabName, SettingsPage.AdditionalTools));
+        Links.Add(new SettingsNavLink("\uE90F", advancedSettingsTabName, SettingsPage.AdvancedSettings));
+        Links.Add(new SettingsNavLink("\uE946", aboutTabName, SettingsPage.About));
 
         InitializeComponent();
 
@@ -62,6 +69,11 @@ public sealed partial class SettingsToolWindow : ToolWindow
         }
 
         ExcludedProcessesTextBox.Text = builder.ToString();
+
+        if (page.HasValue)
+        {
+            NavLinksList.SelectedItem = Links.FirstOrDefault(l => l.SettingsPage == page);
+        }
     }
 
     private void SetRequestedTheme(ElementTheme theme)
@@ -130,25 +142,25 @@ public sealed partial class SettingsToolWindow : ToolWindow
     {
         if (NavLinksList.SelectedIndex > -1)
         {
-            if (NavLinksList.SelectedItem is NavLink link)
+            if (NavLinksList.SelectedItem is SettingsNavLink link)
             {
                 UserProfileGrid.Visibility = Visibility.Collapsed;
                 AdditionalToolsGrid.Visibility = Visibility.Collapsed;
                 AdvancedSettingsGrid.Visibility = Visibility.Collapsed;
                 AboutGrid.Visibility = Visibility.Collapsed;
-                if (link.ContentText == userProfileTabName)
+                if (link.SettingsPage == SettingsPage.UserProfile)
                 {
                     UserProfileGrid.Visibility = Visibility.Visible;
                 }
-                else if (link.ContentText == additionalToolsTabName)
+                else if (link.SettingsPage == SettingsPage.AdditionalTools)
                 {
                     AdditionalToolsGrid.Visibility = Visibility.Visible;
                 }
-                else if (link.ContentText == advancedSettingsTabName)
+                else if (link.SettingsPage == SettingsPage.AdvancedSettings)
                 {
                     AdvancedSettingsGrid.Visibility = Visibility.Visible;
                 }
-                else if (link.ContentText == aboutTabName)
+                else if (link.SettingsPage == SettingsPage.About)
                 {
                     AboutGrid.Visibility = Visibility.Visible;
                 }

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -169,7 +169,7 @@
     <value>Settings</value>
     <comment>The tooltip for a button that takes the user to the settings for PI.</comment>
   </data>
-  <data name="ExternalToolsButton.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="ManageExternalToolsButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>External tools: add/remove, configure and launch</value>
     <comment>The tooltip for a button that takes the user to the external tools section of PI.</comment>
   </data>
@@ -748,5 +748,13 @@
   <data name="FrameworkTypesTextBlock.Text" xml:space="preserve">
     <value>Framework types</value>
     <comment>This refers to the set of application frameworks this application uses.</comment>
+  </data>
+  <data name="BaseAddressTextBlock.Text" xml:space="preserve">
+    <value>Base address</value>
+    <comment>The contents of a text block referring to the base address of a loaded module.</comment>
+  </data>
+  <data name="EntrypointAddressTextBlock.Text" xml:space="preserve">
+    <value>Entrypoint address</value>
+    <comment>The contents of a text block referring to the entrypoint address of a loaded module.</comment>
   </data>
 </root>

--- a/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
@@ -52,20 +52,20 @@ public partial class ExpandedViewControlViewModel : ObservableObject
     private string title = string.Empty;
 
     [ObservableProperty]
-    private ObservableCollection<NavLink> links;
+    private ObservableCollection<PageNavLink> links;
 
     [ObservableProperty]
     private int selectedNavLinkIndex = 0;
 
     public INavigationService NavigationService { get; }
 
-    private readonly NavLink appDetailsNavLink;
-    private readonly NavLink resourceUsageNavLink;
-    private readonly NavLink modulesNavLink;
-    private readonly NavLink watsonNavLink;
-    private readonly NavLink winLogsNavLink;
-    private readonly NavLink processListNavLink;
-    private readonly NavLink insightsNavLink;
+    private readonly PageNavLink appDetailsNavLink;
+    private readonly PageNavLink resourceUsageNavLink;
+    private readonly PageNavLink modulesNavLink;
+    private readonly PageNavLink watsonNavLink;
+    private readonly PageNavLink winLogsNavLink;
+    private readonly PageNavLink processListNavLink;
+    private readonly PageNavLink insightsNavLink;
 
     public ExpandedViewControlViewModel()
     {
@@ -74,13 +74,13 @@ public partial class ExpandedViewControlViewModel : ObservableObject
         PerfCounters.Instance.PropertyChanged += PerfCounterHelper_PropertyChanged;
         ClipboardMonitor.Instance.PropertyChanged += Clipboard_PropertyChanged;
 
-        appDetailsNavLink = new NavLink("\uE71D", CommonHelper.GetLocalizedString("AppDetailsTextBlock/Text"), typeof(AppDetailsPageViewModel));
-        resourceUsageNavLink = new NavLink("\uE950", CommonHelper.GetLocalizedString("ResourceUsageHeaderTextBlock/Text"), typeof(ResourceUsagePageViewModel));
-        modulesNavLink = new NavLink("\uE74C", CommonHelper.GetLocalizedString("ModulesHeaderTextBlock/Text"), typeof(ModulesPageViewModel));
-        watsonNavLink = new NavLink("\uE7BA", CommonHelper.GetLocalizedString("WatsonsHeaderTextBlock/Text"), typeof(WatsonPageViewModel));
-        winLogsNavLink = new NavLink("\uE7C4", CommonHelper.GetLocalizedString("WinLogsHeaderTextBlock/Text"), typeof(WinLogsPageViewModel));
-        processListNavLink = new NavLink("\uE8FD", CommonHelper.GetLocalizedString("ProcessListHeaderTextBlock/Text"), typeof(ProcessListPageViewModel));
-        insightsNavLink = new NavLink("\uE946", CommonHelper.GetLocalizedString("InsightsHeaderTextBlock/Text"), typeof(InsightsPageViewModel));
+        appDetailsNavLink = new PageNavLink("\uE71D", CommonHelper.GetLocalizedString("AppDetailsTextBlock/Text"), typeof(AppDetailsPageViewModel));
+        resourceUsageNavLink = new PageNavLink("\uE950", CommonHelper.GetLocalizedString("ResourceUsageHeaderTextBlock/Text"), typeof(ResourceUsagePageViewModel));
+        modulesNavLink = new PageNavLink("\uE74C", CommonHelper.GetLocalizedString("ModulesHeaderTextBlock/Text"), typeof(ModulesPageViewModel));
+        watsonNavLink = new PageNavLink("\uE7BA", CommonHelper.GetLocalizedString("WatsonsHeaderTextBlock/Text"), typeof(WatsonPageViewModel));
+        winLogsNavLink = new PageNavLink("\uE7C4", CommonHelper.GetLocalizedString("WinLogsHeaderTextBlock/Text"), typeof(WinLogsPageViewModel));
+        processListNavLink = new PageNavLink("\uE8FD", CommonHelper.GetLocalizedString("ProcessListHeaderTextBlock/Text"), typeof(ProcessListPageViewModel));
+        insightsNavLink = new PageNavLink("\uE946", CommonHelper.GetLocalizedString("InsightsHeaderTextBlock/Text"), typeof(InsightsPageViewModel));
 
         links = new();
         AddPagesIfNecessary(TargetAppData.Instance.TargetProcess);


### PR DESCRIPTION
## Summary of the pull request
Previously, we were just adding each external tool to the toolbar. Per spec, we're now adding them to the ExternalTools menu as well.

As part of this, there was some refactoring of the ExternalTool and WindowHelper classes to get the different image formats required for both the toolbar and the menu without duplicating code. Also, as you can't databind to MenuFlyoutItem, and the ExternalTool icon image is generated asynchronously, we're handling the PropertyChanged event in code, so we can update the icon when it gets set.

Also implemented unregistering an ExternalTool from either the bar button or the menuitem for the tool.

Implemented the ExternalTools button Click handler to open the Settings UI and navigate to the Additional Tools section. As part of this, added 2 derived NavLink types, as their usage in Settings and in the ExpandedView are sufficiently different, and updated the SettingsToolWindow to match. Because we can open Settings without the ExpandedView, I've reinstated the original behavior of closing all open child windows when the Bar window closes (right now, this is just the settings window).

Unrelated fixes:
- Reinstated the ModulesPage fields for BaseAddress and EntrypointAddress, as these no longer fail.
- Removed redundant INotifyPropertyChanged from TargetAppData, as it derives from ObservableObject.
