### PR TITLE
Accessibility fixes on Utilities Page

### DIFF
--- a/tools/Utilities/src/Strings/en-us/Resources.resw
+++ b/tools/Utilities/src/Strings/en-us/Resources.resw
@@ -134,6 +134,9 @@
   <data name="LaunchButton.Text" xml:space="preserve">
     <value>Launch</value>
   </data>
+  <data name="LaunchButtonBase.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Launch</value>
+  </data>
   <data name="NavigationPane.Content" xml:space="preserve">
     <value>Utilities</value>
     <comment>Utilities</comment>

--- a/tools/Utilities/src/Views/UtilityView.xaml
+++ b/tools/Utilities/src/Views/UtilityView.xaml
@@ -9,6 +9,7 @@
     d:DesignHeight="300" d:DesignWidth="300">
 
     <Grid
+        AutomationProperties.Name="{x:Bind ViewModel.Title}"
         HorizontalAlignment="Stretch"
         Padding="15 15"
         CornerRadius="{ThemeResource ControlCornerRadius}"
@@ -26,6 +27,7 @@
         </Grid.RowDefinitions>
 
         <Image
+            AutomationProperties.AccessibilityView="Raw"
             Grid.Row="0"
             Source="{x:Bind ViewModel.ImageSource}"
             HorizontalAlignment="Left"
@@ -68,6 +70,7 @@
             Margin="15 0 0 5"/>
 
         <Button
+            x:Uid="LaunchButtonBase"
             Grid.Row="3"
             Margin="15 5 0 0"
             Command="{x:Bind ViewModel.LaunchCommand}">


### PR DESCRIPTION
## Summary of the pull request
Adds automation name to `Launch` button on utilities items, adds automation name to the group and removes the image from being focusable by the narrator. This change makes the overall narrator experience better for users that require it.
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/51347885
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
