### PR TITLE
Mapping of extensions to repository paths in DevHome core

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -43,7 +43,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.500.484" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.1399.520.1732" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -43,7 +43,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.1399.520.1732" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.700.544" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.500.484"/>
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.1399.520.1732"/>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.1399.520.1732"/>
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.700.544"/>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
@@ -29,6 +29,11 @@ public sealed class GitLocalRepository : ILocalRepository
 
     internal GitLocalRepository(string rootFolder, RepositoryCache? cache)
     {
+        if (!Repository.IsValid(rootFolder))
+        {
+            throw new ArgumentException("Invalid repository path");
+        }
+
         RootFolder = rootFolder;
         _repositoryCache = cache;
     }

--- a/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.500.484" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.1399.520.1732" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.1399.520.1732" />
+    <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.700.544" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -24,6 +24,10 @@ namespace Microsoft.Windows.DevHome.SDK
         [experimental]
         [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
         QuickStartProject = 5,
+
+        [experimental]
+        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 5)] 
+        SourceControlIntegration = 6,
     };
 
     // Definitions for exceptions.

--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/Microsoft.Windows.DevHome.SDK.idl
@@ -24,10 +24,6 @@ namespace Microsoft.Windows.DevHome.SDK
         [experimental]
         [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 6)]
         QuickStartProject = 5,
-
-        [experimental]
-        [contract(Microsoft.Windows.DevHome.SDK.DevHomeContract, 5)] 
-        SourceControlIntegration = 6,
     };
 
     // Definitions for exceptions.

--- a/src/Models/ExtensionWrapper.cs
+++ b/src/Models/ExtensionWrapper.cs
@@ -26,6 +26,7 @@ public class ExtensionWrapper : IExtensionWrapper
         [typeof(ISettingsProvider)] = ProviderType.Settings,
         [typeof(IFeaturedApplicationsProvider)] = ProviderType.FeaturedApplications,
         [typeof(IComputeSystemProvider)] = ProviderType.ComputeSystem,
+        [typeof(ILocalRepositoryProvider)] = ProviderType.SourceControlIntegration,
     };
 
     private IExtension? _extensionObject;

--- a/src/Models/ExtensionWrapper.cs
+++ b/src/Models/ExtensionWrapper.cs
@@ -26,7 +26,7 @@ public class ExtensionWrapper : IExtensionWrapper
         [typeof(ISettingsProvider)] = ProviderType.Settings,
         [typeof(IFeaturedApplicationsProvider)] = ProviderType.FeaturedApplications,
         [typeof(IComputeSystemProvider)] = ProviderType.ComputeSystem,
-        [typeof(ILocalRepositoryProvider)] = ProviderType.SourceControlIntegration,
+        [typeof(ILocalRepositoryProvider)] = ProviderType.LocalRepository,
     };
 
     private IExtension? _extensionObject;

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -135,20 +135,6 @@
             </uap3:Properties>
           </uap3:AppExtension>
         </uap3:Extension>
-		  <uap3:Extension Category="windows.appExtension">
-			  <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID5" PublicFolder="Public" DisplayName="SVN" Description="ms-resource:AppDescriptionGitExt">
-				  <uap3:Properties>
-					  <DevHomeProvider>
-						  <Activation>
-							  <CreateInstance ClassId="F47DE62D-F5A4-4455-80BC-46D16C115BDC" />
-						  </Activation>
-						  <SupportedInterfaces>
-							  <SourceControlIntegration />
-						  </SupportedInterfaces>
-					  </DevHomeProvider>
-				  </uap3:Properties>
-			  </uap3:AppExtension>
-		  </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
           <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -95,7 +95,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameCoreExt" Description="ms-resource:AppDescriptionCoreExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionCoreExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
@@ -108,7 +108,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameHyperVExt" Description="ms-resource:AppDescriptionHyperVExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionHyperVExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
@@ -121,6 +121,34 @@
             </uap3:Properties>
           </uap3:AppExtension>
         </uap3:Extension>
