### PR TITLE
Add remaining major UI elements to the bar

### DIFF
--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
@@ -64,10 +64,13 @@
                 <TextBlock Text="&#xecaa;" Margin="0"  />
             </controls:ProcessSelectionButton>
 
+            <controls:PISeperator />
+
             <!-- Per App controls -->
             <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="5" Height="20" Width="20" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
             <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" VerticalAlignment="Center" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
             <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" VerticalAlignment="Center" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
+            <controls:PISeperator  Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
 
             <!-- Per System controls -->
             <Button x:Uid="SwitchLayoutButton" x:Name="SwitchLayoutButton" HorizontalAlignment="Center" Command="{x:Bind _viewModel.SwitchLayoutCommand}">
@@ -85,6 +88,8 @@
                 ExternalToolLaunchRequest="{x:Bind _viewModel.ManageExternalToolsButton_ExternalToolLaunchRequest}">
                 <TextBlock Text="&#xEC7A;"/>
             </controls:ExternalToolsManagementButton>
+
+            <controls:PISeperator />
 
             <ItemsRepeater x:Name="ExternalToolsRepeater" ItemsSource="{x:Bind helpers:ExternalToolsHelper.Instance.FilteredExternalTools, Mode=OneWay}" Layout="{StaticResource ExternalToolsHorizontalLayout}">
                 <DataTemplate x:DataType="helpers:ExternalTool">
@@ -107,9 +112,10 @@
                     </Button>
                 </DataTemplate>
             </ItemsRepeater>
-            </StackPanel>
+            <controls:PISeperator />
+        </StackPanel>
 
-            <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="1">
+        <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="1">
                 <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" Margin="5"/>
                 <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" Margin="5"/>
                 <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" Margin="5"/>

--- a/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/BarWindowHorizontal.xaml
@@ -116,7 +116,7 @@
                     </Button>
                 </DataTemplate>
             </ItemsRepeater>
-            <controls:PISeperator />
+            <controls:PISeperator Visibility="{x:Bind _viewModel.ExternalToolSeperatorVisibility, Mode=OneWay}"/>
         </StackPanel>
 
         <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="1">

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml
@@ -76,7 +76,6 @@
             </controls:ProcessSelectionButton>
 
             <controls:PISeperator Orientation="Horizontal"/>
-            
             <!-- Per App controls -->
             <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="5" Height="20" Width="20" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
             <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" HorizontalAlignment="Center" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
@@ -101,7 +100,6 @@
             </controls:ExternalToolsManagementButton>
 
             <controls:PISeperator Orientation="Horizontal"/>
-            
             <ItemsRepeater x:Name="ExternalToolsRepeater" ItemsSource="{x:Bind helpers:ExternalToolsHelper.Instance.FilteredExternalTools, Mode=OneWay}" Layout="{StaticResource ExternalToolsVerticalLayout}">
                 <DataTemplate x:DataType="helpers:ExternalTool">
                     <Button Click="_viewModel.ExternalToolButton_Click" HorizontalAlignment="Center" ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}" Tag="{x:Bind}">

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml
@@ -10,7 +10,7 @@
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
     Title="" MinHeight="700" MinWidth="70" MaxWidth="70" Width="70" Height="700"
-    TaskBarIcon="Images/pi.ico" IsTitleBarVisible="False"
+    TaskBarIcon="Images/pi.ico"
     IsAlwaysOnTop="{x:Bind _viewModel.IsAlwaysOnTop, Mode=OneWay}"
     Closed="WindowEx_Closed">
     <!-- TODO Make DesktopAcrylicBackdrop/MicaBackdrop and AcrylicBackgroundFillColorBaseBrush user-configurable.-->
@@ -27,25 +27,26 @@
 
         <!-- Chrome buttons for a vertical bar -->
         <StackPanel x:Name="ChromeButtonPanelVertical" Orientation="Vertical" HorizontalAlignment="Center" Margin="0, 10" Grid.Row="0">
