### PR TITLE
Ironsides - Get the top parent window when using the "drag to select a window" feature

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -608,6 +608,15 @@ public class WindowHelper
 
         if (hwnd != HWND.Null)
         {
+            // Walk up until we get the topmost parent window
+            HWND hwndParent = PInvoke.GetParent(hwnd);
+
+            while (hwndParent != HWND.Null)
+            {
+                hwnd = hwndParent;
+                hwndParent = PInvoke.GetParent(hwnd);
+            }
+
             var processID = WindowHelper.GetProcessIdFromWindow(hwnd);
 
             if (processID != 0)

--- a/tools/PI/DevHome.PI/NativeMethods.txt
+++ b/tools/PI/DevHome.PI/NativeMethods.txt
@@ -23,6 +23,7 @@ GetForegroundWindow
 GetMonitorInfo
 GetMonitorInfo
 GetOpenFileName
+GetParent
 GetProcessInformation
 GetScaleFactorForMonitor
 GetTopWindow


### PR DESCRIPTION
## Summary of the pull request

From the PI bar, you can drag and drop the "Processes" button onto a window of a process that you want to attach to. However, it's too easy to pick up a child HWND element of a top level window.... this is really easy to do with Notepad. If you drag onto the content area of Notepad, we'll attach to a content HWND of Notepad. This doesn't seem like it would be a problem, but when you snap to the app, the bar location is weird (it doesn't snap to the top of the Notepad window, but instead to the top of the content window), and when you move Notepad around, the snapped PI bar doesn't move with the app.

## References and relevant issues

## Detailed description of the pull request / Additional comments

When you drag/drop to select a window, we'll walk the HWND parent/child chain to attach to the top parent of the chain. That will make behaviors like snapping and window moving be more predictable.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
