### PR TITLE
Environments page faster loading

### DIFF
--- a/common/Environments/CustomControls/CardHeader.xaml
+++ b/common/Environments/CustomControls/CardHeader.xaml
@@ -52,6 +52,7 @@
             IsTabStop="False"
             HorizontalContentAlignment="Right"
             VerticalContentAlignment="Stretch"
-            ContentTemplate="{x:Bind ActionControlTemplate, Mode=OneWay}"/>
+            ContentTemplate="{x:Bind ActionControlTemplate, Mode=OneWay}"
+            Visibility="{x:Bind OperationsVisibility, Mode=OneWay}"/>
     </Grid>
 </UserControl>

--- a/common/Environments/CustomControls/CardHeader.xaml.cs
+++ b/common/Environments/CustomControls/CardHeader.xaml.cs
@@ -26,6 +26,12 @@ public sealed partial class CardHeader : UserControl
         set => SetValue(HeaderCaptionProperty, value);
     }
 
+    public bool OperationsVisibility
+    {
+        get => (bool)GetValue(OperationsVisibilityProperty);
+        set => SetValue(OperationsVisibilityProperty, value);
+    }
+
     public BitmapImage HeaderIcon
     {
         get => (BitmapImage)GetValue(HeaderIconProperty);
@@ -35,4 +41,5 @@ public sealed partial class CardHeader : UserControl
     private static readonly DependencyProperty ActionControlTemplateProperty = DependencyProperty.Register(nameof(ActionControlTemplate), typeof(DataTemplate), typeof(CardHeader), new PropertyMetadata(null));
     private static readonly DependencyProperty HeaderCaptionProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(string), typeof(CardHeader), new PropertyMetadata(null));
     private static readonly DependencyProperty HeaderIconProperty = DependencyProperty.Register(nameof(HeaderIcon), typeof(BitmapImage), typeof(CardHeader), new PropertyMetadata(null));
+    private static readonly DependencyProperty OperationsVisibilityProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(bool), typeof(CardHeader), new PropertyMetadata(null));
 }

--- a/common/Environments/CustomControls/CardHeader.xaml.cs
+++ b/common/Environments/CustomControls/CardHeader.xaml.cs
@@ -41,5 +41,5 @@ public sealed partial class CardHeader : UserControl
     private static readonly DependencyProperty ActionControlTemplateProperty = DependencyProperty.Register(nameof(ActionControlTemplate), typeof(DataTemplate), typeof(CardHeader), new PropertyMetadata(null));
     private static readonly DependencyProperty HeaderCaptionProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(string), typeof(CardHeader), new PropertyMetadata(null));
     private static readonly DependencyProperty HeaderIconProperty = DependencyProperty.Register(nameof(HeaderIcon), typeof(BitmapImage), typeof(CardHeader), new PropertyMetadata(null));
-    private static readonly DependencyProperty OperationsVisibilityProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(bool), typeof(CardHeader), new PropertyMetadata(null));
+    private static readonly DependencyProperty OperationsVisibilityProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(bool), typeof(CardHeader), new PropertyMetadata(false));
 }

--- a/common/Environments/Models/ComputeSystemCache.cs
+++ b/common/Environments/Models/ComputeSystemCache.cs
@@ -237,16 +237,7 @@ public class ComputeSystemCache
         _ = await GetStateAsync();
         var supportedOperations = SupportedOperations?.Value ?? ComputeSystemOperations.None;
 
-        if (supportedOperations.HasFlag(ComputeSystemOperations.PinToStartMenu))
-        {
-            _ = await GetIsPinnedToStartMenuAsync();
-        }
-
-        if (supportedOperations.HasFlag(ComputeSystemOperations.PinToTaskbar))
-        {
-           _ = await GetIsPinnedToTaskbarAsync();
-        }
-
+        var s2 = DateTime.Now;
         _ = await GetComputeSystemThumbnailAsync(string.Empty);
         _ = await GetComputeSystemPropertiesAsync(string.Empty);
     }

--- a/common/Environments/Models/ComputeSystemCache.cs
+++ b/common/Environments/Models/ComputeSystemCache.cs
@@ -237,7 +237,6 @@ public class ComputeSystemCache
         _ = await GetStateAsync();
         var supportedOperations = SupportedOperations?.Value ?? ComputeSystemOperations.None;
 
-        var s2 = DateTime.Now;
         _ = await GetComputeSystemThumbnailAsync(string.Empty);
         _ = await GetComputeSystemPropertiesAsync(string.Empty);
     }

