### PR TITLE
PI: Winlogs - Do not reset the check/uncheck state of checkbox, if the user has changed it.

### DIFF
--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -8,7 +8,8 @@
     xmlns:models="using:DevHome.PI.Models"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:local="using:DevHome.PI.Controls"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.Resources>

--- a/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
@@ -6,7 +6,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:DevHome.PI.Models"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsList}">

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
@@ -7,7 +7,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:diagnostics="using:System.Diagnostics"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.Resources>

--- a/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
@@ -7,7 +7,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:settings="using:DevHome.PI.Properties"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.Resources>

--- a/tools/PI/DevHome.PI/Pages/ResourceUsagePage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ResourceUsagePage.xaml
@@ -5,7 +5,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.Resources>

--- a/tools/PI/DevHome.PI/Pages/WatsonsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WatsonsPage.xaml
@@ -7,7 +7,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:models="using:DevHome.PI.Models"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.Resources>

--- a/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
@@ -27,15 +27,15 @@
                 Checked="{x:Bind ViewModel.LogStateChanged}" Unchecked="{x:Bind ViewModel.LogStateChanged}" Margin="0,0,8,0"
                 Content="{x:Bind helpers:WinLogsHelper.EtwLogsName}"/>
             <CheckBox
-                x:Uid="DebugOutputCheckbox" x:Name="DebugOutputCheckbox" IsChecked="false" Tag="{x:Bind models:WinLogsTool.DebugOutput}"
+                x:Uid="DebugOutputCheckbox" x:Name="DebugOutputCheckbox" IsChecked="{x:Bind ViewModel.IsDebugOutputEnabled, Mode=TwoWay}" Tag="{x:Bind models:WinLogsTool.DebugOutput}"
                 Checked="{x:Bind ViewModel.LogStateChanged}" Unchecked="{x:Bind ViewModel.LogStateChanged}" Margin="0,0,8,0"
                 Content="{x:Bind helpers:WinLogsHelper.DebugOutputLogsName}"/>
             <CheckBox
-                x:Uid="EventViewerCheckbox" x:Name="EventViewerCheckbox" IsChecked="true" Tag="{x:Bind models:WinLogsTool.EventViewer}"
+                x:Uid="EventViewerCheckbox" x:Name="EventViewerCheckbox" IsChecked="{x:Bind ViewModel.IsEventViewerEnabled, Mode=TwoWay}" Tag="{x:Bind models:WinLogsTool.EventViewer}"
                 Checked="{x:Bind ViewModel.LogStateChanged}" Unchecked="{x:Bind ViewModel.LogStateChanged}" Margin="0,0,8,0"
                 Content="{x:Bind helpers:WinLogsHelper.EventViewerName}"/>
             <CheckBox
-                x:Uid="WatsonCheckbox" x:Name="WatsonCheckbox" IsChecked="true" Tag="{x:Bind models:WinLogsTool.Watson}"
+                x:Uid="WatsonCheckbox" x:Name="WatsonCheckbox" IsChecked="{x:Bind ViewModel.IsWatsonEnabled, Mode=TwoWay}" Tag="{x:Bind models:WinLogsTool.Watson}"
                 Checked="{x:Bind ViewModel.LogStateChanged}" Unchecked="{x:Bind ViewModel.LogStateChanged}" Margin="0,0,8,0"
                 Content="{x:Bind helpers:WinLogsHelper.WatsonName}"/>
             <Button

--- a/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
@@ -9,7 +9,8 @@
     xmlns:local="using:DevHome.PI.Controls"
     xmlns:models="using:DevHome.PI.Models"
     xmlns:helpers="using:DevHome.PI.Helpers"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.RowDefinitions>

--- a/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
@@ -43,6 +43,15 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool isETWLogsEnabled;
 
+    [ObservableProperty]
+    private bool isDebugOutputEnabled;
+
+    [ObservableProperty]
+    private bool isEventViewerEnabled = true;
+
+    [ObservableProperty]
+    private bool isWatsonEnabled = true;
+
     private Process? targetProcess;
     private WinLogsHelper? winLogsHelper;
 


### PR DESCRIPTION
## Summary of the pull request
Bug: If the user checked/unchecked one of the logs checkbox in Winlogs page -> Then go to a different page-> go back to winlogs page, the checkboxes are reset and we do not maintain the state.
Fix: 
1. Store the checkbox status in the viewmodel to make sure the same logs are enabled/disabled when the user goes back to Winlogs page.
2. Also, enable NavigationCacheMode on all main pages to avoid creating new instances of Page everytime a user navigates in and out of it.

## Validation steps performed
1. Attach PI to an app
3. Go to winlogs page
4. Unselect EventViewer and select debugoutput
5. go to any other page
6. Go back to winlogs page and made sure EventViewer is not selected and DebugOutput was selected.

## PR checklist
- [ ] Closes #3049