### PR TITLE
Fix snapping/unsnapping when the bar window is moved

### DIFF
--- a/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/BarWindowVertical.xaml.cs
@@ -111,7 +111,7 @@ public partial class BarWindowVertical : WindowEx
         {
             if (DoesWindow1CoverTheRightSideOfWindow2(ThisHwnd, TargetAppData.Instance.HWnd))
             {
-                _viewModel.IsSnapped = true;
+                _viewModel.SnapBarWindow();
             }
         }
     }
@@ -124,7 +124,7 @@ public partial class BarWindowVertical : WindowEx
             // Moving the window causes it to unsnap
             if (_viewModel.IsSnapped)
             {
-                _viewModel.IsSnapped = false;
+                _viewModel.UnsnapBarWindow();
             }
 
             isWindowMoving = true;

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -120,7 +120,7 @@ public partial class BarWindowViewModel : ObservableObject
         if (value == Orientation.Horizontal)
         {
             // If we were snapped, unsnap
-            IsSnapped = false;
+            UnsnapBarWindow();
         }
         else
         {
@@ -154,6 +154,14 @@ public partial class BarWindowViewModel : ObservableObject
         }
     }
 
+    public void SnapBarWindow()
+    {
+        // First need to be in a Vertical layout
+        BarOrientation = Orientation.Vertical;
+        _snapHelper.Snap();
+        IsSnapped = true;
+    }
+
     public void UnsnapBarWindow()
     {
         _snapHelper.Unsnap();
@@ -169,10 +177,7 @@ public partial class BarWindowViewModel : ObservableObject
         }
         else
         {
-            // First need to be in a Vertical layout
-            BarOrientation = Orientation.Vertical;
-            _snapHelper.Snap();
-            IsSnapped = true;
+            SnapBarWindow();
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
Bug: We were updating the IsSnapped value without performing snap/unsnap action.
Fix: Call viewmodel SnapBarWindow/UnsnapBarWindow, which calls the SnapHelper to performing the action and then update IsSnapped value.

## Validation steps performed
1. Launch PI
2. Attach to an app
3. Drag the PI window when in vertical mode into the right hand side of an attached application
4. Confirmed it snaps to the app.
5. Moved the PI window
6. Confirmed it unsnaps

## PR checklist
- [ ] Closes #3157