### PR TITLE
Using TextScaling to adjust MinWidth in SummaryView

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:commonviews="using:DevHome.Common.Views"
-    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:communityControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -57,11 +57,6 @@
         HorizontalAlignment="Stretch"
         VerticalScrollBarVisibility="Auto"
         VerticalScrollMode="Enabled">
-        <!--  Setting min width here prevents text clipping with "Next Steps"  -->
-        <!--
-            I tried putting minWidth on the "Left Side" stack panel.  WHile it did keep the MinWidth
-            It did clip when the window become too small.
-        -->
         <communityControls:UniformGrid
             x:Name="ParentUniformGrid"
             Margin="{ThemeResource ContentPageMargin}"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -58,8 +58,7 @@
         VerticalScrollBarVisibility="Auto"
         VerticalScrollMode="Enabled">
         <communityControls:UniformGrid
-            MinWidth="600"
-            MaxWidth="{ThemeResource MaxPageContentWidth}"
+            x:Name="ParentUniformGrid"
             Margin="{ThemeResource ContentPageMargin}"
             ColumnSpacing="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFileFlowColumnSpacing}}">
             <Grid.RowDefinitions>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:commonviews="using:DevHome.Common.Views"
-    xmlns:communityControls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -16,6 +16,7 @@
     xmlns:viewModels="using:DevHome.SetupFlow.ViewModels"
     setupFlowBehaviors:SetupFlowNavigationBehavior.NextVisibility="Collapsed"
     setupFlowBehaviors:SetupFlowNavigationBehavior.PreviousVisibility="Collapsed"
+    Unloaded="UserControl_Unloaded"
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:commonviews="using:DevHome.Common.Views"
+    xmlns:communityControls="using:CommunityToolkit.WinUI.Controls"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -56,7 +57,8 @@
         HorizontalAlignment="Stretch"
         VerticalScrollBarVisibility="Auto"
         VerticalScrollMode="Enabled">
-        <Grid
+        <communityControls:UniformGrid
+            MinWidth="600"
             MaxWidth="{ThemeResource MaxPageContentWidth}"
             Margin="{ThemeResource ContentPageMargin}"
             ColumnSpacing="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFileFlowColumnSpacing}}">
@@ -64,11 +66,6 @@
                 <RowDefinition Height="auto" />
                 <RowDefinition />
             </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFlowLeftColumnWidth}}" />
-                <ColumnDefinition Width="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFlowRightColumnWidth}}" />
-            </Grid.ColumnDefinitions>
-
             <StackPanel
                 x:Name="SummaryHeader"
                 Grid.Row="0"
@@ -171,6 +168,6 @@
                 <summaryViews:SummaryNextSteps DataContext="{x:Bind ViewModel}" Visibility="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay}" />
 
             </StackPanel>
-        </Grid>
+        </communityControls:UniformGrid>
     </ScrollViewer>
 </UserControl>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -57,6 +57,11 @@
         HorizontalAlignment="Stretch"
         VerticalScrollBarVisibility="Auto"
         VerticalScrollMode="Enabled">
+        <!--  Setting min width here prevents text clipping with "Next Steps"  -->
+        <!--
+            I tried putting minWidth on the "Left Side" stack panel.  WHile it did keep the MinWidth
+            It did clip when the window become too small.
+        -->
         <communityControls:UniformGrid
             x:Name="ParentUniformGrid"
             Margin="{ThemeResource ContentPageMargin}"
@@ -65,6 +70,10 @@
                 <RowDefinition Height="auto" />
                 <RowDefinition />
             </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFlowLeftColumnWidth}}" />
+                <ColumnDefinition Width="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFlowRightColumnWidth}}" />
+            </Grid.ColumnDefinitions>
             <StackPanel
                 x:Name="SummaryHeader"
                 Grid.Row="0"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml
@@ -60,6 +60,7 @@
         VerticalScrollMode="Enabled">
         <communityControls:UniformGrid
             x:Name="ParentUniformGrid"
+            MaxWidth="{ThemeResource MaxPageContentWidth}"
             Margin="{ThemeResource ContentPageMargin}"
             ColumnSpacing="{x:Bind ViewModel.ShowConfigurationFileResults, Mode=OneWay, Converter={StaticResource ConfigurationFileFlowColumnSpacing}}">
             <Grid.RowDefinitions>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
