### PR TITLE
Add related activityId to Quickstart telemetry for easier correlation

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/QuickStartProjectProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/QuickStartProjectProvider.cs
@@ -47,31 +47,31 @@ public sealed class QuickStartProjectProvider
         SamplePrompts = quickStartProjectProvider.SamplePrompts;
     }
 
-    public QuickStartProjectAdaptiveCardResult CreateAdaptiveCardSessionForExtensionInitialization()
+    public QuickStartProjectAdaptiveCardResult CreateAdaptiveCardSessionForExtensionInitialization(Guid activityId)
     {
         try
         {
-            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundExtensionInitialization");
+            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundExtensionInitialization", relatedActivityId: activityId);
             return _quickStartProjectProvider.CreateAdaptiveCardSessionForExtensionInitialization();
         }
         catch (Exception ex)
         {
             _log.Error(ex, $"CreateAdaptiveCardSessionForExtensionInitialization for: {this} failed due to exception");
-            TelemetryFactory.Get<ITelemetry>().LogException("CreateAdaptiveCardSessionForExtensionInitialization", ex);
+            TelemetryFactory.Get<ITelemetry>().LogException("CreateAdaptiveCardSessionForExtensionInitialization", ex, activityId);
             return new QuickStartProjectAdaptiveCardResult(ex, ex.Message, ex.Message);
         }
     }
 
-    public IQuickStartProjectGenerationOperation CreateProjectGenerationOperation(string prompt, StorageFolder outputFolder)
+    public IQuickStartProjectGenerationOperation CreateProjectGenerationOperation(string prompt, StorageFolder outputFolder, Guid activityId)
     {
         try
         {
-            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundProjectGenerationOperation");
+            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundProjectGenerationOperation", relatedActivityId: activityId);
             return _quickStartProjectProvider.CreateProjectGenerationOperation(prompt, outputFolder);
         }
         catch (Exception ex)
         {
-            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundProjectGenerationOperation", ex);
+            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundProjectGenerationOperation", ex, activityId);
             _log.Error(ex, $"CreateProjectGenerationOperation for: {this} failed due to exception");
             return null;
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -52,6 +52,10 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     private readonly ObservableCollection<ExplorerItem> _dataSource = new();
 
+    private readonly Guid _activityId;
+
+    public Guid ActivityId => _activityId;
+
     private IQuickStartProjectGenerationOperation _quickStartProjectGenerationOperation = null!;
 
     private QuickStartProjectResult _quickStartProject = null!;
@@ -181,6 +185,8 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
         _quickStartProjectService = quickStartProjectService;
         _localSettingsService = localSettingsService;
 
+        _activityId = orchestrator.ActivityId;
+
         // Placeholder launch text while button is disabled.
         LaunchButtonText = StringResource.GetLocalized(StringResourceKey.QuickstartPlaygroundLaunchButton, string.Empty);
     }
@@ -190,7 +196,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     {
         return Task.Run(async () =>
         {
-            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectClicked");
+            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectClicked", relatedActivityId: _activityId);
 
             // TODO: Replace with WindowSaveFileDialog
             var folderPicker = new FolderPicker();
@@ -202,7 +208,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             if (!string.IsNullOrWhiteSpace(location?.Path))
             {
                 CopyDirectory(_outputFolderForCurrentPrompt, location.Path);
-                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectCompleted");
+                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectCompleted", relatedActivityId: _activityId);
             }
         });
     }
@@ -273,7 +279,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
         }
         catch (Exception ex)
         {
-            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundDeleteDirectoryContents", ex);
+            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundDeleteDirectoryContents", ex, _activityId);
         }
     }
 
@@ -431,7 +437,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             ArgumentNullException.ThrowIfNullOrEmpty(userPrompt);
             ArgumentNullException.ThrowIfNull(ActiveQuickstartSelection);
 
-            TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateButtonClicked", LogLevel.Critical, new GenerateButtonClicked(userPrompt));
+            TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateButtonClicked", LogLevel.Critical, new GenerateButtonClicked(userPrompt), _activityId);
 
             // Ensure file view isn't visible (in the case where the user has previously run a Generate command)
             IsFileViewVisible = false;
@@ -460,7 +466,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             var outputFolder = await GetOutputFolder();
             _outputFolderForCurrentPrompt = outputFolder.Path;
 
-            _quickStartProjectGenerationOperation = ActiveQuickstartSelection.CreateProjectGenerationOperation(userPrompt, outputFolder);
+            _quickStartProjectGenerationOperation = ActiveQuickstartSelection.CreateProjectGenerationOperation(userPrompt, outputFolder, _activityId);
             _quickStartProject = await _quickStartProjectGenerationOperation.GenerateAsync().AsTask(progress);
             _quickStartProjectGenerationOperation = null!;
             if (_quickStartProject.Result.Status == ProviderOperationStatus.Success)
