### PR TITLE
AdditionalTools validation & feedback

### DIFF
--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
@@ -83,7 +83,7 @@
                 HorizontalAlignment="Center"
                 Click="ManageExternalToolsButton_Click">
                 <Button.ContextFlyout>
-                    <MenuFlyout x:Name="ExternalToolsMenu">
+                    <MenuFlyout x:Name="ExternalToolsMenu" Opening="ExternalToolsMenu_Opening">
                         <!-- We can't databind to MenuFlyout, so we'll add a MenuFlyoutItem
                         for each external tool in codebehind here. -->
                     </MenuFlyout>

--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
@@ -304,12 +304,12 @@ public partial class BarWindowHorizontal : WindowEx
             if (_selectedExternalTool.IsPinned)
             {
                 PinUnpinMenuItem.Text = _unpinMenuItemText;
-                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE77A" };
+                PinUnpinMenuItem.Icon = _unpinIcon;
             }
             else
             {
                 PinUnpinMenuItem.Text = _pinMenuItemText;
-                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE718" };
+                PinUnpinMenuItem.Icon = _pinIcon;
             }
         }
     }

--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
@@ -232,8 +232,7 @@ public partial class BarWindowHorizontal : WindowEx
     private void ExternalToolsMenu_Opening(object sender, object e)
     {
         // Cancel the opening of the menu if there are no items.
-        var flyout = sender as MenuFlyout;
-        if (flyout is not null && flyout.Items is not null && flyout.Items.Count == 0)
+        if (sender is MenuFlyout flyout && flyout?.Items?.Count == 0)
         {
             flyout.Hide();
         }

--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
@@ -227,6 +227,16 @@ public partial class BarWindowHorizontal : WindowEx
         ExpandedViewControl.NavigateToSettings(typeof(AdditionalToolsViewModel).FullName!);
     }
 
+    private void ExternalToolsMenu_Opening(object sender, object e)
+    {
+        // Cancel the opening of the menu if there are no items.
+        var flyout = sender as MenuFlyout;
+        if (flyout is not null && flyout.Items is not null && flyout.Items.Count == 0)
+        {
+            flyout.Hide();
+        }
+    }
+
     private void ExternalToolMenuItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
     {
         var menuItem = sender as MenuFlyoutItem;
@@ -236,10 +246,12 @@ public partial class BarWindowHorizontal : WindowEx
             if (_selectedExternalTool.IsPinned)
             {
                 PinUnpinMenuItem.Text = _unpinMenuItemText;
+                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE77A" };
             }
             else
             {
                 PinUnpinMenuItem.Text = _pinMenuItemText;
+                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE718" };
             }
 
             ToolContextMenu.ShowAt(menuItem, e.GetPosition(menuItem));
@@ -291,10 +303,12 @@ public partial class BarWindowHorizontal : WindowEx
             if (_selectedExternalTool.IsPinned)
             {
                 PinUnpinMenuItem.Text = _unpinMenuItemText;
+                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE77A" };
             }
             else
             {
                 PinUnpinMenuItem.Text = _pinMenuItemText;
+                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE718" };
             }
         }
     }

--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml.cs
@@ -36,6 +36,8 @@ public partial class BarWindowHorizontal : WindowEx
     private readonly string _pinMenuItemText = CommonHelper.GetLocalizedString("PinMenuItemText");
     private readonly string _unpinMenuItemText = CommonHelper.GetLocalizedString("UnpinMenuItemText");
     private readonly BarWindowViewModel _viewModel;
+    private readonly FontIcon _pinIcon = new() { Glyph = "\uE718" };
+    private readonly FontIcon _unpinIcon = new() { Glyph = "\uE77A" };
 
     private ExternalTool? _selectedExternalTool;
     private INotifyCollectionChanged? _externalTools;
