### PR TITLE
Add Hot Reload for Debug_FailFast configuration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,6 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-    <DisableXbfLineInfo>False</DisableXbfLineInfo>
   </PropertyGroup>
 
 <!--
@@ -40,5 +39,9 @@
     <Compile Condition="$(MSBuildProjectName) == 'DevHomeStub'" Include="$(MSBuildThisFileDirectory)\codeAnalysis\StubSuppressions.cs" Link="GlobalSuppressions.cs" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\codeAnalysis\StyleCop.json" Link="StyleCop.json" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
+    <DisableXbfLineInfo>False</DisableXbfLineInfo>
+  </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <DisableXbfLineInfo>False</DisableXbfLineInfo>
   </PropertyGroup>
 
 <!--


### PR DESCRIPTION
## Summary of the pull request
When not using Debug, Hot Reload does not work by default. In order to use it, the msbuild property `<DisableXbfLineInfo>False</DisableXbfLineInfo>` [must be set](https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/tools-utilities/xaml-hot-reload-troubleshooting?view=vs-2019#verify-that-your-msbuild-properties-are-correct). We can enable it for Debug_FailFast builds in Directory.Build.props so it works everywhere.

## References and relevant issues
#3267
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
