### PR TITLE
Update icon glyphs to use SymbolThemeFontFamily

### DIFF
--- a/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml
@@ -39,7 +39,7 @@
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Spacing="12">
                                     <TextBlock Text="{Binding IconText}" Style="{x:Null}"
-                                        FontFamily="Segoe Fluent Icons" FontSize="12"
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="12"
                                         HorizontalAlignment="Left" VerticalAlignment="Center"/>
                                     <TextBlock Text="{Binding ContentText}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                                 </StackPanel>
@@ -71,7 +71,7 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock 
-                            Text="&#xe713;" FontFamily="Segoe Fluent Icons" FontSize="12"
+                            Text="&#xe713;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="12"
                             HorizontalAlignment="Left" VerticalAlignment="Center"/>
                         <TextBlock 
                             Grid.Column="1" Text="{x:Bind viewModel.SettingsHeader, Mode=OneWay}"

--- a/tools/PI/DevHome.PI/Controls/ExternalToolsManagementButton.cs
+++ b/tools/PI/DevHome.PI/Controls/ExternalToolsManagementButton.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using DevHome.PI.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace DevHome.PI.Controls;
 
@@ -252,9 +253,13 @@ internal sealed class ExternalToolsManagementButton : Button
 
     private FontIcon GetFontIcon(string s)
     {
-        var icon = new FontIcon();
-        icon.FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons");
-        icon.Glyph = s;
+        var fontFamily = (FontFamily)Application.Current.Resources["SymbolThemeFontFamily"];
+
+        var icon = new FontIcon
+        {
+            FontFamily = fontFamily,
+            Glyph = s,
+        };
 
         return icon;
     }

--- a/tools/PI/DevHome.PI/PIApp.xaml
+++ b/tools/PI/DevHome.PI/PIApp.xaml
@@ -13,7 +13,7 @@
             <Style x:Key="ChromeButton" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="Foreground" Value="#A0A0A0"/>
-                <Setter Property="FontFamily" Value="Segoe Fluent Icons"/>
+                <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
                 <Setter Property="FontSize" Value="10"/>
                 <Setter Property="Template">
                     <Setter.Value>

--- a/tools/PI/DevHome.PI/Pages/AdditionalToolsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AdditionalToolsPage.xaml
@@ -21,7 +21,7 @@
 
             <ctControls:SettingsExpander x:Uid="SettingsAddToolCard" IsExpanded="False">
                 <ctControls:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xED0E;"/>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xED0E;"/>
                 </ctControls:SettingsExpander.HeaderIcon>
                 <ctControls:SettingsExpander.Items>
                     <ctControls:SettingsCard HorizontalContentAlignment="Stretch" ContentAlignment="Left">
@@ -32,7 +32,7 @@
             
             <ctControls:SettingsExpander x:Uid="SettingsEditToolCard" IsExpanded="False">
                 <ctControls:SettingsExpander.HeaderIcon>
-                    <FontIcon Glyph="&#xE70F;"/>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE70F;"/>
                 </ctControls:SettingsExpander.HeaderIcon>
                 <ctControls:SettingsExpander.Items>
                     <ctControls:SettingsCard HorizontalContentAlignment="Stretch" ContentAlignment="Left">

--- a/tools/PI/DevHome.PI/Pages/AdvancedSettingsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AdvancedSettingsPage.xaml
@@ -21,28 +21,28 @@
 
             <ctControls:SettingsCard x:Uid="MonitorCpuSettingCard">
                 <ctControls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE950;"/>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE950;"/>
                 </ctControls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="CpuUsageToggle" Toggled="CpuUsageToggle_Toggled"/>
             </ctControls:SettingsCard>
             
             <ctControls:SettingsCard x:Uid="ShowInsightsCard">
                 <ctControls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE9D9;"/>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE9D9;"/>
                 </ctControls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="ShowInsightsToggle" Toggled="ShowInsightsToggle_Toggled"/>
             </ctControls:SettingsCard>
             
             <ctControls:SettingsCard x:Uid="EnableClipboardMonitoringCard">
                 <ctControls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xF0E3;"/>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xF0E3;"/>
                 </ctControls:SettingsCard.HeaderIcon>
                 <ToggleSwitch x:Name="EnableClipboardMonitoringToggle" Toggled="EnableClipboardMonitoringToggle_Toggled"/>
             </ctControls:SettingsCard>
             
             <ctControls:SettingsCard x:Uid="ExcludedProcessesCard">
                 <ctControls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE71C;"/>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE71C;"/>
                 </ctControls:SettingsCard.HeaderIcon>
                 <Grid HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>

--- a/tools/PI/DevHome.PI/Pages/PreferencesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/PreferencesPage.xaml
@@ -21,7 +21,7 @@
             
             <ctControls:SettingsCard x:Uid="SettingsThemeCard">
                 <ctControls:SettingsCard.HeaderIcon>
-                    <FontIcon Glyph="&#xE790;" />
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE790;" />
                 </ctControls:SettingsCard.HeaderIcon>
                 <ComboBox x:Name="ThemeSelectionComboBox">
                     <ComboBoxItem x:Uid="SettingsThemeDefault" Tag="{x:Bind xaml:ElementTheme.Default}" AutomationProperties.AutomationId="SettingsThemeDefault" />

