### PR TITLE
Add Preview button to SSH Widget

### DIFF
--- a/extensions/CoreWidgetProvider/Helpers/Resources.cs
+++ b/extensions/CoreWidgetProvider/Helpers/Resources.cs
@@ -88,6 +88,7 @@ public static class Resources
             "CPUUsage_Widget_Template/CPU_Speed",
             "CPUUsage_Widget_Template/Processes",
             "CPUUsage_Widget_Template/End_Process",
+            "Widget_Template_Button/Preview",
             "Widget_Template_Button/Save",
             "Widget_Template_Button/Cancel",
         ];

--- a/extensions/CoreWidgetProvider/Strings/en-US/Resources.resw
+++ b/extensions/CoreWidgetProvider/Strings/en-US/Resources.resw
@@ -162,6 +162,10 @@
   <data name="CPUUsage_Widget_Template.End_Process" xml:space="preserve">
     <value>End process</value>
   </data>
+  <data name="Widget_Template_Button.Preview" xml:space="preserve">
+    <value>Preview</value>
+    <comment>Shown in Widget, Button text</comment>
+  </data>
   <data name="Widget_Template_Button.Save" xml:space="preserve">
     <value>Save</value>
     <comment>Shown in Widget, Button text</comment>

--- a/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -178,12 +178,12 @@ internal sealed class SSHWalletWidget : CoreWidget
         }
         else if (dataObject.ConfigFile != null)
         {
-            // This is the action when the user clicks the Preview button in the Configure state.
+            // The user clicked the Preview button in the Configure state.
             chosenPath = dataObject.ConfigFile;
         }
         else if (dataObject.FilePath != null)
         {
-            // This is the action when the user uses the File Picker to select a file "filePath" in the Configure state.
+            // The user used the File Picker to select a file in the Configure state.
             chosenPath = dataObject.FilePath;
         }
 

--- a/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -166,29 +166,32 @@ internal sealed class SSHWalletWidget : CoreWidget
         Page = WidgetPageState.Loading;
         UpdateWidget();
 
-        // This is the action when the user clicks the submit button after entering a path while in
-        // the Configure state.
         Page = WidgetPageState.Configure;
         var data = args.Data;
         var dataObject = JsonSerializer.Deserialize(data, SourceGenerationContext.Default.DataPayload);
-        if (dataObject != null && dataObject.ConfigFile != null)
-        {
-            var updateRequestOptions = new WidgetUpdateRequestOptions(Id)
-            {
-                Data = GetConfiguration(dataObject.ConfigFile),
-                CustomState = ConfigFile,
-                Template = GetTemplateForPage(Page),
-            };
 
-            WidgetManager.GetDefault().UpdateWidget(updateRequestOptions);
+        var chosenPath = string.Empty;
+
+        if (dataObject == null)
+        {
+            return;
+        }
+        else if (dataObject.ConfigFile != null)
+        {
+            // This is the action when the user clicks the Preview button in the Configure state.
+            chosenPath = dataObject.ConfigFile;
+        }
+        else if (dataObject.FilePath != null)
+        {
+            // This is the action when the user uses the File Picker to select a file "filePath" in the Configure state.
+            chosenPath = dataObject.FilePath;
         }
 
-        // This is the action when the user uses the File Picker to select a file "filePath" in the Configure state.
-        if (dataObject != null && dataObject.FilePath != null)
+        if (!string.IsNullOrEmpty(chosenPath))
         {
             var updateRequestOptions = new WidgetUpdateRequestOptions(Id)
             {
-                Data = GetConfiguration(dataObject.FilePath),
+                Data = GetConfiguration(chosenPath),
                 CustomState = ConfigFile,
                 Template = GetTemplateForPage(Page),
             };

--- a/extensions/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
+++ b/extensions/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
@@ -16,6 +16,42 @@
       "value": "${$root.configuration.currentOrDefaultConfigFile}"
     },
     {
+      "type": "ColumnSet",
+      "spacing": "Medium",
+      "columns": [
+        {
+          "type": "Column",
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "Container",
+              "items": [
+                {
+                  "type": "ActionSet",
+                  "actions": [
+                    {
+                      "type": "Action.Execute",
+                      "title": "%Widget_Template_Button/Preview%",
+                      "verb": "CheckPath",
+                      "associatedInputs": "Auto"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "width": "stretch"
+        }
+      ]
+    },
+    {
       "type": "Container",
       "items": [
         {
@@ -33,21 +69,6 @@
     {
       "type": "Container",
       "items": [
-        {
-          "type": "TextBlock",
-          "text": "%SSH_Widget_Template/ConfigFilePath%",
-          "wrap": true,
-          "spacing": "Medium",
-          "size": "Small",
-          "isSubtle": true
-        },
-        {
-          "type": "TextBlock",
-          "text": "${configFile}",
-          "wrap": true,
-          "size": "medium",
-          "spacing": "None"
-        },
         {
           "type": "TextBlock",
           "text": "%SSH_Widget_Template/NumOfHosts%",
@@ -71,7 +92,7 @@
     },
     {
       "type": "ColumnSet",
-      "spacing": "ExtraLarge",
+      "spacing": "Large",
       "columns": [
         {
           "type": "Column",


### PR DESCRIPTION
## Summary of the pull request

With the new File Picker in the SSH widget, a user had to use it, rather than being able to type a path. This change allows the user to either use the file picker or type a path and click the "Preview" button in order to validate the file and click save. I also removed a duplicate path listing in the Preview view, so everything would fit better.
![image](https://github.com/microsoft/devhome/assets/47155823/8d968a3e-a403-4ee1-b5d5-c7e073c3015b) ![image](https://github.com/microsoft/devhome/assets/47155823/3059a11a-04ee-4f41-b164-53515dc89c75) 
![image](https://github.com/microsoft/devhome/assets/47155823/2b4bf8d6-7a31-45b8-b6fd-3849b65c75ad)



## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3156
- [ ] Tests added/passed
- [ ] Documentation updated
