### PR TITLE
Fix WhatsNewPage build warnings

### DIFF
--- a/exclusion.dic
+++ b/exclusion.dic
@@ -29,3 +29,5 @@
 ﻿jsonc
 ﻿appsettings
 ﻿awaitable
+﻿Whats
+﻿disksandvolumes

--- a/src/Models/WhatsNewCard.cs
+++ b/src/Models/WhatsNewCard.cs
@@ -42,7 +42,7 @@ public class WhatsNewCard
         get; set;
     }
 
-    public string? Button
+    public string? ButtonText
     {
         get; set;
     }

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -192,16 +192,16 @@
   <data name="AppDisplayNameStable" xml:space="preserve">
     <value>Dev Home (Preview)</value>
   </data>
-  <data name="WhatsNewPage_DevDashCard.Button" xml:space="preserve">
+  <data name="WhatsNewPage_DevDashCard.ButtonText" xml:space="preserve">
     <value>Pin widgets</value>
   </data>
-  <data name="WhatsNewPage_DevDriveCard.Button" xml:space="preserve">
+  <data name="WhatsNewPage_DevDriveCard.ButtonText" xml:space="preserve">
     <value>Create Dev Drive</value>
   </data>
   <data name="WhatsNewPage_DevDriveCard.Link" xml:space="preserve">
     <value>Learn more</value>
   </data>
-  <data name="WhatsNewPage_DevIdCard.Button" xml:space="preserve">
+  <data name="WhatsNewPage_DevIdCard.ButtonText" xml:space="preserve">
     <value>Connect accounts</value>
   </data>
   <data name="WhatsNewPage_GetStartedButton.Content" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Administrator: Dev Home (Preview)</value>
     <comment>Name of app when run as administrator</comment>
   </data>
-  <data name="WhatsNewPage_ExtensionsCard.Button" xml:space="preserve">
+  <data name="WhatsNewPage_ExtensionsCard.ButtonText" xml:space="preserve">
     <value>Explore extensions</value>
-    <comment>Button on extensions card on "whats new" page</comment>
+    <comment>Button text on extensions card on "whats new" page</comment>
   </data>
   <data name="WhatsNewPage_ExtensionsCard.Description" xml:space="preserve">
     <value>Extensions help you get more out of Dev Home. For example, get recommendations for other repositories to add when setting up your machine in Dev Home and add other widgets to your dashboard.</value>

--- a/src/ViewModels/WhatsNewViewModel.cs
+++ b/src/ViewModels/WhatsNewViewModel.cs
@@ -3,19 +3,25 @@
 
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Services;
 using DevHome.Models;
 
 namespace DevHome.ViewModels;
 
-public class WhatsNewViewModel : ObservableObject
+public partial class WhatsNewViewModel : ObservableObject
 {
     public ObservableCollection<WhatsNewCard> Source { get; } = new ObservableCollection<WhatsNewCard>();
 
     public ObservableCollection<WhatsNewCard> BigSource { get; } = new ObservableCollection<WhatsNewCard>();
 
-    public int NumberOfBigCards
+    public int NumberOfBigCards { get; set; }
+
+    private readonly INavigationService _navigationService;
+
+    public WhatsNewViewModel(INavigationService navigationService)
     {
-        get; set;
+        _navigationService = navigationService;
     }
 
     public void AddCard(WhatsNewCard card)
@@ -113,5 +119,11 @@ public class WhatsNewViewModel : ObservableObject
 
     public void OnNavigatedFrom()
     {
+    }
+
+    [RelayCommand]
+    private void NavigateToGetStarted()
+    {
+        _navigationService.NavigateTo(typeof(SetupFlow.ViewModels.SetupFlowViewModel).FullName!);
     }
 }

--- a/src/ViewModels/WhatsNewViewModel.cs
+++ b/src/ViewModels/WhatsNewViewModel.cs
@@ -112,7 +112,7 @@ public partial class WhatsNewViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void NavigateToGetStarted()
+    private void HeaderButtonNavigate()
     {
         _navigationService.NavigateTo(typeof(SetupFlow.ViewModels.SetupFlowViewModel).FullName!);
     }

