### PR TITLE
Machine config list navigation, and repo config names.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -216,6 +216,9 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         get; set;
     }
 
+    /// <summary>
+    /// Gets or sets the string that the narrator should say when the repo is selected in the config screen.
+    /// </summary>
     public string RepoConfigAutomationName
     {
         get; set;

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/CloningInformation.cs
@@ -216,6 +216,11 @@ public partial class CloningInformation : ObservableObject, IEquatable<CloningIn
         get; set;
     }
 
+    public string RepoConfigAutomationName
+    {
+        get; set;
+    }
+
     /// <summary>
     /// Gets or sets the name of the button that allows a user to remove the repository from being cloned.
     /// This name can't be static because each button name needs to be unique.  Because each name needs to be unique

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -445,6 +445,44 @@ public partial class AddRepoViewModel : ObservableObject
         _selectedRepoProvider = repositoryProviderName;
     }
 
+    /// <summary>
+    /// Adds or removes the default dev drive.  This dev drive will be made at the loading screen.
+    /// </summary>
+    [RelayCommand]
+    private void MakeNewDevDrive(bool isCheckBoxChecked)
+    {
+        // Getting here means
+        // 1. The user does not have any existing dev drives
+        // 2. The user wants to clone to a new dev drive.
+        // 3. The user un-checked this and does not want a new dev drive.
+        if (isCheckBoxChecked)
+        {
+            UpdateDevDriveInfo();
+        }
+        else
+        {
+            FolderPickerViewModel.CloneLocationAlias = string.Empty;
+            FolderPickerViewModel.InDevDriveScenario = false;
+            EditDevDriveViewModel.RemoveNewDevDrive();
+            FolderPickerViewModel.EnableBrowseButton();
+            FolderPickerViewModel.CloneLocation = _addRepoDialog.OldCloneLocation;
+        }
+    }
+
+    /// <summary>
+    /// Update dialog to show Dev Drive information.
+    /// </summary>
+    public void UpdateDevDriveInfo()
+    {
+        EditDevDriveViewModel.MakeDefaultDevDrive();
+        FolderPickerViewModel.DisableBrowseButton();
+        _addRepoDialog.OldCloneLocation = FolderPickerViewModel.CloneLocation;
+        FolderPickerViewModel.CloneLocation = EditDevDriveViewModel.GetDriveDisplayName();
+        FolderPickerViewModel.CloneLocationAlias = EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
+        FolderPickerViewModel.InDevDriveScenario = true;
+        EditDevDriveViewModel.IsDevDriveCheckboxChecked = true;
+    }
+
     [RelayCommand]
     private void CancelButtonPressed()
     {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -1066,6 +1066,7 @@ public partial class AddRepoViewModel : ObservableObject
             cloningInformation.OwningAccount = developerId;
             cloningInformation.EditClonePathAutomationName = _stringResource.GetLocalized(StringResourceKey.RepoPageEditClonePathAutomationProperties, Path.Join(_selectedRepoProvider, repositoryToAdd.RepoDisplayName));
             cloningInformation.RemoveFromCloningAutomationName = _stringResource.GetLocalized(StringResourceKey.RepoPageRemoveRepoAutomationProperties, Path.Join(_selectedRepoProvider, repositoryToAdd.RepoDisplayName));
+            cloningInformation.RepoConfigAutomationName = Path.Join(_providers.DisplayName(_selectedRepoProvider), repositoryToAdd.RepoDisplayName);
             EverythingToClone.Add(cloningInformation);
         }
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -170,7 +170,13 @@
                 into the command.  I tried converting this to use a command on SelectionChanged and pass SelectedItems into the command.
                 I ran into issues because the viewmodel expects one repository at a time.  Not a list.
                 Another issue is .SelectRange() needs to be called to "select" repos when the dialog is opened more than once. -->
-                <ListView x:Name="RepositoriesListView" Visibility="{x:Bind AddRepoViewModel.IsFetchingRepos, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" SelectionMode="Multiple" Height="300" HorizontalAlignment="Stretch" SelectionChanged="RepositoriesListView_SelectionChanged" ItemsSource="{x:Bind AddRepoViewModel.RepositoriesToDisplay, Mode=OneWay}">
+                <ListView x:Name="RepositoriesListView"
+                          Visibility="{x:Bind AddRepoViewModel.IsFetchingRepos, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
+                          SelectionMode="Multiple"
+                          Height="300"
+                          HorizontalAlignment="Stretch"
+                          SelectionChanged="RepositoriesListView_SelectionChanged"
+                          ItemsSource="{x:Bind AddRepoViewModel.RepositoriesToDisplay, Mode=OneWay}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:RepoViewListItem">
                             <Grid ColumnSpacing="7" AutomationProperties.Name="{x:Bind RepoDisplayName}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -282,12 +282,18 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <CheckBox
