### PR TITLE
Ironsides - Fix title bar colors

### DIFF
--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -10,11 +10,13 @@ using DevHome.PI.Helpers;
 using DevHome.PI.Models;
 using DevHome.PI.Properties;
 using DevHome.PI.ViewModels;
+using Microsoft.UI;
 using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
+using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
 using Windows.Win32.Foundation;
 using WinRT.Interop;
@@ -27,6 +29,8 @@ public partial class BarWindowHorizontal : WindowEx
 {
     private readonly Settings _settings = Settings.Default;
     private readonly BarWindowViewModel _viewModel;
+    private readonly UISettings _uiSettings = new();
+
     private bool isClosing;
 
     // Constants that control window sizes
@@ -76,6 +80,14 @@ public partial class BarWindowHorizontal : WindowEx
         var settingSize = Settings.Default.ExpandedLargeSize;
         _restoreState.Height = settingSize.Height;
         _restoreState.Width = settingSize.Width;
+
+        _uiSettings.ColorValuesChanged += (sender, args) =>
+        {
+            TheDispatcher.TryEnqueue(() =>
+            {
+                ApplySystemThemeToCaptionButtons();
+            });
+        };
     }
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -206,6 +218,19 @@ public partial class BarWindowHorizontal : WindowEx
         if (Content is FrameworkElement rootElement)
         {
             rootElement.RequestedTheme = theme;
+
+            if (theme == ElementTheme.Dark)
+            {
+                SetCaptionButtonColors(Colors.White);
+            }
+            else if (theme == ElementTheme.Light)
+            {
+                SetCaptionButtonColors(Colors.Black);
+            }
+            else
+            {
+                ApplySystemThemeToCaptionButtons();
+            }
         }
     }
 
@@ -288,5 +313,34 @@ public partial class BarWindowHorizontal : WindowEx
     private void MainPanel_SizeChanged(object sender, SizeChangedEventArgs e)
     {
         SetRegionsForTitleBar();
+    }
+
+    // workaround as Appwindow titlebar doesn't update caption button colors correctly when changed while app is running
+    // https://task.ms/44172495
+    public void ApplySystemThemeToCaptionButtons()
+    {
+        if (Content is FrameworkElement rootElement)
+        {
+            Windows.UI.Color color;
+            if (rootElement.ActualTheme == ElementTheme.Dark)
+            {
+                color = Colors.White;
+            }
+            else
+            {
+                color = Colors.Black;
+            }
+
+            SetCaptionButtonColors(color);
+        }
+
+        return;
+    }
+
+    public void SetCaptionButtonColors(Windows.UI.Color color)
+    {
+        var res = Application.Current.Resources;
+        res["WindowCaptionForeground"] = color;
+        AppWindow.TitleBar.ButtonForegroundColor = color;
     }
 }


### PR DESCRIPTION
## Summary of the pull request

This applies the title bar color workaround to PI that was done for the WinUI3 Gallery app, specifically

https://github.com/microsoft/WinUI-Gallery/blob/cb7c59a925171751ec559c563f5171d9686cda2a/WinUIGallery/Helper/TitleBarHelper.cs#L25

Both PI and DevHome suffered from this issue... this PR only fixes PI. You can see the difference below...

If you switch to Dark mode when the apps are running, and PI has foreground focus, you'll see colors are correct (PI's buttons are white, DevHome's buttons are grey). If DH has focus, you'll see its button colors are incorrectly black (the color of light mode).

![Screenshot 2024-06-10 142808](https://github.com/microsoft/devhome/assets/49733346/6848b8ab-5dba-4039-b1cb-bcf17e6d5b20)

![Screenshot 2024-06-10 142803](https://github.com/microsoft/devhome/assets/49733346/17c480fd-c4cd-4737-bf5d-428b195c3f5e)

It appears this WinAppSDK bug is fixed in 1.6, so hopefully this is a short-term workaround.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3053 
- [ ] Tests added/passed
- [ ] Documentation updated