-            <TextBlock x:Name="GripTextBlock" Text="&#xe76f;&#xe76f;" FontSize="10" Margin="0" HorizontalAlignment="Center" FontFamily="Segoe Fluent Icons"  PointerPressed="Window_PointerPressed" PointerMoved="Window_PointerMoved" PointerReleased="Window_PointerReleased"/>
-                <Button
-                    x:Uid="SnapButton"
-                    Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"
-                    Margin="0,20, 0, 0"
-                    Style="{StaticResource ChromeButton}"
-                    HorizontalAlignment="Center"
-                    IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}"
-                    Command="{x:Bind _viewModel.ToggleSnapCommand}" >
-                    <TextBlock Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>
-                </Button>
-                <Button
-                    x:Uid="VerticalCloseButton"
-                    Style="{StaticResource ChromeButton}"
-                    Click="CloseButton_Click" 
-                    HorizontalAlignment="Center"
-                    Margin="0,20, 0, 0" >
-                    <TextBlock Text="&#xE8BB;"/>
-                </Button>
+            <Rectangle x:Name="SeparatorRectangleVertical" RadiusX="2" RadiusY="2" Width="32" Height="5" Fill="{ThemeResource AppBarSeparatorForegroundThemeBrush}" Margin="4" PointerPressed="Window_PointerPressed" PointerMoved="Window_PointerMoved" PointerReleased="Window_PointerReleased"/>
+ 
+            <Button
+                x:Uid="SnapButton"
+                Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"
+                Margin="0,20, 0, 0"
+                Style="{StaticResource ChromeButton}"
+                HorizontalAlignment="Center"
+                IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}"
+                Command="{x:Bind _viewModel.ToggleSnapCommand}" >
+                <TextBlock Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>
+            </Button>
+            <Button
+                x:Uid="VerticalCloseButton"
+                Style="{StaticResource ChromeButton}"
+                Click="CloseButton_Click" 
+                HorizontalAlignment="Center"
+                Margin="0,20, 0, 0" >
+                <TextBlock Text="&#xE8BB;"/>
+            </Button>
         </StackPanel>
 
 
@@ -74,11 +75,14 @@
                 <TextBlock Text="&#xecaa;" Margin="0" />
             </controls:ProcessSelectionButton>
 
+            <controls:PISeperator Orientation="Horizontal"/>
+            
             <!-- Per App controls -->
             <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="5" Height="20" Width="20" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
             <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" HorizontalAlignment="Center" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
             <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" HorizontalAlignment="Center" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
-           
+            <controls:PISeperator Orientation="Horizontal" Visibility="{x:Bind _viewModel.AppBarVisibility, Mode=OneWay}"/>
+
             <!-- Per System controls -->
             <Button x:Uid="SwitchLayoutButton" x:Name="SwitchLayoutButton" Command="{x:Bind _viewModel.SwitchLayoutCommand}" HorizontalAlignment="Center">
                 <TextBlock Text="&#xe8b4;"/>
@@ -96,6 +100,8 @@
                 <TextBlock Text="&#xEC7A;"/>
             </controls:ExternalToolsManagementButton>
 
+            <controls:PISeperator Orientation="Horizontal"/>
+            
             <ItemsRepeater x:Name="ExternalToolsRepeater" ItemsSource="{x:Bind helpers:ExternalToolsHelper.Instance.FilteredExternalTools, Mode=OneWay}" Layout="{StaticResource ExternalToolsVerticalLayout}">
                 <DataTemplate x:DataType="helpers:ExternalTool">
                     <Button Click="_viewModel.ExternalToolButton_Click" HorizontalAlignment="Center" ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}" Tag="{x:Bind}">
@@ -117,6 +123,7 @@
                     </Button>
                 </DataTemplate>
             </ItemsRepeater>
+            <controls:PISeperator Orientation="Horizontal" Visibility="{x:Bind _viewModel.ExternalToolSeperatorVisibility, Mode=OneWay}"/>
         </StackPanel>
 
         <StackPanel x:Name="SystemResourceStackPanel" Orientation="Vertical" Grid.Row="2" Margin="0,0,0,5">

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml
@@ -10,7 +10,7 @@
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
     Title="" MinHeight="700" MinWidth="70" MaxWidth="70" Width="70" Height="700"
-    TaskBarIcon="Images/pi.ico"
+    TaskBarIcon="Images/pi.ico" IsTitleBarVisible="False"
     IsAlwaysOnTop="{x:Bind _viewModel.IsAlwaysOnTop, Mode=OneWay}"
     Closed="WindowEx_Closed">
     <!-- TODO Make DesktopAcrylicBackdrop/MicaBackdrop and AcrylicBackgroundFillColorBaseBrush user-configurable.-->

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
@@ -63,7 +63,7 @@ public partial class BarWindowVertical : WindowEx
         ThemeName t = ThemeName.Themes.First(t => t.Name == _settings.CurrentTheme);
         SetRequestedTheme(t.Theme);
 
-        // RemoveThickFrameAttribute();
+        RemoveThickFrameAttribute();
 
         // Regardless of what is set in the XAML, our initial window width is too big. Setting this to 70 (same as the XAML file)
         Width = 70;

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
@@ -51,6 +51,9 @@ public partial class BarWindowVertical : WindowEx
         // The main constructor is used in all cases, including when there's no target window.
         TheDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
