### PR TITLE
Updated AppDetails to get process CPU architecture on ARM as well as x64

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.Win32.SafeHandles;
 using Serilog;
 using Windows.Devices.Display;
 using Windows.Devices.Enumeration;
@@ -23,6 +24,8 @@ using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
 using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.System.SystemInformation;
+using Windows.Win32.System.Threading;
 using Windows.Win32.UI.Accessibility;
 using Windows.Win32.UI.WindowsAndMessaging;
 
@@ -230,20 +233,13 @@ public class WindowHelper
         return rectangle;
     }
 
-    public static Windows.Graphics.RectInt32 GetRect(Rect bounds, double scale)
+    public static RectInt32 GetRect(Rect bounds, double scale)
     {
-        return new Windows.Graphics.RectInt32(
+        return new RectInt32(
             _X: (int)Math.Round(bounds.X * scale),
             _Y: (int)Math.Round(bounds.Y * scale),
             _Width: (int)Math.Round(bounds.Width * scale),
             _Height: (int)Math.Round(bounds.Height * scale));
-    }
-
-    public enum BinaryType : int
-    {
-        Unknown = -1,
-        X32 = 0,
-        X64 = 6,
     }
 
     internal static unsafe string GetWindowTitle(HWND hWnd)
@@ -631,5 +627,84 @@ public class WindowHelper
         {
             _log.Error(ex, "Error showing timed message dialog");
         }
+    }
+
+    internal enum CpuArchitecture
+    {
+        X86,
+        X64,
+        ARM,
+        ARM64,
+        Unknown,
+    }
+
+    internal static CpuArchitecture GetTargetArchitecture(IMAGE_FILE_MACHINE target)
+    {
+        return target switch
+        {
+            IMAGE_FILE_MACHINE.IMAGE_FILE_MACHINE_I386 => CpuArchitecture.X86,
+            IMAGE_FILE_MACHINE.IMAGE_FILE_MACHINE_AMD64 => CpuArchitecture.X64,
+            IMAGE_FILE_MACHINE.IMAGE_FILE_MACHINE_ARM => CpuArchitecture.ARM,
+            IMAGE_FILE_MACHINE.IMAGE_FILE_MACHINE_ARM64 => CpuArchitecture.ARM64,
+            _ => CpuArchitecture.Unknown,
+        };
+    }
+
+    internal static string GetAppArchitecture(SafeProcessHandle handle, string moduleName)
+    {
+        var cpuArchitecture = CommonHelper.GetLocalizedString("CpuArchitecture_Unknown");
+        unsafe
+        {
+            IMAGE_FILE_MACHINE processInfo;
+            IMAGE_FILE_MACHINE machineInfo;
+            var isWow64Result = PInvoke.IsWow64Process2(handle, out processInfo, &machineInfo);
+            if (isWow64Result)
+            {
+                var processArchitecture = GetTargetArchitecture(processInfo);
+                var machineArchitecture = GetTargetArchitecture(machineInfo);
+
+                // "Unknown" means this is not a WOW64 process.
+                if (processArchitecture == CpuArchitecture.Unknown)
+                {
+                    if (machineArchitecture == CpuArchitecture.X64)
+                    {
+                        // If this is an x64 machine and it's not a WOW64 process, it's an x64 process.
+                        cpuArchitecture = CommonHelper.GetLocalizedString("CpuArchitecture_X64onX64");
+                    }
+                    else
+                    {
+                        // If this is not an x64 machine, we need to get the process architecture from the process itself.
+                        var processMachineInfo = default(PROCESS_MACHINE_INFORMATION);
+                        var getProcInfoResult
+                            = PInvoke.GetProcessInformation(
+                            handle,
+                            PROCESS_INFORMATION_CLASS.ProcessMachineTypeInfo,
+                            &processMachineInfo,
+                            (uint)Marshal.SizeOf<PROCESS_MACHINE_INFORMATION>());
+                        if (getProcInfoResult)
+                        {
+                            // Report the process architecture and the machine architecture.
+                            processArchitecture = GetTargetArchitecture(processMachineInfo.ProcessMachine);
+                            cpuArchitecture = CommonHelper.GetLocalizedString(
+                                "CpuArchitecture_ProcessOnMachine", processArchitecture, machineArchitecture);
+                        }
+                        else
+                        {
+                            // If we can't get the process architecture, just report the machine architecture.
+                            cpuArchitecture = CommonHelper.GetLocalizedString(
+                                "CpuArchitecture_UnknownOnMachine", machineArchitecture);
+                        }
+                    }
+                }
+                else
+                {
+                    // This is a WOW64 process, so report the process architecture and the machine architecture.
+                    cpuArchitecture = CommonHelper.GetLocalizedString(
+                        "CpuArchitecture_ProcessOnMachine", processArchitecture, machineArchitecture);
+                }
+            }
+        }
+
+        return cpuArchitecture;
     }
 }

--- a/tools/PI/DevHome.PI/Models/AppRuntimeInfo.cs
+++ b/tools/PI/DevHome.PI/Models/AppRuntimeInfo.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
-using DevHome.PI.Helpers;
 using Microsoft.UI.Xaml;
 
 namespace DevHome.PI.Models;
@@ -24,7 +23,7 @@ public partial class AppRuntimeInfo : ObservableObject
     private string mainModuleFileName = string.Empty;
 
     [ObservableProperty]
-    private WindowHelper.BinaryType binaryType = WindowHelper.BinaryType.Unknown;
+    private string cpuArchitecture = string.Empty;
 
     [ObservableProperty]
     private bool isPackaged = false;

