### PR TITLE
PI: Handle PI page crashes when target app has terminated.

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/WatsonHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WatsonHelper.cs
@@ -130,12 +130,13 @@ internal sealed class WatsonHelper : IDisposable
     {
         Dictionary<string, WatsonReport> reports = [];
         EventLog eventLog = new("Application");
+        var targetProcessName = targetProcess.ProcessName;
 
         foreach (EventLogEntry entry in eventLog.Entries)
         {
             if (entry.InstanceId == 1000
                 && entry.Source.Equals("Application Error", StringComparison.OrdinalIgnoreCase)
-                && entry.ReplacementStrings[10].Contains(targetProcess.ProcessName, StringComparison.OrdinalIgnoreCase))
+                && entry.ReplacementStrings[10].Contains(targetProcessName, StringComparison.OrdinalIgnoreCase))
             {
                 var timeGenerated = entry.TimeGenerated;
                 var moduleName = entry.ReplacementStrings[3];

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -41,7 +41,7 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Uid="IDTextBlock"/>
                 <TextBox Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.ProcessId, Mode=OneWay}" IsReadOnly="True"/>
-                
+
                 <!-- These fields can't be reported if we get an exception accessing them,
                 for example if the target app is running elevated but PI is not. -->
                 <Grid Grid.Row="1" Grid.ColumnSpan="2" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}">
@@ -89,14 +89,26 @@
                         </ItemsControl.ItemsPanel>
                     </ListView>
                 </Grid>
-                
-                <TextBlock Grid.Row="2" x:Uid="IsRunningAsSystemTextBlock"/>
-                <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsSystem, Mode=OneWay}" IsReadOnly="True"/>
-                <TextBlock Grid.Row="3" x:Uid="IsRunningAsAdminTextBlock"/>
-                <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsAdmin, Mode=OneWay}" IsReadOnly="True"/>
-                
+
+                <!-- These fields can't be reported if the target process has exited -->
+                <Grid Grid.Row="2" Grid.ColumnSpan="2" Visibility="{x:Bind ViewModel.ProcessRunningParamsVisibility, Mode=OneWay}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="200"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Row="1" x:Uid="IsRunningAsSystemTextBlock"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsSystem, Mode=OneWay}" IsReadOnly="True"/>
+                    <TextBlock Grid.Row="2" x:Uid="IsRunningAsAdminTextBlock"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsRunningAsAdmin, Mode=OneWay}" IsReadOnly="True"/>
+                </Grid>
+
                 <Button 
-                    Grid.Row="4" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Margin="0,8,0,0"
+                    Grid.Row="3" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Margin="0,8,0,0"
                     Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" 
                     Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
             </Grid>

--- a/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml.cs
+++ b/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class ProcessListPage : Page
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
+        ViewModel.ResetPage();
         Application.Current.GetService<TelemetryReporter>().SwitchTo(Feature.ProcessList);
     }
 }

--- a/tools/PI/DevHome.PI/ViewModels/AppDetailsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/AppDetailsPageViewModel.cs
@@ -24,6 +24,9 @@ public partial class AppDetailsPageViewModel : ObservableObject
     [ObservableProperty]
     private Visibility runAsAdminVisibility = Visibility.Collapsed;
 
+    [ObservableProperty]
+    private Visibility processRunningParamsVisibility = Visibility.Collapsed;
+
     private Process? targetProcess;
 
     public AppDetailsPageViewModel()
@@ -49,13 +52,19 @@ public partial class AppDetailsPageViewModel : ObservableObject
             try
             {
                 AppInfo.ProcessId = targetProcess.Id;
-                AppInfo.IsRunningAsSystem = TargetAppData.Instance.IsRunningAsSystem;
 
-                if (!process.HasExited)
+                if (process.HasExited)
                 {
-                    AppInfo.BasePriority = targetProcess.BasePriority;
-                    AppInfo.IsRunningAsAdmin = TargetAppData.Instance.IsRunningAsAdmin;
+                    AppInfo.Visibility = Visibility.Collapsed;
+                    ProcessRunningParamsVisibility = Visibility.Collapsed;
+                }
+                else
+                {
                     AppInfo.Visibility = Visibility.Visible;
+                    ProcessRunningParamsVisibility = Visibility.Visible;
+                    AppInfo.IsRunningAsSystem = TargetAppData.Instance.IsRunningAsSystem;
+                    AppInfo.IsRunningAsAdmin = TargetAppData.Instance.IsRunningAsAdmin;
+                    AppInfo.BasePriority = targetProcess.BasePriority;
                     AppInfo.PriorityClass = (int)targetProcess.PriorityClass;
 
                     if (targetProcess.MainModule != null)

--- a/tools/PI/DevHome.PI/ViewModels/ProcessListPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ProcessListPageViewModel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -12,7 +13,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DevHome.PI.Models;
 using DevHome.PI.Properties;
+using DevHome.PI.Telemetry;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
 
 namespace DevHome.PI.ViewModels;
 
@@ -41,6 +44,22 @@ public partial class ProcessListPageViewModel : ObservableObject
         filteredProcesses = new();
         filterProcessText = string.Empty;
         GetFilteredProcessList();
+
+        TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
+    }
+
+    public void ResetPage()
+    {
+        FilterProcessText = string.Empty;
+        GetFilteredProcessList();
+    }
+
+    private void TargetApp_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if ((e.PropertyName == nameof(TargetAppData.TargetProcess)) || (e.PropertyName == nameof(TargetAppData.HasExited)))
+        {
+            GetFilteredProcessList();
+        }
     }
 
     private void GetFilteredProcessList()


### PR DESCRIPTION
## Detailed description of the pull request / Additional comments
When the target app terminates before going to any page, some of the pages crashed or showed incorrect data:
1. ProcessList Page:
    a. Did not refresh the list of processes when the target app terminated, hence showing "ProblemApp2" even if it is terminated. Fixed this by refreshing the process list when targetapp is changed or terminated.
    b. Also, observed that if we close bar window and restart it, the last filtered text did not clean, so added a ResetPage method, which is called every time a user navigates to the page, clearing any filtering.

2. AppDetails Page:
   This page crashed if the user had not loaded it before the targetapp terminates. The crash was caused because PI could not determine if we were running as system or admin. Since the process is not running, we do not have to show these. Updated to include ProcessRunningParamsVisibility, which will hide IsRunningAsSystem and IsRunningAsAdmin details when the process has already exited.

3. Watson Page:
   This page caused PI to crash if there were pending reports being read. Handled it by storing the processname information in a variable and using it in the loop.

4. Modules Page:
   This page did not show any hang as mentioned in #3024, so no changes were made to it.

## Validation steps performed
1. Launch PI
6. Associate with ProblemApp2.
7. Terminate ProblemApp2.
8. Validate that ProblemApp2 is not listed in the ProcessList page.
9. Go to App details page and confirm PI does not crash. It only shows Process ID.
10. Go to LoadedModules page and confirm PI does not hang.

## PR checklist
- [ ] Closes #3024 