+        ExtendsContentIntoTitleBar = true;
+        AppWindow.TitleBar.IconShowOptions = IconShowOptions.HideIconAndSystemMenu;
+
         InitializeComponent();
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
     }

--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
@@ -16,7 +16,7 @@ using Microsoft.UI.Xaml.Input;
 using Windows.UI.WindowManagement;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using Windows.Win32.UI.Accessibility;
+using Windows.Win32.UI.WindowsAndMessaging;
 using WinRT.Interop;
 using WinUIEx;
 using static DevHome.PI.Helpers.WindowHelper;
@@ -51,9 +51,6 @@ public partial class BarWindowVertical : WindowEx
         // The main constructor is used in all cases, including when there's no target window.
         TheDispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-        ExtendsContentIntoTitleBar = true;
-        AppWindow.TitleBar.IconShowOptions = IconShowOptions.HideIconAndSystemMenu;
-
         InitializeComponent();
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
     }
@@ -66,8 +63,22 @@ public partial class BarWindowVertical : WindowEx
         ThemeName t = ThemeName.Themes.First(t => t.Name == _settings.CurrentTheme);
         SetRequestedTheme(t.Theme);
 
+        // RemoveThickFrameAttribute();
+
         // Regardless of what is set in the XAML, our initial window width is too big. Setting this to 70 (same as the XAML file)
         Width = 70;