--- a/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
@@ -44,7 +44,7 @@
                 </ComboBox>
                 <Button x:Uid="RefreshButton" x:Name="RefreshButton" BorderThickness="0" Margin="8,0,0,0" Grid.Column="1"
                     Command="{x:Bind ViewModel.RefreshFilteredProcessListCommand}">
-                    <TextBlock Text="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="20"/>
+                    <TextBlock Text="&#xE72C;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20"/>
                 </Button>
             </Grid>
         </Grid>

--- a/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
@@ -42,12 +42,12 @@
             <Button
                 x:Uid="ClearWinLogsButton" x:Name="ClearWinLogsButton"
                 BorderThickness="0" Command="{x:Bind ViewModel.ClearWinLogsCommand}">
-                <TextBlock Text="&#xE74D;" FontFamily="Segoe Fluent Icons" FontSize="20"/>
+                <TextBlock Text="&#xE74D;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20"/>
             </Button>
             <local:GlowButton 
                 x:Uid="InsightsButton" x:Name="InsightsButton" Margin="6,0,0,0"
                 BorderThickness="0"              
-                Text="&#xE946;" FontFamily="Segoe Fluent Icons" FontSize="20" Foreground="#0089FF"
+                Text="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Foreground="#0089FF"
                 Command="{x:Bind ViewModel.ShowInsightsPageCommand}" 
                 Visibility="{x:Bind ViewModel.InsightsButtonVisibility, Mode=OneWay}">
             </local:GlowButton>

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -13,7 +13,6 @@
     TaskBarIcon="Images/pi.ico"
     Closed="WindowEx_Closed">
 
-    <!-- TODO Make DesktopAcrylicBackdrop/MicaBackdrop and AcrylicBackgroundFillColorBaseBrush user-configurable.-->
     <Window.SystemBackdrop>
         <MicaBackdrop/>
     </Window.SystemBackdrop>
@@ -47,7 +46,7 @@
         <StackPanel x:Name="AllControls" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Left" Background="Transparent" >
             <StackPanel.Resources>
                 <Style TargetType="TextBlock">
-                    <Setter Property="FontFamily" Value="Segoe Fluent Icons"/>
+                    <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
                     <Setter Property="FontSize" Value="20"/>
                 </Style>
                 <Style TargetType="Button">
@@ -76,7 +75,7 @@
                     <MenuFlyout>
                         <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
                             <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE894;"/>
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                     </MenuFlyout>
@@ -114,12 +113,12 @@
                             <MenuFlyout x:Name="ToolContextMenu">
                                 <MenuFlyoutItem x:Uid="UnpinMenuItem" Name="UnpinMenuItem" Click="{x:Bind TogglePinnedState}">
                                     <MenuFlyoutItem.Icon>
-                                        <FontIcon Glyph="&#xE77A;"/>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE77A;"/>
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                                 <MenuFlyoutItem x:Uid="UnregisterMenuItem" Name="UnregisterMenuItem" Click="{x:Bind UnregisterTool}">
                                     <MenuFlyoutItem.Icon>
-                                        <FontIcon Glyph="&#xECC9;"/>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xECC9;"/>
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                             </MenuFlyout>

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
@@ -53,7 +53,7 @@
         <StackPanel x:Name="AllControls" Orientation="Vertical" Grid.Row="1" HorizontalAlignment="Center" Margin="0" Background="Transparent">
             <StackPanel.Resources>
                 <Style TargetType="TextBlock">
-                    <Setter Property="FontFamily" Value="Segoe Fluent Icons"/>
+                    <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
                     <Setter Property="FontSize" Value="20"/>
                 </Style>
                 <Style TargetType="Button">
@@ -82,7 +82,7 @@
                     <MenuFlyout>
                         <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
                             <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE894;"/>
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                     </MenuFlyout>
@@ -119,12 +119,12 @@
                             <MenuFlyout x:Name="ToolContextMenu">
                                 <MenuFlyoutItem x:Uid="UnpinMenuItem" Name="UnpinMenuItem" Click="{x:Bind TogglePinnedState}">
                                     <MenuFlyoutItem.Icon>
-                                        <FontIcon Glyph="&#xE77A;"/>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE77A;"/>
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                                 <MenuFlyoutItem x:Uid="UnregisterMenuItem" Name="UnregisterMenuItem" Click="{x:Bind UnregisterTool}">
                                     <MenuFlyoutItem.Icon>
-                                        <FontIcon Glyph="&#xECC9;"/>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xECC9;"/>
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                             </MenuFlyout>


### PR DESCRIPTION
## Summary of the pull request

This fix uses the SymbolThemeFontFamily resource defined in Microsoft.WinUI\Themes\generic.xaml. This specifies to prefer the Segoe Fluent Icons fontfamily, and if that's not available, to fall back to the older Segoe MDL2 Assets which are available on Windows 10. All the values used in Project Ironsides have directly-equivalent glyphs in the older font. 

Tested on Windows 11 and Windows 10.

## References and relevant issues
Fixed the following:
- Closes #3146