@@ -246,12 +248,12 @@ public partial class BarWindowHorizontal : WindowEx
             if (_selectedExternalTool.IsPinned)
             {
                 PinUnpinMenuItem.Text = _unpinMenuItemText;
-                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE77A" };
+                PinUnpinMenuItem.Icon = _unpinIcon;
             }
             else
             {
                 PinUnpinMenuItem.Text = _pinMenuItemText;
-                PinUnpinMenuItem.Icon = new FontIcon { Glyph = "\uE718" };
+                PinUnpinMenuItem.Icon = _pinIcon;
             }
 
             ToolContextMenu.ShowAt(menuItem, e.GetPosition(menuItem));

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml
@@ -85,7 +85,7 @@
                 x:Uid="ManageExternalToolsButton"
                 HorizontalAlignment="Center">
                 <Button.ContextFlyout>
-                    <MenuFlyout x:Name="ExternalToolsMenu">
+                    <MenuFlyout x:Name="ExternalToolsMenu" Opening="ExternalToolsMenu_Opening">
                         <!-- We can't databind to MenuFlyout, so we'll add a MenuFlyoutItem
                         for each external tool in codebehind here. -->
                     </MenuFlyout>

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
@@ -95,6 +95,16 @@ public partial class BarWindowVertical : WindowEx
         Width = 70;
     }
 
