### PR TITLE
Replaced all fontsize declarations with standard StaticResources

### DIFF
--- a/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml
@@ -17,7 +17,7 @@
 
         <TextBlock
             x:Uid="ExpandedViewHeaderTextBlock" x:Name="ExpandedViewTitleTextBlock" Text="{x:Bind viewModel.Title, Mode=OneWay}"
-            FontSize="16" FontWeight="Bold" FontFamily="Segoe UI"/>
+            FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="Bold" FontFamily="Segoe UI"/>
 
         <Grid Grid.Row="1" Margin="0,8,0,0">
             <Grid.ColumnDefinitions>
@@ -39,7 +39,7 @@
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Spacing="12">
                                     <TextBlock Text="{Binding IconText}" Style="{x:Null}"
-                                        FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="12"
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource CaptionTextBlockFontSize}"
                                         HorizontalAlignment="Left" VerticalAlignment="Center"/>
                                     <TextBlock Text="{Binding ContentText}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                                 </StackPanel>
@@ -71,7 +71,7 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock 
-                            Text="&#xe713;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="12"
+                            Text="&#xe713;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource CaptionTextBlockFontSize}"
                             HorizontalAlignment="Left" VerticalAlignment="Center"/>
                         <TextBlock 
                             Grid.Column="1" Text="{x:Bind viewModel.SettingsHeader, Mode=OneWay}"
@@ -98,17 +98,17 @@
                     HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6" 
                     HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock x:Uid="ClickboardErrorTextBlock" FontSize="10"/>
+                        <TextBlock x:Uid="ClickboardErrorTextBlock" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
                     </Expander.Header>
                     <Grid>
                         <Grid.Resources>
                             <Style TargetType="TextBlock">
-                                <Setter Property="FontSize" Value="10"/>
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
                                 <Setter Property="Margin" Value="12,0,0,0"/>
                                 <Setter Property="VerticalAlignment" Value="Center"/>
                             </Style>
                             <Style TargetType="TextBox">
-                                <Setter Property="FontSize" Value="10"/>
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
                                 <Setter Property="IsReadOnly" Value="True"/>
                                 <Setter Property="BorderThickness" Value="0"/>
                                 <Setter Property="Margin" Value="0,8,0,0"/>
@@ -142,7 +142,7 @@
                     <StackPanel Orientation="Horizontal">
                         <StackPanel.Resources>
                             <Style TargetType="TextBlock">
-                                <Setter Property="FontSize" Value="8"/>
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
                                 <Setter Property="Margin" Value="12,0,0,0"/>
                                 <Setter Property="VerticalAlignment" Value="Center"/>
                                 <Setter Property="HorizontalAlignment" Value="Left"/>

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -25,7 +25,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Uid="AppDetailsTextBlock" FontSize="20" Margin="0,0,0,8"/>
+        <TextBlock x:Uid="AppDetailsTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <Grid x:Name="AppDetailsPanel">

--- a/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
@@ -10,7 +10,14 @@
     NavigationCacheMode="Enabled">
 
     <Grid>
-        <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsList}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock x:Uid="InsightsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+        <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsList}" Grid.Row="1">
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="models:Insight">
                     <Expander IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}" ExpandDirection="Down" HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6">

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
@@ -22,7 +22,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Uid="ModulesHeaderTextBlock" FontSize="20" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
+        <TextBlock x:Uid="ModulesHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
         <Button Grid.Row="1" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
         <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}">
             <Grid.ColumnDefinitions>
@@ -50,18 +50,18 @@
                 <StackPanel x:Name="ModuleDetailsPanel" Margin="8,0,0,0">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
                         <TextBlock Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).ModuleName, Mode=OneWay}"
-                                   FontSize="24" FontWeight="Bold"/>
+                                   FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="Bold"/>
                     </StackPanel>
                     <StackPanel>
-                        <TextBlock x:Uid="FileVersionInfoTextBlock" FontSize="18" />
+                        <TextBlock x:Uid="FileVersionInfoTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" />
                         <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).FileVersionInfo, Mode=OneWay}"
                                  FontFamily="Consolas" TextWrapping="Wrap" IsReadOnly="True"/>
 