-                        Click="MakeNewDevDriveCheckBox_Click" 
                         IsEnabled="{x:Bind AddRepoViewModel.EditDevDriveViewModel.IsDevDriveCheckboxEnabled}" 
                         IsChecked="{x:Bind AddRepoViewModel.EditDevDriveViewModel.IsDevDriveCheckboxChecked, Mode=TwoWay}" 
                         Grid.Column="0" 
                         Grid.Row="0"
-                        x:Uid="NewDevDriveComboBox"/>
+                        x:Uid="NewDevDriveComboBox"
+                        x:Name="NewDevDriveComboBox">
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="Click">
+                            <ic:InvokeCommandAction Command="{x:Bind AddRepoViewModel.MakeNewDevDriveCommand}" CommandParameter="{x:Bind NewDevDriveComboBox.IsChecked, Mode=OneWay}"/>
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                </CheckBox>
                 <HyperlinkButton 
                         x:Uid="CustomizeHyperLink"
                         Grid.Column="1" 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -44,9 +44,9 @@ public partial class AddRepoDialog : ContentDialog
     public SetupFlowOrchestrator Orchestrator { get; set; }
 
     /// <summary>
-    /// Hold the clone location in case the user decides not to add a dev drive.
+    /// Gets or sets the clone location in case the user decides not to add a dev drive.
     /// </summary>
-    private string _oldCloneLocation;
+    public string OldCloneLocation { get; set; }
 
     public AddRepoDialog(
         SetupFlowOrchestrator setupFlowOrchestrator,
@@ -223,30 +223,6 @@ public partial class AddRepoDialog : ContentDialog
     }
 
     /// <summary>
-    /// Adds or removes the default dev drive.  This dev drive will be made at the loading screen.
-    /// </summary>
-    private void MakeNewDevDriveCheckBox_Click(object sender, RoutedEventArgs e)
-    {
-        // Getting here means
-        // 1. The user does not have any existing dev drives
-        // 2. The user wants to clone to a new dev drive.
-        // 3. The user un-checked this and does not want a new dev drive.
-        var isChecked = (sender as CheckBox).IsChecked;
-        if (isChecked.Value)
-        {
-            UpdateDevDriveInfo();
-        }
-        else
-        {
-            AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias = string.Empty;
-            AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario = false;
-            AddRepoViewModel.EditDevDriveViewModel.RemoveNewDevDrive();
-            AddRepoViewModel.FolderPickerViewModel.EnableBrowseButton();
-            AddRepoViewModel.FolderPickerViewModel.CloneLocation = _oldCloneLocation;
-        }
-    }
-
-    /// <summary>
     /// Putting the event in the view so SelectRange can be called.
     /// SelectRange needs a reference to the ListView.
     /// </summary>
@@ -260,20 +236,6 @@ public partial class AddRepoDialog : ContentDialog
             AddRepoViewModel.FilterRepositories(FilterTextBox.Text);
             SelectRepositories(AddRepoViewModel.EverythingToClone);
         }
