### PR TITLE
Fix crash when opening a Content dialog at text scaling of 200% with content from an adaptive card

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.0-beta" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.0.0-beta" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.1.0-beta" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.5.0" />
     <PackageReference Include="CommunityToolkit.Common" Version="8.2.2" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Shimmer" Version="0.1.230830" />

--- a/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
+++ b/common/Views/AdaptiveCardViews/ContentDialogWithNonInteractiveContent.xaml.cs
@@ -29,7 +29,11 @@ public sealed partial class ContentDialogWithNonInteractiveContent : ContentDial
             var renderer = await rendererService.GetRendererAsync();
             renderer.HostConfig.ContainerStyles.Default.BackgroundColor = Microsoft.UI.Colors.Transparent;
             var card = renderer.RenderAdaptiveCardFromJsonString(content.ContentDialogInternalAdaptiveCardJson?.Stringify() ?? string.Empty);
-            Content = card.FrameworkElement;
+            Content = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Content = card.FrameworkElement,
+            };
             SecondaryButtonText = content.SecondaryButtonText;
             this.Focus(FocusState.Programmatic);
         });

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -62,7 +62,7 @@
   <ItemGroup>
     <!-- Temporarily duplicate the Adaptive Card from DevHome.Common -->
     <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.0-beta" GeneratePathProperty="true" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.0.0-beta" GeneratePathProperty="true" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.1.0-beta" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240311-x1907" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">


### PR DESCRIPTION
## Summary of the pull request
`WholeItemsPanel` would crash because of an invalid QI.  The fix is [here](https://github.com/microsoft/AdaptiveCards/commit/e36e4996d5e5b920a95bcc930e4f8c0011cb3cda).  The crash occurred after clicking "Learn More" in the environments page for Hyper-V environments.

This PR upgrades the nuget version and adds a scroll bar to the content dialog.

## References and relevant issues

https://task.ms/50454043

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually ran.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![ContentDialogAt200Percent](https://github.com/microsoft/devhome/assets/2517139/030efcec-5695-460c-b276-6181405e106a)
