### PR TITLE
Move the rotate button to titlebar

### DIFF
--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -133,7 +133,7 @@
     <value>Unregister</value>
     <comment>The label for Unregister menu flyout for an icon in the toolbar. This will cause the program to no longer be registered with the bar.</comment>
   </data>
-  <data name="SwitchLayoutButton.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="RotateLayoutButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Switch between horizontal and vertical layout</value>
     <comment>The tooltip for a button which toggles the orientation of the bar between horizontal and vertical</comment>
   </data>

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -168,7 +168,7 @@ public partial class BarWindowViewModel : ObservableObject
     }
 
     [RelayCommand]
-    public void SwitchLayout()
+    public void RotateLayout()
     {
         if (BarOrientation == Orientation.Horizontal)
         {

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -52,7 +52,7 @@
                      FontSize="{StaticResource CaptionTextBlockFontSize}"
                      Command="{x:Bind _viewModel.RotateLayoutCommand}" 
                      HorizontalAlignment="Left">
-                    <TextBlock x:Name="RotateLayoutButtonText" Text="&#xe7ad;" />
+                    <TextBlock x:Name="RotateLayoutButtonText" Text="&#xe8b4;" />
                 </Button>
                 <Button
                      x:Uid="ExpandCollapseLayoutButton" 

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -47,12 +47,20 @@
                     <TextBlock x:Name="SnapButtonText" Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>
                 </Button>
                 <Button
-                    x:Uid="ExpandCollapseLayoutButton" 
-                    Style="{StaticResource ChromeButton}" 
-                    FontSize="{StaticResource CaptionTextBlockFontSize}"
-                    Command="{x:Bind _viewModel.ToggleExpandedContentVisibilityCommand}" 
-                    HorizontalAlignment="Left" 
-                    ToolTipService.ToolTip="{x:Bind _viewModel.CurrentExpandToolTip, Mode=OneWay}">
+                     x:Uid="RotateLayoutButton" 
+                     Style="{StaticResource ChromeButton}" 
+                     FontSize="{StaticResource CaptionTextBlockFontSize}"
+                     Command="{x:Bind _viewModel.RotateLayoutCommand}" 
+                     HorizontalAlignment="Left">
+                    <TextBlock x:Name="RotateLayoutButtonText" Text="&#xe7ad;" />
+                </Button>
+                <Button
+                     x:Uid="ExpandCollapseLayoutButton" 
+                     Style="{StaticResource ChromeButton}" 
+                     FontSize="{StaticResource CaptionTextBlockFontSize}"
+                     Command="{x:Bind _viewModel.ToggleExpandedContentVisibilityCommand}" 
+                     HorizontalAlignment="Left" 
+                     ToolTipService.ToolTip="{x:Bind _viewModel.CurrentExpandToolTip, Mode=OneWay}">
                     <TextBlock x:Name="ExpandCollapseLayoutButtonText" />
                 </Button>
             </StackPanel>
@@ -102,11 +110,7 @@
             </StackPanel>
 
             <!-- Per System controls -->
-            <Button x:Uid="SwitchLayoutButton" x:Name="SwitchLayoutButton" HorizontalAlignment="Center" Command="{x:Bind _viewModel.SwitchLayoutCommand}">
-                <TextBlock Text="&#xe8b4;"/>
-            </Button>
-
-            <controls:ExternalToolsManagementButton
+              <controls:ExternalToolsManagementButton
                 x:Name="ManageExternalToolsButton"
                 x:Uid="ManageExternalToolsButton"
                 HorizontalAlignment="Center"

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -365,11 +365,13 @@ public partial class BarWindowHorizontal : WindowEx
         {
             SnapButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForegroundDisabled"];
             ExpandCollapseLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForegroundDisabled"];
+            RotateLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForegroundDisabled"];
         }
         else
         {
             SnapButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForeground"];
             ExpandCollapseLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForeground"];
+            RotateLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForeground"];
         }
     }
 }

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
@@ -60,7 +60,7 @@
                 x:Name="RotateLayoutButton" 
                 Command="{x:Bind _viewModel.RotateLayoutCommand}" 
                 HorizontalAlignment="Center">
-                <TextBlock Text="&#xe7ad;" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
+                <TextBlock Text="&#xe8b4;" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
             </Button>
             <Button
                 x:Uid="ExpandLayoutButton" 

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
@@ -55,6 +55,13 @@
                 Style="{StaticResource ChromeButton}" >
                 <TextBlock Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
             </Button>
+            <Button 
+                x:Uid="RotateLayoutButton" 
+                x:Name="RotateLayoutButton" 
+                Command="{x:Bind _viewModel.RotateLayoutCommand}" 
+                HorizontalAlignment="Center">
+                <TextBlock Text="&#xe7ad;" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
+            </Button>
             <Button
                 x:Uid="ExpandLayoutButton" 
                 Style="{StaticResource ChromeButton}" 
@@ -96,11 +103,7 @@
             </StackPanel>
                         
             <!-- Per System controls -->
-            <Button x:Uid="SwitchLayoutButton" x:Name="SwitchLayoutButton" Command="{x:Bind _viewModel.SwitchLayoutCommand}" HorizontalAlignment="Center">
-                <TextBlock Text="&#xe8b4;"/>
-            </Button>
-
-            <controls:ExternalToolsManagementButton
+          <controls:ExternalToolsManagementButton
                 x:Name="ManageExternalToolsButton"
                 x:Uid="ManageExternalToolsButton"
                 HorizontalAlignment="Center"


### PR DESCRIPTION
This PR is going to feel like a little deja vu. This moves the "rotate the bar" button into the titlebar as well... now all of the window manipulation buttons will be centrally located.

Before

![afterhor](https://github.com/microsoft/devhome/assets/49733346/c12ff980-4ef5-48c9-957a-3b9b2b5be783)
![aftervert](https://github.com/microsoft/devhome/assets/49733346/1a9ed89c-58d0-45b0-a961-08fb55f415e2)

After

![AfterHor2](https://github.com/microsoft/devhome/assets/49733346/e85c3933-95d9-4c09-9bb8-ff647bce131a)
![aftervert2](https://github.com/microsoft/devhome/assets/49733346/51c1db6f-ad96-485d-94f1-8f35d342adc9)


## Summary of the pull request

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
