### PR TITLE
Enable FailFastOnErrors for debug builds

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -79,6 +79,9 @@ public partial class App : Application, IApp
     public App()
     {
         InitializeComponent();
+#if DEBUG
+        DebugSettings.FailFastOnErrors = true;
+#endif
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
         Host = Microsoft.Extensions.Hosting.Host.
@@ -170,10 +173,6 @@ public partial class App : Application, IApp
 
         UnhandledException += App_UnhandledException;
         AppInstance.GetCurrent().Activated += OnActivated;
-
-#if DEBUG
-        DebugSettings.FailFastOnErrors = true;
-#endif
     }
 
     public void ShowMainWindow()

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -170,6 +170,10 @@ public partial class App : Application, IApp
 
         UnhandledException += App_UnhandledException;
         AppInstance.GetCurrent().Activated += OnActivated;
+
+#if DEBUG
+        DebugSettings.FailFastOnErrors = true;
+#endif
     }
 
     public void ShowMainWindow()

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -156,6 +156,10 @@
     <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
+
   <!-- Third party notice file -->
   <ItemGroup>
     <Content Include="$(SolutionDir)NOTICE.txt">

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -29,5 +29,9 @@ public sealed partial class MainWindow : WinUIEx.WindowEx
         Application.Current.GetService<IExtensionService>().SignalStopExtensionsAsync();
         TelemetryFactory.Get<ITelemetry>().Log("DevHome_MainWindow_Closed_Event", LogLevel.Critical, new DevHomeClosedEvent(mainWindowCreated));
         Log.Information("Terminating via MainWindow_Closed.");
+
+        // WinUI bug is causing a crash on shutdown when FailFastOnErrors is set to true (#51773592).
+        // Workaround by turning it off before shutdown.
+        App.Current.DebugSettings.FailFastOnErrors = false;
     }
 }


### PR DESCRIPTION
## Summary of the pull request

We want to enable FailFastOnErrors for better diagnostics (#3019). There is currently a XAML bug causing a crash on shutdown when it is on. To work around this bug, turn off FailFastOnErrors before we hit the error. We may miss out on some diagnostics during shutdown, but we're not very concerned with those. Turning it off during MainWindow.Closed() at the advice of the WinUI team.

## Validation steps performed
Validated locally with a debug build.

## PR checklist
- [x] Closes #3136