+    }
+
+    private void RemoveThickFrameAttribute()
+    {
+        // This is a workaround for this issue
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/8947
+        //
+        // This prevents a white strip to be at the top of our window (visible in dark mode). Unfortunately this workaround removes the rounded corners from the bar.
+        var style = PInvoke.GetWindowLong(ThisHwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
+        style &= ~(int)WINDOW_STYLE.WS_THICKFRAME;
+        _ = PInvoke.SetWindowLong(ThisHwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, style);
+        PInvoke.SetWindowPos(ThisHwnd, HWND.Null, 0, 0, 0, 0, Windows.Win32.UI.WindowsAndMessaging.SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER);
     }
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/tools/PI/DevHome.PI/Controls/PISeperator.xaml
+++ b/tools/PI/DevHome.PI/Controls/PISeperator.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DevHome.PI.Controls.PISeperator"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DevHome.PI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Rectangle x:Name="SeparatorRectangle"
+                            RadiusX="{ThemeResource AppBarSeparatorCornerRadius}"
+                            RadiusY="{ThemeResource AppBarSeparatorCornerRadius}"
+                            Width="{ThemeResource AppBarSeparatorWidth}"
+                            Fill="{ThemeResource AppBarSeparatorForegroundThemeBrush}"
+                            Margin="4"/>
+    </Grid>
+</UserControl>

--- a/tools/PI/DevHome.PI/Controls/PISeperator.xaml
+++ b/tools/PI/DevHome.PI/Controls/PISeperator.xaml
@@ -9,11 +9,19 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Rectangle x:Name="SeparatorRectangle"
+        <Rectangle x:Name="SeparatorRectangleVertical"
                             RadiusX="{ThemeResource AppBarSeparatorCornerRadius}"
                             RadiusY="{ThemeResource AppBarSeparatorCornerRadius}"
                             Width="{ThemeResource AppBarSeparatorWidth}"
                             Fill="{ThemeResource AppBarSeparatorForegroundThemeBrush}"
-                            Margin="4"/>
+                            Margin="4" />
+        <Rectangle x:Name="SeparatorRectangleHorizontal"
+                            Visibility="Collapsed"
+                            RadiusX="{ThemeResource AppBarSeparatorCornerRadius}"
+                            RadiusY="{ThemeResource AppBarSeparatorCornerRadius}"
+                            Height="{ThemeResource AppBarSeparatorWidth}"
+                            Width="22"
+                            Fill="{ThemeResource AppBarSeparatorForegroundThemeBrush}"
+                            Margin="4" />
     </Grid>
 </UserControl>

--- a/tools/PI/DevHome.PI/Controls/PISeperator.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/PISeperator.xaml.cs
@@ -3,12 +3,38 @@
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP;
+using Microsoft.UI.System;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.PI.Controls;
 
 public sealed partial class PISeperator : UserControl
 {
+    private Orientation _orientation = Orientation.Vertical;
+
+    public Orientation Orientation
+    {
+        get => _orientation;
+
+        set
+        {
+            _orientation = value;
+
+            if (value == Orientation.Vertical)
+            {
+                SeparatorRectangleVertical.Visibility = Visibility.Visible;
+                SeparatorRectangleHorizontal.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                SeparatorRectangleHorizontal.Visibility = Visibility.Visible;
+                SeparatorRectangleVertical.Visibility = Visibility.Collapsed;
+            }
+        }
+    }
+
     public PISeperator()
     {
         this.InitializeComponent();

--- a/tools/PI/DevHome.PI/Controls/PISeperator.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/PISeperator.xaml.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.PI.Controls;
+
+public sealed partial class PISeperator : UserControl
+{
+    public PISeperator()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/tools/PI/DevHome.PI/DevHome.PI.csproj
+++ b/tools/PI/DevHome.PI/DevHome.PI.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <None Remove="Controls\ExpandedViewControl.xaml" />
     <None Remove="Controls\GlowButton.xaml" />
+    <None Remove="Controls\PISeperator.xaml" />
     <None Remove="errors.db" />
     <None Remove="Images\PI.ico" />
     <None Remove="Pages\AboutPage.xaml" />
@@ -53,6 +54,7 @@
        XAML know where the main application object is defined-->
   <ItemGroup>
     <Page Remove="PIApp.xaml" />
+    <Page Remove="Themes\Generic.xaml" />
     <ApplicationDefinition Include="PIApp.xaml">
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
@@ -106,7 +108,6 @@
   -->
   <ItemGroup>
     <Folder Include="Adapters\" />
-    <Folder Include="Themes\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
@@ -155,6 +156,12 @@
     </Page>
     <None Update="appsettings_pi.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <Page Update="Controls\PISeperator.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <None Update="Themes\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
     </None>
     <Page Update="Pages\AboutPage.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/tools/PI/DevHome.PI/DevHome.PI.csproj
+++ b/tools/PI/DevHome.PI/DevHome.PI.csproj
@@ -54,7 +54,6 @@
        XAML know where the main application object is defined-->
   <ItemGroup>
     <Page Remove="PIApp.xaml" />
-    <Page Remove="Themes\Generic.xaml" />
     <ApplicationDefinition Include="PIApp.xaml">
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
@@ -108,6 +107,7 @@
   -->
   <ItemGroup>
     <Folder Include="Adapters\" />
+    <Folder Include="Themes\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\DevHome.Common.csproj" />
@@ -160,9 +160,6 @@
     <Page Update="Controls\PISeperator.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <None Update="Themes\Generic.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </None>
     <Page Update="Pages\AboutPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -52,6 +54,9 @@ public partial class BarWindowViewModel : ObservableObject
 
     [ObservableProperty]
     private Visibility _appBarVisibility = Visibility.Visible;
+
+    [ObservableProperty]
+    private Visibility _externalToolSeperatorVisibility = Visibility.Collapsed;
 
     [ObservableProperty]
     private string _applicationName = string.Empty;
@@ -104,6 +109,15 @@ public partial class BarWindowViewModel : ObservableObject
         CurrentSnapButtonText = IsSnapped ? _UnsnapButtonText : _SnapButtonText;
 
         _snapHelper = new();
+
+        ((INotifyCollectionChanged)ExternalToolsHelper.Instance.FilteredExternalTools).CollectionChanged += FilteredExternalTools_CollectionChanged;
+        FilteredExternalTools_CollectionChanged(null, null);
+    }
+
+    private void FilteredExternalTools_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs? e)
+    {
+        // Only show the seperator if we're showing pinned tools
+        ExternalToolSeperatorVisibility = ExternalToolsHelper.Instance.FilteredExternalTools.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
     }
 
     partial void OnIsSnappedChanged(bool value)


### PR DESCRIPTION
## Summary of the pull request

This wraps up the major UI elements needed for the bar, including the seperators between major UI elements in the bar, the proper gripper in the vertical position, and adds a workaround for a white stripe that the vertical bar has in dark mode.

## References and relevant issues

## Detailed description of the pull request / Additional comments

The separators use the same style as the AppBarSeperator. I couldn't use that element as-is, as it requires the use of a CommandBar, and at first glance looks like it would be useful here, in practice it doesn't meet our requirements.

For issue #3056, this appears to be an issue tracked in WinUI - https://github.com/microsoft/microsoft-ui-xaml/issues/8947

It looks like this...

![Screenshot 2024-06-06 111307](https://github.com/microsoft/devhome/assets/49733346/6fef4535-939e-46de-aaee-5b70c63d7c11)

The workaround mentioned in the bug says to remove the THICKFRAME attribute from the window. While this does remove the white bar, it also removes the rounded corners. Not sure which is best... I'm going with the squared corners for now.


![Screenshot 2024-06-06 111147](https://github.com/microsoft/devhome/assets/49733346/c5088962-c261-47a9-a2e7-3873b5ad0d25)

## Validation steps performed

## PR checklist
- [ ] Closes #3057 #3056 #3052 
- [ ] Tests added/passed
- [ ] Documentation updated
