### PR TITLE
PI: Fix Modules page crash - Create ProcessModuleInfo model and handle FileNotFoundException

### DIFF
--- a/tools/PI/DevHome.PI/Models/ProcessModuleInfo.cs
+++ b/tools/PI/DevHome.PI/Models/ProcessModuleInfo.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.IO;
+
+namespace DevHome.PI.Models;
+
+public class ProcessModuleInfo
+{
+    public string ModuleName { get; }
+
+    public string FileVersionInfo { get; }
+
+    public string FileVersion { get; }
+
+    public nint BaseAddress { get; }
+
+    public nint EntryPointAddress { get; }
+
+    public int ModuleMemorySize { get; }
+
+    public ProcessModuleInfo(ProcessModule module)
+    {
+        ModuleName = module.ModuleName;
+        try
+        {
+            FileVersionInfo = module.FileVersionInfo.ToString();
+            FileVersion = module.FileVersionInfo.FileVersion ?? string.Empty;
+        }
+        catch (FileNotFoundException)
+        {
+            FileVersionInfo = string.Empty;
+            FileVersion = string.Empty;
+        }
+
+        BaseAddress = module.BaseAddress;
+        EntryPointAddress = module.EntryPointAddress;
+        ModuleMemorySize = module.ModuleMemorySize;
+    }
+}

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:diagnostics="using:System.Diagnostics"
+    xmlns:models="using:DevHome.PI.Models"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d"
     NavigationCacheMode="Enabled">
@@ -34,10 +34,10 @@
             <ListView x:Name="ModulesListView" SelectionMode="Single" ItemsSource="{x:Bind ViewModel.ModuleList, Mode=OneWay}"
                       SelectedIndex="{x:Bind ViewModel.SelectedModuleIndex, Mode=TwoWay}">
                 <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="diagnostics:ProcessModule">
+                    <DataTemplate x:DataType="models:ProcessModuleInfo">
                         <StackPanel Orientation="Vertical" Margin="0,0,0,10">
                             <TextBlock Text="{x:Bind ModuleName}" FontWeight="Bold"/>
-                            <TextBlock Text="{x:Bind FileVersionInfo.FileVersion}" Margin="0"/>
+                            <TextBlock Text="{x:Bind FileVersion}" Margin="0"/>
                         </StackPanel>
                     </DataTemplate>
                 </ListView.ItemTemplate>
@@ -49,20 +49,20 @@
             <ScrollViewer Grid.Column="2" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto">
                 <StackPanel x:Name="ModuleDetailsPanel" Margin="8,0,0,0">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
-                        <TextBlock Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).ModuleName, Mode=OneWay}"
+                        <TextBlock Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).ModuleName, Mode=OneWay}"
                                    FontSize="24" FontWeight="Bold"/>
                     </StackPanel>
                     <StackPanel>
                         <TextBlock x:Uid="FileVersionInfoTextBlock" FontSize="18" />
-                        <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).FileVersionInfo, Mode=OneWay}"
+                        <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).FileVersionInfo, Mode=OneWay}"
                                  FontFamily="Consolas" TextWrapping="Wrap" IsReadOnly="True"/>
 
                         <TextBlock x:Uid="BaseAddressTextBlock" FontSize="18" Margin="0,6,0,0"/>
-                        <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).BaseAddress, Mode=OneWay}" IsReadOnly="True"/>
+                        <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).BaseAddress, Mode=OneWay}" IsReadOnly="True"/>
                         <TextBlock x:Uid="EntrypointAddressTextBlock" FontSize="18" Margin="0,6,0,0"/>
-                        <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).EntryPointAddress, Mode=OneWay}" IsReadOnly="True"/>                        
+                        <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).EntryPointAddress, Mode=OneWay}" IsReadOnly="True"/>                        
                         <TextBlock x:Uid="MemorySizeTextBlock" FontSize="18" Margin="0,6,0,0"/>
-                        <TextBox Text="{x:Bind ((diagnostics:ProcessModule)ModulesListView.SelectedItem).ModuleMemorySize, Mode=OneWay}" IsReadOnly="True"/>
+                        <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).ModuleMemorySize, Mode=OneWay}" IsReadOnly="True"/>
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>

--- a/tools/PI/DevHome.PI/ViewModels/ModulesPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ModulesPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -18,7 +17,7 @@ namespace DevHome.PI.ViewModels;
 public partial class ModulesPageViewModel : ObservableObject
 {
     [ObservableProperty]
-    private ObservableCollection<ProcessModule> moduleList;
+    private ObservableCollection<ProcessModuleInfo> moduleList;
 
     [ObservableProperty]
     private int selectedModuleIndex;
@@ -63,7 +62,7 @@ public partial class ModulesPageViewModel : ObservableObject
 
                     foreach (var module in moduleList)
                     {
-                        ModuleList.Add(module);
+                        ModuleList.Add(new ProcessModuleInfo(module));
                     }
 
                     if (ModuleList.Count > 0)


### PR DESCRIPTION
## Summary of the pull request
Bug: System.Diagnostics.FileVersionInfo.GetVersionInfo threw FileNotFoundException for a few dlls when attached to OneNote.
Fix: Handle FileNotFoundException in a new model ProcessModuleInfo, which stores the processModule information.

## Validation steps performed
1. Launch PI
2. Attached to C2R OneNote
3. Go to modules page
4. Confirmed PI does not crash.

## PR checklist
- [ ] Closes #3035
