### PR TITLE
PI: Fix Winlogs to show Debugoutput when the user has enabled it and changed targetapp

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/WinLogsHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WinLogsHelper.cs
@@ -30,13 +30,10 @@ public class WinLogsHelper : IDisposable
     private Thread? eventViewerThread;
     private Thread? watsonThread;
 
-    public bool IsETWEnabled { get; }
-
     public WinLogsHelper(Process targetProcess, ObservableCollection<WinLogsEntry> output)
     {
         this.targetProcess = targetProcess;
         this.output = output;
-        IsETWEnabled = ETWHelper.IsUserInPerformanceLogUsersGroup();
 
         // Initialize ETW logs
         etwHelper = new ETWHelper(targetProcess, output);
@@ -49,19 +46,29 @@ public class WinLogsHelper : IDisposable
 
         // Initialize Watson
         watsonHelper = new WatsonHelper(targetProcess, null, output);
-
-        Start();
     }
 
-    public void Start()
+    public void Start(bool isEtwEnabled, bool isDebugOutputEnabled, bool isEventViewerEnabled, bool isWatsonEnabled)
     {
-        if (IsETWEnabled)
+        if (isEtwEnabled)
         {
             StartETWLogsThread();
         }
 
-        StartEventViewerThread();
-        StartWatsonThread();
+        if (isDebugOutputEnabled)
+        {
+            StartDebugOutputsThread();
+        }
+
+        if (isEventViewerEnabled)
+        {
+            StartEventViewerThread();
+        }
+
+        if (isWatsonEnabled)
+        {
+            StartWatsonThread();
+        }
     }
 
     public void Stop()

--- a/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
@@ -88,8 +88,9 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
             {
                 if (!process.HasExited)
                 {
+                    IsETWLogsEnabled = ETWHelper.IsUserInPerformanceLogUsersGroup();
                     winLogsHelper = new WinLogsHelper(targetProcess, winLogsOutput);
-                    IsETWLogsEnabled = winLogsHelper.IsETWEnabled;
+                    winLogsHelper.Start(IsETWLogsEnabled, IsDebugOutputEnabled, IsEventViewerEnabled, IsWatsonEnabled);
                 }
             }
             catch (Win32Exception ex)


### PR DESCRIPTION
## Summary of the pull request
DebugOutput were not captured when the user changed the targetapp since we had disabled them at Start by default.

Fixed this by passing the enabled/disabled state for all the log helpers when we start winlogs for the new target app.

## Validation steps performed
1. launch PI
2. Go to winlogs page
3. enable Debugoutput
4. change target app
5. Verified that debugout is visible

## PR checklist
- [ ] Closes #3245 
