### PR TITLE
Fix issues with window jumping between monitors when switching between horizontal/vertical/expanded/unexpanded

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/CommonHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/CommonHelper.cs
@@ -5,12 +5,18 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Management.Automation;
+using System.Runtime.InteropServices;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
 using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.ApplicationModel;
+using Windows.Wdk.System.Threading;
+using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.System.Threading;
+using PInvokeWdk = Windows.Wdk.PInvoke;
 
 namespace DevHome.PI.Helpers;
 
@@ -69,5 +75,37 @@ internal sealed class CommonHelper
                 _log.Error(ex, "UAC to run PI as admin was denied");
             }
         }
+    }
+
+    public static unsafe int GetParentProcessId(Process process)
+    {
+        var pbi = default(PROCESS_BASIC_INFORMATION);
+        int status = PInvokeWdk.NtQueryInformationProcess((HANDLE)process.Handle, PROCESSINFOCLASS.ProcessBasicInformation, &pbi, (uint)Marshal.SizeOf(pbi), null);
+        if (status != 0)
+        {
+            throw new InvalidOperationException("Failed to query process information.");
+        }
+
+        return (int)pbi.InheritedFromUniqueProcessId;
+    }
+
+    public static HWND? TryGetParentProcessHWND()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            var parentProcessId = GetParentProcessId(process);
+            if (parentProcessId != 0)
+            {
+                using var parentProcess = Process.GetProcessById(parentProcessId);
+                return new HWND(parentProcess.MainWindowHandle);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to get parent process HWND");
+        }
+
+        return null;
     }
 }

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -28,6 +28,7 @@ using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.System.SystemInformation;
 using Windows.Win32.System.Threading;
 using Windows.Win32.UI.Accessibility;
+using Windows.Win32.UI.Shell.Common;
 using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace DevHome.PI.Helpers;
@@ -596,6 +597,13 @@ public class WindowHelper
         PInvoke.GetMonitorInfo(monitor, ref monitorInfo);
         var screenBounds = monitorInfo.rcMonitor;
         return screenBounds;
+    }
+
+    internal static double GetDpiScaleForWindow(HWND hWnd)
+    {
+        var monitor = PInvoke.MonitorFromWindow(hWnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
+        PInvoke.GetScaleFactorForMonitor(monitor, out DEVICE_SCALE_FACTOR scaleFactor).ThrowOnFailure();
+        return (double)scaleFactor / 100;
     }
 
     internal static void GetAppInfoUnderMouseCursor(out Process? process, out HWND hwnd)

--- a/tools/PI/DevHome.PI/NativeMethods.txt
+++ b/tools/PI/DevHome.PI/NativeMethods.txt
@@ -49,10 +49,15 @@ LoadImage
 MessageBox
 MonitorFromWindow
 MoveWindow
+NtQueryInformationProcess
 OpenClipboard
 OpenProcessToken
 RegisterHotKey
 RemoveClipboardFormatListener
+RmRegisterResources
+RmStartSession
+RmGetList
+RmEndSession
 SendMessage
 SetFocus
 SetForegroundWindow
@@ -89,8 +94,13 @@ INVALID_HANDLE_VALUE
 LR_*
 MOD_*
 // MONITOR_DEFAULTTONEAREST
+PROCESS_BASIC_INFORMATION
 PROCESS_INFORMATION_CLASS
 PROCESS_MACHINE_INFORMATION
+RM_APP_TYPE
+RM_UNIQUE_PROCESS
+RM_PROCESS_INFO
+RM_REBOOT_REASON
 SECTION_FLAGS
 SW_*
 VIRTUAL_KEY
@@ -101,11 +111,3 @@ WINEVENT_OUTOFCONTEXT
 WINEVENT_SKIPOWNPROCESS
 WM_*
 WS_*
-RmRegisterResources
-RmStartSession
-RmGetList
-RmEndSession
-RM_APP_TYPE
-RM_UNIQUE_PROCESS
-RM_PROCESS_INFO
-RM_REBOOT_REASON

--- a/tools/PI/DevHome.PI/Views/BarWindow.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindow.cs
@@ -85,8 +85,6 @@ public partial class BarWindow
         {
             PerfCounters.Instance.Start();
         }
-
-        _horizontalWindow.Show();
     }
 
     private void Window_Closed(object sender, WindowEventArgs args)
