### PR TITLE
Update utilities to launch via AppExecutionAlias rather than directly from the folder to utilize correct AUMID

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -6,6 +6,7 @@ using DevHome.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.UI.Dispatching;
 using Serilog;
+using Windows.ApplicationModel;
 
 namespace DevHome;
 
@@ -73,9 +74,11 @@ public static class Program
         {
             try
             {
+                var appExAliasAbsFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}");
+
                 var processStartInfo = new ProcessStartInfo
                 {
-                    FileName = utilityToLaunch,
+                    FileName = Path.Combine(appExAliasAbsFolderPath, utilityToLaunch),
                     Arguments = utilityLaunchArgs,
                 };
 

--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -45,7 +45,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 ImageSource = Path.Combine(AppContext.BaseDirectory, "Assets\\EnvironmentVariables", "EnvironmentVariables.ico"),
                 SupportsLaunchAsAdmin = Microsoft.UI.Xaml.Visibility.Visible,
             },
-            new(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}\\devhome.pi.exe"), experimentationService, "ProjectIronsidesExperiment")
+            new(Path.Combine(appExAliasAbsFolderPath, "devhome.pi.exe"), experimentationService, "ProjectIronsidesExperiment")
             {
                 Title = stringResource.GetLocalized("ProjectIronsidesTitle"),
                 Description = stringResource.GetLocalized("ProjectIronsidesDesc"),


### PR DESCRIPTION
## Summary of the pull request
More quality of life improvements for people developing utilities within Dev Home.  Now the --UtilityLaunch parameter references an AppExecutionAlias rather than a relative file path. This ensures that apps started this way are running under their own AUMID rather than Dev Home's AUMID.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