-    }
-
-    /// <summary>
-    /// Update dialog to show Dev Drive information.
-    /// </summary>
-    public void UpdateDevDriveInfo()
-    {
-        AddRepoViewModel.EditDevDriveViewModel.MakeDefaultDevDrive();
-        AddRepoViewModel.FolderPickerViewModel.DisableBrowseButton();
-        _oldCloneLocation = AddRepoViewModel.FolderPickerViewModel.CloneLocation;
-        AddRepoViewModel.FolderPickerViewModel.CloneLocation = AddRepoViewModel.EditDevDriveViewModel.GetDriveDisplayName();
-        AddRepoViewModel.FolderPickerViewModel.CloneLocationAlias = AddRepoViewModel.EditDevDriveViewModel.GetDriveDisplayName(DevDriveDisplayNameKind.FormattedDriveLabelKind);
-        AddRepoViewModel.FolderPickerViewModel.InDevDriveScenario = true;
-        AddRepoViewModel.EditDevDriveViewModel.IsDevDriveCheckboxChecked = true;
     }
 
     private void FilterSuggestions(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -22,7 +22,8 @@
             <Style x:Key="ListViewItemStretchStyle" TargetType="ListViewItem">
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                 <Setter Property="Margin" Value="0, 0, 0, 4" />
-                <Setter Property="Padding" Value="0" />
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="IsTabStop" Value="False"/>
             </Style>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
@@ -104,7 +105,7 @@
                                                IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
                                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                                AutomationProperties.AccessibilityView="Control"
-                                               ActionIcon="{x:Null}" >
+                                               ActionIcon="{x:Null}">
                                 <ctControls:SettingsCard.HeaderIcon>
                                     <ImageIcon
                                         Opacity="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
@@ -189,9 +190,9 @@
 
                     <StackPanel Spacing="{StaticResource SettingsCardSpacing}" AutomationProperties.Name="{x:Bind ViewModel.MainPageQuickStepsGroupName}">
                         <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_QuickConfiguration" />
-
-                        <!-- settings card for creating an environment -->
-                        <ctControls:SettingsCard 
+                        <ListView ItemContainerStyle="{ThemeResource ListViewItemStretchStyle}" SelectionMode="Single">
+                            <!-- settings card for creating an environment -->
+                            <ctControls:SettingsCard 
                            x:Uid="MainPageCreateEnvironment"
                            AutomationProperties.AutomationId="CreateEnvironment"
                            IsClickEnabled="True"
@@ -200,13 +201,13 @@
                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                            AutomationProperties.AccessibilityView="Control"
                            ActionIcon="{x:Null}" >
-                            <ctControls:SettingsCard.HeaderIcon>
-                                <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/CreateVirtualEnvironment.png" />
-                            </ctControls:SettingsCard.HeaderIcon>
-                        </ctControls:SettingsCard>
+                                <ctControls:SettingsCard.HeaderIcon>
+                                    <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/CreateVirtualEnvironment.png" />
+                                </ctControls:SettingsCard.HeaderIcon>
+                            </ctControls:SettingsCard>
 
-                        <!-- settings card for cloning repositories -->
-                        <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
+                            <!-- settings card for cloning repositories -->
+                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
                                            AutomationProperties.AutomationId="CloneRepoButton"
                                            IsClickEnabled="True"
                                            Command="{x:Bind ViewModel.StartRepoConfigCommand}"
@@ -214,13 +215,13 @@
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                            AutomationProperties.AccessibilityView="Control"
                                            ActionIcon="{x:Null}" >
-                            <ctControls:SettingsCard.HeaderIcon>
-                                <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
-                            </ctControls:SettingsCard.HeaderIcon>
-                        </ctControls:SettingsCard>
-                        <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
-                        <Grid Background="Transparent">
-                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
+                                <ctControls:SettingsCard.HeaderIcon>
+                                    <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
+                                </ctControls:SettingsCard.HeaderIcon>
+                            </ctControls:SettingsCard>
+                            <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
+                            <Grid Background="Transparent">
+                                <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
                                                IsClickEnabled="True"
                                                AutomationProperties.AutomationId="InstallAppsButton"
                                                Command="{x:Bind ViewModel.StartAppManagementCommand}"
@@ -229,34 +230,35 @@
                                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                                AutomationProperties.AccessibilityView="Control"
                                                ActionIcon="{x:Null}" >
-                                <ctControls:SettingsCard.HeaderIcon>
-                                    <ImageIcon
+                                    <ctControls:SettingsCard.HeaderIcon>
+                                        <ImageIcon
                                         Opacity="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
                                         Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_AppManagement.png" />
-                                </ctControls:SettingsCard.HeaderIcon>
-                            </ctControls:SettingsCard>
+                                    </ctControls:SettingsCard.HeaderIcon>
+                                </ctControls:SettingsCard>
 
-                            <!-- Tooltip visible when the settings card is disabled -->
-                            <ToolTipService.ToolTip>
-                                <ToolTip
+                                <!-- Tooltip visible when the settings card is disabled -->
+                                <ToolTipService.ToolTip>
+                                    <ToolTip
                                     x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_MainPage_AppInstallerRequiredTooltip"
                                     IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem,Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
-                            </ToolTipService.ToolTip>
-                        </Grid>
-                        <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
+                                </ToolTipService.ToolTip>
+                            </Grid>
+                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
                                            AutomationProperties.AutomationId="DevDriveButton"
                                            IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
                                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
                                            AutomationProperties.AccessibilityView="Control"
                                            Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
-                            <ctControls:SettingsCard.ActionIcon>
-                                <!-- The open new window icon -->
-                                <FontIcon Glyph="&#xE8A7;" />
-                            </ctControls:SettingsCard.ActionIcon>
-                            <ctControls:SettingsCard.HeaderIcon>
-                                <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_DevDrive.png" />
-                            </ctControls:SettingsCard.HeaderIcon>
-                        </ctControls:SettingsCard>
+                                <ctControls:SettingsCard.ActionIcon>
+                                    <!-- The open new window icon -->
+                                    <FontIcon Glyph="&#xE8A7;" />
+                                </ctControls:SettingsCard.ActionIcon>
+                                <ctControls:SettingsCard.HeaderIcon>
+                                    <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_DevDrive.png" />
+                                </ctControls:SettingsCard.HeaderIcon>
+                            </ctControls:SettingsCard>
+                        </ListView>
                     </StackPanel>
                 </StackPanel>
             </Grid>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -23,6 +23,10 @@
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                 <Setter Property="Margin" Value="0, 0, 0, 4" />
                 <Setter Property="Padding" Value="0"/>
+                
+                <!-- Include a false tabstop because the buttons on each menu item is a tab stop.
+                This creates an odd behavior because each item can be tabbed into.
+                Remove the tab stop from the list item.-->
                 <Setter Property="IsTabStop" Value="False"/>
             </Style>
             <ResourceDictionary.MergedDictionaries>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -101,15 +101,16 @@
                         <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
                         <ListView ItemContainerStyle="{ThemeResource ListViewItemStretchStyle}" SelectionMode="Single">
                             <Grid Background="Transparent">
-                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
-                                               AutomationProperties.AutomationId="EndToEndSetupButton"
-                                               IsClickEnabled="True"
-                                               Command="{x:Bind ViewModel.StartSetupCommand}"
-                                               CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
-                                               IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
-                                               ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                               AutomationProperties.AccessibilityView="Control"
-                                               ActionIcon="{x:Null}">
+                            <ctControls:SettingsCard
+                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
+                                AutomationProperties.AutomationId="EndToEndSetupButton"
+                                IsClickEnabled="True"
+                                Command="{x:Bind ViewModel.StartSetupCommand}"
+                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                                IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
+                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                AutomationProperties.AccessibilityView="Control"
+                                ActionIcon="{x:Null}">
                                 <ctControls:SettingsCard.HeaderIcon>
                                     <ImageIcon
                                         Opacity="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
@@ -150,15 +151,16 @@
                                 <ToolTip x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_MainPage_AppInstallerRequiredTooltip" IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
                             </ToolTipService.ToolTip>
                         </Grid>
-                        <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_ConfigurationFile"
-                                           AutomationProperties.AutomationId="DSCConfigurationButton"
-                                           IsClickEnabled="True"
-                                           Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
-                                           CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
-                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Control"
-                                           IsEnabled="{x:Bind ViewModel.EnableConfigurationFileItem, Mode=OneWay}"
-                                           ActionIcon="{x:Null}" >
+                        <ctControls:SettingsCard
+                            x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_ConfigurationFile"
+                            AutomationProperties.AutomationId="DSCConfigurationButton"
+                            IsClickEnabled="True"
+                            Command="{x:Bind ViewModel.StartConfigurationFileCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                            AutomationProperties.AccessibilityView="Control"
+                            IsEnabled="{x:Bind ViewModel.EnableConfigurationFileItem, Mode=OneWay}"
+                            ActionIcon="{x:Null}" >
                             <ctControls:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_ConfigurationFile.png" />
                             </ctControls:SettingsCard.HeaderIcon>
@@ -173,15 +175,16 @@
                         </ctControls:SettingsCard>
                         
                         <!-- Settings for Quickstart Playground-->
-                        <ctControls:SettingsCard x:Uid="MainPage_QuickstartPlayground"
-                                           AutomationProperties.AutomationId="QuickstartPlayground"
-                                           IsClickEnabled="True"
-                                           Command="{x:Bind ViewModel.StartQuickstartCommand}"
-                                           CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
-                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Control"
-                                           ActionIcon="{x:Null}" 
-                                           Visibility="{x:Bind ViewModel.EnableQuickstartPlayground}" >
+                        <ctControls:SettingsCard
+                            x:Uid="MainPage_QuickstartPlayground"
+                            AutomationProperties.AutomationId="QuickstartPlayground"
+                            IsClickEnabled="True"
+                            Command="{x:Bind ViewModel.StartQuickstartCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                            ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                            AutomationProperties.AccessibilityView="Control"
+                            ActionIcon="{x:Null}" 
+                            Visibility="{x:Bind ViewModel.EnableQuickstartPlayground}" >
                             <ctControls:SettingsCard.HeaderIcon>
                                 <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_QuickstartPlayground.png" />
                             </ctControls:SettingsCard.HeaderIcon>
@@ -197,43 +200,45 @@
                         <ListView ItemContainerStyle="{ThemeResource ListViewItemStretchStyle}" SelectionMode="Single">
                             <!-- settings card for creating an environment -->
                             <ctControls:SettingsCard 
-                           x:Uid="MainPageCreateEnvironment"
-                           AutomationProperties.AutomationId="CreateEnvironment"
-                           IsClickEnabled="True"
-                           Command="{x:Bind ViewModel.StartCreateEnvironmentCommand}"
-                           CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
-                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                           AutomationProperties.AccessibilityView="Control"
-                           ActionIcon="{x:Null}" >
+                                x:Uid="MainPageCreateEnvironment"
+                                AutomationProperties.AutomationId="CreateEnvironment"
+                                IsClickEnabled="True"
+                                Command="{x:Bind ViewModel.StartCreateEnvironmentCommand}"
+                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                AutomationProperties.AccessibilityView="Control"
+                                ActionIcon="{x:Null}" >
                                 <ctControls:SettingsCard.HeaderIcon>
                                     <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/CreateVirtualEnvironment.png" />
                                 </ctControls:SettingsCard.HeaderIcon>
                             </ctControls:SettingsCard>
 
                             <!-- settings card for cloning repositories -->
-                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
-                                           AutomationProperties.AutomationId="CloneRepoButton"
-                                           IsClickEnabled="True"
-                                           Command="{x:Bind ViewModel.StartRepoConfigCommand}"
-                                           CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
-                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Control"
-                                           ActionIcon="{x:Null}" >
+                            <ctControls:SettingsCard
+                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_CloneRepos"
+                                AutomationProperties.AutomationId="CloneRepoButton"
+                                IsClickEnabled="True"
+                                Command="{x:Bind ViewModel.StartRepoConfigCommand}"
+                                CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                AutomationProperties.AccessibilityView="Control"
+                                ActionIcon="{x:Null}" >
                                 <ctControls:SettingsCard.HeaderIcon>
                                     <ImageIcon Source="ms-appx:///DevHome.SetupFlow/Assets/Setup_RepoConfig.png" />
                                 </ctControls:SettingsCard.HeaderIcon>
                             </ctControls:SettingsCard>
                             <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
                             <Grid Background="Transparent">
-                                <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
-                                               IsClickEnabled="True"
-                                               AutomationProperties.AutomationId="InstallAppsButton"
-                                               Command="{x:Bind ViewModel.StartAppManagementCommand}"
-                                               CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
-                                               IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
-                                               ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                               AutomationProperties.AccessibilityView="Control"
-                                               ActionIcon="{x:Null}" >
+                                <ctControls:SettingsCard
+                                    x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_InstallApps"
+                                    IsClickEnabled="True"
+                                    AutomationProperties.AutomationId="InstallAppsButton"
+                                    Command="{x:Bind ViewModel.StartAppManagementCommand}"
+                                    CommandParameter="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Header}"
+                                    IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay}"
+                                    ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                    AutomationProperties.AccessibilityView="Control"
+                                    ActionIcon="{x:Null}" >
                                     <ctControls:SettingsCard.HeaderIcon>
                                         <ImageIcon
                                         Opacity="{x:Bind ViewModel.EnablePackageInstallerItem, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