+        <uap3:Extension Category="windows.appExtension">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID4" PublicFolder="Public" DisplayName="Git" Description="ms-resource:AppDescriptionGitExt">
+            <uap3:Properties>
+              <DevHomeProvider>
+                <Activation>
+                  <CreateInstance ClassId="BDA76685-E749-4f09-8F13-C466D0802DA1" />
+                </Activation>
+                <SupportedInterfaces>
+                  <SourceControlIntegration />
+                </SupportedInterfaces>
+              </DevHomeProvider>
+            </uap3:Properties>
+          </uap3:AppExtension>
+        </uap3:Extension>
+		  <uap3:Extension Category="windows.appExtension">
+			  <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID5" PublicFolder="Public" DisplayName="SVN" Description="ms-resource:AppDescriptionGitExt">
+				  <uap3:Properties>
+					  <DevHomeProvider>
+						  <Activation>
+							  <CreateInstance ClassId="F47DE62D-F5A4-4455-80BC-46D16C115BDC" />
+						  </Activation>
+						  <SupportedInterfaces>
+							  <SourceControlIntegration />
+						  </SupportedInterfaces>
+					  </DevHomeProvider>
+				  </uap3:Properties>
+			  </uap3:AppExtension>
+		  </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
           <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -122,7 +122,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID3" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionGitExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID3" PublicFolder="Public" DisplayName="Git" Description="ms-resource:AppDescriptionGitExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -95,7 +95,7 @@
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionCoreExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID1" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameCoreExt" Description="ms-resource:AppDescriptionCoreExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
@@ -108,7 +108,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionHyperVExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID2" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameHyperVExt" Description="ms-resource:AppDescriptionHyperVExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
@@ -122,7 +122,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID4" PublicFolder="Public" DisplayName="Git" Description="ms-resource:AppDescriptionGitExt">
+          <uap3:AppExtension Name="com.microsoft.devhome" Id="PG-SP-ID3" PublicFolder="Public" DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescriptionGitExt">
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -129,7 +129,7 @@
                   <CreateInstance ClassId="BDA76685-E749-4f09-8F13-C466D0802DA1" />
                 </Activation>
                 <SupportedInterfaces>
-                  <SourceControlIntegration />
+                  <LocalRepository />
                 </SupportedInterfaces>
               </DevHomeProvider>
             </uap3:Properties>

--- a/tools/Customization/DevHome.Customization/Helpers/ErrorType.cs
+++ b/tools/Customization/DevHome.Customization/Helpers/ErrorType.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DevHome.Customization.Helpers;
+
+public enum ErrorType
+{
+    None,
+    Unknown,
+    RepositoryProvderCreationFailed,
+    OpenRepositoryFailed,
+    SourceControlExtensionValidationFailed,
+}

--- a/tools/Customization/DevHome.Customization/Helpers/ResultType.cs
+++ b/tools/Customization/DevHome.Customization/Helpers/ResultType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DevHome.Customization.Helpers;
+
+public enum ResultType
+{
+    Unknown,
+    Success,
+    Failure,
+}

--- a/tools/Customization/DevHome.Customization/Helpers/SourceControlValidationResult.cs
+++ b/tools/Customization/DevHome.Customization/Helpers/SourceControlValidationResult.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DevHome.Customization.Helpers;
+
+public class SourceControlValidationResult
+{
+    public ResultType Result { get; private set; } = ResultType.Unknown;
+
+    public ErrorType Error { get; private set; } = ErrorType.Unknown;
+
+    public Exception? Exception
+    {
+        get; private set;
+    }
+
+    public SourceControlValidationResult()
+    {
+        Result = ResultType.Success;
+        Error = ErrorType.None;
+    }
+
+    public SourceControlValidationResult(ResultType result, ErrorType error, Exception? exception)
+    {
+        Result = result;
+        Error = error;
+        Exception = exception;
+    }
+}

--- a/tools/Customization/DevHome.Customization/Helpers/SourceControlValidationResult.cs
+++ b/tools/Customization/DevHome.Customization/Helpers/SourceControlValidationResult.cs
@@ -17,7 +17,17 @@ public class SourceControlValidationResult
 
     public Exception? Exception
     {
-        get; private set;
+        get; set;
+    }
+
+    public string? DisplayMessage
+    {
+        get; set;
+    }
+
+    public string? DiagnosticText
+    {
+        get; set;
     }
 
     public SourceControlValidationResult()