-                        <TextBlock x:Uid="BaseAddressTextBlock" FontSize="18" Margin="0,6,0,0"/>
+                        <TextBlock x:Uid="BaseAddressTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" Margin="0,6,0,0"/>
                         <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).BaseAddress, Mode=OneWay}" IsReadOnly="True"/>
-                        <TextBlock x:Uid="EntrypointAddressTextBlock" FontSize="18" Margin="0,6,0,0"/>
-                        <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).EntryPointAddress, Mode=OneWay}" IsReadOnly="True"/>                        
-                        <TextBlock x:Uid="MemorySizeTextBlock" FontSize="18" Margin="0,6,0,0"/>
+                        <TextBlock x:Uid="EntrypointAddressTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" Margin="0,6,0,0"/>
+                        <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).EntryPointAddress, Mode=OneWay}" IsReadOnly="True"/>
+                        <TextBlock x:Uid="MemorySizeTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" Margin="0,6,0,0"/>
                         <TextBox Text="{x:Bind ((models:ProcessModuleInfo)ModulesListView.SelectedItem).ModuleMemorySize, Mode=OneWay}" IsReadOnly="True"/>
                     </StackPanel>
                 </StackPanel>

--- a/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
@@ -13,15 +13,19 @@
     <Grid>
         <Grid.Resources>
             <Style TargetType="TextBlock">
-                <Setter Property="FontSize" Value="14"/>
+                <Setter Property="FontSize" Value="{StaticResource BodyTextBlockFontSize}"/>
                 <Setter Property="FontFamily" Value="Segoe UI"/>
             </Style>
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Grid Margin="16,16,0,0">
+
+        <TextBlock x:Uid="ProcessListHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+        <Grid Margin="16,16,0,0" Grid.Row="1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -44,13 +48,14 @@
                 </ComboBox>
                 <Button x:Uid="RefreshButton" x:Name="RefreshButton" BorderThickness="0" Margin="8,0,0,0" Grid.Column="1"
                     Command="{x:Bind ViewModel.RefreshFilteredProcessListCommand}">
-                    <TextBlock Text="&#xE72C;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20"/>
+                    <TextBlock Text="&#xE72C;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource SubtitleTextBlockFontSize}"/>
                 </Button>
             </Grid>
         </Grid>
+        
         <controls:DataGrid
             x:Uid="ProcessDataGrid"
-            x:Name="ProcessDataGrid" Grid.Row="1" Margin="16,4,0,0"
+            x:Name="ProcessDataGrid" Grid.Row="2" Margin="16,4,0,0"
             VerticalScrollBarVisibility="Visible"
             AlternatingRowBackground="Transparent"
             AlternatingRowForeground="Gray"

--- a/tools/PI/DevHome.PI/Pages/ResourceUsagePage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ResourceUsagePage.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Uid="ResourceUsageHeaderTextBlock" FontSize="20" Margin="0,0,0,8"/>
+        <TextBlock x:Uid="ResourceUsageHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
         <Grid x:Name="ResourceUsagePanel" Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>

--- a/tools/PI/DevHome.PI/Pages/WatsonsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WatsonsPage.xaml
@@ -22,7 +22,7 @@
             <RowDefinition Height="3*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Uid="WatsonsHeaderTextBlock" FontSize="20" Margin="0,0,0,8"/>
+        <TextBlock x:Uid="WatsonsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
         <controls:DataGrid
             x:Name="WatsonsDataGrid" Grid.Row="1" Margin="0,6,0,0"

--- a/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
@@ -20,7 +20,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Uid="WinLogsHeaderTextBlock" FontSize="20" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
+        <TextBlock x:Uid="WinLogsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
         <Button Grid.Row="1" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
         <StackPanel x:Name="WinLogsOptions" Grid.Row="2" Orientation="Horizontal" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}">
             <CheckBox