--- a/common/Environments/Styles/HorizontalCardStyles.xaml
+++ b/common/Environments/Styles/HorizontalCardStyles.xaml
@@ -61,6 +61,7 @@
         TargetType="Grid">
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="ColumnSpacing" Value="20" />
+        <Setter Property="Height" Value="36" />
         <Setter Property="Margin" Value="0,5,0,0" />
     </Style>
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -152,11 +152,12 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
                 // Add valid data to the DotOperations collection
                 _mainWindow.DispatcherQueue.TryEnqueue(() =>
                 {
-                    ShouldShowDotOperations = true;
                     foreach (var data in validData)
                     {
                         DotOperations.Add(data);
                     }
+
+                    ShouldShowDotOperations = true;
                 });
             });
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
@@ -130,7 +131,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
 
             _ = Task.Run(async () =>
             {
-                var s1 = DateTime.Now;
+                var start = DateTime.Now;
                 List<OperationsViewModel> validData = new();
                 foreach (var data in await DataExtractor.FillDotButtonPinOperationsAsync(ComputeSystem))
                 {
@@ -148,10 +149,10 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
                     WeakReferenceMessenger.Default.Register<ComputeSystemOperationCompletedMessage, OperationsViewModel>(this, data.ViewModel);
                 }
 
-                _log.Information($"Registering pin operations for {Name} in background took {DateTime.Now - s1}");
+                _log.Information($"Registering pin operations for {Name} in background took {DateTime.Now - start}");
 
                 // Add valid data to the DotOperations collection
-                _windowEx.DispatcherQueue.TryEnqueue(() =>
+                _mainWindow.DispatcherQueue.TryEnqueue(() =>
                 {
                     ShouldShowDotOperations = true;
                     foreach (var data in validData)

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -127,6 +127,7 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         await _semaphoreSlimLock.WaitAsync();
         try
         {
+            ShouldShowDotOperations = false;
             RegisterForAllOperationMessages(DataExtractor.FillDotButtonOperations(ComputeSystem, _mainWindow), DataExtractor.FillLaunchButtonOperations(ComputeSystem));
 
             _ = Task.Run(async () =>
@@ -137,9 +138,6 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
                 {
                     if ((!data.WasPinnedStatusSuccessful) || (data.ViewModel == null))
                     {
-                        // TODO: pinned status for dev box for example fails often. So we'll log it and not show notifications so we don't overload the user with
-                        // failure notifications until the feature is fixed. We simply do not show the pinned icons in these cases since we don't know which ones
-                        // to show.
                         _log.Error($"Pinned status check failed: for '{Name}': {data?.PinnedStatusDisplayMessage}. DiagnosticText: {data?.PinnedStatusDiagnosticText}");
                         continue;
                     }

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -139,7 +139,8 @@
                         <commonCustomControls:CardHeader
                             HeaderCaption="{x:Bind ProviderDisplayName, Mode=OneWay}"
                             HeaderIcon="{x:Bind HeaderImage, Mode=OneWay}"
-                            ActionControlTemplate="{StaticResource ThreeDotsButton}" />
+                            ActionControlTemplate="{StaticResource ThreeDotsButton}"
+                            OperationsVisibility="{x:Bind ShouldShowDotOperations, Mode=OneWay}"/>
                     </Grid>
                     <!-- Card Body : Name, thumbnail, 'Launch' button -->
                     <Grid Grid.Row="1">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetView.xaml
@@ -43,7 +43,7 @@
                         Style="{StaticResource HorizontalCardRootForSetupTargetFlow}"
                         IsTabStop="False">
                         <Grid
-                            RowSpacing="5">
+                            Padding="0 -13 0 -10">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />


### PR DESCRIPTION
## Summary of the pull request
This PR improves the loading of the setup/config flow page by around 5s/10s = 50% and the Environments page by around 5s/14s = 35%. The major delay here was due to checking of the pinning status of the VMs. This is now removed from the setup/config flow as it isn't required. And for the Environments page, moved to the background and only shown after the operation is completed.

Before:
https://github.com/microsoft/devhome/assets/16077119/b004a231-b419-422c-9dee-71fb5ad7f93a

After:
https://github.com/microsoft/devhome/assets/16077119/cacd4427-ba6f-4bee-9b0e-047cedbff1f6

## Validation steps performed
Checked locally.

## PR checklist
- [ ] Closes #3003 
- [ ] Tests added/passed
- [ ] Documentation updated