+    private void ExternalToolsMenu_Opening(object sender, object e)
+    {
+        // Cancel the opening of the menu if there are no items.
+        var flyout = sender as MenuFlyout;
+        if (flyout is not null && flyout.Items is not null && flyout.Items.Count == 0)
+        {
+            flyout.Hide();
+        }
+    }
+
     private void ExternalToolButton_Click(object sender, RoutedEventArgs e)
     {
         if (sender is Button clickedButton)

--- a/tools/PI/DevHome.PI/Controls/AddToolControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/AddToolControl.xaml
@@ -23,26 +23,22 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="100"/>
                         <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock 
-                        x:Uid="ToolPathHeaderTextBlock" 
-                        VerticalAlignment="Center" />
-                    <TextBox 
-                        x:Name="ToolPathTextBox" Grid.Column="1" MinWidth="800"
-                        TextChanged="UpdateSampleCommandline"/>
                     <Button 
-                        x:Uid="ToolBrowseButton" Name="BrowseButton" Grid.Column="2"
-                        Width="100" Margin="8,0,0,0" HorizontalAlignment="Left"
-                        Click="BrowseButton_Click"/>
+                        x:Name="ToolBrowseButton" x:Uid="ToolBrowseButton" 
+                        HorizontalAlignment="Left" MinWidth="100"
+                        Click="ToolBrowseButton_Click"/>
+                    <TextBox 
+                        x:Name="ToolPathTextBox" Grid.Column="1" MinWidth="800" Margin="8,0,0,0" 
+                        IsReadOnly="True"/>
                 </Grid>
                 <Grid Margin="0,6,0,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="100"/>
                         <ColumnDefinition Width="200"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock x:Uid="ToolNameHeaderTextBlock" VerticalAlignment="Center"/>
-                    <TextBox x:Name="ToolNameTextBox" Grid.Column="1" HorizontalAlignment="Stretch"/>
+                    <TextBlock x:Uid="ToolNameHeaderTextBlock" VerticalAlignment="Center" MinWidth="100"/>
+                    <TextBox x:Name="ToolNameTextBox" Grid.Column="1" HorizontalAlignment="Stretch" Margin="8,0,0,0" />
                 </Grid>
             </StackPanel>
         </Border>
@@ -58,7 +54,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="100"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <RadioButton 
@@ -75,7 +71,7 @@
                         x:Uid="PrefixTextBlock" Grid.Column="1" Margin="0,0,8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Right"/>
                     <TextBox 
-                        x:Name="PrefixTextBox" Grid.Column="2" Width="100" HorizontalAlignment="Right" 
+                        x:Name="PrefixTextBox" Grid.Column="2" MinWidth="150" HorizontalAlignment="Right" 
                         TextChanged="UpdateSampleCommandline"/>
                 </Grid>
             </Grid>

--- a/tools/PI/DevHome.PI/Controls/AddToolControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/AddToolControl.xaml
@@ -17,91 +17,83 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border>
-            <StackPanel Orientation="Vertical">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="100"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Button 
-                        x:Name="ToolBrowseButton" x:Uid="ToolBrowseButton" 
-                        HorizontalAlignment="Left" MinWidth="100"
-                        Click="ToolBrowseButton_Click"/>
-                    <TextBox 
-                        x:Name="ToolPathTextBox" Grid.Column="1" MinWidth="800" Margin="8,0,0,0" 
-                        IsReadOnly="True"/>
-                </Grid>
-                <Grid Margin="0,6,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="100"/>
-                        <ColumnDefinition Width="200"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock x:Uid="ToolNameHeaderTextBlock" VerticalAlignment="Center" MinWidth="100"/>
-                    <TextBox x:Name="ToolNameTextBox" Grid.Column="1" HorizontalAlignment="Stretch" Margin="8,0,0,0" />
-                </Grid>
-            </StackPanel>
-        </Border>
-
-        <Border Grid.Row="1" Margin="0,12,0,0">
+        <StackPanel Orientation="Vertical">
             <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <TextBlock x:Uid="BasicArgumentsTextBlock"/>
-                <Grid Grid.Row="1" Margin="0,6,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <RadioButton 
-                            x:Uid="NoneRadio" x:Name="NoneRadio" IsChecked="True" GroupName="SwitchGroup" 
-                            Checked="UpdateSampleCommandline"/>
-                        <RadioButton 
-                            x:Uid="HwndRadio" x:Name="HwndRadio" GroupName="SwitchGroup" 
-                            Checked="UpdateSampleCommandline"/>
-                        <RadioButton 
-                            x:Uid="ProcessIdRadio" x:Name="ProcessIdRadio" GroupName="SwitchGroup" 
-                            Checked="UpdateSampleCommandline"/>
-                    </StackPanel>
-                    <TextBlock 
-                        x:Uid="PrefixTextBlock" Grid.Column="1" Margin="0,0,8,0"
-                        VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <TextBox 
-                        x:Name="PrefixTextBox" Grid.Column="2" MinWidth="150" HorizontalAlignment="Right" 
-                        TextChanged="UpdateSampleCommandline"/>
-                </Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Button 
+                    x:Name="ToolBrowseButton" x:Uid="ToolBrowseButton" 
+                    HorizontalAlignment="Left" MinWidth="100"
+                    Click="ToolBrowseButton_Click"/>
+                <TextBox 
+                    x:Name="ToolPathTextBox" Grid.Column="1" MinWidth="800" Margin="8,0,0,0" 
+                    IsReadOnly="True"/>
             </Grid>
-        </Border>
+            <Grid Margin="0,6,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100"/>
+                    <ColumnDefinition Width="200"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Uid="ToolNameHeaderTextBlock" VerticalAlignment="Center" MinWidth="100"/>
+                <TextBox x:Name="ToolNameTextBox" Grid.Column="1" HorizontalAlignment="Stretch" Margin="8,0,0,0" />
+            </Grid>
+        </StackPanel>
 
-        <Border Grid.Row="2" Margin="0,12,0,0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <TextBlock x:Uid="OtherArgumentsTextBlock"/>
-                <TextBox
-                    x:Name="OtherArgsTextBox" Grid.Row="1" TextWrapping="Wrap" MinHeight="60"
+        <Grid Grid.Row="1" Margin="0,12,0,0">
+        <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock x:Uid="BasicArgumentsTextBlock"/>
+            <Grid Grid.Row="1" Margin="0,6,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <RadioButton 
+                        x:Uid="NoneRadio" x:Name="NoneRadio" IsChecked="True" GroupName="SwitchGroup" 
+                        Checked="UpdateSampleCommandline"/>
+                    <RadioButton 
+                        x:Uid="HwndRadio" x:Name="HwndRadio" GroupName="SwitchGroup" 
+                        Checked="UpdateSampleCommandline"/>
+                    <RadioButton 
+                        x:Uid="ProcessIdRadio" x:Name="ProcessIdRadio" GroupName="SwitchGroup" 
+                        Checked="UpdateSampleCommandline"/>
+                </StackPanel>
+                <TextBlock 
+                    x:Uid="PrefixTextBlock" Grid.Column="1" Margin="0,0,8,0"
+                    VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                <TextBox 
+                    x:Name="PrefixTextBox" Grid.Column="2" MinWidth="150" HorizontalAlignment="Right" 
                     TextChanged="UpdateSampleCommandline"/>
             </Grid>
-        </Border>
+        </Grid>
 
-        <Border Grid.Row="3" Margin="0,12,0,0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <TextBlock x:Uid="SampleCommandLineTextBlock"/>
-                <TextBox
-                    x:Name="SampleCommandTextBox" Grid.Row="1" MinHeight="60"
-                    TextWrapping="Wrap" IsReadOnly="True"/>
-            </Grid>
-        </Border>
+        <Grid Grid.Row="2" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock x:Uid="OtherArgumentsTextBlock"/>
+            <TextBox
+                x:Name="OtherArgsTextBox" Grid.Row="1" TextWrapping="Wrap" MinHeight="60"
+                TextChanged="UpdateSampleCommandline"/>
+        </Grid>
+
+        <Grid Grid.Row="3" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock x:Uid="SampleCommandLineTextBlock"/>
+            <TextBox
+                x:Name="SampleCommandTextBox" Grid.Row="1" MinHeight="60"
+                TextWrapping="Wrap" IsReadOnly="True"/>
+        </Grid>
 
         <ToggleSwitch 
             x:Uid="IsPinnedToggleSwitch" x:Name="IsPinnedToggleSwitch"

--- a/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml
@@ -42,7 +42,11 @@
 
         <StackPanel x:Name="GridButtonPanel" Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Right" Margin="0,4,0,8">
             <Button 
-                x:Uid="UnregisterToolButton" x:Name="UnregisterToolButton" Width="120" Height="36" Margin="4,0,0,0" 
+                x:Uid="UnregisterToolButton" 
+                x:Name="UnregisterToolButton" 
+                Width="120" 
+                Height="36" 
+                Margin="4,0,0,0" 
                 Click="UnregisterToolButton_Click"/>
         </StackPanel>
     </Grid>

--- a/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:local="using:DevHome.PI.Helpers"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -15,6 +16,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        
         <controls:DataGrid
             x:Name="ToolsDataGrid"
             VerticalScrollBarVisibility="Visible"
@@ -27,17 +29,21 @@
             CanUserReorderColumns="True"
             CanUserResizeColumns="True"
             ColumnHeaderHeight="32"
-            MaxColumnWidth="400"
             FrozenColumnCount="0"
             GridLinesVisibility="None"
-            HeadersVisibility="Column">
+            HeadersVisibility="Column"
+            ItemsSource="{x:Bind local:ExternalToolsHelper.Instance.AllExternalTools}"
+            SelectionChanged="ToolsDataGrid_SelectionChanged">
             <controls:DataGrid.Columns>
-                <controls:DataGridTextColumn x:Uid="EditToolsNameColumn" Binding="{Binding Name}" Width="150"/>
+                <controls:DataGridTextColumn x:Uid="EditToolsNameColumn" Binding="{Binding Name}" MinWidth="150"/>
+                <controls:DataGridTextColumn x:Uid="EditToolsNameColumn" Binding="{Binding Executable}" Width="*"/>
             </controls:DataGrid.Columns>
         </controls:DataGrid>
 
         <StackPanel x:Name="GridButtonPanel" Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Right" Margin="0,4,0,8">
-            <Button x:Uid="DeleteToolButton" x:Name="DeleteToolButton" Width="120" Height="36" Margin="4,0,0,0" Click="DeleteToolButton_Click"/>
+            <Button 
+                x:Uid="UnregisterToolButton" x:Name="UnregisterToolButton" Width="120" Height="36" Margin="4,0,0,0" 
+                Click="UnregisterToolButton_Click"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml.cs
@@ -12,16 +12,37 @@ public sealed partial class EditToolsControl : UserControl
     public EditToolsControl()
     {
         InitializeComponent();
-        ToolsDataGrid.ItemsSource = ExternalToolsHelper.Instance.AllExternalTools;
+        EnableUnregisterButton();
     }
 
-    private void DeleteToolButton_Click(object sender, RoutedEventArgs e)
+    private void UnregisterToolButton_Click(object sender, RoutedEventArgs e)
     {
-        var selectedItem = ToolsDataGrid.SelectedItem;
-
-        if (selectedItem is ExternalTool)
+        var selectedItems = ToolsDataGrid.SelectedItems;
+        for (var i = selectedItems.Count - 1; i >= 0; i--)
         {
-            ExternalToolsHelper.Instance.RemoveExternalTool((ExternalTool)selectedItem);
+            if (selectedItems[i] is ExternalTool tool)
+            {
+                ExternalToolsHelper.Instance.RemoveExternalTool(tool);
+            }
         }
+
+        EnableUnregisterButton();
+    }
+
+    private void EnableUnregisterButton()
+    {
+        if (ToolsDataGrid.SelectedItems is not null && ToolsDataGrid.SelectedItems.Count > 0)
+        {
+            UnregisterToolButton.IsEnabled = true;
+        }
+        else
+        {
+            UnregisterToolButton.IsEnabled = false;
+        }
+    }
+
+    private void ToolsDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        EnableUnregisterButton();
     }
 }