--- a/src/ViewModels/WhatsNewViewModel.cs
+++ b/src/ViewModels/WhatsNewViewModel.cs
@@ -111,16 +111,6 @@ public partial class WhatsNewViewModel : ObservableObject
         }
     }
 
-    public void OnNavigatedTo(object parameter)
-    {
-        Source.Clear();
-        BigSource.Clear();
-    }
-
-    public void OnNavigatedFrom()
-    {
-    }
-
     [RelayCommand]
     private void NavigateToGetStarted()
     {

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -5,7 +5,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls" 
     xmlns:models="using:DevHome.Models"
     xmlns:behaviors="using:DevHome.Common.Behaviors" 
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
@@ -76,7 +75,7 @@
                 </StackPanel>
 
                 <!-- Big Cards -->
-                <muxc:ItemsRepeater
+                <ItemsRepeater
                     Name="BigFeaturesContainer"
                     Grid.Row="1"
                     Margin="35, 5, 45, 10"
@@ -84,7 +83,7 @@
                     animations:Connected.ListItemKey="animationKeyContentGrid"
                     ItemsSource="{x:Bind ViewModel.BigSource,Mode=OneWay}">
 
-                    <muxc:ItemsRepeater.Resources>
+                    <ItemsRepeater.Resources>
                         <!-- This repeater is responsible for the big cards. To add another here, make sure to assign IsBig as true -->
                         <models:WhatsNewCard 
                             x:Uid="WhatsNewPage_ExtensionsCard"
@@ -97,17 +96,17 @@
                             PageKey="DevHome.ExtensionLibrary.ViewModels.ExtensionLibraryViewModel"
                             IsBig="True"
                             Priority="0" />
-                    </muxc:ItemsRepeater.Resources>
+                    </ItemsRepeater.Resources>
 
-                    <muxc:ItemsRepeater.Layout>
-                        <muxc:StackLayout 
+                    <ItemsRepeater.Layout>
+                        <StackLayout 
                             x:Name="BigCardGrid"
                             Spacing="12"
                             Orientation="Vertical" >
-                        </muxc:StackLayout>
-                    </muxc:ItemsRepeater.Layout>
+                        </StackLayout>
+                    </ItemsRepeater.Layout>
 
-                    <muxc:ItemsRepeater.ItemTemplate>
+                    <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="models:WhatsNewCard">
                             <Grid
                                 HorizontalAlignment="Stretch"
@@ -180,11 +179,11 @@
                                 </StackPanel>
                             </Grid>
                         </DataTemplate>
-                    </muxc:ItemsRepeater.ItemTemplate>
-                </muxc:ItemsRepeater>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
 
                 <!-- Small Cards -->
-                <muxc:ItemsRepeater
+                <ItemsRepeater
                     Name="FeaturesContainer"
                     Grid.Row="2"
                     Margin="35, 5, 45, 45"
@@ -192,7 +191,7 @@
                     animations:Connected.ListItemKey="animationKeyContentGrid"
                     ItemsSource="{x:Bind ViewModel.Source, Mode=OneWay}">
 
-                    <muxc:ItemsRepeater.Resources>
+                    <ItemsRepeater.Resources>
                         <models:WhatsNewCard 
                             x:Uid="WhatsNewPage_DevDashCard"
                             x:Key="WhatsNewPage_DevDashCard"
@@ -219,10 +218,10 @@
                             LightThemeImage="ms-appx:///Assets/WhatsNewPage/LightTheme/DevDriveHero.png"
                             PageKey="ms-settings:disksandvolumes"
                             Priority="3" />
-                    </muxc:ItemsRepeater.Resources>
+                    </ItemsRepeater.Resources>
 
-                    <muxc:ItemsRepeater.Layout>
-                        <muxc:UniformGridLayout 
+                    <ItemsRepeater.Layout>
+                        <UniformGridLayout 
                             x:Name="CardGrid"
                             Orientation="Horizontal" 
                             MinItemWidth="200"
@@ -232,9 +231,9 @@
                             ItemsStretch="Fill"
                             MaximumRowsOrColumns="3"
                             ItemsJustification="Center" />
-                    </muxc:ItemsRepeater.Layout>
+                    </ItemsRepeater.Layout>
 
-                    <muxc:ItemsRepeater.ItemTemplate>
+                    <ItemsRepeater.ItemTemplate>
                         <DataTemplate 
                             x:DataType="models:WhatsNewCard">
                             <Grid
@@ -319,8 +318,8 @@
                                 </Button>
                             </Grid>
                         </DataTemplate>
-                    </muxc:ItemsRepeater.ItemTemplate>
-                </muxc:ItemsRepeater>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
             </Grid>
         </RelativePanel>
     </ScrollViewer>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -151,31 +151,31 @@
                                     <TextBlock
                                         HorizontalAlignment="Left"
                                         Style="{ThemeResource BodyTextStyle}"
-                                        Text="{x:Bind Title}" />
+                                        Text="{x:Bind Title, Mode=OneTime}" />
 
                                     <TextBlock
                                         Margin="0 8 0 10"
                                         TextWrapping="Wrap"
                                         HorizontalAlignment="Left"
-                                        Text="{x:Bind Description}"/>
+                                        Text="{x:Bind Description, Mode=OneTime}"/>
 
                                     <HyperlinkButton
-                                        Content="{x:Bind Link}"
+                                        Content="{x:Bind Link, Mode=OneTime}"
                                         Foreground="{ThemeResource LearnMoreForeground}"
                                         NavigateUri="https://go.microsoft.com/fwlink/?linkid=2236041"
                                         Padding="0"
                                         Margin="0"
-                                        Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
+                                        Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneTime}" />
 
                                     <Button 
                                         Margin="0 0 0 10"
                                         Padding="50 5 50 5"
                                         DataContext="{x:Bind PageKey}"