@@ -42,12 +42,12 @@
             <Button
                 x:Uid="ClearWinLogsButton" x:Name="ClearWinLogsButton"
                 BorderThickness="0" Command="{x:Bind ViewModel.ClearWinLogsCommand}">
-                <TextBlock Text="&#xE74D;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20"/>
+                <TextBlock Text="&#xE74D;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource SubtitleTextBlockFontSize}"/>
             </Button>
             <local:GlowButton 
                 x:Uid="InsightsButton" x:Name="InsightsButton" Margin="6,0,0,0"
                 BorderThickness="0"              
-                Text="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Foreground="#0089FF"
+                Text="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource SubtitleTextBlockFontSize}" Foreground="#0089FF"
                 Command="{x:Bind ViewModel.ShowInsightsPageCommand}" 
                 Visibility="{x:Bind ViewModel.InsightsButtonVisibility, Mode=OneWay}">
             </local:GlowButton>

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -145,10 +145,6 @@
     <value>Expand or collapse the large content panel</value>
     <comment>The tooltip for a button which expands or collapses the large content panel.</comment>
   </data>
-  <data name="UnSnapButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Un-snap: make the bar free-floating</value>
-    <comment>The tooltip for a button that causes the bar to unsnap from the current window.</comment>
-  </data>
   <data name="ReSnapButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Snap the bar to the current foreground window</value>
     <comment>The tooltip for a button that causes the bar to snap to the current foreground window.</comment>
@@ -905,9 +901,9 @@
     <value>Select a process to investigate</value>
     <comment>Describes using a button in Project Ironsides's UX to investigate another process running on the system</comment>
   </data>
-  <data name="SnapButton.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="SnapToolTip" xml:space="preserve">
     <value>Attach the diagnostic bar to the target application</value>
-    <comment>Describes using a button in Project Ironsides's UX</comment>
+    <comment>The tooltip text for a button that attaches the bar to the target application.</comment>
   </data>
   <data name="Title.Text" xml:space="preserve">
     <value>Dev Home Project Ironsides</value>
@@ -956,5 +952,9 @@
   <data name="DetachMenuItem.Text" xml:space="preserve">
     <value>Detach</value>
     <comment>Menu Item that allows the user to detach from the current process</comment>
+  </data>
+  <data name="UnsnapToolTip" xml:space="preserve">
+    <value>Detach the diagnostic bar from the target application</value>
+    <comment>The tooltip text for a button that detaches the bar from the target application.</comment>
   </data>
 </root>

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -18,7 +17,6 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Graphics;
 using Windows.System;
 using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.Gdi;
 
 namespace DevHome.PI.ViewModels;
 
@@ -29,6 +27,8 @@ public partial class BarWindowViewModel : ObservableObject
 
     private readonly string _errorTitleText = CommonHelper.GetLocalizedString("ToolLaunchErrorTitle");
     private readonly string _errorMessageText = CommonHelper.GetLocalizedString("ToolLaunchErrorMessage");
+    private readonly string _unsnapToolTip = CommonHelper.GetLocalizedString("UnsnapToolTip");
+    private readonly string _snapToolTip = CommonHelper.GetLocalizedString("SnapToolTip");
 
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
     private readonly List<Button> _externalToolButtons = [];
@@ -50,6 +50,9 @@ public partial class BarWindowViewModel : ObservableObject
 
     [ObservableProperty]
     private string _currentSnapButtonText = _SnapButtonText;
+
+    [ObservableProperty]
+    private string _currentSnapToolTip;
 
     [ObservableProperty]
     private string _appCpuUsage = string.Empty;
@@ -100,9 +103,7 @@ public partial class BarWindowViewModel : ObservableObject
         SystemDiskUsage = CommonHelper.GetLocalizedString("DiskPerfPercentUsageTextFormatNoLabel", PerfCounters.Instance.SystemDiskUsage);
 
         var process = TargetAppData.Instance.TargetProcess;
-
         IsAppBarVisible = process is not null;
-
         if (process != null)
         {
             ApplicationName = process.ProcessName;
@@ -112,7 +113,7 @@ public partial class BarWindowViewModel : ObservableObject
         }
 
         CurrentSnapButtonText = IsSnapped ? _UnsnapButtonText : _SnapButtonText;
