### PR TITLE
Make 'View logs' link available on all builds

### DIFF
--- a/settings/DevHome.Settings/Views/AboutPage.xaml
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml
@@ -31,10 +31,10 @@
                         </StackPanel>
                     </ctControls:SettingsCard>
                     <ctControls:SettingsCard
-                        Visibility="Collapsed"
                         x:Name="ViewLogsSettingsCard"
                         x:Uid="ViewLogs"
                         IsClickEnabled="True"
+                        Command="{x:Bind OpenLogsLocationCommand}"
                         ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}" />
                 </ctControls:SettingsExpander.Items>
             </ctControls:SettingsExpander>

--- a/settings/DevHome.Settings/Views/AboutPage.xaml.cs
+++ b/settings/DevHome.Settings/Views/AboutPage.xaml.cs
@@ -8,7 +8,6 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Views;
 using DevHome.Settings.ViewModels;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Serilog;
 
 namespace DevHome.Settings.Views;
@@ -21,17 +20,6 @@ public sealed partial class AboutPage : DevHomePage
     {
         ViewModel = Application.Current.GetService<AboutViewModel>();
         this.InitializeComponent();
-
-#if DEBUG
-        Loaded += ShowViewLogsButton;
-#endif
-    }
-
-#if DEBUG
-    private void ShowViewLogsButton(object sender, RoutedEventArgs e)
-    {
-        ViewLogsSettingsCard.Visibility = Visibility.Visible;
-        ViewLogsSettingsCard.Command = OpenLogsLocationCommand;
     }
 
     [RelayCommand]
@@ -48,5 +36,4 @@ public sealed partial class AboutPage : DevHomePage
             log.Error(e, $"Error opening log location");
         }
     }
-#endif
 }


### PR DESCRIPTION
## Summary of the pull request
There is a link in the "About" settings page to open the Dev Home logs in File Explorer, that we've kept only on Debug builds. It seems to work and is useful, so let's make the link available everywhere.
It's a good intermediate while we tweak #2952/#2953

![image](https://github.com/microsoft/devhome/assets/47155823/5fb4360c-eea1-4059-944f-24020579dc36)
