### PR TITLE
Move PinnedWidgets collection to ViewModel

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -39,7 +39,7 @@ public sealed partial class WidgetControl : UserControl
     // https://learn.microsoft.com/en-us/windows/apps/design/widgets/widgets-design-fundamentals
     // Adaptive cards render with 8px padding on each side, so we subtract that from the header height,
     // as well as 1px for the border.
-    private const double _headerHeightUnscaled = 39;
+    private const double HeaderHeightUnscaled = 39;
 
     private SelectableMenuFlyoutItem _currentSelectedSize;
 
@@ -118,7 +118,7 @@ public sealed partial class WidgetControl : UserControl
 
     private void SetScaledWidthAndHeight(double textScale)
     {
-        HeaderHeight = new GridLength(_headerHeightUnscaled * textScale);
+        HeaderHeight = new GridLength(HeaderHeightUnscaled * textScale);
         WidgetHeight = GetPixelHeightFromWidgetSize(WidgetSource.WidgetSize) * textScale;
         WidgetWidth = WidgetHelpers.WidgetPxWidth * textScale;
     }

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -89,6 +89,7 @@ public sealed partial class WidgetControl : UserControl
     private void OnUnloaded()
     {
         _uiSettings.TextScaleFactorChanged -= HandleTextScaleFactorChangedAsync;
+        WidgetSource = null;
     }
 
     private async void HandleTextScaleFactorChangedAsync(UISettings sender, object args)

--- a/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Controls/WidgetControl.xaml.cs
@@ -14,7 +14,6 @@ using DevHome.Dashboard.ComSafeWidgetObjects;
 using DevHome.Dashboard.Helpers;
 using DevHome.Dashboard.Services;
 using DevHome.Dashboard.ViewModels;
-using DevHome.Dashboard.Views;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -177,7 +176,7 @@ public sealed partial class WidgetControl : UserControl
                 _log.Debug($"User removed widget, delete widget {widgetIdToDelete}");
                 var stringResource = new StringResource("DevHome.Dashboard.pri", "DevHome.Dashboard/Resources");
                 Application.Current.GetService<IScreenReaderService>().Announce(stringResource.GetLocalized("WidgetRemoved"));
-                DashboardView.PinnedWidgets.Remove(widgetViewModel);
+                Application.Current.GetService<DashboardViewModel>().PinnedWidgets.Remove(widgetViewModel);
                 try
                 {
                     await widgetToDelete.DeleteAsync();

--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -13,7 +13,7 @@ public static class ServiceExtensions
     public static IServiceCollection AddDashboard(this IServiceCollection services, HostBuilderContext context)
     {
         // View-models
-        services.AddSingleton<DashboardViewModel>();
+        services.AddTransient<DashboardViewModel>();
         services.AddTransient<DashboardBannerViewModel>();
         services.AddTransient<AddWidgetViewModel>();
 

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Helpers;
 using DevHome.Dashboard.Services;
@@ -18,6 +19,8 @@ public partial class DashboardViewModel : ObservableObject
 
     public IWidgetScreenshotService WidgetScreenshotService { get; }
 
+    public ObservableCollection<WidgetViewModel> PinnedWidgets { get; set; }
+
     [ObservableProperty]
     private bool _isLoading;
 
@@ -34,6 +37,8 @@ public partial class DashboardViewModel : ObservableObject
         WidgetHostingService = widgetHostingService;
         WidgetIconService = widgetIconService;
         WidgetScreenshotService = widgetScreenshotService;
+
+        PinnedWidgets = new ObservableCollection<WidgetViewModel>();
     }
 
     public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -83,7 +83,7 @@
 
                     <!-- Widget grid -->
                     <GridView x:Name="WidgetGridView"
-                              ItemsSource="{x:Bind ViewModel.PinnedWidgets}"
+                              ItemsSource="{x:Bind ViewModel.PinnedWidgets, Mode=OneWay}"
                               CanReorderItems="True"
                               CanDragItems="True"
                               DragItemsStarting="WidgetGridView_DragItemsStarting">

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -11,7 +11,6 @@
     xmlns:pg="using:DevHome.Common"
     xmlns:commonviews="using:DevHome.Common.Views"
     xmlns:vm="using:DevHome.Dashboard.ViewModels"
-    xmlns:views="using:DevHome.Dashboard.Views"
     xmlns:controls="using:DevHome.Dashboard.Controls"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
@@ -84,7 +83,7 @@
 
                     <!-- Widget grid -->
                     <GridView x:Name="WidgetGridView"
-                              ItemsSource="{x:Bind views:DashboardView.PinnedWidgets}"
+                              ItemsSource="{x:Bind ViewModel.PinnedWidgets}"
                               CanReorderItems="True"
                               CanDragItems="True"
                               DragItemsStarting="WidgetGridView_DragItemsStarting">
@@ -131,7 +130,7 @@
                     <StackPanel x:Name="NoWidgetsStackPanel"
                                 HorizontalAlignment="Center"
                                 Margin="0,150,0,0"
-                                Visibility="{x:Bind ViewModel.GetNoWidgetMessageVisibility(views:DashboardView.PinnedWidgets.Count, ViewModel.IsLoading), Mode=OneWay}">
+                                Visibility="{x:Bind ViewModel.GetNoWidgetMessageVisibility(ViewModel.PinnedWidgets.Count, ViewModel.IsLoading), Mode=OneWay}">
                         <TextBlock x:Uid="NoWidgetsAdded" HorizontalAlignment="Center" />
                         <commonviews:AddCreateHyperlinkButton x:Name="AddFirstWidgetLink" x:Uid="AddFirstWidgetLink" HorizontalAlignment="Center" Command="{x:Bind AddWidgetClickCommand}" />
                     </StackPanel>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -186,7 +186,7 @@ public partial class DashboardView : ToolPage, IDisposable
                 _log.Information($"Is first dashboard run = {isFirstDashboardRun}");
                 if (isFirstDashboardRun)
                 {
-                    await Application.Current.GetService<ILocalSettingsService>().SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstDashboardRun, true);
+                    await _localSettingsService.SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstDashboardRun, true);
                 }
 
                 await InitializePinnedWidgetListAsync(isFirstDashboardRun);

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -132,6 +132,9 @@ public partial class DashboardView : ToolPage, IDisposable
     [RelayCommand]
     private async Task OnUnloadedAsync()
     {
+        ViewModel.PinnedWidgets.CollectionChanged -= OnPinnedWidgetsCollectionChangedAsync;
+        Bindings.StopTracking();
+
         Application.Current.GetService<WidgetAdaptiveCardRenderingService>().RendererUpdated -= HandleRendererUpdated;
 
         _log.Debug($"Leaving Dashboard, deactivating widgets.");
@@ -145,6 +148,7 @@ public partial class DashboardView : ToolPage, IDisposable
             _log.Error(ex, "Exception in UnsubscribeFromWidgets:");
         }
 
+        ViewModel.PinnedWidgets.Clear();
         await UnsubscribeFromWidgetCatalogEventsAsync();
     }
 


### PR DESCRIPTION
## Summary of the pull request
Moves PinnedWidgets to the DashboardViewModel. More significantly, unhooks handlers and removes references that were keeping objects alive past when they needed to be.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Ran under Performance Profiler, watched Task Manager while navigating.

## PR checklist
- [ ] Closes #672
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