-
+        CurrentSnapToolTip = IsSnapped ? _unsnapToolTip : _snapToolTip;
         _snapHelper = new();
 
         ((INotifyCollectionChanged)ExternalToolsHelper.Instance.FilteredExternalTools).CollectionChanged += FilteredExternalTools_CollectionChanged;
@@ -128,6 +129,7 @@ public partial class BarWindowViewModel : ObservableObject
     partial void OnIsSnappedChanged(bool value)
     {
         CurrentSnapButtonText = IsSnapped ? _UnsnapButtonText : _SnapButtonText;
+        CurrentSnapToolTip = IsSnapped ? _unsnapToolTip : _snapToolTip;
     }
 
     partial void OnBarOrientationChanged(Orientation value)

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -9,7 +9,7 @@
     xmlns:controls="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="70" MinWidth="700" Height="70" Width="700" MaxHeight="70"
+    Title="" MinHeight="72" MinWidth="700" Height="72" Width="700" MaxHeight="72"
     TaskBarIcon="Images/pi.ico"
     Closed="WindowEx_Closed">
 
@@ -32,12 +32,17 @@
                 <ColumnDefinition x:Name="RightPaddingColumn" Width="0"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock x:Uid="Title" FontSize="10" Margin="10,0,0,0" HorizontalAlignment="Left" Grid.Column="1" VerticalAlignment="Center"/>
-            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0, 0, 10, 0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}">
+            <TextBlock x:Uid="Title" Grid.Column="1" Style="{StaticResource CaptionTextBlockStyle}" Margin="10,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,10,0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}">
                 <Button
-                      x:Uid="SnapButton" Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}"
-                      x:Name="SnapButton" Style="{StaticResource ChromeButton}" FontSize="11"
-                      Command="{x:Bind _viewModel.ToggleSnapCommand}" HorizontalAlignment="Left" IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}">
+                    x:Uid="SnapButton" 
+                    Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}"
+                    x:Name="SnapButton" Style="{StaticResource ChromeButton}" 
+                    FontSize="{StaticResource CaptionTextBlockFontSize}"
+                    Command="{x:Bind _viewModel.ToggleSnapCommand}" 
+                    HorizontalAlignment="Left" 
+                    IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}"
+                    ToolTipService.ToolTip="{x:Bind _viewModel.CurrentSnapToolTip, Mode=OneWay}">
                     <TextBlock Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>
                 </Button>
             </StackPanel>
@@ -47,7 +52,7 @@
             <StackPanel.Resources>
                 <Style TargetType="TextBlock">
                     <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
-                    <Setter Property="FontSize" Value="20"/>
+                    <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}"/>
                 </Style>
                 <Style TargetType="Button">
                     <Setter Property="BorderThickness" Value="0"/>
@@ -64,7 +69,7 @@
             </StackPanel.Resources>
             
             <controls:ProcessSelectionButton x:Uid="ProcessChooserButton" x:Name="ProcessChooserButton" Command="{x:Bind _viewModel.ProcessChooserCommand}" HorizontalAlignment="Center" Margin="0">
-                <TextBlock Text="&#xecaa;" Margin="0"  />
+                <TextBlock Text="&#xecaa;" Margin="0"/>
             </controls:ProcessSelectionButton>
 
             <controls:PISeparator />
@@ -81,8 +86,8 @@
                     </MenuFlyout>
                 </StackPanel.ContextFlyout>
                 <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="5" Height="20" Width="20" />
-                <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" VerticalAlignment="Center" />
-                <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" VerticalAlignment="Center" />
+                <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" Margin="5" VerticalAlignment="Center" />
+                <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" Margin="5" VerticalAlignment="Center" />
                 <controls:PISeparator />
             </StackPanel>
 
@@ -130,9 +135,9 @@
         </StackPanel>
 
         <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="1">