-                                        AutomationProperties.AutomationId="{x:Bind AutomationId}"
+                                        AutomationProperties.AutomationId="{x:Bind AutomationId, Mode=OneTime}"
                                         Click="Button_ClickAsync"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Bottom"
-                                        Content="{x:Bind Button}" />
+                                        Content="{x:Bind Button, Mode=OneTime}" />
 
                                 </StackPanel>
                             </Grid>
@@ -275,7 +275,7 @@
                                         <TextBlock
                                             HorizontalAlignment="Left"
                                             Style="{ThemeResource BodyTextStyle}"
-                                            Text="{x:Bind Title}" />
+                                            Text="{x:Bind Title, Mode=OneTime}" />
 
                                         <StackPanel Margin="0 16 0 20">
                                             <TextBlock
@@ -283,7 +283,7 @@
                                                 TextWrapping="Wrap"
                                                 VerticalAlignment="Top"
                                                 TextTrimming="WordEllipsis"
-                                                Text="{x:Bind Description}"/>
+                                                Text="{x:Bind Description, Mode=OneTime}" />
 
                                             <HyperlinkButton
                                                 Content="{x:Bind Link}"
@@ -292,7 +292,7 @@
                                                 VerticalAlignment="Top"
                                                 Padding="0"
                                                 Margin="0"
-                                                Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneWay}" />
+                                                Visibility="{x:Bind HasLinkAndShouldShowIt(Link, ShouldShowLink), Mode=OneTime}" />
                                         </StackPanel>
                                     </StackPanel>
                                 </ScrollViewer>
@@ -300,19 +300,19 @@
                                 <Button
                                     Grid.Row="2"
                                     Margin="15 0 15 10"
-                                    AutomationProperties.AutomationId="{x:Bind AutomationId}"
+                                    AutomationProperties.AutomationId="{x:Bind AutomationId, Mode=OneTime}"
                                     DataContext="{x:Bind PageKey}"
                                     Click="Button_ClickAsync"
                                     HorizontalAlignment="Stretch"
-                                    AutomationProperties.Name="{x:Bind Button}"
+                                    AutomationProperties.Name="{x:Bind Button, Mode=OneTime}"
                                     VerticalAlignment="Bottom">
                                     <Button.Content>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="{x:Bind Button}" Margin="0 0 5 0" />