@@ -248,12 +253,13 @@
                                     IsEnabled="{x:Bind ViewModel.EnablePackageInstallerItem,Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" />
                                 </ToolTipService.ToolTip>
                             </Grid>
-                            <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
-                                           AutomationProperties.AutomationId="DevDriveButton"
-                                           IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
-                                           ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
-                                           AutomationProperties.AccessibilityView="Control"
-                                           Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
+                            <ctControls:SettingsCard
+                                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_DevDrive"
+                                AutomationProperties.AutomationId="DevDriveButton"
+                                IsClickEnabled="True" Command="{x:Bind ViewModel.LaunchDisksAndVolumesSettingsPageCommand}" 
+                                ActionIconToolTip="{Binding Header, RelativeSource={RelativeSource Mode=Self}}"
+                                AutomationProperties.AccessibilityView="Control"
+                                Visibility="{x:Bind ViewModel.ShowDevDriveItem, Mode=OneWay}" >
                                 <ctControls:SettingsCard.ActionIcon>
                                     <!-- The open new window icon -->
                                     <FontIcon Glyph="&#xE8A7;" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -19,7 +19,11 @@
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
             <converters:BoolToObjectConverter x:Key="BoolToOpacityConverter" TrueValue="1" FalseValue="0.4" />
             <x:Double x:Key="SettingsCardHeaderIconMaxSize">32</x:Double>
