### PR TITLE
Fix timed message

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -556,7 +556,7 @@ public class WindowHelper
     // Only one ContentDialog can be shown at a time, so we have to keep track of the current one.
     private static ContentDialog? ContentDialog { get; set; }
 
-    internal static async void ShowTimedMessageDialog(FrameworkElement frameworkElement, string message, string closeButtonText)
+    internal static void ShowTimedMessageDialog(FrameworkElement frameworkElement, string message, string closeButtonText)
     {
         if (ContentDialog is not null)
         {
@@ -590,12 +590,13 @@ public class WindowHelper
 
         try
         {
-            await ContentDialog.ShowAsync();
-            timer.Start();
             ContentDialog.Closed += (s, e) =>
             {
+                timer.Stop();
                 ContentDialog = null;
             };
+            _ = ContentDialog.ShowAsync();
+            timer.Start();
         }
         catch (Exception ex)
         {

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -556,7 +556,7 @@ public class WindowHelper
     // Only one ContentDialog can be shown at a time, so we have to keep track of the current one.
     private static ContentDialog? ContentDialog { get; set; }
 
-    internal static void ShowTimedMessageDialog(FrameworkElement frameworkElement, string message, string closeButtonText)
+    internal static async void ShowTimedMessageDialog(FrameworkElement frameworkElement, string message, string closeButtonText)
     {
         if (ContentDialog is not null)
         {
@@ -590,13 +590,13 @@ public class WindowHelper
 
         try
         {
+            ContentDialog.Opened += (s, e) => timer.Start();
             ContentDialog.Closed += (s, e) =>
             {
                 timer.Stop();
                 ContentDialog = null;
             };
-            _ = ContentDialog.ShowAsync();
-            timer.Start();
+            await ContentDialog.ShowAsync();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary of the pull request
Ironsides uses a contentdialog to confirm when the user adds an external tool. This message is set to time-out automatically after 3 seconds, but it wasn't always timing out. Not a huge deal, since the dialog also offers a close button so that the user can close it any time. This fix fixes the timeout (and the user can still close it any time).

## References and relevant issues
Fixed the following:
- Closes #3224
