### PR TITLE
Rules/analyzer fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,6 +128,9 @@ csharp_style_expression_bodied_operators = false:silent
 csharp_style_expression_bodied_indexers = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:silent
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
@@ -189,10 +192,6 @@ dotnet_naming_style.pascal_case.required_suffix =
 dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
-dotnet_naming_style.pascal_case.required_prefix =
-dotnet_naming_style.pascal_case.required_suffix =
-dotnet_naming_style.pascal_case.word_separator =
-dotnet_naming_style.pascal_case.capitalization = pascal_case
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
@@ -211,8 +210,9 @@ dotnet_naming_symbols.const_private_fields.required_modifiers = const
 dotnet_naming_style.require_underscore_prefix_and_camel_case.required_prefix = _
 dotnet_naming_style.require_underscore_prefix_and_camel_case.capitalization = camel_case
 
-dotnet_naming_style.requre_no_prefix_and_pascal_case.required_prefix =
-dotnet_naming_style.requre_no_prefix_and_pascal_case.capitalization = pascal_case
+# Define rule that something must not begin with an underscore and be in pascal case
+dotnet_naming_style.require_no_prefix_and_pascal_case.required_prefix =
+dotnet_naming_style.require_no_prefix_and_pascal_case.capitalization = pascal_case
 
 # Appy our rule to private fields.
 dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.symbols = private_fields
@@ -220,8 +220,9 @@ dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_cas
 dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.severity = warning
 
 dotnet_naming_rule.const_fields_must_begin_with_no_prefix_and_be_in_pascal_case.symbols = const_private_fields
-dotnet_naming_rule.const_fields_must_begin_with_no_prefix_and_be_in_pascal_case.style = requre_no_prefix_and_pascal_case
+dotnet_naming_rule.const_fields_must_begin_with_no_prefix_and_be_in_pascal_case.style = require_no_prefix_and_pascal_case
 dotnet_naming_rule.const_fields_must_begin_with_no_prefix_and_be_in_pascal_case.severity = warning
+
 # Spelling
 
 spelling_exclusion_path = .\exclusion.dic

--- a/extensions/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
+++ b/extensions/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
@@ -59,12 +59,6 @@
     <ProjectReference Include="..\HyperVExtension.HostGuestCommunication\HyperVExtension.HostGuestCommunication.csproj" />
     <ProjectReference Include="..\Telemetry\HyperVExtension.Telemetry.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <ReferenceCopyLocalPaths Include="$(ProjectDir)..\DevSetupEngineIdl\bin\$(Platform)\$(Configuration)\\Microsoft.Windows.DevHome.DevSetupEngine.winmd" />

--- a/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
@@ -61,13 +61,6 @@
     <ProjectReference Include="..\Telemetry\HyperVExtension.Telemetry.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <!--
     Copy DevSetupAgent_<Patform>.zip to the output directory so it picked up by MSIX packaging.
     If building from the build script the zip file should exist as it's created as part of the script execution.

--- a/extensions/HyperVExtension/src/HyperVExtensionServer/HyperVExtensionServer.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtensionServer/HyperVExtensionServer.csproj
@@ -30,10 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/extensions/HyperVExtension/src/Telemetry/HyperVExtension.Telemetry.csproj
+++ b/extensions/HyperVExtension/src/Telemetry/HyperVExtension.Telemetry.csproj
@@ -19,11 +19,4 @@
   <ItemGroup>
     <ProjectReference Include="..\HyperVExtension.Common\HyperVExtension.Common.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/extensions/HyperVExtension/test/HyperVExtension/HyperVExtension.UnitTest.csproj
+++ b/extensions/HyperVExtension/test/HyperVExtension/HyperVExtension.UnitTest.csproj
@@ -28,12 +28,6 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\HyperVExtension.Common\HyperVExtension.Common.csproj" />
     <ProjectReference Include="..\..\src\HyperVExtension\HyperVExtension.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of the pull request
Fix some issues in .editorconfig:
* Add csharp_style rules that always get added when opening the file in the editorconfig editor
* Remove 4 duplicated dotnet_naming_style.pascal_case rules
* Fix typo in require_no_prefix_and_pascal_case

Remove PackageReferences to Microsoft.CodeAnalysis.NetAnalyzers Version 7.0.4. By using .NET 8, these analyzers are turned on by default. We don't want to force the lower version. https://learn.microsoft.com/en-us/visualstudio/code-quality/install-net-analyzers?view=vs-2022

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
