### PR TITLE
Add Dev Home log collecting powershell script

### DIFF
--- a/DevHome.sln
+++ b/DevHome.sln
@@ -150,6 +150,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WindowsSandboxExtension", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsSandboxExtension", "extensions\WindowsSandboxExtension\WindowsSandboxExtension.csproj", "{118E20E8-FD8A-40CF-83A5-F912B9187787}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{E768781A-D1F7-4C03-B46D-E76354FAB587}"
+	ProjectSection(SolutionItems) = preProject
+		tools\scripts\CaptureDevHomeLogs.ps1 = tools\scripts\CaptureDevHomeLogs.ps1
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|arm64 = Debug|arm64
@@ -788,6 +793,7 @@ Global
 		{5F9749BC-F34E-4F45-933F-61E0F3ED521F} = {FAB6FAA7-ADF4-4B65-9831-0C819915E6E1}
 		{4ACF917D-B2CC-4CF2-8EE1-0EBBB52A69F0} = {DCAF188B-60C3-4EDB-8049-BAA927FBCD7D}
 		{118E20E8-FD8A-40CF-83A5-F912B9187787} = {4ACF917D-B2CC-4CF2-8EE1-0EBBB52A69F0}
+		{E768781A-D1F7-4C03-B46D-E76354FAB587} = {A972EC5B-FC61-4964-A6FF-F9633EB75DFD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {030B5641-B206-46BB-BF71-36FF009088FA}

--- a/tools/scripts/CaptureDevHomeLogs.ps1
+++ b/tools/scripts/CaptureDevHomeLogs.ps1
@@ -1,0 +1,57 @@
+# Script to capture log files and create a zip file for upload to GitHub or log analysis.
+
+param(
+    [switch]$StopDevHome = $false
+)
+
+# List of supported package names for this tool. If a new Dev Home package is added
+# with the same log format, add it to this list.
+$devHomePackageNames = @(
+    'Microsoft.Windows.DevHome_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHomeAzureExtension_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHomeAzureExtension.Canary_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHomeAzureExtension.Dev_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHomeGitHubExtension_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHomeGitHubExtension.Canary_8wekyb3d8bbwe'
+    'Microsoft.Windows.DevHomeGitHubExtension.Dev_8wekyb3d8bbwe'
+)
+
+# Terminate Dev Home processes if user passed StopDevHome flag.
+if ($StopDevHome)
+{
+    Write-Host "Stopping all Dev Home processes"
+    Get-Process *DevHome* -ErrorAction Continue | Stop-Process
+}
+
+$LogFolderName = $(Get-Date -Format yyyy-MM-dd-HHmmss_) + "DevHomeLogs"
+$TempRoot = [System.IO.Path]::GetTempPath()
+$TempFolder = Join-Path -Path $TempRoot -ChildPath $LogFolderName
+New-Item -ItemType Directory -Force -Path $TempFolder | Out-Null
+
+# Only collect logs from known Dev Home packages
+# Preserve folder structure to ensure no collisions in the archive.
+$AppDataPackagesPath = Join-Path -Path $env:LOCALAPPDATA -ChildPath Packages
+ForEach ($packageName in $devHomePackageNames)
+{
+    $packageFolderPath = Join-Path -Path $AppDataPackagesPath -ChildPath $packageName
+    if (!(Test-Path $packageFolderPath))
+    {
+        Continue
+    }
+ 
+    $targetRoot = Join-Path -Path $TempFolder -ChildPath $packageName
+    & robocopy /s $packageFolderPath $targetRoot *.dhlog | Out-Null
+}
+
+# Archive the folder and then remove the temp folder.
+$ArchiveFileName = $LogFolderName + ".zip"
+$ArchiveFilePath = Join-Path -Path $TempRoot -ChildPath $ArchiveFileName
+$ArchiveSourcePath = Join-Path -Path $TempFolder -ChildPath "\*"
+Compress-Archive -Path $ArchiveSourcePath -DestinationPath $ArchiveFilePath
+Remove-Item $TempFolder -Recurse
+
+Set-Clipboard -Value $ArchiveFilePath
+Write-Host "Logs are archived in the following location, which was copied to your clipboard:"
+Write-Host $ArchiveFilePath


### PR DESCRIPTION
## Summary of the pull request
Adds a refined log gathering script from the feedback and discussion of PR #2953 .  The changes to the script were quite extensive and so it was cleaner to create a new PR.

This script collects all .dhlogs from across the different Microsoft-published DevHome packages and extensions.

## References and relevant issues

## Detailed description of the pull request / Additional comments
Script was added to tools/scripts folder, and also updated in the Dev Home solution so it can be easily found and updated from there.

Script features:
* Names by timestamp to the second, which is not perfectly unique but should be good enough for any reasonable use and is very human readable.
* Has a "-StopDevHome" parameter to terminate any Dev Home processes running, which can hold the lock on files. Since this is destructive it is not the default.
* Archive is created in the user's temp folder.
* Preserves folder structure of the logs within their respective packages to avoid collisions between different packages with similar log naming.
* Only gets .dhlog files from the specified set of package names, which includes DevHome, GitHub extension, and Azure extension, and their Canary and Dev versions.
* Copies the resulting archive path to the clipboard for easy pasting and prints it to the screen.
 
## Validation steps performed
* Tested gathering logs from across multiple packages.
* Verified each of the above features.
* Confirmed resulting archive can be readily opened in Explorer or by an archive-reading tooling.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