-                <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" Margin="5"/>
-                <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" Margin="5"/>
-                <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" Margin="5"/>
+            <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" Margin="5"/>
+            <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" Margin="5"/>
+            <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" Margin="5"/>
             </StackPanel>
 
         <Border

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
@@ -9,11 +9,10 @@
     xmlns:controls="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="700" MinWidth="70" MaxWidth="70" Width="70" Height="700"
+    Title="" MinHeight="700" MinWidth="72" MaxWidth="72" Width="72" Height="700"
     TaskBarIcon="Images/pi.ico" IsTitleBarVisible="False"
     IsAlwaysOnTop="{x:Bind _viewModel.IsAlwaysOnTop, Mode=OneWay}"
     Closed="WindowEx_Closed">
-    <!-- TODO Make DesktopAcrylicBackdrop/MicaBackdrop and AcrylicBackgroundFillColorBaseBrush user-configurable.-->
     <Window.SystemBackdrop>
         <MicaBackdrop/>
     </Window.SystemBackdrop>
@@ -36,7 +35,8 @@
                 Style="{StaticResource ChromeButton}"
                 HorizontalAlignment="Center"
                 IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}"
-                Command="{x:Bind _viewModel.ToggleSnapCommand}" >
+                Command="{x:Bind _viewModel.ToggleSnapCommand}"
+                ToolTipService.ToolTip="{x:Bind _viewModel.CurrentSnapToolTip, Mode=OneWay}">
                 <TextBlock Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>
             </Button>
             <Button
@@ -54,7 +54,7 @@
             <StackPanel.Resources>
                 <Style TargetType="TextBlock">
                     <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
-                    <Setter Property="FontSize" Value="20"/>
+                    <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}"/>
                 </Style>
                 <Style TargetType="Button">
                     <Setter Property="BorderThickness" Value="0"/>
@@ -88,8 +88,8 @@
                     </MenuFlyout>
                 </StackPanel.ContextFlyout>
                 <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="5" Height="20" Width="20" />
-                <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" HorizontalAlignment="Center" />
-                <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" Margin="5" HorizontalAlignment="Center" />
+                <TextBlock x:Uid="AppPID" Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" Margin="5" HorizontalAlignment="Center" />
+                <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" Margin="5" HorizontalAlignment="Center" />
                 <controls:PISeparator Orientation="Horizontal"/>
             </StackPanel>
                         
@@ -136,9 +136,9 @@
         </StackPanel>
 
         <StackPanel x:Name="SystemResourceStackPanel" Orientation="Vertical" Grid.Row="2" Margin="0,0,0,5">
-            <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5, 0, 5, 0"/>
-            <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5, 5, 5, 5"/>
-            <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5, 0, 5, 0"/>
+            <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5, 0, 5, 0"/>
+            <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5, 5, 5, 5"/>
+            <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="5, 0, 5, 0"/>
         </StackPanel>
     </Grid>
 </winex:WindowEx>

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using DevHome.Common.Extensions;
 using DevHome.PI.Helpers;
@@ -78,7 +77,7 @@ public partial class BarWindowVertical : WindowEx
         var style = PInvoke.GetWindowLong(ThisHwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
         style &= ~(int)WINDOW_STYLE.WS_THICKFRAME;
         _ = PInvoke.SetWindowLong(ThisHwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, style);
-        PInvoke.SetWindowPos(ThisHwnd, HWND.Null, 0, 0, 0, 0, Windows.Win32.UI.WindowsAndMessaging.SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER);
+        PInvoke.SetWindowPos(ThisHwnd, HWND.Null, 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER);
     }
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request

This uses the standard XAML type ramp: https://learn.microsoft.com/en-us/windows/apps/design/style/xaml-theme-resources#the-xaml-type-ramp. This sets the smallest font to be 12. Accordingly, this fix also increased the min width/height of the collapsed bar from 70 to 72 to accommodate the increased size of the text items.

Also fixed the missing headers on the ProcessList and Insights pages.

Also made the tooltip for the snap/unsnap button dynamic, to match the current snapped state.

## References and relevant issues
Fixed the following:
- Closes #3159
- Closes #3212
- Closes #3210