--- a/tools/PI/DevHome.PI/NativeMethods.txt
+++ b/tools/PI/DevHome.PI/NativeMethods.txt
@@ -23,6 +23,7 @@ GetForegroundWindow
 GetMonitorInfo
 GetMonitorInfo
 GetOpenFileName
+GetProcessInformation
 GetTopWindow
 GetWindowInfo
 GetWindowLong
@@ -40,6 +41,7 @@ IsIconic
 IsImmersiveProcess
 IsWindow
 IsWindowVisible
+IsWow64Process2
 IsZoomed
 LoadIcon
 LoadImage
@@ -85,6 +87,8 @@ INVALID_HANDLE_VALUE
 LR_*
 MOD_*
 // MONITOR_DEFAULTTONEAREST
+PROCESS_INFORMATION_CLASS
+PROCESS_MACHINE_INFORMATION
 SECTION_FLAGS
 SW_*
 VIRTUAL_KEY

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -65,8 +65,8 @@
                     <TextBox Grid.Row="1" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.PriorityClass, Mode=OneWay}" IsReadOnly="True" />
                     <TextBlock Grid.Row="2" x:Uid="MainModuleTextBlock" />
                     <TextBox Grid.Row="2" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.MainModuleFileName, Mode=OneWay}" IsReadOnly="True" TextWrapping="Wrap" />
-                    <TextBlock Grid.Row="3" x:Uid="BinaryTypeTextBlock" />
-                    <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.BinaryType, Mode=OneWay}" IsReadOnly="True" />
+                    <TextBlock Grid.Row="3" x:Uid="CpuArchitectureTextBlock" />
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.CpuArchitecture, Mode=OneWay}" IsReadOnly="True" />
                     <TextBlock Grid.Row="4" x:Uid="MSIXPackagedTextBlock" />
                     <TextBox Grid.Row="4" Grid.Column="1" Text="{x:Bind ViewModel.AppInfo.IsPackaged, Mode=OneWay}" IsReadOnly="True" />
                     <TextBlock Grid.Row="5" x:Uid="MicrosoftStoreAppTextBlock" />

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -915,7 +915,7 @@
   </data>
   <data name="CpuArchitecture_ProcessOnMachine" xml:space="preserve">
     <value>{0} process running on {1} machine</value>
-    <comment>Locked={"{0}"}. Locked={"{1}"} Message text when the process is the specified CPU architecture running on the specified CPU machine. {0} is the process architecture, {1} is the machine architecture.</comment>
+    <comment>Locked={"{0}", "{1}"} Message text when the process is the specified CPU architecture running on the specified CPU machine. {0} is the process architecture, {1} is the machine architecture.</comment>
   </data>
   <data name="CpuArchitecture_Unknown" xml:space="preserve">
     <value>Unknown</value>

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -193,9 +193,9 @@
     <value>Main module</value>
     <comment>This refers to the main module of an application like winword.exe or notepad.exe as an example.</comment>
   </data>
-  <data name="BinaryTypeTextBlock.Text" xml:space="preserve">
-    <value>Binary type</value>
-    <comment>This refers to the type of application binary, console/windows etc.</comment>
+  <data name="CpuArchitectureTextBlock.Text" xml:space="preserve">
+    <value>CPU architecture</value>
+    <comment>This refers to the CPU architecture of the target process and the host machine.</comment>
   </data>
   <data name="MSIXPackagedTextBlock.Text" xml:space="preserve">
     <value>MSIX packaged</value>
@@ -845,9 +845,9 @@
     <value>The starting priority for threads created within this process</value>
     <comment>Tooltip for the Base Priority field.</comment>
   </data>
-  <data name="BinaryTypeTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="CpuArchitectureTextBlock.ToolTipService.ToolTip" xml:space="preserve">
     <value>The CPU architecture of the target process</value>
-    <comment>Tooltip for the Binary Type field.</comment>
+    <comment>Tooltip for the CPU Architecture field.</comment>
   </data>
   <data name="FrameworkTypesTextBlock.ToolTipService.ToolTip" xml:space="preserve">
     <value>The windowing or application frameworks used in this app</value>
@@ -912,5 +912,21 @@
   <data name="VerticalCloseButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Close</value>
     <comment>Describes a button that will close PI's window</comment>
+  </data>
+  <data name="CpuArchitecture_ProcessOnMachine" xml:space="preserve">
+    <value>{0} process running on {1} machine</value>
+    <comment>Locked={"{0}"}. Locked={"{1}"} Message text when the process is the specified CPU architecture running on the specified CPU machine. {0} is the process architecture, {1} is the machine architecture.</comment>
+  </data>
+  <data name="CpuArchitecture_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+    <comment>Message text when the CPU architecture of the process is unknown.</comment>
+  </data>
+  <data name="CpuArchitecture_UnknownOnMachine" xml:space="preserve">
+    <value>Unknown process type running on {0}</value>
+    <comment>Locked={"{0}"}. Message text when the process is unknown CPU architecture running on the specified CPU machine. {0} is the machine architecture.</comment>
+  </data>
+  <data name="CpuArchitecture_X64onX64" xml:space="preserve">
+    <value>X64 process running on X64 machine</value>
+    <comment>Message text when the process is x64 CPU architecture running on an X64 CPU machine.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Prior to this, we were using GetBinaryType to get the CPU architecture of the target process, but this only differentiates x86/x64 (and legacy types), but doesn't allow for ARM. Replaced this with calls to IsWow64Process2 and GetProcessInformation. Tested on x64 and ARM64 devices.

## References and relevant issues
Fixed the following:
- Closes #3029