@@ -15,17 +15,15 @@ public sealed partial class SummaryView : UserControl
 {
     private readonly UISettings _uiSettings = new();
 
-    private double _textScale = 1.0;
-
     private const double BaseWidth = 550;
 
     public SummaryView()
     {
         this.InitializeComponent();
 
-        _textScale = _uiSettings.TextScaleFactor;
+        var textScale = _uiSettings.TextScaleFactor;
         _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChanged;
-        ParentUniformGrid.MinWidth = BaseWidth * _textScale;
+        ParentUniformGrid.MinWidth = BaseWidth * textScale;
     }
 
     public SummaryViewModel ViewModel => (SummaryViewModel)this.DataContext;
@@ -34,8 +32,8 @@ public sealed partial class SummaryView : UserControl
     {
         Application.Current.GetService<DispatcherQueue>().EnqueueAsync(() =>
         {
-            _textScale = sender.TextScaleFactor;
-            ParentUniformGrid.MinWidth = BaseWidth * _textScale;
+            var textScale = sender.TextScaleFactor;
+            ParentUniformGrid.MinWidth = BaseWidth * textScale;
             InvalidateMeasure();
         });
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
@@ -21,6 +21,9 @@ public sealed partial class SummaryView : UserControl
     {
         this.InitializeComponent();
 
+        // Setting min width on the Uniform Grid prevents text clipping with "Next Steps"
+        // I tried putting minWidth on the "Left Side" stack panel.  While it did keep the MinWidth
+        // It did clip when the window become too small.
         var textScale = _uiSettings.TextScaleFactor;
         _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChanged;
         ParentUniformGrid.MinWidth = BaseWidth * textScale;
@@ -36,5 +39,10 @@ public sealed partial class SummaryView : UserControl
             ParentUniformGrid.MinWidth = BaseWidth * textScale;
             InvalidateMeasure();
         });
+    }
+
+    private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+    {
+        _uiSettings.TextScaleFactorChanged -= HandleTextScaleFactorChanged;
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
@@ -1,22 +1,42 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AdaptiveCards.Rendering.WinUI3;
-using CommunityToolkit.Mvvm.Messaging;
-using DevHome.SetupFlow.Models.Environments;
+using CommunityToolkit.WinUI;
+using DevHome.Common.Extensions;
 using DevHome.SetupFlow.ViewModels;
-using DevHome.SetupFlow.Windows;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Windows.UI.ViewManagement;
 
 namespace DevHome.SetupFlow.Views;
 
 public sealed partial class SummaryView : UserControl
 {
+    private readonly UISettings _uiSettings = new();
+
+    private double _textScale = 1.0;
+
+    private const double BaseWidth = 550;
+
     public SummaryView()
     {
         this.InitializeComponent();
+
+        _textScale = _uiSettings.TextScaleFactor;
+        _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChanged;
+        ParentUniformGrid.MinWidth = BaseWidth * _textScale;
     }
 
     public SummaryViewModel ViewModel => (SummaryViewModel)this.DataContext;
+
+    private void HandleTextScaleFactorChanged(UISettings sender, object args)
+    {
+        Application.Current.GetService<DispatcherQueue>().EnqueueAsync(() =>
+        {
+            _textScale = sender.TextScaleFactor;
+            ParentUniformGrid.MinWidth = BaseWidth * _textScale;
+            InvalidateMeasure();
+        });
+    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SummaryView.xaml.cs
@@ -21,9 +21,9 @@ public sealed partial class SummaryView : UserControl
     {
         this.InitializeComponent();
 
-        // Setting min width on the Uniform Grid prevents text clipping with "Next Steps"
-        // I tried putting minWidth on the "Left Side" stack panel.  While it did keep the MinWidth
-        // It did clip when the window become too small.
+        // Setting MinWidth on the UniformGrid prevents text clipping in "Next Steps".
+        // Setting MinWidth on the "Left Side" stack panel keeps the MinWidth but still clips
+        // when the window becomes too small.
         var textScale = _uiSettings.TextScaleFactor;
         _uiSettings.TextScaleFactorChanged += HandleTextScaleFactorChanged;
         ParentUniformGrid.MinWidth = BaseWidth * textScale;


### PR DESCRIPTION
## Summary of the pull request
The hyper link text "Change Developer settings in WIndows" is cut off at high Text Scaling.  Two changes
1. Une a UniformGrid to re-adjust the UI.
2. Multiple a base width by text scaling to get the correct MinWidth.

## References and relevant issues

https://task.ms/50454382

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events

Pictures
I change in text scaling was applied to the same summary screen.  The screen responds to text scaling changes as well.

No text scaling!
![MinWidthAtZeroScaling](https://github.com/microsoft/devhome/assets/2517139/e7666f58-ec18-4b07-b577-836e194fa193)

225% scaling
![MinWidthAt225Percent](https://github.com/microsoft/devhome/assets/2517139/d08940d0-ae26-4cd0-941c-5690aa80219e)

Movie!
How MinWidth works with configuration file

https://github.com/microsoft/devhome/assets/2517139/228b1e66-53e6-48ea-8ce7-e21148a21a0a