-
+            <Style x:Key="ListViewItemStretchStyle" TargetType="ListViewItem">
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="Margin" Value="0, 0, 0, 4" />
+                <Setter Property="Padding" Value="0" />
+            </Style>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
@@ -87,10 +91,11 @@
                         BackgroundSource="{ThemeResource Setup_Banner_Back}"
                         OverlaySource="{ThemeResource Setup_Banner_Front}" />
 
-                    <StackPanel Spacing="{StaticResource SettingsCardSpacing}" AutomationProperties.Name="{x:Bind ViewModel.MainPageEnvironmentSetupGroupName}">
+                    <StackPanel AutomationProperties.Name="{x:Bind ViewModel.MainPageEnvironmentSetupGroupName}">
                         <TextBlock x:Name="SetupEnvironmentHeader"  Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_EnvironmentSetup"/>
                         <!-- Transparent Grid wrapper for displaying tooltip on disabled settings card -->
-                        <Grid Background="Transparent">
+                        <ListView ItemContainerStyle="{ThemeResource ListViewItemStretchStyle}" SelectionMode="Single">
+                            <Grid Background="Transparent">
                             <ctControls:SettingsCard x:Uid="ms-resource:///DevHome.SetupFlow/Resources/MainPage_SetupFlow"
                                                AutomationProperties.AutomationId="EndToEndSetupButton"
                                                IsClickEnabled="True"