@@ -468,13 +474,17 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
                 SetUpFileView();
                 SetupLaunchButton();
                 EnableProjectButtons = true;
-                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundGenerateSuccceded");
+                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundGenerateSuccceded", relatedActivityId: _activityId);
             }
             else
             {
                 IsErrorViewVisible = true;
                 ErrorMessage = StringResource.GetLocalized("QuickstartPlaygroundGenerationFailedDetails", _quickStartProject.Result.DisplayMessage);
-                TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateFailed", LogLevel.Critical, new ProjectGenerationErrorInfo(_quickStartProject.Result.DisplayMessage, _quickStartProject.Result.ExtendedError, _quickStartProject.Result.DiagnosticText));
+                TelemetryFactory.Get<ITelemetry>().Log(
+                    "QuickstartPlaygroundGenerateFailed",
+                    LogLevel.Critical,
+                    new ProjectGenerationErrorInfo(_quickStartProject.Result.DisplayMessage, _quickStartProject.Result.ExtendedError, _quickStartProject.Result.DiagnosticText),
+                    _activityId);
             }
         }
         finally
@@ -501,7 +511,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     [RelayCommand(CanExecute = nameof(EnableProjectButtons))]
     private async Task LaunchProjectHost(IQuickStartProjectHost? projectHost = null)
     {
-        TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundLaunchProjectClicked");
+        TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundLaunchProjectClicked", relatedActivityId: _activityId);
         var projectHostToLaunch = projectHost ?? QuickStartProjectHosts[0];
         await Task.Run(projectHostToLaunch.Launch);
     }
@@ -527,7 +537,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     public void ProvideFeedback(bool isPositive, string feedback)
     {
-        TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundFeedbackSubmitted", LogLevel.Critical, new FeedbackSubmitted(isPositive, feedback));
+        TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundFeedbackSubmitted", LogLevel.Critical, new FeedbackSubmitted(isPositive, feedback), _activityId);
         _quickStartProject?.FeedbackHandler?.ProvideFeedback(isPositive, feedback);
     }
 
@@ -623,28 +633,28 @@ public class ExplorerItem : INotifyPropertyChanged
         get; set;
     }
 
-    private ObservableCollection<ExplorerItem>? children;
+    private ObservableCollection<ExplorerItem>? _children;
 
     public ObservableCollection<ExplorerItem> Children
     {
         get
         {
-            children ??= new ObservableCollection<ExplorerItem>();
-            return children;
+            _children ??= new ObservableCollection<ExplorerItem>();
+            return _children;
         }
-        set => children = value;
+        set => _children = value;
     }
 
-    private bool isExpanded;
+    private bool _isExpanded;
 
     public bool IsExpanded
     {
-        get => isExpanded;
+        get => _isExpanded;
         set
         {
-            if (isExpanded != value)
+            if (_isExpanded != value)
             {
-                isExpanded = value;
+                _isExpanded = value;
                 NotifyPropertyChanged(nameof(IsExpanded));
             }
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -52,9 +52,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     private readonly ObservableCollection<ExplorerItem> _dataSource = new();
 
-    private readonly Guid _activityId;
-
-    public Guid ActivityId => _activityId;
+    public Guid ActivityId { get; }
 
     private IQuickStartProjectGenerationOperation _quickStartProjectGenerationOperation = null!;
 
@@ -185,7 +183,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
         _quickStartProjectService = quickStartProjectService;
         _localSettingsService = localSettingsService;
 
-        _activityId = orchestrator.ActivityId;
+        ActivityId = orchestrator.ActivityId;
 
         // Placeholder launch text while button is disabled.
         LaunchButtonText = StringResource.GetLocalized(StringResourceKey.QuickstartPlaygroundLaunchButton, string.Empty);
@@ -196,7 +194,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     {
         return Task.Run(async () =>
         {
-            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectClicked", relatedActivityId: _activityId);
+            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectClicked", relatedActivityId: ActivityId);
 
             // TODO: Replace with WindowSaveFileDialog
             var folderPicker = new FolderPicker();
@@ -208,7 +206,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             if (!string.IsNullOrWhiteSpace(location?.Path))
             {
                 CopyDirectory(_outputFolderForCurrentPrompt, location.Path);
-                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectCompleted", relatedActivityId: _activityId);
+                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundSaveProjectCompleted", relatedActivityId: ActivityId);
             }
         });
     }
@@ -279,7 +277,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
         }
         catch (Exception ex)
         {
-            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundDeleteDirectoryContents", ex, _activityId);
+            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundDeleteDirectoryContents", ex, ActivityId);
         }
     }
 