+                                            <TextBlock Text="{x:Bind Button, Mode=OneTime}" Margin="0 0 5 0" />
                                             <!-- The open new window icon -->
                                             <FontIcon 
                                                 Glyph="&#xE8A7;" 
-                                                Visibility="{x:Bind ShouldShowIcon}" 
+                                                Visibility="{x:Bind ShouldShowIcon, Mode=OneTime}"
                                                 FontSize="12"/>
                                         </StackPanel>
                                     </Button.Content>

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -132,12 +132,7 @@
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
 
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-
                                 <Image
-                                    Grid.Row="0"
                                     Grid.Column="0"
                                     Source="{ThemeResource ItemImage}"
                                     MaxHeight="188"
@@ -155,7 +150,7 @@
                                         Margin="0 8 0 10"
                                         TextWrapping="Wrap"
                                         HorizontalAlignment="Left"
-                                        Text="{x:Bind Description, Mode=OneTime}"/>
+                                        Text="{x:Bind Description, Mode=OneTime}" />
 
                                     <HyperlinkButton
                                         Content="{x:Bind Link, Mode=OneTime}"

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -173,7 +173,7 @@
                                         Click="Button_ClickAsync"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Bottom"
-                                        Content="{x:Bind Button, Mode=OneTime}" />
+                                        Content="{x:Bind ButtonText, Mode=OneTime}" />
 
                                 </StackPanel>
                             </Grid>
@@ -302,11 +302,11 @@
                                     DataContext="{x:Bind PageKey}"
                                     Click="Button_ClickAsync"
                                     HorizontalAlignment="Stretch"
-                                    AutomationProperties.Name="{x:Bind Button, Mode=OneTime}"
+                                    AutomationProperties.Name="{x:Bind ButtonText, Mode=OneTime}"
                                     VerticalAlignment="Bottom">
                                     <Button.Content>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="{x:Bind Button, Mode=OneTime}" Margin="0 0 5 0" />
+                                            <TextBlock Text="{x:Bind ButtonText, Mode=OneTime}" Margin="0 0 5 0" />
                                             <!-- The open new window icon -->
                                             <FontIcon 
                                                 Glyph="&#xE8A7;" 

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -70,7 +70,7 @@
                         Margin="0 16"
                         MinWidth="248"
                         Style="{ThemeResource AccentButtonStyle}"
-                        Command="{x:Bind ViewModel.NavigateToGetStartedCommand}" />
+                        Command="{x:Bind ViewModel.HeaderButtonNavigateCommand}" />
                 </StackPanel>
 
                 <!-- Big Cards -->

--- a/src/Views/WhatsNewPage.xaml
+++ b/src/Views/WhatsNewPage.xaml
@@ -7,7 +7,6 @@
     xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:models="using:DevHome.Models"
     xmlns:behaviors="using:DevHome.Common.Behaviors" 
-    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     Loaded="OnLoaded"
     SizeChanged="OnSizeChanged"
@@ -71,7 +70,7 @@
                         Margin="0 16"
                         MinWidth="248"
                         Style="{ThemeResource AccentButtonStyle}"
-                        Click="MachineConfigButton_Click" />
+                        Command="{x:Bind ViewModel.NavigateToGetStartedCommand}" />
                 </StackPanel>
 
                 <!-- Big Cards -->

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -55,7 +55,7 @@ public sealed partial class WhatsNewPage : Page
             {
                 if (!DevDriveUtil.IsDevDriveFeatureEnabled)
                 {
-                    card.Button = Application.Current.GetService<IStringResource>().GetLocalized(_devDriveLinkResourceKey);
+                    card.ButtonText = Application.Current.GetService<IStringResource>().GetLocalized(_devDriveLinkResourceKey);
                     card.ShouldShowLink = false;
                 }
             }

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -87,12 +87,6 @@ public sealed partial class WhatsNewPage : Page
         MoveBigCardsIfNeeded(this.ActualWidth);
     }
 