@@ -179,6 +184,7 @@
                                 <TextBlock x:Uid="MainPage_QuickstartPlayground_Description"/>
                             </ctControls:SettingsCard.Description>
                         </ctControls:SettingsCard>
+                        </ListView>
                     </StackPanel>
 
                     <StackPanel Spacing="{StaticResource SettingsCardSpacing}" AutomationProperties.Name="{x:Bind ViewModel.MainPageQuickStepsGroupName}">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml
@@ -94,7 +94,7 @@
                 </ListView.Header>
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="models:CloningInformation">
-                        <Grid>
+                        <Grid AutomationProperties.Name="{x:Bind RepoConfigAutomationName}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/RepoConfigView.xaml.cs
@@ -72,7 +72,7 @@ public sealed partial class RepoConfigView : UserControl
 
         if (_addRepoDialog.AddRepoViewModel.EditDevDriveViewModel.CanShowDevDriveUI && ViewModel.ShouldAutoCheckDevDriveCheckbox)
         {
-            _addRepoDialog.UpdateDevDriveInfo();
+            _addRepoDialog.AddRepoViewModel.UpdateDevDriveInfo();
         }
 
         _addRepoDialog.IsSecondaryButtonEnabled = true;


### PR DESCRIPTION
## Summary of the pull request
The buttons in the Machine Configuration main page could be navigated only via tabs.  Not the arrow keys.
I put the items in a ListView.  Now all items in the group can be navigated with the arrow keys.

The repo names in the RepoConfig page had the incorrect automation names.  Fixed that.

Moved some DevDrive code over to the view model.

## References and relevant issues

https://task.ms/50553376
https://task.ms/49676606

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually ran and tested.

For the narrator, I added repos and listened to the narrator when they were on the repo config screen.

For Dev Drive
1. Cloned repos onto a new dev drive.
2. Toggled the checkbox on both the Add Repo dialog and the Edit clone path dialog.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