--- a/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/EditToolsControl.xaml.cs
@@ -31,14 +31,7 @@ public sealed partial class EditToolsControl : UserControl
 
     private void EnableUnregisterButton()
     {
-        if (ToolsDataGrid.SelectedItems is not null && ToolsDataGrid.SelectedItems.Count > 0)
-        {
-            UnregisterToolButton.IsEnabled = true;
-        }
-        else
-        {
-            UnregisterToolButton.IsEnabled = false;
-        }
+        UnregisterToolButton.IsEnabled = ToolsDataGrid.SelectedItems?.Count > 0;
     }
 
     private void ToolsDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -597,6 +597,7 @@ public class WindowHelper
         ContentDialog = new ContentDialog
         {
             XamlRoot = frameworkElement.XamlRoot,
+            RequestedTheme = frameworkElement.ActualTheme,
             Content = message,
             CloseButtonText = closeButtonText,
         };

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -597,7 +597,6 @@ public class WindowHelper
         ContentDialog = new ContentDialog
         {
             XamlRoot = frameworkElement.XamlRoot,
-            RequestedTheme = frameworkElement.ActualTheme,
             Content = message,
             CloseButtonText = closeButtonText,
         };

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -41,7 +41,7 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Uid="IDTextBlock"/>
                 <TextBox Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.ProcessId, Mode=OneWay}" IsReadOnly="True"/>
