### PR TITLE
PI: Expand new insight when added from winlogs page

### DIFF
--- a/tools/PI/DevHome.PI/Models/Insight.cs
+++ b/tools/PI/DevHome.PI/Models/Insight.cs
@@ -23,6 +23,8 @@ public sealed class Insight
     internal string Description { get; set; } = string.Empty;
 
     internal InsightType InsightType { get; set; } = InsightType.Unknown;
+
+    internal bool IsExpanded { get; set; }
 }
 
 internal sealed class InsightRegex

--- a/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
@@ -12,7 +12,7 @@
         <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsList}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="models:Insight">
-                    <Expander IsExpanded="False" ExpandDirection="Down" HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6">
+                    <Expander IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}" ExpandDirection="Down" HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6">
                         <Expander.Header>
                             <TextBlock Text="{x:Bind Title}"/>
                         </Expander.Header>

--- a/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
@@ -193,6 +193,7 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
         {
             if (newInsight is not null)
             {
+                newInsight.IsExpanded = true;
                 var insightsPageViewModel = Application.Current.GetService<InsightsPageViewModel>();
                 insightsPageViewModel.AddInsight(newInsight);
                 InsightsButtonVisibility = Visibility.Visible;


### PR DESCRIPTION
## References and relevant issues
[When you create a new insight this doesn't open the insight expander](https://github.com/microsoft/devhome/issues/3059)

## Detailed description of the pull request / Additional comments
When a new insight is added from winlogs page, and the user goes to Insights page using the Insights button, we should show all details about the new insight and set IsExpanded as true.

## Validation steps performed
1. Launch PI
2. Attach to process
3. Go to Winlogs page
4. Trigger a log which adds a new insight
5. Go to Insights page and see that the Expander is in expanded state.


## PR checklist
- [ ] Closes #3059
