### PR TITLE
Handle UnauthorizedAccessException in ETWHelper

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/ETWHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/ETWHelper.cs
@@ -55,18 +55,26 @@ internal sealed class ETWHelper : IDisposable
                 session.Dispose();
             }
 
-            using (session = new TraceEventSession(sessionName))
+            try
             {
-                // Filter the provider events based on processId
-                var providerOptions = new TraceEventProviderOptions { ProcessIDFilter = [targetProcess.Id] };
-                foreach (var provider in ProviderList)
+                using (session = new TraceEventSession(sessionName))
                 {
-                    session.EnableProvider(provider, TraceEventLevel.Always, options: providerOptions);
-                }
+                    // Filter the provider events based on processId
+                    var providerOptions = new TraceEventProviderOptions { ProcessIDFilter = [targetProcess.Id] };
+                    foreach (var provider in ProviderList)
+                    {
+                        session.EnableProvider(provider, TraceEventLevel.Always, options: providerOptions);
+                    }
 
-                session.Source.Dynamic.All += EventsHandler;
-                session.Source.UnhandledEvents += UnHandledEventsHandler;
-                session.Source.Process();
+                    session.Source.Dynamic.All += EventsHandler;
+                    session.Source.UnhandledEvents += UnHandledEventsHandler;
+                    session.Source.Process();
+                }
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                WinLogsEntry entry = new(DateTime.Now, WinLogCategory.Error, ex.Message, WinLogsHelper.EtwLogsName);
+                output.Add(entry);
             }
         }
     }

--- a/tools/PI/DevHome.PI/Helpers/ETWHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/ETWHelper.cs
@@ -73,6 +73,7 @@ internal sealed class ETWHelper : IDisposable
             }
             catch (UnauthorizedAccessException ex)
             {
+                Stop();
                 WinLogsEntry entry = new(DateTime.Now, WinLogCategory.Error, ex.Message, WinLogsHelper.EtwLogsName);
                 output.Add(entry);
             }


### PR DESCRIPTION
## Summary of the pull request
Catching UnauthorizedAccessException is a short-term fix for PI crash. Created a new scenario #3227 to handle the long-term solution for suggesting the user to logout and login before they can see ETW logs.

## Validation steps performed
1. Removed user from Performance Log Users group
2. Logout-> Login
3. Launch PI and enable ETW logs
4. Confirmed PI does not crash.

## PR checklist
- [ ] Closes #3226