-                
+
                 <!-- These fields can't be reported if we get an exception accessing them,
                 for example if the target app is running elevated but PI is not. -->
                 <Grid Grid.Row="1" Grid.ColumnSpan="2" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}">

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -41,7 +41,7 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Uid="IDTextBlock"/>
                 <TextBox Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.ProcessId, Mode=OneWay}" IsReadOnly="True"/>
-
+                
                 <!-- These fields can't be reported if we get an exception accessing them,
                 for example if the target app is running elevated but PI is not. -->
                 <Grid Grid.Row="1" Grid.ColumnSpan="2" Visibility="{x:Bind ViewModel.AppInfo.Visibility, Mode=OneWay}">
@@ -71,7 +71,7 @@
                     <TextBlock Grid.Row="5" x:Uid="MicrosoftStoreAppTextBlock" />
                     <TextBox Grid.Row="5" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsStoreApp, Mode=OneWay}" IsReadOnly="True" />
 
-                    <TextBlock Grid.Row="6" x:Uid="FrameworkTypesTextBlock" />
+                    <TextBlock Grid.Row="6" x:Uid="FrameworkTypesTextBlock" TextWrapping="Wrap"/>
                     <ListView 
                         Grid.Row="6" Grid.Column="1" IsItemClickEnabled="False"
                         ItemsSource="{x:Bind ViewModel.AppInfo.FrameworkTypes, Mode=OneWay}">

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -405,9 +405,9 @@
     <value>Name</value>
     <comment>The name of a tool that could be edited.</comment>
   </data>
