### PR TITLE
Show message when running Dashboard as admin

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -189,6 +189,10 @@
     <value>Add new widget</value>
     <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't added any widgets.</comment>
   </data>
+  <data name="RunningAsAdminMessage.Text" xml:space="preserve">
+    <value>Dev Home cannot display the Dashboard while running as Administrator.</value>
+    <comment>Message shown when the user ran as admin and we can't show the dashboard.</comment>
+  </data>
   <data name="RestartDevHomeMessage.Text" xml:space="preserve">
     <value>We're having trouble displaying widgets. Restarting Dev Home may help.</value>
     <comment>Message shown when there's no widget service and the user should restart Dev Home.</comment>

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -190,7 +190,7 @@
     <comment>The hyperlink to bring the user to the Add Widget dialog. Shows if the user hasn't added any widgets.</comment>
   </data>
   <data name="RunningAsAdminMessage.Text" xml:space="preserve">
-    <value>Dev Home cannot display the Dashboard while running as Administrator.</value>
+    <value>Dashboard cannot be displayed while running as Administrator.</value>
     <comment>Message shown when the user ran as admin and we can't show the dashboard.</comment>
   </data>
   <data name="RestartDevHomeMessage.Text" xml:space="preserve">

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using DevHome.Common.Helpers;
 using DevHome.Dashboard.Services;
 using Microsoft.UI.Xaml;
 
@@ -38,5 +39,10 @@ public partial class DashboardViewModel : ObservableObject
     public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)
     {
         return (widgetCount == 0 && !isLoading && HasWidgetService) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public bool IsRunningAsAdmin()
+    {
+        return RuntimeHelper.IsCurrentProcessRunningAsAdmin();
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -137,6 +137,9 @@
                     </StackPanel>
 
                     <!-- Widget messages -->
+                    <StackPanel x:Name="RunningAsAdminMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                        <TextBlock x:Uid="RunningAsAdminMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
+                    </StackPanel>
                     <StackPanel x:Name="RestartDevHomeMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
                         <TextBlock x:Uid="RestartDevHomeMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
                     </StackPanel>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -172,7 +172,12 @@ public partial class DashboardView : ToolPage, IDisposable
         LoadingWidgetsProgressRing.Visibility = Visibility.Visible;
         ViewModel.IsLoading = true;
 
-        if (ViewModel.WidgetServiceService.CheckForWidgetServiceAsync())
+        if (ViewModel.IsRunningAsAdmin())
+        {
+            _log.Error($"Dev Home is running as admin, can't show Dashboard");
+            RunningAsAdminMessageStackPanel.Visibility = Visibility.Visible;
+        }
+        else if (ViewModel.WidgetServiceService.CheckForWidgetServiceAsync())
         {
             ViewModel.HasWidgetService = true;
             if (await SubscribeToWidgetCatalogEventsAsync())


### PR DESCRIPTION
## Summary of the pull request
Dev Home cannot show widgets when running as administrator, due to the rules around COM and elevation (#1391). If the user runs Dev Home as admin, show a more helpful message.

(Pretend the screenshot has the updated message)
![image](https://github.com/microsoft/devhome/assets/47155823/64a29195-b007-4920-8bd1-148b08e05c3c)

## References and relevant issues
#1391

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
