### PR TITLE
Fix Quiet Mode telemetry tagging

### DIFF
--- a/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
+++ b/telemetry/DevHome.Telemetry.Native/inc/DevHomeTelemetryProvider.h
@@ -10,6 +10,32 @@
 #define __WIL_TRACELOGGING_CONFIG_H
 #include <wil/Tracelogging.h>
 
+#define DEFINE_CRITICAL_DATA_EVENT_PARAM10(                                                                                                                                   \
+    EventId, VarType1, varName1, VarType2, varName2, VarType3, varName3, VarType4, varName4, VarType5, varName5, VarType6, varName6, VarType7, varName7, VarType8, varName8, VarType9, varName9, VarType10, varName10) \
+    DEFINE_TRACELOGGING_EVENT_PARAM10(                                                                                                                                        \
+        EventId,                                                                                                                                                             \
+        VarType1,                                                                                                                                                            \
+        varName1,                                                                                                                                                            \
+        VarType2,                                                                                                                                                            \
+        varName2,                                                                                                                                                            \
+        VarType3,                                                                                                                                                            \
+        varName3,                                                                                                                                                            \
+        VarType4,                                                                                                                                                            \
+        varName4,                                                                                                                                                            \
+        VarType5,                                                                                                                                                            \
+        varName5,                                                                                                                                                            \
+        VarType6,                                                                                                                                                            \
+        varName6,                                                                                                                                                            \
+        VarType7,                                                                                                                                                            \
+        varName7,                                                                                                                                                            \
+        VarType8,                                                                                                                                                            \
+        varName8,                                                                                                                                                            \
+        VarType9,                                                                                                                                                            \
+        varName9,                                                                                                                                                            \
+        VarType10,                                                                                                                                                           \
+        varName10,                                                                                                                                                           \
+        TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA))
+
 // [uuid(2e74ff65-bbda-5e80-4c0a-bd8320d4223b)]
 class DevHomeTelemetryProvider : public wil::TraceLoggingProvider
 {
@@ -55,15 +81,15 @@ public:
             );
         }
 
-        DEFINE_TRACELOGGING_EVENT_PARAM4(
-            ComputerInfo,
+        DEFINE_CRITICAL_DATA_EVENT_PARAM4(
+            QuietBackgroundProcesses_ComputerInfo,
             DWORD, processorCount,
             PCWSTR, processor,
             PCWSTR, motherboard,
             DWORD, ram);
 
-        DEFINE_TRACELOGGING_EVENT_PARAM10(
-            SessionCategoryMetrics,
+        DEFINE_CRITICAL_DATA_EVENT_PARAM10(
+            QuietBackgroundProcesses_SessionCategoryMetrics,
             int, numProcesses_unknown,
             int, numProcesses_user,
             int, numProcesses_system,
@@ -75,8 +101,8 @@ public:
             int, totalCpuTimesByCategory_developer,
             int, totalCpuTimesByCategory_background);
 
-        DEFINE_TRACELOGGING_EVENT_PARAM10(
-            ProcessInfo,
+        DEFINE_CRITICAL_DATA_EVENT_PARAM10(
+            QuietBackgroundProcesses_ProcessInfo,
             int, reason,
             bool, isInSystem32,
             PCWSTR, processName,

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.cpp
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/Helpers.cpp
@@ -131,7 +131,7 @@ void UploadPerformanceDataTelemetry(std::chrono::milliseconds samplingPeriod, co
 
     // Upload computer information
     auto computerInformation = GetComputerInformation();
-    activity.ComputerInfo(
+    activity.QuietBackgroundProcesses_ComputerInfo(
         computerInformation.processorCount,
         computerInformation.processor.c_str(),
         computerInformation.motherboard.c_str(),
@@ -147,7 +147,7 @@ void UploadPerformanceDataTelemetry(std::chrono::milliseconds samplingPeriod, co
     }
 
     // Upload category metrics
-    activity.SessionCategoryMetrics(
+    activity.QuietBackgroundProcesses_SessionCategoryMetrics(
         numProcesses[0],
         numProcesses[1],
         numProcesses[2],
@@ -198,10 +198,17 @@ void UploadPerformanceDataTelemetry(std::chrono::milliseconds samplingPeriod, co
             continue;
         }
 
-        activity.ProcessInfo(
+        // Report process name with service name in telemetry
+        auto processNameTelemetry = std::wstring(item.name);
+        if (item.serviceName)
+        {
+            processNameTelemetry += std::wstring{} + L" (" + item.serviceName + L")";
+        }
+
+        activity.QuietBackgroundProcesses_ProcessInfo(
             reason,
             wil::compare_string_ordinal(item.path, system32Path, true) == 0,
-            item.name,
+            processNameTelemetry.c_str(),
             item.category,
             item.packageFullName,
 


### PR DESCRIPTION
## Summary of the pull request

Add QuietBackgroundProcesses_ prefix to all quiet events.

Include service name in ProcessInfo event (for svchost.exe entries).

Tag quiet events as Critical and Measures.

## References and relevant issues
#3305 
