### PR TITLE
Adding tooltip to More Options three dots button in Extensions Library page

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -130,4 +130,8 @@
     <value>More options</value>
     <comment>Name of the button that brings up the "More options" menu</comment>
   </data>
+  <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>More options</value>
+    <comment>ToolTip of the button that brings up the "More options" menu</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Added a tooltip to the `More Options` button in the `Extensions Library` page.
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/49656893
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
