### PR TITLE
Dev Drive Insights - Prepopulate the cache directory and enable the make changes button

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/DevDriveInsights/OptimizeDevDriveDialogViewModel.cs
@@ -63,16 +63,16 @@ public partial class OptimizeDevDriveDialogViewModel : ObservableObject
         string exampleDevDriveLocation,
         List<string> existingDevDriveLetters)
     {
-        DirectoryPathTextBox = string.Empty;
         var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
         ExistingDevDriveLetters = existingDevDriveLetters;
         ExampleDevDriveLocation = stringResource.GetLocalized("ExampleText") + exampleDevDriveLocation;
+        DirectoryPathTextBox = exampleDevDriveLocation;
         ChooseDirectoryPromptText = stringResource.GetLocalized("ChooseDirectoryPromptText");
         MakeChangesText = stringResource.GetLocalized("MakeChangesText");
         ExistingCacheLocation = existingCacheLocation;
         EnvironmentVariableToBeSet = environmentVariableToBeSet;
         OptimizeDevDriveDialogDescription = stringResource.GetLocalized("OptimizeDevDriveDialogDescription/Text", ExistingCacheLocation, EnvironmentVariableToBeSet);
-        IsPrimaryButtonEnabled = false;
+        IsPrimaryButtonEnabled = true;
         ErrorMessage = string.Empty;
         IsNotDevDrive = false;
     }


### PR DESCRIPTION
## Summary of the pull request

Prepopulate the Dev Drive Insights cache directory and enable the make changes button.

## References and relevant issues

Fixes #2681 

## Detailed description of the pull request / Additional comments

**Before:**

![Before](https://github.com/microsoft/devhome/assets/5017479/2a1386a0-7a96-40d9-9915-9e6072b4a655)

**After:**

![After](https://github.com/microsoft/devhome/assets/5017479/bf83b320-addd-41c6-9e43-e13345154888)

## Validation steps performed

## PR checklist
- [x] Closes #2681 
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
