### PR TITLE
Fix PID formatting for the expanded view statusbar

### DIFF
--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -538,8 +538,8 @@
     <comment>Description of the error code</comment>
   </data>
   <data name="TargetAppPidTextFormat" xml:space="preserve">
-    <value>pid: {0:0.0}</value>
-    <comment>Locked={"{0:0.0}"} Showing a process identifier. {0} is a percentage 0-100</comment>
+    <value>pid: {0}</value>
+    <comment>Locked={"{0}"} Showing a process identifier. {0} is an integer</comment>
   </data>
   <data name="CpuPerfTextFormat" xml:space="preserve">
     <value>cpu: {0:0.0}%</value>


### PR DESCRIPTION
## Summary of the pull request

The PID in the expanded view was being formatted as having a decimal place. Looked like a copy/paste error.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3026 
- [ ] Tests added/passed
- [ ] Documentation updated
