### PR TITLE
Enable FailFastOnErrors for Debug builds

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -179,6 +179,10 @@ public partial class App : Application, IApp
 
         UnhandledException += App_UnhandledException;
         AppInstance.GetCurrent().Activated += OnActivated;
+
+#if DEBUG
+        DebugSettings.FailFastOnErrors = true;
+#endif
     }
 
     public void ShowMainWindow()

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -154,6 +154,10 @@
     <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
+
   <!-- Third party notice file -->
   <ItemGroup>
     <Content Include="$(SolutionDir)NOTICE.txt">

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -66,13 +66,13 @@
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
-		<com:Extension Category="windows.comServer">
-		  <com:ComServer>
-			<com:ExeServer Executable="WindowsSandboxExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="WindowsSandboxExtension">
-		      <com:Class Id="6A52115B-083C-4FB1-85F4-BBE23289220E" DisplayName="WindowsSandboxExtension" />
-			</com:ExeServer>
-	      </com:ComServer>
-		</com:Extension>
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="WindowsSandboxExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="WindowsSandboxExtension">
+              <com:Class Id="6A52115B-083C-4FB1-85F4-BBE23289220E" DisplayName="WindowsSandboxExtension" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="CoreWidgetProvider">
@@ -114,21 +114,21 @@
             </uap3:Properties>
           </uap3:AppExtension>
         </uap3:Extension>
-		<uap3:Extension Category="windows.appExtension">
-			<uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID3" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameWindowsSandboxExt" Description="ms-resource:AppDescriptionWindowsSandboxExt">
-				<uap3:Properties>
-					<DevHomeProvider>
-						<Activation>
-							<CreateInstance ClassId="6A52115B-083C-4FB1-85F4-BBE23289220E" />
-						</Activation>
-						<SupportedInterfaces>
-							<ComputeSystem />
-						</SupportedInterfaces>
-					</DevHomeProvider>
-				</uap3:Properties>
-			</uap3:AppExtension>
-		 </uap3:Extension>
-		<uap3:Extension Category="windows.appExtension">
+        <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID3" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameWindowsSandboxExt" Description="ms-resource:AppDescriptionWindowsSandboxExt">
+            <uap3:Properties>
+              <DevHomeProvider>
+                <Activation>
+                  <CreateInstance ClassId="6A52115B-083C-4FB1-85F4-BBE23289220E" />
+                </Activation>
+                <SupportedInterfaces>
+                  <ComputeSystem />
+                </SupportedInterfaces>
+              </DevHomeProvider>
+            </uap3:Properties>
+          </uap3:AppExtension>
+        </uap3:Extension>
+        <uap3:Extension Category="windows.appExtension">
           <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>


### PR DESCRIPTION
## Summary of the pull request
Enable FailFastOnErrors, only on Debug builds for now. This will help us weed out hits. Eventually, we would want to turn it on everywhere for easier diagnostics.

Build auto-fixed some errant tabs in the package.appxmanifest, so included that fix as well.

## Validation steps performed
Did quick sanity check in Dev Home. Ran all automated tests and didn't see any additional failures.

## PR checklist
- Partially addresses #3019