@@ -26,7 +36,7 @@ public class SourceControlValidationResult
         Error = ErrorType.None;
     }
 
-    public SourceControlValidationResult(ResultType result, ErrorType error, Exception? exception)
+    public SourceControlValidationResult(ResultType result, ErrorType error, Exception? exception, string? displayMessage, string? diagnosticText)
     {
         Result = result;
         Error = error;

--- a/tools/Customization/DevHome.Customization/Models/SourceControlIntegration.cs
+++ b/tools/Customization/DevHome.Customization/Models/SourceControlIntegration.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using DevHome.Customization.Views;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Win32;
@@ -12,6 +13,8 @@ namespace DevHome.Customization.Models;
 
 public class SourceControlIntegration
 {
+    private static readonly Serilog.ILogger Log = Serilog.Log.ForContext("SourceContext", nameof(Models.SourceControlIntegration));
+
     public static bool ValidateSourceControlExtension(string extensionCLSID, string rootPath)
     {
         var providerPtr = IntPtr.Zero;

--- a/tools/Customization/DevHome.Customization/Models/SourceControlIntegration.cs
+++ b/tools/Customization/DevHome.Customization/Models/SourceControlIntegration.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Windows.DevHome.SDK;
+using Serilog;
+using Windows.Win32;
+using WinRT;
+
+namespace DevHome.Customization.Models;
+
+public class SourceControlIntegration
+{
+    public static bool ValidateSourceControlExtension(string extensionCLSID, string rootPath)
+    {
+        var providerPtr = IntPtr.Zero;
+        try
+        {
+            var hr = PInvoke.CoCreateInstance(Guid.Parse(extensionCLSID), null, Windows.Win32.System.Com.CLSCTX.CLSCTX_LOCAL_SERVER, typeof(ILocalRepositoryProvider).GUID, out var extensionObj);
+            providerPtr = Marshal.GetIUnknownForObject(extensionObj);
+            if (hr < 0)
+            {
+                Log.Error(hr.ToString(), "Failure occurred while creating instance of repository provider");
+                return false;
+            }
+
+            ILocalRepositoryProvider provider = MarshalInterface<ILocalRepositoryProvider>.FromAbi(providerPtr);
+            GetLocalRepositoryResult result = provider.GetRepository(rootPath);
+
+            if (result.Result.Status == ProviderOperationStatus.Failure)
+            {
+                Log.Error("Could not open local repository.");
+                Log.Error(result.Result.DisplayMessage);
+                return false;
+            }
+            else
+            {
+                Log.Information("Local repository opened successfully.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "An exception occurred while validating source control extension.");
+            return false;
+        }
+        finally
+        {
+            if (providerPtr != IntPtr.Zero)
+            {
+                Marshal.Release(providerPtr);
+            }
+        }
+
+        return true;
+    }
+}

--- a/tools/Customization/DevHome.Customization/Models/SourceControlIntegration.cs
+++ b/tools/Customization/DevHome.Customization/Models/SourceControlIntegration.cs
@@ -27,7 +27,7 @@ public class SourceControlIntegration
             if (hr < 0)
             {
                 Log.Error(hr.ToString(), "Failure occurred while creating instance of repository provider");
-                return new SourceControlValidationResult(ResultType.Failure, ErrorType.RepositoryProvderCreationFailed, null);
+                return new SourceControlValidationResult(ResultType.Failure, ErrorType.RepositoryProvderCreationFailed, null, null, null);
             }
 
             ILocalRepositoryProvider provider = MarshalInterface<ILocalRepositoryProvider>.FromAbi(providerPtr);
@@ -37,7 +37,7 @@ public class SourceControlIntegration
             {
                 Log.Error("Could not open local repository.");
                 Log.Error(result.Result.DisplayMessage);
-                return new SourceControlValidationResult(ResultType.Failure, ErrorType.OpenRepositoryFailed, null);
+                return new SourceControlValidationResult(ResultType.Failure, ErrorType.OpenRepositoryFailed, result.Result.ExtendedError, result.Result.DisplayMessage, result.Result.DiagnosticText);
             }
             else
             {
@@ -47,7 +47,7 @@ public class SourceControlIntegration
         catch (Exception ex)
         {
             Log.Error(ex, "An exception occurred while validating source control extension.");
-            return new SourceControlValidationResult(ResultType.Failure, ErrorType.SourceControlExtensionValidationFailed, ex);
+            return new SourceControlValidationResult(ResultType.Failure, ErrorType.SourceControlExtensionValidationFailed, ex, null, null);
         }
         finally
         {

--- a/tools/Customization/DevHome.Customization/NativeMethods.txt
+++ b/tools/Customization/DevHome.Customization/NativeMethods.txt
@@ -1,3 +1,4 @@
 ﻿SHGetSetSettings
 ReadCabinetState
 WriteCabinetState
+CoCreateInstance

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerSourceControlIntegrationViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerSourceControlIntegrationViewModel.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DevHome.Common.Contracts.Services;
+using DevHome.Common.Extensions;
+using DevHome.Common.Models;
+using DevHome.Common.Services;
+using DevHome.Customization.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.DevHome.SDK;
+
+namespace DevHome.Customization.ViewModels;
+
+public partial class FileExplorerSourceControlIntegrationViewModel : ObservableObject
+{
+    public ObservableCollection<Breadcrumb> Breadcrumbs { get; }
+
+    public IExtensionWrapper LocalRepositoryProvider { get; }
+
+    public string ProviderName => LocalRepositoryProvider.ExtensionDisplayName;
+
+    public FileExplorerSourceControlIntegrationViewModel(IExtensionWrapper localRepoProvider)
+    {
+        LocalRepositoryProvider = localRepoProvider;
+
+        var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
+        Breadcrumbs =
+        [
+            new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
+            new(stringResource.GetLocalized("FileExplorer_Header"), typeof(FileExplorerViewModel).FullName!)
+        ];
+    }
+}

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -46,6 +46,8 @@ public partial class FileExplorerViewModel : ObservableObject
         var experimentationService = Application.Current.GetService<IExperimentationService>();
         if (experimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration"))
         {
+            // Currently, the UI displays a drop down which allows the user to select from a list of source control providers avaiable to Dev Home. This is
+            // subject to change per UI design specifications.
             var extensionService = Application.Current.GetService<IExtensionService>();
             var sourceControlExtensions = Task.Run(async () => await extensionService.GetInstalledExtensionsAsync(ProviderType.SourceControlIntegration)).Result.ToList();
             sourceControlExtensions.Sort((a, b) => string.Compare(a.ExtensionDisplayName, b.ExtensionDisplayName, System.StringComparison.OrdinalIgnoreCase));
@@ -72,10 +74,16 @@ public partial class FileExplorerViewModel : ObservableObject
         }
     }
 
-    public void AddRepositoryPath(string extension, string rootPath)
+    public bool AddRepositoryPath(string extension, string rootPath)
     {
         var normalizedPath = rootPath.ToUpper(CultureInfo.InvariantCulture).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        RepoTracker.AddRepositoryPath(extension, normalizedPath);
+        if (SourceControlIntegration.ValidateSourceControlExtension(extension, normalizedPath))
+        {
+             RepoTracker.AddRepositoryPath(extension, normalizedPath);
+             return true;
+        }
+
+        return false;
     }
 
     public bool ShowFileExtensions

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -74,13 +74,14 @@ public partial class FileExplorerViewModel : ObservableObject
         }
     }
 
-    public bool AddRepositoryPath(string extension, string rootPath)
+    public bool AddRepositoryPath(string extensionCLSID, string rootPath)
     {
         var normalizedPath = rootPath.ToUpper(CultureInfo.InvariantCulture).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        if (SourceControlIntegration.ValidateSourceControlExtension(extension, normalizedPath))
+        var result = SourceControlIntegration.ValidateSourceControlExtension(extensionCLSID, normalizedPath);
+        if (result.Result == Helpers.ResultType.Success)
         {
-             RepoTracker.AddRepositoryPath(extension, normalizedPath);
-             return true;
+            RepoTracker.AddRepositoryPath(extensionCLSID, normalizedPath);
+            return true;
         }
 
         return false;

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -49,7 +49,7 @@ public partial class FileExplorerViewModel : ObservableObject
             // Currently, the UI displays a drop down which allows the user to select from a list of source control providers avaiable to Dev Home. This is
             // subject to change per UI design specifications.
             var extensionService = Application.Current.GetService<IExtensionService>();
-            var sourceControlExtensions = Task.Run(async () => await extensionService.GetInstalledExtensionsAsync(ProviderType.SourceControlIntegration)).Result.ToList();
+            var sourceControlExtensions = Task.Run(async () => await extensionService.GetInstalledExtensionsAsync(ProviderType.LocalRepository)).Result.ToList();
             sourceControlExtensions.Sort((a, b) => string.Compare(a.ExtensionDisplayName, b.ExtensionDisplayName, System.StringComparison.OrdinalIgnoreCase));
             sourceControlExtensions.ForEach((sourceControlExtension) =>
             {

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -3,9 +3,18 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:views="using:DevHome.Customization.Views"
+    xmlns:views="using:DevHome.Customization.Views" xmlns:converters="using:CommunityToolkit.WinUI.Converters" xmlns:viewmodels="using:DevHome.Customization.ViewModels"
     behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
     behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
+
+    <Page.Resources>
+        <converters:DoubleToVisibilityConverter x:Key="CountToVisibilityConverter" GreaterThan="0" FalseValue="Collapsed" TrueValue="Visible"/>
+
+        <DataTemplate x:Key="LocalRepositoryProviderButtonTemplate" x:DataType="viewmodels:FileExplorerSourceControlIntegrationViewModel">
+            <Button Content="{x:Bind ProviderName}" HorizontalAlignment="Stretch" Click="AddRepository_Click" Tag="{x:Bind}"/>
+        </DataTemplate>
+
+    </Page.Resources>
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
@@ -25,9 +34,29 @@
                   MinWidth="300" 
                   HorizontalAlignment="Left"/>
 
-                    <Button  Content="Add" 
+                    <Button  
+                         Content="Add" 
                          Click="AddButton_Click" 
-                         Margin="10, 27, 0, 0"/>
+                         Margin="10, 27, 0, 0">
+                    <Button.Resources>
+                        <Flyout x:Name="LocalRepositoryProvidersFlyout" Placement="Bottom">
+                                <ItemsRepeater ItemsSource="{x:Bind ViewModel.LocalRepositoryProviders}"
+                                               ItemTemplate="{StaticResource LocalRepositoryProviderButtonTemplate}"
+                                               HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                                <ItemsRepeater.Layout>
+                                    <StackLayout Orientation="Vertical" Spacing="8" />
+                                </ItemsRepeater.Layout>
+                            </ItemsRepeater>
+                            <Flyout.FlyoutPresenterStyle>
+                                <Style TargetType="FlyoutPresenter">
+                                    <Setter Property="IsTabStop" Value="True"/>
+                                    <Setter Property="TabNavigation" Value="Cycle"/>
+                                    <Setter Property="MinWidth" Value="150" />
+                                </Style>
+                            </Flyout.FlyoutPresenterStyle>
+                        </Flyout>
+                    </Button.Resources>
+                    </Button>
                     <InfoBar x:Name="RootPathErrorBar"
                          x:Uid="ErrorRootPathValidation"
                          Title="Error"

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -3,7 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:views="using:DevHome.Customization.Views" xmlns:converters="using:CommunityToolkit.WinUI.Converters" xmlns:viewmodels="using:DevHome.Customization.ViewModels"
+    xmlns:views="using:DevHome.Customization.Views" 
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters" 
+    xmlns:viewmodels="using:DevHome.Customization.ViewModels"
     behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
     behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
@@ -6,8 +6,6 @@ using System.IO;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using DevHome.Customization.ViewModels;
-using DevHome.FileExplorerSourceControlIntegration.Services;
-using FileExplorerSourceControlIntegration;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
@@ -102,7 +100,10 @@ public sealed partial class FileExplorerPage : Page
     {
         if (ValidateRepositoryPath(rootPath))
         {
-            ViewModel.AddRepositoryPath(localRepositoryProvider.ExtensionClassId, RootPathTextBox.Text);
+            if (!ViewModel.AddRepositoryPath(localRepositoryProvider.ExtensionClassId, RootPathTextBox.Text))
+            {
+                RootPathErrorBar.IsOpen = true;
+            }
         }
 
         ViewModel.RefreshTrackedRepositories();

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
@@ -44,16 +44,15 @@ public sealed partial class FileExplorerPage : Page
 
     public void AddButton_Click(object sender, RoutedEventArgs e)
     {
-        RootPath = RootPathTextBox.Text;
-
-        if (ValidateRepositoryPath(RootPath))
+        var numProviders = ViewModel.LocalRepositoryProviders.Count;
+        if (numProviders == 1)
         {
-            // TODO: Determine if the extension GUID should be stored instead of name as it is more identifiable and/or determine any other unique property to use for
-            // mapping here
-            ViewModel.AddRepositoryPath("git", RootPath);
+            RegisterRepository(ViewModel.LocalRepositoryProviders[0].LocalRepositoryProvider, RootPathTextBox.Text);
         }
-
-        ViewModel.RefreshTrackedRepositories();
+        else if (numProviders > 1)
+        {
+            LocalRepositoryProvidersFlyout.ShowAt(sender as Button);
+        }
     }
 
     public bool ValidateRepositoryPath(string rootPath)
@@ -81,5 +80,31 @@ public sealed partial class FileExplorerPage : Page
         }
 
         return true;
+    }
+
+    private void AddRepository_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender as Button is Button registerRepoButton)
+        {
+            if (registerRepoButton.Tag is FileExplorerSourceControlIntegrationViewModel fileExplorerSourceControlIntegrationViewModel)
+            {
+                RegisterRepository(fileExplorerSourceControlIntegrationViewModel.LocalRepositoryProvider, RootPathTextBox.Text);
+            }
+            else
+            {
+                log.Information($"AddRepository_Click(): registerRepoButton.Tag is not FileExplorerSourceControlIntegrationViewModel - Sender: {sender} RoutedEventArgs: {e}");
+                return;
+            }
+        }
+    }
+
+    public void RegisterRepository(IExtensionWrapper localRepositoryProvider, string rootPath)
+    {
+        if (ValidateRepositoryPath(rootPath))
+        {
+            ViewModel.AddRepositoryPath(localRepositoryProvider.ExtensionClassId, RootPathTextBox.Text);
+        }
+
+        ViewModel.RefreshTrackedRepositories();
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class FileExplorerPage : Page
         get; set;
     }
 
-    private static readonly System.Buffers.SearchValues<char> InvalidChars = System.Buffers.SearchValues.Create("<>*?|.");
+    private static readonly System.Buffers.SearchValues<char> InvalidChars = System.Buffers.SearchValues.Create("<>*?|");
 
     private readonly Serilog.ILogger log = Log.ForContext("SourceContext", nameof(FileExplorerPage));
 

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
@@ -82,7 +82,7 @@ public sealed partial class FileExplorerPage : Page
 
     private void AddRepository_Click(object sender, RoutedEventArgs e)
     {
-        if (sender as Button is Button registerRepoButton)
+        if (sender is Button registerRepoButton)
         {
             if (registerRepoButton.Tag is FileExplorerSourceControlIntegrationViewModel fileExplorerSourceControlIntegrationViewModel)
             {

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -78,6 +78,7 @@ public class RepositoryTracking
             {
                 TrackedRepositories[rootPath] = extensionCLSID!;
                 fileService.Save(RepoStoreOptions.RepoStoreFolderPath, RepoStoreOptions.RepoStoreFileName, TrackedRepositories);
+                log.Information("Repository added to repo store");
                 try
                 {
                     RepositoryChanged?.Invoke(extensionCLSID, RepositoryChange.Added);
@@ -86,8 +87,6 @@ public class RepositoryTracking
                 {
                     log.Error(ex, $"Added event signaling failed: ");
                 }
-
-                log.Information("Repository added to repo store");
             }
             else
             {

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -67,19 +67,17 @@ public class RepositoryTracking
         log.Information($"Repositories retrieved from Repo Store, number of registered repositories: {TrackedRepositories.Count}");
     }
 
-    // TO DO: Determine if the extension GUID should be stored instead of name as it is more identifiable and/or determine any other unique property to use for
-    // mapping here
-    public void AddRepositoryPath(string extension, string rootPath)
+    public void AddRepositoryPath(string extensionId, string rootPath)
     {
         lock (trackRepoLock)
         {
             if (!TrackedRepositories.ContainsKey(rootPath))
             {
-                TrackedRepositories[rootPath] = extension!;
+                TrackedRepositories[rootPath] = extensionId!;
                 fileService.Save(RepoStoreOptions.RepoStoreFolderPath, RepoStoreOptions.RepoStoreFileName, TrackedRepositories);
                 try
                 {
-                    RepositoryChanged?.Invoke(extension, RepositoryChange.Added);
+                    RepositoryChanged?.Invoke(extensionId, RepositoryChange.Added);
                 }
                 catch (Exception ex)
                 {
@@ -99,12 +97,12 @@ public class RepositoryTracking
     {
         lock (trackRepoLock)
         {
-            TrackedRepositories.TryGetValue(rootPath, out var extension);
+            TrackedRepositories.TryGetValue(rootPath, out var extensionId);
             TrackedRepositories.Remove(rootPath);
             fileService.Save(RepoStoreOptions.RepoStoreFolderPath, RepoStoreOptions.RepoStoreFileName, TrackedRepositories);
             try
             {
-                RepositoryChanged?.Invoke(extension ??= string.Empty, RepositoryChange.Removed);
+                RepositoryChanged?.Invoke(extensionId ??= string.Empty, RepositoryChange.Removed);
             }
             catch (Exception ex)
             {

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -145,6 +145,7 @@ public class RepositoryTracking
     {
         lock (trackRepoLock)
         {
+            ReloadRepositoryStoreIfChangesDetected();
             var rootPathRegistered = TrackedRepositories.Keys.FirstOrDefault(key => StringComparer.OrdinalIgnoreCase.Equals(key, rootPath));
             if (rootPathRegistered != null)
             {

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -59,8 +59,7 @@ public class RepositoryTracking
     {
         lock (trackRepoLock)
         {
-            Dictionary<string, string> caseSensitiveDictionary = new Dictionary<string, string>();
-            caseSensitiveDictionary = fileService.Read<Dictionary<string, string>>(RepoStoreOptions.RepoStoreFolderPath, RepoStoreOptions.RepoStoreFileName);
+            var caseSensitiveDictionary = fileService.Read<Dictionary<string, string>>(RepoStoreOptions.RepoStoreFolderPath, RepoStoreOptions.RepoStoreFileName);
 
             // No repositories are currently being tracked. The file will be created on first add to repository tracking.
             if (caseSensitiveDictionary == null)

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
-using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
 using DevHome.FileExplorerSourceControlIntegration.Services;
+using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation.Collections;

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
+using DevHome.FileExplorerSourceControlIntegration.Services;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation.Collections;
@@ -46,9 +47,10 @@ public class SourceControlProvider :
         var providerPtr = IntPtr.Zero;
         try
         {
-            // "BDA76685-E749-4f09-8F13-C466D0802DA1" is the hardcoded GUID for the git extension. In a future change, the value will no longer be hard-coded and
-            // will be discoverable given a root path from a storage location
-            var hr = PInvoke.CoCreateInstance(Guid.Parse("BDA76685-E749-4f09-8F13-C466D0802DA1"), null, CLSCTX.CLSCTX_LOCAL_SERVER, typeof(ILocalRepositoryProvider).GUID, out var extensionObj);
+            var repositoryTracker = new RepositoryTracking(null);
+            var activationGUID = repositoryTracker.GetSourceControlProviderForRootPath(rootPath);
+
+            var hr = PInvoke.CoCreateInstance(Guid.Parse(activationGUID), null, CLSCTX.CLSCTX_LOCAL_SERVER, typeof(ILocalRepositoryProvider).GUID, out var extensionObj);
             providerPtr = Marshal.GetIUnknownForObject(extensionObj);
             if (hr < 0)
             {

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
@@ -21,9 +21,11 @@ public class SourceControlProvider :
     Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer.IPerFolderRootSelector
 {
     private readonly Serilog.ILogger log = Log.ForContext("SourceContext", nameof(SourceControlProvider));
+    private readonly RepositoryTracking repositoryTracker;
 
     public SourceControlProvider()
     {
+        repositoryTracker = new RepositoryTracking(null);
     }
 
     public Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer.IPerFolderRootPropertyProvider? GetProvider(string rootPath)
@@ -47,7 +49,7 @@ public class SourceControlProvider :
         var providerPtr = IntPtr.Zero;
         try
         {
-            var repositoryTracker = new RepositoryTracking(null);
+            repositoryTracker.ReloadRepositoryStoreIfChangesDetected();
             var activationGUID = repositoryTracker.GetSourceControlProviderForRootPath(rootPath);
 
             var hr = PInvoke.CoCreateInstance(Guid.Parse(activationGUID), null, CLSCTX.CLSCTX_LOCAL_SERVER, typeof(ILocalRepositoryProvider).GUID, out var extensionObj);

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
@@ -49,7 +49,6 @@ public class SourceControlProvider :
         var providerPtr = IntPtr.Zero;
         try
         {
-            repositoryTracker.ReloadRepositoryStoreIfChangesDetected();
             var activationGUID = repositoryTracker.GetSourceControlProviderForRootPath(rootPath);
 
             var hr = PInvoke.CoCreateInstance(Guid.Parse(activationGUID), null, CLSCTX.CLSCTX_LOCAL_SERVER, typeof(ILocalRepositoryProvider).GUID, out var extensionObj);

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegrationUnitTest/RepositoryTrackingServiceUnitTest.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegrationUnitTest/RepositoryTrackingServiceUnitTest.cs
@@ -16,6 +16,8 @@ public class RepositoryTrackingServiceUnitTest
 
     private readonly string rootPath = "c:\\test\\rootPath";
 
+    private readonly string caseAlteredRootPath = "C:\\TEST\\ROOTPATH";
+
     [TestMethod]
     public void AddRepository()
     {
@@ -60,12 +62,38 @@ public class RepositoryTrackingServiceUnitTest
     }
 
     [TestMethod]
+    public void GetAllRepositories_Empty()
+    {
+        var result = RepoTracker.GetAllTrackedRepositories();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
     public void GetSourceControlProviderFromRepositoryPath()
     {
         RepoTracker.AddRepositoryPath(extension, rootPath);
         var result = RepoTracker.GetSourceControlProviderForRootPath(rootPath);
         Assert.IsNotNull(result);
         Assert.AreEqual(extension, result);
+        RepoTracker.RemoveRepositoryPath(rootPath);
+    }
+
+    [TestMethod]
+    public void AddRepository_DoesNotAddDuplicateValues()
+    {
+        RepoTracker.AddRepositoryPath(extension, rootPath);
+
+        // Atempt to add duplicate entry that is altered in case
+        RepoTracker.AddRepositoryPath(extension, caseAlteredRootPath);
+
+        // Ensure duplicate is not added and count is 1
+        var result = RepoTracker.GetAllTrackedRepositories();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Count);
+        Assert.IsTrue(result.ContainsKey(rootPath));
+        Assert.IsTrue(result.ContainsValue(extension));
+
         RepoTracker.RemoveRepositoryPath(rootPath);
     }
 


### PR DESCRIPTION
## Summary of the pull request
This PR contains code changes for a root path to be validated in association with a given source control provider on Dev Home to be mapped accordingly. The CLSID for the extension point is used to map to the persisted registered repository root paths. The CLSID is chosen as it is compatible with both packaged and unpackaged extensions, this value is not recycled by unrelated applications and is explicitly defined. 

**Note: The UI in this PR is subject to change ** 


## References and relevant issues

## Detailed description of the pull request / Additional comments
- Declare git extension as an app extension for Dev Home
- Find all extensions in Dev Home that support source control integration
_Note: This currently finds and binds the extension name to the UI. Per design, this is subject to change i.e. Dev Home may become responsible for recognizing the right extension and automatically mapping._ 
- Validate if a given repository root path is valid for a source control extension before registration i.e. before mapping the source control provider to the root path
- Find the activation guid (instead of hardcoded value) to activate and return ILocalRepositoryProvider from mapping done during add/register
- Add validation for repository path in git extension
- Searching inside 'repository store' is case insensitive 

## Validation steps performed
Build release msix 
Run added unit tests
Test functionality of msix package on a VM

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
