### PR TITLE
Fix "Learn more" link in UtilityView

### DIFF
--- a/tools/Utilities/src/DevHome.Utilities.csproj
+++ b/tools/Utilities/src/DevHome.Utilities.csproj
@@ -18,10 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="DevHome.Utilities\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Page Update="Views\UtilityView.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/tools/Utilities/src/Strings/en-us/Resources.resw
+++ b/tools/Utilities/src/Strings/en-us/Resources.resw
@@ -131,10 +131,13 @@
     <value>Hosts File Editor</value>
     <comment>;Locked={"Hosts"}</comment>
   </data>
-  <data name="LaunchButton.Text" xml:space="preserve">
+  <data name="LearnMoreHyperlinkButton.Content" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
+  <data name="LaunchButton.Content" xml:space="preserve">
     <value>Launch</value>
   </data>
-  <data name="LaunchButtonBase.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+  <data name="LaunchButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Launch</value>
   </data>
   <data name="NavigationPane.Content" xml:space="preserve">

--- a/tools/Utilities/src/ViewModels/UtilityViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilityViewModel.cs
@@ -17,10 +17,9 @@ namespace DevHome.Utilities.ViewModels;
 public partial class UtilityViewModel : ObservableObject
 {
 #nullable enable
-
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(UtilityViewModel));
-    private readonly IExperimentationService? experimentationService;
-    private readonly string? experimentalFeature;
+    private readonly IExperimentationService? _experimentationService;
+    private readonly string? _experimentalFeature;
     private readonly string _exeName;
 #nullable disable
 
@@ -29,9 +28,9 @@ public partial class UtilityViewModel : ObservableObject
         get
         {
             // Query if there is an experimental feature and return its enabled value
-            if (experimentalFeature is not null)
+            if (_experimentalFeature is not null)
             {
-                var isExperimentalFeatureEnabled = experimentationService?.IsFeatureEnabled(experimentalFeature) ?? true;
+                var isExperimentalFeatureEnabled = _experimentationService?.IsFeatureEnabled(_experimentalFeature) ?? true;
                 return isExperimentalFeatureEnabled;
             }
 
@@ -60,9 +59,9 @@ public partial class UtilityViewModel : ObservableObject
 #nullable enable
     public UtilityViewModel(string exeName, IExperimentationService? experimentationService = null, string? experimentalFeature = null)
     {
-        this._exeName = exeName;
-        this.experimentationService = experimentationService;
-        this.experimentalFeature = experimentalFeature;
+        _exeName = exeName;
+        _experimentationService = experimentationService;
+        _experimentalFeature = experimentalFeature;
         LaunchCommand = new RelayCommand(Launch);
         _log.Information($"UtilityViewModel created for Title: {Title}, exe: {exeName}");
     }

--- a/tools/Utilities/src/Views/UtilityView.xaml
+++ b/tools/Utilities/src/Views/UtilityView.xaml
@@ -3,18 +3,18 @@
     x:Class="DevHome.Utilities.Views.UtilityView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-    mc:Ignorable="d" 
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    mc:Ignorable="d"
     d:DesignHeight="300" d:DesignWidth="300">
 
     <Grid
         AutomationProperties.Name="{x:Bind ViewModel.Title}"
         AutomationProperties.AutomationId="{x:Bind ViewModel.UtilityAutomationId, Mode=OneWay}"
         HorizontalAlignment="Stretch"
-        Padding="15 15"
+        Padding="30 20"
+        RowSpacing="10"
         CornerRadius="{ThemeResource ControlCornerRadius}"
-        Margin="0"
         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
         BorderThickness="{ThemeResource ExpanderBorderThickness}"
@@ -28,18 +28,16 @@
         </Grid.RowDefinitions>
 
         <Image
-            AutomationProperties.AccessibilityView="Raw"
             Grid.Row="0"
+            AutomationProperties.AccessibilityView="Raw"
             Source="{x:Bind ViewModel.ImageSource}"
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
-            Margin="15 5 0 0"
             Width="64"
-            Height="64"/>
+            Height="64" />
 
         <ScrollViewer
-            Grid.Row="1"
-            Padding="15 10 15 8">
+            Grid.Row="1">
 
             <StackPanel>
                 <TextBlock
@@ -48,39 +46,33 @@
                     Text="{x:Bind ViewModel.Title}" />
 
                 <TextBlock
-                    Margin="0 16 0 5"
+                    Margin="0 16 0 0"
                     TextWrapping="Wrap"
                     VerticalAlignment="Top"
                     TextTrimming="WordEllipsis"
-                    Text="{x:Bind ViewModel.Description}"/>
+                    Text="{x:Bind ViewModel.Description}" />
 
                 <HyperlinkButton
-                    Content="Learn More"
+                    x:Uid="LearnMoreHyperlinkButton"
                     NavigateUri="{x:Bind ViewModel.NavigateUri}"
+                    Padding="0 6 0 7"
                     VerticalAlignment="Top"
-                    Padding="0 0 0 0"
-                    HorizontalAlignment="Left"/>
+                    HorizontalAlignment="Left" />
             </StackPanel>
         </ScrollViewer>
 
         <ToggleSwitch
-            x:Uid="SupportsLaunchAsAdmin"
             Grid.Row="2"
+            x:Uid="SupportsLaunchAsAdmin"
             IsOn="{x:Bind ViewModel.LaunchAsAdmin, Mode=TwoWay}"
             Visibility="{x:Bind ViewModel.SupportsLaunchAsAdmin, Mode=OneWay}"
-            Margin="15 0 0 5" 
-            AutomationProperties.AutomationId="AdminToggleAutomationId"/>
+            AutomationProperties.AutomationId="AdminToggleAutomationId" />
 
         <Button
-            x:Uid="LaunchButtonBase"
             Grid.Row="3"
-            Margin="15 5 0 0"
+            x:Uid="LaunchButton"
             Command="{x:Bind ViewModel.LaunchCommand}"
             AutomationProperties.AutomationId="LaunchButtonAutomationId">
-
-            <StackPanel Orientation="Horizontal">
-                <TextBlock x:Uid="LaunchButton" />
-            </StackPanel>
         </Button>
 
     </Grid>


### PR DESCRIPTION
## Summary of the pull request
"Learn more" string was wrong and needed to be localized.
Fixed some overly complicated spacing.
Fixed some variable names to comply with naming rules.
![image](https://github.com/microsoft/devhome/assets/47155823/564f7423-c121-4a3a-a7e0-ef5b299a8f4c)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3217
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