@@ -437,7 +435,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             ArgumentNullException.ThrowIfNullOrEmpty(userPrompt);
             ArgumentNullException.ThrowIfNull(ActiveQuickstartSelection);
 
-            TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateButtonClicked", LogLevel.Critical, new GenerateButtonClicked(userPrompt), _activityId);
+            TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundGenerateButtonClicked", LogLevel.Critical, new GenerateButtonClicked(userPrompt), ActivityId);
 
             // Ensure file view isn't visible (in the case where the user has previously run a Generate command)
             IsFileViewVisible = false;
@@ -466,7 +464,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             var outputFolder = await GetOutputFolder();
             _outputFolderForCurrentPrompt = outputFolder.Path;
 
-            _quickStartProjectGenerationOperation = ActiveQuickstartSelection.CreateProjectGenerationOperation(userPrompt, outputFolder, _activityId);
+            _quickStartProjectGenerationOperation = ActiveQuickstartSelection.CreateProjectGenerationOperation(userPrompt, outputFolder, ActivityId);
             _quickStartProject = await _quickStartProjectGenerationOperation.GenerateAsync().AsTask(progress);
             _quickStartProjectGenerationOperation = null!;
             if (_quickStartProject.Result.Status == ProviderOperationStatus.Success)
@@ -474,7 +472,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
                 SetUpFileView();
                 SetupLaunchButton();
                 EnableProjectButtons = true;
-                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundGenerateSuccceded", relatedActivityId: _activityId);
+                TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundGenerateSuccceded", relatedActivityId: ActivityId);
             }
             else
             {
@@ -484,7 +482,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
                     "QuickstartPlaygroundGenerateFailed",
                     LogLevel.Critical,
                     new ProjectGenerationErrorInfo(_quickStartProject.Result.DisplayMessage, _quickStartProject.Result.ExtendedError, _quickStartProject.Result.DiagnosticText),
-                    _activityId);
+                    ActivityId);
             }
         }
         finally
@@ -511,7 +509,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     [RelayCommand(CanExecute = nameof(EnableProjectButtons))]
     private async Task LaunchProjectHost(IQuickStartProjectHost? projectHost = null)
     {
-        TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundLaunchProjectClicked", relatedActivityId: _activityId);
+        TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundLaunchProjectClicked", relatedActivityId: ActivityId);
         var projectHostToLaunch = projectHost ?? QuickStartProjectHosts[0];
         await Task.Run(projectHostToLaunch.Launch);
     }
@@ -537,7 +535,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     public void ProvideFeedback(bool isPositive, string feedback)
     {
-        TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundFeedbackSubmitted", LogLevel.Critical, new FeedbackSubmitted(isPositive, feedback), _activityId);
+        TelemetryFactory.Get<ITelemetry>().Log("QuickstartPlaygroundFeedbackSubmitted", LogLevel.Critical, new FeedbackSubmitted(isPositive, feedback), ActivityId);
         _quickStartProject?.FeedbackHandler?.ProvideFeedback(isPositive, feedback);
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
@@ -188,7 +188,7 @@ public sealed partial class QuickstartPlaygroundView : UserControl
     {
         if (ViewModel.ActiveQuickstartSelection is not null)
         {
-            var adaptiveCardSessionResult = ViewModel.ActiveQuickstartSelection.CreateAdaptiveCardSessionForExtensionInitialization();
+            var adaptiveCardSessionResult = ViewModel.ActiveQuickstartSelection.CreateAdaptiveCardSessionForExtensionInitialization(ViewModel.ActivityId);
             await ShowAdaptiveCardOnContentDialog(adaptiveCardSessionResult);
         }
     }


### PR DESCRIPTION
## Summary of the pull request
Add related activityId to Quickstart telemetry for easier correlation

## References and relevant issues

## Detailed description of the pull request / Additional comments
This PR updates the events logged by the Quickstart Playground feature to include a relatedActivityId value (taken from the Orchestrator). This is passed to the logging methods where the library will handle including this in the event payload, so that it will become much easier sequence the data. 

Visual Studio also flagged some naming issues with the classes related to the Explorer view, so I fixed those while I was at it.

## Validation steps performed
I used Diagnostic Data Viewer to validate the related activity Id field was being populated for a project generation scenario. I also did some ad-hoc manual testing of Quickstart Playground to ensure there were no user-facing changes in behavior. 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [X] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
