### PR TITLE
Prevent symbol publishing collisions with other branches

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -81,7 +81,7 @@ extends:
             symbolProject: 'DevHome'
             indexSources: false
             symbolsArtifactName: 'DevHomeSDK'
-            symbolsVersion: '$(Build.BuildNumber)'
+            symbolsVersion: '$(BuildingBranch)$(Build.BuildNumber)'
             searchPattern: |
               **/bin/**/*.pdb
               **/bin/**/*.exe
@@ -225,7 +225,7 @@ extends:
                 subscription: $(SymbolSubscription)
                 indexSources: true
                 symbolsArtifactName: 'DevHome_${{ platform }}_${{ configuration }}'
-                symbolsVersion: $(Build.BuildNumber)
+                symbolsVersion: '$(BuildingBranch)$(Build.BuildNumber)'
                 searchPattern: >-
                   $(Build.SourcesDirectory)\**\bin\**\*.pdb
 


### PR DESCRIPTION
## Summary of the pull request
Symbol publishing is having a name collision when different versions of Dev Home get built the same day (main/staging/release).  Adding the building branch to the publish name to prevent that.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
