### PR TITLE
Announcing widget errors and warnings

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -361,43 +361,41 @@ public partial class WidgetViewModel : ObservableObject
     {
         // We are only interested in plain texts. Buttons, Actions, Images
         // and textboxes are all ignored. Including ActionSets and ImageSets.
-        if (element is AdaptiveTextBlock)
+        if (element is AdaptiveTextBlock textBlock)
         {
-            var textBlock = (AdaptiveTextBlock)element;
             if (isInsideWarningContainer)
             {
                 _screenReaderService.Announce(textBlock.Text);
             }
+
+            return;
         }
 
         // We are treating any text inside a container with the "Warning" style
         // as an actual warning to be announced.
         // For now, the only types of containers widgets use are Containers and Columns. In the future,
         // we may add Caroussels, Tables and Facts to this list.
-        if (element is AdaptiveContainer)
+        if (element is AdaptiveContainer container)
         {
-            var container = (AdaptiveContainer)element;
             foreach (var subelement in container.Items)
             {
-                SearchForWarning(subelement, isInsideWarningContainer || container.Style == ContainerStyle.Warning);
+                SearchForWarning(subelement, isInsideWarningContainer || (container.Style == ContainerStyle.Warning));
             }
         }
 
-        if (element is AdaptiveColumnSet)
+        if (element is AdaptiveColumnSet columnSet)
         {
-            var columnSet = (AdaptiveColumnSet)element;
             foreach (var subelement in columnSet.Columns)
             {
-                SearchForWarning(subelement, isInsideWarningContainer || columnSet.Style == ContainerStyle.Warning);
+                SearchForWarning(subelement, isInsideWarningContainer || (columnSet.Style == ContainerStyle.Warning));
             }
         }
 
-        if (element is AdaptiveColumn)
+        if (element is AdaptiveColumn column)
         {
-            var column = (AdaptiveColumn)element;
             foreach (var subelement in column.Items)
             {
-                SearchForWarning(subelement, isInsideWarningContainer || column.Style == ContainerStyle.Warning);
+                SearchForWarning(subelement, isInsideWarningContainer || (column.Style == ContainerStyle.Warning));
             }
         }
     }

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -393,7 +393,7 @@ public partial class WidgetViewModel : ObservableObject
             {
                 if (containerElement.GetType() == containerType.Key)
                 {
-                    MethodInfo itemsMethod = containerType.Key.GetMethod(containerType.Value, BindingFlags.Public | BindingFlags.Instance);
+                    var itemsMethod = containerType.Key.GetMethod(containerType.Value, BindingFlags.Public | BindingFlags.Instance);
 
                     foreach (var subelement in itemsMethod.Invoke(containerElement, null) as IEnumerable)
                     {

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
@@ -20,6 +21,7 @@ using DevHome.Telemetry;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
@@ -355,6 +357,11 @@ public partial class WidgetViewModel : ObservableObject
 
     private void AnnounceWarnings(AdaptiveCard card)
     {
+        if (!AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged))
+        {
+            return;
+        }
+
         foreach (var element in card.Body)
         {
             SearchForWarning(element, false);


### PR DESCRIPTION
## Summary of the pull request
When we have a warning inside a widget, or an error message, the narrator should announce this event to the user, reading the message for them. 
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/48793024
## Detailed description of the pull request / Additional comments
This changes adds a linear search on the widget whenever it is rendered, looking for potential warning messages, which here are any TextBlocks inside containers with `warning` style. When found, we use the announcement service to narrate it to the user.

In the case of an error card, all the message is announced to the user when rendered.
## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
