### PR TITLE
Allow widgets to take foreground rights on user interaction

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
@@ -359,4 +359,9 @@ public class ComSafeWidget
             return string.Empty;
         });
     }
+
+    public Widget GetUnsafeWidgetObject()
+    {
+        return _oopWidget;
+    }
 }

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
@@ -11,6 +11,7 @@ using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
 using Windows.Foundation;
+using WinRT;
 
 namespace DevHome.Dashboard.ComSafeWidgetObjects;
 
@@ -186,6 +187,16 @@ public class ComSafeWidget
             try
             {
                 await LazilyLoadOopWidget();
+                try
+                {
+                    CoAllowSetForegroundWindow(_oopWidget);
+                }
+                catch (Exception ex)
+                {
+                    // If CoAllowSetForegroundWindow fails, we should still continue with the call to NotifyActionInvokedAsync.
+                    _log.Warning(ex, $"Call to CoAllowSetForegroundWindow failed");
+                }
+
                 await Task.Run(async () => await _oopWidget.NotifyActionInvokedAsync(verb, data));
                 return;
             }
@@ -363,5 +374,16 @@ public class ComSafeWidget
     public Widget GetUnsafeWidgetObject()
     {
         return _oopWidget;
+    }
+
+    // CoAllowSetForegroundWindow must be called on a raw COM interface, not a .NET CCW, in order to work correctly, since
+    // the underlying functionality is implemented by COM runtime and the object itself. CoAllowSetForegroundWindow wrapper
+    // below takes a WinRT object and extracts the raw COM interface pointer from it before calling native CoAllowSetForegroundWindow.
+    [DllImport("ole32.dll", ExactSpelling = true, PreserveSig = false)]
+    private static extern void CoAllowSetForegroundWindow(IntPtr pUnk, IntPtr lpvReserved);
+
+    private void CoAllowSetForegroundWindow(Widget widget)
+    {
+        CoAllowSetForegroundWindow(((IWinRTObject)widget).NativeObject.ThisPtr, 0);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ComSafeWidgetObjects/ComSafeWidget.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using DevHome.Common.Extensions;
@@ -11,7 +12,6 @@ using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
 using Windows.Foundation;
-using WinRT;
 
 namespace DevHome.Dashboard.ComSafeWidgetObjects;
 
@@ -190,6 +190,7 @@ public class ComSafeWidget
                 try
                 {
                     CoAllowSetForegroundWindow(_oopWidget);
+                    Log.Information("CoAllowSetForegroundWindow result: {GetLastError}", Marshal.GetLastWin32Error().ToString(CultureInfo.CurrentCulture));
                 }
                 catch (Exception ex)
                 {
@@ -379,11 +380,11 @@ public class ComSafeWidget
     // CoAllowSetForegroundWindow must be called on a raw COM interface, not a .NET CCW, in order to work correctly, since
     // the underlying functionality is implemented by COM runtime and the object itself. CoAllowSetForegroundWindow wrapper
     // below takes a WinRT object and extracts the raw COM interface pointer from it before calling native CoAllowSetForegroundWindow.
-    [DllImport("ole32.dll", ExactSpelling = true, PreserveSig = false)]
+    [DllImport("ole32.dll", ExactSpelling = true, PreserveSig = false, SetLastError = true)]
     private static extern void CoAllowSetForegroundWindow(IntPtr pUnk, IntPtr lpvReserved);
 
     private void CoAllowSetForegroundWindow(Widget widget)
     {
-        CoAllowSetForegroundWindow(((IWinRTObject)widget).NativeObject.ThisPtr, 0);
+        CoAllowSetForegroundWindow(Marshal.GetIUnknownForObject(widget), IntPtr.Zero);
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
@@ -22,7 +21,6 @@ using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
 using Windows.Data.Json;
-using WinRT;
 
 namespace DevHome.Dashboard.ViewModels;
 
@@ -319,16 +317,6 @@ public partial class WidgetViewModel : ObservableObject
             }
 
             _log.Information($"Verb = {executeAction.Verb}, Data = {dataToSend}");
-
-            try
-            {
-                CoAllowSetForegroundWindow(Widget.GetUnsafeWidgetObject());
-            }
-            catch (Exception ex)
-            {
-                _log.Warning(ex, "Failed to call CoAllowSetForegroundWindow");
-            }
-
             await Widget.NotifyActionInvokedAsync(executeAction.Verb, dataToSend);
         }
 
@@ -350,16 +338,5 @@ public partial class WidgetViewModel : ObservableObject
     public void UnsubscribeFromWidgetUpdates()
     {
         Widget.WidgetUpdated -= HandleWidgetUpdated;
-    }
-
-    // CoAllowSetForegroundWindow must be called on a raw COM interface, not a .NET CCW, in order to work correctly, since
-    // the underlying functionality is implemented by COM runtime and the object itself. CoAllowSetForegroundWindow wrapper
-    // below takes a WinRT object and extracts the raw COM interface pointer from it before calling native CoAllowSetForegroundWindow.
-    [DllImport("ole32.dll", ExactSpelling = true, PreserveSig = false)]
-    private static extern void CoAllowSetForegroundWindow(IntPtr pUnk, IntPtr lpvReserved);
-
-    private void CoAllowSetForegroundWindow(Widget widget)
-    {
-        CoAllowSetForegroundWindow(((IWinRTObject)widget).NativeObject.ThisPtr, 0);
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Various widgets launch UI, and it is a problem when they can't launch to the foreground because they don't have foreground rights. When a user interacts with a widget, we notify the widget of that interaction (so they can respond to it) via the `Widget.NotifyActionInvokedAsync()` API. Before we call that API, we should give the widget process foreground rights, so they can take them and launch to the foreground if they choose.

## References and relevant issues
#2747

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
