### PR TITLE
Fixing the filter text box in environments from clipping at Text Scaling.

### DIFF
--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -215,9 +215,9 @@
         </Grid>
 
         <!-- Filtering and sorting -->
-        <Grid Grid.Row="1" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+        <Grid Grid.Row="1" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}" ColumnSpacing="5">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="10*" />
+                <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary of the pull request
The filter text box on the "Environments" page would with clip, or disappear, what text scaling is applied because the width of the column was 10*.  

I tried two fixed.
1. Changing the width of the text box to MinWidth.
2. Changing the width of the column to auto.

Solution 1 did not fix the issue.
Solution 2 did.

Added column spacing so the "Provider" did not butt up against the text box.

## References and relevant issues

https://task.ms/50453170

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually tested.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![FilterTextBoxNotClipping](https://github.com/microsoft/devhome/assets/2517139/aef8c35f-aa50-488a-a352-5c7daab80e71)

