### PR TITLE
Make three dots button in environments cards visible by default

### DIFF
--- a/common/Environments/CustomControls/CardHeader.xaml.cs
+++ b/common/Environments/CustomControls/CardHeader.xaml.cs
@@ -41,5 +41,5 @@ public sealed partial class CardHeader : UserControl
     private static readonly DependencyProperty ActionControlTemplateProperty = DependencyProperty.Register(nameof(ActionControlTemplate), typeof(DataTemplate), typeof(CardHeader), new PropertyMetadata(null));
     private static readonly DependencyProperty HeaderCaptionProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(string), typeof(CardHeader), new PropertyMetadata(null));
     private static readonly DependencyProperty HeaderIconProperty = DependencyProperty.Register(nameof(HeaderIcon), typeof(BitmapImage), typeof(CardHeader), new PropertyMetadata(null));
-    private static readonly DependencyProperty OperationsVisibilityProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(bool), typeof(CardHeader), new PropertyMetadata(false));
+    private static readonly DependencyProperty OperationsVisibilityProperty = DependencyProperty.Register(nameof(HeaderCaption), typeof(bool), typeof(CardHeader), new PropertyMetadata(true));
 }


### PR DESCRIPTION
## Summary of the pull request
Since the default visibility for the three dots is now false, it prevents the three dots from appearing when we show the create [CreateComputeSystemOperationViewModel](https://github.com/microsoft/devhome/blob/main/tools/Environments/DevHome.Environments/ViewModels/CreateComputeSystemOperationViewModel.cs) in the UI. By default it should actually be visible, and then a view model can choose to collapse it if it wants to like when a pinning operation occurs.

Video showing creation operation card not showing three dots:

https://github.com/microsoft/devhome/assets/105318831/d452af1e-8d16-493e-8d67-890a203ba9a7




Video showing that the creation operation card now shows three dots:

https://github.com/microsoft/devhome/assets/105318831/0385d42f-b91c-48e6-8998-07e4c0410552



## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
