### PR TITLE
Fix issue related to not having a window for delete opertions

### DIFF
--- a/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
+++ b/tools/Environments/DevHome.Environments/Helpers/DataExtractor.cs
@@ -7,7 +7,7 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Services;
 using DevHome.Environments.Models;
 using DevHome.Environments.ViewModels;
-using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 
 namespace DevHome.Environments.Helpers;
@@ -23,7 +23,8 @@ public class DataExtractor
     /// ToDo: Add a pause after each operation
     /// </summary>
     /// <param name="computeSystem">Compute system used to fill OperationsViewModel's callback function.</param>
-    public static List<OperationsViewModel> FillDotButtonOperations(ComputeSystemCache computeSystem, DispatcherQueue dispatcherQueue)
+    /// <param name="window">The window object used for operations that require presenting UI.</param>
+    public static List<OperationsViewModel> FillDotButtonOperations(ComputeSystemCache computeSystem, Window window)
     {
         var operations = new List<OperationsViewModel>();
         var supportedOperations = computeSystem.SupportedOperations.Value;
@@ -37,7 +38,7 @@ public class DataExtractor
         if (supportedOperations.HasFlag(ComputeSystemOperations.Delete))
         {
             operations.Add(new OperationsViewModel(
-                _stringResource.GetLocalized("Operations_Delete"), "\uE74D", computeSystem.DeleteAsync, ComputeSystemOperations.Delete, dispatcherQueue));
+                _stringResource.GetLocalized("Operations_Delete"), "\uE74D", computeSystem.DeleteAsync, ComputeSystemOperations.Delete, window));
         }
 
         return operations;

--- a/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs
@@ -7,6 +7,7 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
 using DevHome.Common.Services;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 
@@ -21,7 +22,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private readonly IComputeSystemManager _computeSystemManager;
 
-    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly Window _mainWindow;
 
     private readonly StringResource _stringResource;
 
@@ -49,13 +50,13 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
     public CreateComputeSystemOperationViewModel(
         IComputeSystemManager computeSystemManager,
         StringResource stringResource,
-        DispatcherQueue dispatcherQueue,
+        Window mainWindow,
         Func<ComputeSystemCardBase, bool> removalAction,
         Action<ComputeSystemViewModel> addComputeSystemAction,
         CreateComputeSystemOperation operation)
     {
         IsOperationInProgress = true;
-        _dispatcherQueue = dispatcherQueue;
+        _mainWindow = mainWindow;
         _removalAction = removalAction;
         _addComputeSystemAction = addComputeSystemAction;
         _stringResource = stringResource;
@@ -95,7 +96,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private void UpdateStatusIfCompleted(CreateComputeSystemResult createComputeSystemResult)
     {
-        _dispatcherQueue.TryEnqueue(() =>
+        _mainWindow.DispatcherQueue.TryEnqueue(() =>
         {
             // Update the creation status
             IsOperationInProgress = false;
@@ -128,7 +129,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private void UpdateUiMessage(string operationStatus, uint percentage = 0)
     {
-        _dispatcherQueue.TryEnqueue(() =>
+        _mainWindow.DispatcherQueue.TryEnqueue(() =>
         {
             if (operationStatus == null)
             {
@@ -142,7 +143,7 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
 
     private void RemoveViewModelFromUI()
     {
-        _dispatcherQueue.TryEnqueue(() =>
+        _mainWindow.DispatcherQueue.TryEnqueue(() =>
         {
             _removalAction(this);
             RemoveEventHandlers();
@@ -159,11 +160,11 @@ public partial class CreateComputeSystemOperationViewModel : ComputeSystemCardBa
             Operation.ProviderDetails.ComputeSystemProvider,
             _removalAction,
             Operation.ProviderDetails.ExtensionWrapper.PackageFullName,
-            _dispatcherQueue);
+            _mainWindow);
 
         await newComputeSystemViewModel.InitializeCardDataAsync();
 
-        _dispatcherQueue.TryEnqueue(() =>
+        _mainWindow.DispatcherQueue.TryEnqueue(() =>
         {
             newComputeSystemViewModel.InitializeUXData();
             _addComputeSystemAction(newComputeSystemViewModel);

--- a/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
@@ -7,7 +7,6 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using DevHome.Common.Services;
 using DevHome.Environments.Models;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
@@ -48,8 +47,6 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
 
     private Action? DevHomeAction { get; }
 
-    private readonly DispatcherQueue? _dispatcherQueue;
-
     private readonly Window? _mainWindow;
 
     private readonly StringResource _stringResource = new("DevHome.Environments.pri", "DevHome.Environments/Resources");
@@ -59,14 +56,12 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
         string icon,
         Func<string, Task<ComputeSystemOperationResult>> command,
         ComputeSystemOperations computeSystemOperation,
-        DispatcherQueue? dispatcherQueue = null,
         Window? mainWindow = null)
     {
         _operationKind = OperationKind.ExtensionTask;
         Name = name;
         IconGlyph = icon;
         ExtensionTask = command;
-        _dispatcherQueue = dispatcherQueue;
         ComputeSystemOperation = computeSystemOperation;
         _mainWindow = mainWindow;
     }
@@ -129,7 +124,7 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
                 XamlRoot = _mainWindow?.Content.XamlRoot,
             };
 
-            _dispatcherQueue?.TryEnqueue(async () =>
+            _mainWindow?.DispatcherQueue?.TryEnqueue(async () =>
             {
                 var result = await noWifiDialog.ShowAsync();
 


### PR DESCRIPTION
## Summary of the pull request
Consolidate on Window as the optional parameter for OperationsViewModel  to avoid state tearing in delete operations which require a window to present a dialog.

## References and relevant issues
Regression from #2934

## Detailed description of the pull request / Additional comments
Compute system operations may invoke UI for certain operations, such as a confirmation prompt dialog in the case of delete. For these a Window object is needed to parent the dialog, etc. 

The original change in #2934 consolidated a bunch of references to WindowEx by decomposing it to UI thread requirements which need a DispatcherQueue and Window requirements, as an oversight that change only provided the dispatcher queue to compute system view models because the OperationsViewModel constructor had two optional arguments that default to null (i.e. a DispatcherQueue and a Window). It was not clear that if one of these was provided, both must be non-null. This change converges on the Window alone being the optional parameter since the DispatcherQueue can be acquired from it.

## Validation steps performed
Select '...' on an environment that supports delete and ensure the correct window is used.

## PR checklist
- [ ] Closes #2973
- [ ] Tests added/passed
- [ ] Documentation updated
