### PR TITLE
Fix in-app theming

### DIFF
--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -34,7 +34,7 @@
             </Grid.ColumnDefinitions>
 
             <TextBlock x:Uid="Title" Grid.Column="1" Style="{StaticResource CaptionTextBlockStyle}" Margin="10,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,10,0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}">
+            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}">
                 <Button
                     x:Uid="SnapButton" 
                     Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}"

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -39,6 +39,11 @@ public partial class BarWindowHorizontal : WindowEx
     private readonly BarWindowViewModel _viewModel;
     private readonly UISettings _uiSettings = new();
 
+    private readonly SolidColorBrush _darkModeActiveCaptionBrush;
+    private readonly SolidColorBrush _darkModeDeactiveCaptionBrush;
+    private readonly SolidColorBrush _nonDarkModeActiveCaptionBrush;
+    private readonly SolidColorBrush _nonDarkModeDeactiveCaptionBrush;
+
     private bool _isClosing;
     private WindowActivationState _currentActivationState = WindowActivationState.Deactivated;
 
@@ -86,6 +91,19 @@ public partial class BarWindowHorizontal : WindowEx
         _restoreState.Height = settingSize.Height;
         _restoreState.Width = settingSize.Width;
         ExpandCollapseLayoutButtonText.Text = _viewModel.ShowingExpandedContent ? CollapseButtonText : ExpandButtonText;
+
+        // Precreate the brushes for the caption buttons
+        // In Dark Mode, the active state is white, and the deactive state is translucent white
+        // In Light Mode, the active state is black, and the deactive state is translucent black
+        Windows.UI.Color color = Colors.White;
+        _darkModeActiveCaptionBrush = new SolidColorBrush(color);
+        color.A = 0x66;
+        _darkModeDeactiveCaptionBrush = new SolidColorBrush(color);
+
+        color = Colors.Black;
+        _nonDarkModeActiveCaptionBrush = new SolidColorBrush(color);
+        color.A = 0x66;
+        _nonDarkModeDeactiveCaptionBrush = new SolidColorBrush(color);
 
         _uiSettings.ColorValuesChanged += (sender, args) =>
         {
@@ -368,21 +386,9 @@ public partial class BarWindowHorizontal : WindowEx
         FrameworkElement? rootElement = Content as FrameworkElement;
         Debug.Assert(rootElement != null, "Expected Content to be a FrameworkElement");
 
-        Windows.UI.Color color;
-        if (rootElement.ActualTheme == ElementTheme.Dark)
-        {
-            color = Colors.White;
-        }
-        else
-        {
-            color = Colors.Black;
-        }
-
         if (_currentActivationState == WindowActivationState.Deactivated)
         {
-            // Deactivated state has a translucent brush
-            color.A = 0x66;
-            SolidColorBrush brush = new(color);
+            SolidColorBrush brush = (rootElement.ActualTheme == ElementTheme.Dark) ? _darkModeDeactiveCaptionBrush : _nonDarkModeDeactiveCaptionBrush;
 
             SnapButtonText.Foreground = brush;
             ExpandCollapseLayoutButtonText.Foreground = brush;
@@ -390,7 +396,7 @@ public partial class BarWindowHorizontal : WindowEx
         }
         else
         {
-            SolidColorBrush brush = new(color);
+            SolidColorBrush brush = (rootElement.ActualTheme == ElementTheme.Dark) ? _darkModeActiveCaptionBrush : _nonDarkModeActiveCaptionBrush;
 
             SnapButtonText.Foreground = brush;
             ExpandCollapseLayoutButtonText.Foreground = brush;

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using DevHome.Common.Extensions;
 using DevHome.PI.Controls;
@@ -204,6 +205,9 @@ public partial class BarWindowHorizontal : WindowEx
             barWindow?.Close();
             _isClosing = false;
         }
+
+        // Unsubscribe from the activation handler
+        Activated -= Window_Activated;
     }
 
     private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -361,17 +365,36 @@ public partial class BarWindowHorizontal : WindowEx
 
     private void UpdateCustomTitleBarButtonsTextColor()
     {
-        if (_currentActivationState == WindowActivationState.Deactivated)
+        FrameworkElement? rootElement = Content as FrameworkElement;
+        Debug.Assert(rootElement != null, "Expected Content to be a FrameworkElement");
+
+        Windows.UI.Color color;
+        if (rootElement.ActualTheme == ElementTheme.Dark)
         {
-            SnapButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForegroundDisabled"];
-            ExpandCollapseLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForegroundDisabled"];
-            RotateLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForegroundDisabled"];
+            color = Colors.White;
         }
         else
         {
-            SnapButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForeground"];
-            ExpandCollapseLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForeground"];
-            RotateLayoutButtonText.Foreground = (SolidColorBrush)Application.Current.Resources["WindowCaptionForeground"];
+            color = Colors.Black;
+        }
+
+        if (_currentActivationState == WindowActivationState.Deactivated)
+        {
+            // Deactivated state has a translucent brush
+            color.A = 0x66;
+            SolidColorBrush brush = new(color);
+
+            SnapButtonText.Foreground = brush;
+            ExpandCollapseLayoutButtonText.Foreground = brush;
+            RotateLayoutButtonText.Foreground = brush;
+        }
+        else
+        {
+            SolidColorBrush brush = new(color);
+
+            SnapButtonText.Foreground = brush;
+            ExpandCollapseLayoutButtonText.Foreground = brush;
+            RotateLayoutButtonText.Foreground = brush;
         }
     }
 }


### PR DESCRIPTION
## Summary of the pull request

When the app's theme has been changed during runtime, calls to Application.Current.Resources["WindowCaptionForegroundDisabled"];

don't pick up the updated theme colors. This caused our custom titlebar buttons to be painted with the system-themed colors, not the app-specific colors.

## References and relevant issues

## Detailed description of the pull request / Additional comments

Unfortunately I couldn't find a way to pull updated theme resources from the per-app themed element. I hoped something like

rootElement.Resources["WindowCaptionForegroundDisabled"];

would have given me what I wanted, but unfortunately not.

There were already assumptions in the code (due to workarounds with other titlebar issues) that ensured that titlebar icons were white in dark mode, and black in light mode. When the app was deactivated, the standard theme was applying an alpha value of 0x66 to the foreground color, and so I replicated it here as well.

Last but not least, now that I was accessing window properties as part of handling window activation/deactivation , I hit an issue where I was trying to access window properties after the WinUI window had been destroyed and getting an exception. The internet tells me the best way to address this is to unsubscribe from my event handles in the WindowClosed event, and so I did.

## Validation steps performed

Twiddled the system-wide theme back and forth and ensured the buttons were the right color. Twiddled the per-app theme back and forth to ensure buttons were the right color too.

## PR checklist
- [ ] Closes #3318 
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
