### PR TITLE
Updated style for the ExternalToolsManagementButton button

### DIFF
--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
@@ -54,6 +54,10 @@
                     <Setter Property="BorderThickness" Value="0"/>
                     <Setter Property="Background" Value="Transparent"/>
                 </Style>
+                <Style TargetType="controls:ExternalToolsManagementButton">
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
                 <Style TargetType="controls:ProcessSelectionButton">
                     <Setter Property="BorderThickness" Value="0"/>
                     <Setter Property="Background" Value="Transparent"/>

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml
@@ -60,6 +60,10 @@
                     <Setter Property="Background" Value="Transparent"/>
                     <Setter Property="HorizontalAlignment" Value="Center"/>
                 </Style>
+                <Style TargetType="controls:ExternalToolsManagementButton">
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
                 <Style TargetType="controls:ProcessSelectionButton">
                     <Setter Property="BorderThickness" Value="0"/>
                     <Setter Property="Background" Value="Transparent"/>


### PR DESCRIPTION
## Summary of the pull request

I had missed setting the style of the ExternalToolsManagementButton. This now sets it to the same style as the other buttons on the bar.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
