### PR TITLE
Wrap CoreWidgetProvider UpdateWidget in try/catch

### DIFF
--- a/extensions/CoreWidgetProvider/Program.cs
+++ b/extensions/CoreWidgetProvider/Program.cs
@@ -93,7 +93,7 @@ public sealed class Program
         var widgetProviderInstance = new Widgets.WidgetProvider();
         widgetServer.RegisterWidget(() => widgetProviderInstance);
 
-        // This will make the main thread wait until the event is signalled by the extension class.
+        // This will make the main thread wait until the event is signaled by the extension class.
         // Since we have single instance of the extension object, we exit as soon as it is disposed.
         extensionDisposedEvent.WaitOne();
         Log.Information($"Extension is disposed.");

--- a/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/CoreWidget.cs
@@ -109,7 +109,14 @@ internal abstract class CoreWidget : WidgetImpl
         };
 
         Log.Debug($"Updating widget for {Page}");
-        WidgetManager.GetDefault().UpdateWidget(updateOptions);
+        try
+        {
+            WidgetManager.GetDefault().UpdateWidget(updateOptions);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Exception updating widget via WidgetManager.");
+        }
     }
 
     public virtual string GetTemplatePath(WidgetPageState page)

--- a/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -192,8 +192,14 @@ internal sealed class SSHWalletWidget : CoreWidget
                 CustomState = ConfigFile,
                 Template = GetTemplateForPage(Page),
             };
-
-            WidgetManager.GetDefault().UpdateWidget(updateRequestOptions);
+            try
+            {
+                WidgetManager.GetDefault().UpdateWidget(updateRequestOptions);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Exception updating widget via WidgetManager.");
+            }
         }
     }
 
@@ -364,7 +370,14 @@ internal sealed class SSHWalletWidget : CoreWidget
         };
 
         Log.Debug($"Updating widget for {Page}");
-        WidgetManager.GetDefault().UpdateWidget(updateOptions);
+        try
+        {
+            WidgetManager.GetDefault().UpdateWidget(updateOptions);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Exception updating widget via WidgetManager.");
+        }
     }
 
     public override string GetTemplatePath(WidgetPageState page)

--- a/extensions/HyperVExtension/src/HyperVExtensionServer/Program.cs
+++ b/extensions/HyperVExtension/src/HyperVExtensionServer/Program.cs
@@ -111,7 +111,7 @@ public sealed class Program
         // If you want to instantiate a new instance each time the host asks, create the new instance inside the delegate.
         extensionServer.RegisterExtension(() => hyperVExtension, true);
 
-        // This will make the main thread wait until the event is signalled by the extension class.
+        // This will make the main thread wait until the event is signaled by the extension class.
         // Since we have single instance of the extension object, we exit as soon as it is disposed.
         hyperVExtension.ExtensionDisposedEvent.WaitOne();
         Log.Information($"Extension is disposed.");


### PR DESCRIPTION
## Summary of the pull request
We see crashes coming from the WidgetManager doing UpdateWidget(). Wrap our calls in try/catch to try to avoid crashing.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