-  <data name="DeleteToolButton.Content" xml:space="preserve">
-    <value>Delete tool</value>
-    <comment>Content on a button to delete a tool.</comment>
+  <data name="UnregisterToolButton.Content" xml:space="preserve">
+    <value>Unregister</value>
+    <comment>Text on a button for unregistering a tool.</comment>
   </data>
   <data name="SettingsToolHeaderTextBlock.Text" xml:space="preserve">
     <value>Settings</value>
@@ -730,7 +730,7 @@
     <comment>Locked={"{0}", "{1}"} A description to help a user that is dealing with non-specific error situation. {0} is the error name. {1} is the error description.</comment>
   </data>
   <data name="FrameworkTypesTextBlock.Text" xml:space="preserve">
-    <value>Framework types</value>
+    <value>Framework types used in this app</value>
     <comment>This refers to the set of application frameworks this application uses.</comment>
   </data>
   <data name="BaseAddressTextBlock.Text" xml:space="preserve">
@@ -846,7 +846,63 @@
     <comment>Header for the settings item to add a tool to the product.</comment>
   </data>
   <data name="SettingsEditToolCard.Header" xml:space="preserve">
-    <value>Edit or delete existing tools</value>
-    <comment>Header for the setting item to edit or delete tools from the product.</comment>
+    <value>Edit or unregister existing tools</value>
+    <comment>Header for the setting item to edit or unregister tools from the product.</comment>
+  </data>
+  <data name="BasePriorityTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The starting priority for threads created within this process</value>
+    <comment>Tooltip for the Base Priority field.</comment>
+  </data>
+  <data name="BinaryTypeTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The CPU architecture of the target process</value>
+    <comment>Tooltip for the Binary Type field.</comment>
+  </data>
+  <data name="FrameworkTypesTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The windowing or application frameworks used in this app</value>
+    <comment>Tooltip for the Framework Types field.</comment>
+  </data>
+  <data name="IDTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The process ID of the target process</value>
+    <comment>Tooltip for the PID field.</comment>
+  </data>
+  <data name="IsRunningAsAdminTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>True if the target process is running under an Administrator account</value>
+    <comment>Tooltip for the Running as Admin field.</comment>
+  </data>
+  <data name="IsRunningAsSystemTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>True if the target process is running as a System process, based on its Session ID</value>
+    <comment>Tooltip for the Running as System field.</comment>
+  </data>
+  <data name="MainModuleTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The executable used to start the process</value>
+    <comment>Tooltip for the Main Module field.</comment>
+  </data>
+  <data name="MicrosoftStoreAppTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>True if this app was deployed via the Microsoft Store</value>
+    <comment>Tooltip for the Microsoft Store field.</comment>
+  </data>
+  <data name="MSIXPackagedTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>True if this process is packaged with MSIX</value>
+    <comment>Tooltip for the MSIX Packaged field.</comment>
+  </data>
+  <data name="PriorityClassTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Threads with different priorities in the process run relative to the priority class of the process</value>
+    <comment>Tooltip for the Priority Class field.</comment>
+  </data>
+  <data name="MessageCloseText" xml:space="preserve">
+    <value>Close</value>
+    <comment>Text used on the Close button on a message dialog.</comment>
+  </data>
+  <data name="ToolRegisteredMessage" xml:space="preserve">
+    <value>External tool {0} registered</value>
+    <comment>Message shown to the user when an external tool is registered.</comment>
+  </data>
+  <data name="EditToolsExecutableColumn.Header" xml:space="preserve">
+    <value>Executable</value>
+    <comment>The executable path of an external tool.</comment>
+  </data>
+  <data name="InvalidToolInfoMessage" xml:space="preserve">
+    <value>Invalid tool path or name</value>
+    <comment>Text for the message to show to the user when the supplied path or name is not valid.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
In Settings | Additional Tools, ensure the toolpath and name are valid, and provide user feedback when registering a tool (via a new timed message dialog in WindowHelper). Also only enable the Unregister button if the user selects at least one tool (and enable unregistering multiple tools at once).

Also, added tooltips to all the fields on the App Details page; suppress the external tools menuflyout if there are no external tools; and fixed the pin/unpin menu icon.

## References and relevant issues
Fixed the following:
- Closes #3040
- Closes #3041
- Closes #3042
- Closes #3043
- Closes #3045
- Closes #3047

