### PR TITLE
PI: Stop Perfcounter when bar is closed

### DIFF
--- a/tools/PI/DevHome.PI/BarWindow.cs
+++ b/tools/PI/DevHome.PI/BarWindow.cs
@@ -99,6 +99,7 @@ public partial class BarWindow
     {
         // If we receive a window closed event, clean up the system
         TargetAppData.Instance.ClearAppData();
+        PerfCounters.Instance.Stop();
 
         var primaryWindow = Application.Current.GetService<PrimaryWindow>();
         primaryWindow.ClearBarWindow();


### PR DESCRIPTION
## References and relevant issues
When the bar is closed and then an elevated instance is started, there are 2 instances of PI running.

## Detailed description of the pull request / Additional comments
Problem: The elevated instance of PI does not start until the unelevated instance exits. The unelevated instance of PI does not exit due to Perfcounters running.

Fix: stop the perf counters when the barwindow is closed.

## Validation steps performed
1. Launch PI
2. Close the bar window
3. launch PI elevated and made sure there is only one instance of PI running.