@@ -141,11 +139,14 @@ public partial class BarWindow
     {
         if (_horizontalWindow.Visible)
         {
+            _verticalWindow.UpdatePositionFromHwnd(CurrentHwnd);
+
             _horizontalWindow.Hide();
             _verticalWindow.Show();
         }
         else
         {
+            _horizontalWindow.UpdatePositionFromHwnd(CurrentHwnd);
             _verticalWindow.Hide();
             _horizontalWindow.Show();
         }

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -129,9 +129,7 @@ public partial class BarWindowHorizontal : WindowEx
         SetRequestedTheme(t.Theme);
 
         // Calculate the DPI scale.
-        var monitor = PInvoke.MonitorFromWindow(ThisHwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
-        PInvoke.GetScaleFactorForMonitor(monitor, out DEVICE_SCALE_FACTOR scaleFactor).ThrowOnFailure();
-        _dpiScale = (double)scaleFactor / 100;
+        _dpiScale = GetDpiScaleForWindow(ThisHwnd);
 
         SetDefaultPosition();
 
@@ -276,47 +274,21 @@ public partial class BarWindowHorizontal : WindowEx
         MaxHeight = double.NaN;
 
         var monitorRect = GetMonitorRectForWindow(ThisHwnd);
-        var monitor = PInvoke.MonitorFromWindow(ThisHwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
-        PInvoke.GetScaleFactorForMonitor(monitor, out DEVICE_SCALE_FACTOR scaleFactor).ThrowOnFailure();
-        var dpiScale = (double)scaleFactor / 100;
+        var dpiScale = GetDpiScaleForWindow(ThisHwnd);
 
-        // If they expand to ExpandedView and they're not snapped
-        if (!_viewModel.IsSnapped)
-        {
-            // Conversely if they're snapped, the position is determined by the snap,
-            // and we potentially adjust the size to ensure it doesn't extend beyond the screen.
-            var availableWidth = monitorRect.Width - Math.Abs(AppWindow.Position.X - monitorRect.left) - RightSideGap;
-            _restoreState.Width = (int)((double)availableWidth / dpiScale);
+        // Expand the window but keep the x,y coordinates of top-left most corner of the window the same so it doesn't
+        // jump around the screen.
+        var availableWidth = monitorRect.Width - Math.Abs(AppWindow.Position.X - monitorRect.left) - RightSideGap;
+        _restoreState.Width = (int)((double)availableWidth / dpiScale);
 
-            Width = _restoreState.Width;
+        Width = _restoreState.Width;
 
-            var availableHeight = monitorRect.Height - Math.Abs(AppWindow.Position.Y - monitorRect.top);
+        var availableHeight = monitorRect.Height - Math.Abs(AppWindow.Position.Y - monitorRect.top);
 
-            _restoreState.Height = (int)((double)availableHeight / dpiScale);
+        _restoreState.Height = (int)((double)availableHeight / dpiScale);
 
-            this.MoveAndResize(
-                AppWindow.Position.X, AppWindow.Position.Y, _restoreState.Width, _restoreState.Height);
-        }
-        else
-        {
-            // Conversely if they're snapped, the position is determined by the snap,
-            // and we potentially adjust the size to ensure it doesn't extend beyond the screen.
-            var availableWidth = _monitorRect.Width - Math.Abs(AppWindow.Position.X) - RightSideGap;
-            if (availableWidth < _restoreState.Width)
-            {
-                _restoreState.Width = availableWidth;
-            }
-
-            Width = _restoreState.Width;
-
-            var availableHeight = _monitorRect.Height - Math.Abs(AppWindow.Position.Y);
-            if (availableHeight < _restoreState.Height)
-            {
-                _restoreState.Height = availableHeight;
-            }
-
-            Height = _restoreState.Height;
-        }
+        this.MoveAndResize(
+            AppWindow.Position.X, AppWindow.Position.Y, _restoreState.Width, _restoreState.Height);
     }
 
     private void CollapseLargeContentPanel()

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
@@ -69,9 +69,7 @@ public partial class BarWindowVertical : WindowEx
         Width = 70;
 
         // Calculate the DPI scale.
-        var monitor = PInvoke.MonitorFromWindow(ThisHwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
-        PInvoke.GetScaleFactorForMonitor(monitor, out DEVICE_SCALE_FACTOR scaleFactor).ThrowOnFailure();
-        _dpiScale = (double)scaleFactor / 100;
+        _dpiScale = GetDpiScaleForWindow(ThisHwnd);
 
         SetDefaultPosition();
     }

--- a/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
@@ -13,8 +13,6 @@ using Windows.System;
 using Windows.Win32;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using WinUIEx;
-
-using static DevHome.PI.Helpers.CommonHelper;
 using static DevHome.PI.Helpers.WindowHelper;
 
 namespace DevHome.PI;

--- a/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
@@ -13,6 +13,8 @@ using Windows.System;
 using Windows.Win32;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using WinUIEx;
+
+using static DevHome.PI.Helpers.CommonHelper;
 using static DevHome.PI.Helpers.WindowHelper;
 
 namespace DevHome.PI;


### PR DESCRIPTION
## Summary of the pull request
PI was setting its positions and offsets relative to 0,0 even when the window could be on a secondary monitor. Additionally, it was not taking into the context of where the horizontal/vertical window were located prior to expanding/rotating which could cause it to jump back to the left most monitor.
This change also tries to ensure that PI launches on the same monitor as the process that launched it, if that process had a window.
## References and relevant issues

## Detailed description of the pull request / Additional comments
Adds context including the creating process window to determine where to position the new window.  

## Validation steps performed
On a 2-monitor setup ensure that PI launches and transitions all orientations on the right most monitor without ever jumping to the left most monitor.
After initially launching on the right most monitor, move PI to the left most monitor and rotate/expand and ensure that PI does not jump to the right most monitor. 
## PR checklist
- [x] Closes #3330
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
