### PR TITLE
Project Ironsides - Adjust bar height to match snapped window's height

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/SnapHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/SnapHelper.cs
@@ -139,7 +139,12 @@ public class SnapHelper
         }
 
         PInvoke.GetWindowRect(TargetAppData.Instance.HWnd, out var rect);
+
+        int width = rect.right - rect.left;
+        int height = rect.bottom - rect.top;
+
         barWindow.UpdateBarWindowPosition(new PointInt32(rect.right - SnapOffsetHorizontal, rect.top));
+        barWindow.UpdateBarWindowSize(new SizeInt32(width, height));
 
         // Only reset BarWindow on top, if TargetApp is in foreground.
         if (TargetAppData.Instance.HWnd == PInvoke.GetForegroundWindow())

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -90,6 +90,9 @@ public partial class BarWindowViewModel : ObservableObject
     [ObservableProperty]
     private PointInt32 _windowPosition;
 
+    [ObservableProperty]
+    private SizeInt32 _requestedWindowSize;
+
     internal HWND? ApplicationHwnd { get; private set; }
 
     public BarWindowViewModel()

--- a/tools/PI/DevHome.PI/Views/BarWindow.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindow.cs
@@ -156,6 +156,11 @@ public partial class BarWindow
         _viewModel.WindowPosition = position;
     }
 
+    public void UpdateBarWindowSize(SizeInt32 size)
+    {
+        _viewModel.RequestedWindowSize = size;
+    }
+
     public void ResetBarWindowOnTop()
     {
         _viewModel.ResetBarWindowOnTop();

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml
@@ -9,7 +9,7 @@
     xmlns:controls="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="700" MinWidth="72" MaxWidth="72" Width="72" Height="700"
+    Title="" MinHeight="500" MinWidth="72" MaxWidth="72" Width="72" Height="700"
     TaskBarIcon="Images/pi.ico" IsTitleBarVisible="False"
     IsAlwaysOnTop="{x:Bind _viewModel.IsAlwaysOnTop, Mode=OneWay}"
     Closed="WindowEx_Closed">

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
@@ -80,6 +80,10 @@ public partial class BarWindowVertical : WindowEx
         {
             this.Move(_viewModel.WindowPosition.X, _viewModel.WindowPosition.Y);
         }
+        else if (string.Equals(e.PropertyName, nameof(BarWindowViewModel.RequestedWindowSize), StringComparison.OrdinalIgnoreCase))
+        {
+            Height = _viewModel.RequestedWindowSize.Height;
+        }
     }
 
     private void WindowEx_Closed(object sender, WindowEventArgs args)

--- a/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowVertical.xaml.cs
@@ -103,7 +103,7 @@ public partial class BarWindowVertical : WindowEx
         }
         else if (string.Equals(e.PropertyName, nameof(BarWindowViewModel.RequestedWindowSize), StringComparison.OrdinalIgnoreCase))
         {
-            Height = _viewModel.RequestedWindowSize.Height;
+            Height = _viewModel.RequestedWindowSize.Height - 6; // 6 is a magic number that we lose due to removing the Thick Frame attribute
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request

This change changes the bar, when in the vertical position and snapped to a target window, to dynamically adjust its height (to a minimum of 500 pixels) to the same as the window it is snapped to.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
