### PR TITLE
Change PI cpu usage to match widget usage

### DIFF
--- a/tools/PI/DevHome.PI/Models/PerfCounters.cs
+++ b/tools/PI/DevHome.PI/Models/PerfCounters.cs
@@ -19,11 +19,11 @@ public partial class PerfCounters : ObservableObject, IDisposable
     public static readonly PerfCounters Instance = new();
 
     private const string ProcessCategory = "Process";
-    private const string ProcessorCategory = "Processor";
+    private const string ProcessorCategory = "Processor Information";
     private const string MemoryCategory = "Memory";
     private const string DiskCategory = "PhysicalDisk";
 
-    private const string CpuCounterName = "% Processor Time";
+    private const string CpuCounterName = "% Processor Utility";
     private const string RamCounterName = "Working Set - Private";
     private const string SystemRamCounterName = "Committed Bytes";
     private const string SystemDiskCounterName = "% Disk Time";
@@ -172,7 +172,7 @@ public partial class PerfCounters : ObservableObject, IDisposable
     {
         try
         {
-            CpuUsage = cpuCounter?.NextValue() / Environment.ProcessorCount ?? 0;
+            CpuUsage = (cpuCounter?.NextValue() ?? 0) / 100;
             GpuUsage = GetGpuUsage(gpuCounters);
 
             // Report app memory usage in MB


### PR DESCRIPTION
## Summary of the pull request
Changes the CPU usage calculation in Project Ironsides to match that of the CPU widget. Both are now very close to task manager's reporting, within reasonable expectations given different polling times and that one monitor's execution can affect the CPU and thereby change the other monitors' results.

## References and relevant issues
Closes #3160 

## Detailed description of the pull request / Additional comments
The values are unlikely to match exactly due to different polling times. Task manager, the widget, and PI poll at 1s intervals, but even slight differences in the time they poll can give different results. Since PerformanceCounter.NextValue() is actually itself rather heavy on CPU, one monitor can affect other monitors. For this reason, two components can use the same perf counter but have slightly different results, so we do not expect them to match precisely. We do expect them to be reasonably close over time.

In analyzing which metric was most correct, I compared Task Manager CPU utilization to the CPU widget utilization and found them to be very close, producing a very similar graph and numbers that were often the same.  Since it appears these two are consistent with each other, I changed the PI CPU usage to match the CPU widget's perf counter category, name, and calculation.

## Validation steps performed
* Built and ran, compared Task Manager, the CPU widget, and PI's perf usage. They are now all reasonably close.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
