### PR TITLE
Missing using statement in canary build flow

### DIFF
--- a/common/Services/QuickstartSetupService.cs
+++ b/common/Services/QuickstartSetupService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Common.Contracts;
 using DevHome.Services.Core.Contracts;


### PR DESCRIPTION
## Summary of the pull request
- Missing using statement in canary build flow

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
