### PR TITLE
Adding theme to LoginUIDialog

### DIFF
--- a/settings/DevHome.Settings/Views/LoginUIDialog.xaml.cs
+++ b/settings/DevHome.Settings/Views/LoginUIDialog.xaml.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using DevHome.Common.Extensions;
+using DevHome.Contracts.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -12,6 +14,7 @@ public sealed partial class LoginUIDialog : ContentDialog
     {
         this.InitializeComponent();
         LoginUIContent.Content = extensionAdaptiveCardPanel;
+        RequestedTheme = Application.Current.GetService<IThemeSelectorService>().Theme;
     }
 
     private void CloseButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the pull request
The LoginUIDialog was not following the same theme set in DevHome, ending up using the same theme of the user's OS. This pull request fixes that issue and its resulting accessibility issues.
## References and relevant issues
https://dev.azure.com/microsoft/OS/_workitems/edit/51611631
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