-    private void MachineConfigButton_Click(object sender, RoutedEventArgs e)
-    {
-        var navigationService = Application.Current.GetService<INavigationService>();
-        navigationService.NavigateTo(typeof(SetupFlow.ViewModels.SetupFlowViewModel).FullName!);
-    }
-
     private async void Button_ClickAsync(object sender, RoutedEventArgs e)
     {
         var btn = sender as Button;

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -22,7 +22,6 @@ public sealed partial class WhatsNewPage : Page
     private readonly Uri _devDrivePageKeyUri = new("ms-settings:disksandvolumes");
     private readonly Uri _devDriveLearnMoreLinkUri = new("https://go.microsoft.com/fwlink/?linkid=2236041");
     private const string _devDriveLinkResourceKey = "WhatsNewPage_DevDriveCard/Link";
-    private const string _accountsPageNavigationLink = "DevHome.Settings.ViewModels.AccountsViewModel";
 
     public WhatsNewViewModel ViewModel
     {
@@ -91,7 +90,7 @@ public sealed partial class WhatsNewPage : Page
     private void MachineConfigButton_Click(object sender, RoutedEventArgs e)
     {
         var navigationService = Application.Current.GetService<INavigationService>();
-        navigationService.NavigateTo(typeof(DevHome.SetupFlow.ViewModels.SetupFlowViewModel).FullName!);
+        navigationService.NavigateTo(typeof(SetupFlow.ViewModels.SetupFlowViewModel).FullName!);
     }
 
     private async void Button_ClickAsync(object sender, RoutedEventArgs e)
@@ -116,12 +115,12 @@ public sealed partial class WhatsNewPage : Page
         }
         else
         {
-            if (pageKey.Equals(_accountsPageNavigationLink, StringComparison.OrdinalIgnoreCase))
+            if (pageKey.Equals(typeof(Settings.ViewModels.AccountsViewModel).FullName, StringComparison.OrdinalIgnoreCase))
             {
                 TelemetryFactory.Get<ITelemetry>().Log(
-                                                        "EntryPoint_DevId_Event",
-                                                        LogLevel.Critical,
-                                                        new EntryPointEvent(EntryPointEvent.EntryPoint.WhatsNewPage));
+                    "EntryPoint_DevId_Event",
+                    LogLevel.Critical,
+                    new EntryPointEvent(EntryPointEvent.EntryPoint.WhatsNewPage));
             }
 
             var navigationService = Application.Current.GetService<INavigationService>();
@@ -146,14 +145,6 @@ public sealed partial class WhatsNewPage : Page
         else
         {
             ViewModel.SwitchToLargerView();
-        }
-    }
-
-    public static class MyHelpers
-    {
-        public static Type GetType(object ele)
-        {
-            return ele.GetType();
         }
     }
 }

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -23,10 +23,7 @@ public sealed partial class WhatsNewPage : Page
     private readonly Uri _devDriveLearnMoreLinkUri = new("https://go.microsoft.com/fwlink/?linkid=2236041");
     private const string _devDriveLinkResourceKey = "WhatsNewPage_DevDriveCard/Link";
 
-    public WhatsNewViewModel ViewModel
-    {
-        get;
-    }
+    public WhatsNewViewModel ViewModel { get; }
 
     public WhatsNewPage()
     {
@@ -124,7 +121,7 @@ public sealed partial class WhatsNewPage : Page
 
     public void OnSizeChanged(object sender, SizeChangedEventArgs args)
     {
-        if ((Page)sender == this)
+        if (sender as Page == this)
         {
             MoveBigCardsIfNeeded(args.NewSize.Width);
         }


### PR DESCRIPTION
## Summary of the pull request

* WhatsNewPage was building with this xaml compiler warning: `OneWay bindings require at least one of their steps to support raising notifications when their value changes`. Change these bindings to OneTime (since that's what they effectively were) and be explicit about the other bindings that are OneTime.
* Rename WhatsNewCard.Button to WhatsNewCard.ButtonText, to more accurately reflect what it is
* Move one command to ViewModel. More may be done here, but it would be a more complicated change and this seemed like a good chunk.
* Remove `muxc:` prefix from XAML. It isn't needed.
* Remove navigation methods that were never actually called.

## Validation steps performed
Tested locally.