### PR TITLE
Project Ironsides - Move the horizontal external tools bar to a CommandBar

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/ExternalTool.cs
+++ b/tools/PI/DevHome.PI/Helpers/ExternalTool.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Serilog;
@@ -197,11 +198,13 @@ public partial class ExternalTool : ObservableObject
         return result;
     }
 
+    [RelayCommand]
     public void TogglePinnedState()
     {
         IsPinned = !IsPinned;
     }
 
+    [RelayCommand]
     public void UnregisterTool()
     {
         ExternalToolsHelper.Instance.RemoveExternalTool(this);

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1036,5 +1036,9 @@
   <data name="ProcessesLabel.Text" xml:space="preserve">
     <value>Processes</value>
     <comment>A text label for the Processes button</comment>
+  </data>
+  <data name="ManageExternalToolsMenuText" xml:space="preserve">
+    <value>Manage Tools</value>
+    <comment>Label for a button to allow users to manage external tools</comment>
   </data>
 </root>

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -9,7 +9,7 @@
     xmlns:controls="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="72" MinWidth="700" Height="72" Width="700" MaxHeight="72"
+    Title="" MinHeight="72" MinWidth="700" Height="100" Width="700" MaxHeight="100"
     TaskBarIcon="Images/pi.ico"
     Activated="Window_Activated"
     Closed="WindowEx_Closed">
@@ -66,7 +66,14 @@
             </StackPanel>
         </Grid>
 
-        <StackPanel x:Name="AllControls" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Left" Background="Transparent" >
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition x:Name="ToolColumn" Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel x:Name="AllControls" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left" Background="Transparent" >
             <StackPanel.Resources>
                 <Style TargetType="TextBlock">
                     <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
@@ -113,46 +120,28 @@
             </StackPanel>
 
             <!-- Per System controls -->
-              <controls:ExternalToolsManagementButton
+                <controls:ExternalToolsManagementButton
                 x:Name="ManageExternalToolsButton"
                 x:Uid="ManageExternalToolsButton"
                 HorizontalAlignment="Center"
                 Command="{x:Bind _viewModel.ManageExternalToolsButtonCommand}"
                 ExternalToolLaunchRequest="{x:Bind _viewModel.ManageExternalToolsButton_ExternalToolLaunchRequest}">
-                <TextBlock Text="&#xEC7A;"/>
-            </controls:ExternalToolsManagementButton>
+                    <TextBlock Text="&#xEC7A;"/>
+                </controls:ExternalToolsManagementButton>
 
-            <controls:PISeparator />
+                <controls:PISeparator />
+            </StackPanel>
+            
+            <CommandBar x:Name="MyCommandBar" IsDynamicOverflowEnabled="True" Grid.Column="1" />
+       
 
-            <ItemsRepeater x:Name="ExternalToolsRepeater" ItemsSource="{x:Bind helpers:ExternalToolsHelper.Instance.FilteredExternalTools, Mode=OneWay}" Layout="{StaticResource ExternalToolsHorizontalLayout}">
-                <DataTemplate x:DataType="helpers:ExternalTool">
-                    <Button Click="_viewModel.ExternalToolButton_Click" HorizontalAlignment="Center" ToolTipService.ToolTip="{x:Bind Name, Mode=OneWay}" Tag="{x:Bind}">
-                        <Image Source="{x:Bind ToolIcon, Mode=OneWay}" Width="22" Height="22" Stretch="Uniform"/>
-                        <Button.ContextFlyout>
-                            <MenuFlyout x:Name="ToolContextMenu">
-                                <MenuFlyoutItem x:Uid="UnpinMenuItem" Name="UnpinMenuItem" Click="{x:Bind TogglePinnedState}">
-                                    <MenuFlyoutItem.Icon>
-                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE77A;"/>
-                                    </MenuFlyoutItem.Icon>
-                                </MenuFlyoutItem>
-                                <MenuFlyoutItem x:Uid="UnregisterMenuItem" Name="UnregisterMenuItem" Click="{x:Bind UnregisterTool}">
-                                    <MenuFlyoutItem.Icon>
-                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xECC9;"/>
-                                    </MenuFlyoutItem.Icon>
-                                </MenuFlyoutItem>
-                            </MenuFlyout>
-                        </Button.ContextFlyout>
-                    </Button>
-                </DataTemplate>
-            </ItemsRepeater>
-            <controls:PISeparator Visibility="{x:Bind _viewModel.ExternalToolSeparatorVisibility, Mode=OneWay}"/>
-        </StackPanel>
-
-        <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="1" Spacing="10" Margin="0 0 10 0">
+        <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Column="3" Spacing="10" Margin="0 0 10 0">
             <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
             <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
             <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
         </StackPanel>
+
+        </Grid>
 
         <Border
             x:Name="LargeContentPanel" Visibility="Collapsed" Grid.Row="2"

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -9,7 +9,7 @@
     xmlns:controls="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="72" MinWidth="700" Height="100" Width="700" MaxHeight="100"
+    Title="" MinHeight="72" MinWidth="700" Height="105" Width="700" MaxHeight="105"
     TaskBarIcon="Images/pi.ico"
     Activated="Window_Activated"
     Closed="WindowEx_Closed">

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -9,7 +9,7 @@
     xmlns:controls="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="72" MinWidth="700" Height="105" Width="700" MaxHeight="105"
+    Title="" MinHeight="90" MinWidth="700" Height="90" Width="700" MaxHeight="90"
     TaskBarIcon="Images/pi.ico"
     Activated="Window_Activated"
     Closed="WindowEx_Closed">
@@ -71,75 +71,69 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition x:Name="ToolColumn" Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <StackPanel x:Name="AllControls" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left" Background="Transparent" >
-            <StackPanel.Resources>
-                <Style TargetType="TextBlock">
-                    <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
-                    <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}"/>
-                </Style>
-                <Style TargetType="Button">
-                    <Setter Property="BorderThickness" Value="0"/>
-                    <Setter Property="Background" Value="Transparent"/>
-                </Style>
-                <Style TargetType="controls:ExternalToolsManagementButton">
-                    <Setter Property="BorderThickness" Value="0"/>
-                    <Setter Property="Background" Value="Transparent"/>
-                </Style>
-                <Style TargetType="controls:ProcessSelectionButton">
-                    <Setter Property="BorderThickness" Value="0"/>
-                    <Setter Property="Background" Value="Transparent"/>
-                </Style>
-            </StackPanel.Resources>
+                <StackPanel.Resources>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
+                        <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}"/>
+                    </Style>
+                    <Style TargetType="Button">
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                    </Style>
+                    <Style TargetType="controls:ExternalToolsManagementButton">
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                    </Style>
+                    <Style TargetType="controls:ProcessSelectionButton">
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Background" Value="Transparent"/>
+                    </Style>
+                </StackPanel.Resources>
 
-            <!-- Process Chooser area -->
-            <StackPanel Orientation="Horizontal" Visibility="{x:Bind _viewModel.IsProcessChooserVisible, Mode=OneWay}" Margin="0,0,0,0" >
-                <controls:ProcessSelectionButton x:Uid="ProcessChooserButton" Command="{x:Bind _viewModel.ProcessChooserCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="&#xe179;"/>
-                </controls:ProcessSelectionButton>
-                <TextBlock x:Uid="ProcessesLabel" x:Name="ProcessesLabel" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
-                <controls:PISeparator />
+                <!-- Process Chooser area -->
+                <StackPanel Orientation="Horizontal" Visibility="{x:Bind _viewModel.IsProcessChooserVisible, Mode=OneWay}" Margin="0,0,0,0" >
+                    <controls:ProcessSelectionButton x:Uid="ProcessChooserButton" Command="{x:Bind _viewModel.ProcessChooserCommand}" VerticalAlignment="Center">
+                        <TextBlock Text="&#xe179;"/>
+                    </controls:ProcessSelectionButton>
+                    <TextBlock x:Uid="ProcessesLabel" x:Name="ProcessesLabel" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- Per App controls -->
+                <StackPanel Orientation="Horizontal" Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}" Spacing="10" Margin="10 0 0 0">
+                    <StackPanel.ContextFlyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </StackPanel.ContextFlyout>
+                    <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Height="20" Width="20" />
+                    <TextBlock x:Uid="AppName" Text="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
+                    <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
+                </StackPanel>
+                <CommandBar>
+                    <AppBarSeparator/>
+                </CommandBar>
             </StackPanel>
 
-            <!-- Per App controls -->
-            <StackPanel Orientation="Horizontal" Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}" Spacing="10" Margin="10 0 0 0">
-                <StackPanel.ContextFlyout>
-                    <MenuFlyout>
-                        <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
-                    </MenuFlyout>
-                </StackPanel.ContextFlyout>
-                <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Height="20" Width="20" />
-                <TextBlock x:Uid="AppName" Text="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
-                <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
-                <controls:PISeparator />
+            <CommandBar x:Name="MyCommandBar" HorizontalAlignment="Left" IsDynamicOverflowEnabled="True" Grid.Column="1" Opening="MyCommandBar_Opening" Closed="MyCommandBar_Closing" />
+
+
+            <CommandBar Grid.Column="2">
+                <AppBarSeparator/>
+            </CommandBar>
+
+            <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Column="3" Spacing="10" Margin="0 0 10 0">
+                <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
+                <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
+                <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
             </StackPanel>
-
-            <!-- Per System controls -->
-                <controls:ExternalToolsManagementButton
-                x:Name="ManageExternalToolsButton"
-                x:Uid="ManageExternalToolsButton"
-                HorizontalAlignment="Center"
-                Command="{x:Bind _viewModel.ManageExternalToolsButtonCommand}"
-                ExternalToolLaunchRequest="{x:Bind _viewModel.ManageExternalToolsButton_ExternalToolLaunchRequest}">
-                    <TextBlock Text="&#xEC7A;"/>
-                </controls:ExternalToolsManagementButton>
-
-                <controls:PISeparator />
-            </StackPanel>
-            
-            <CommandBar x:Name="MyCommandBar" IsDynamicOverflowEnabled="True" Grid.Column="1" />
-       
-
-        <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Column="3" Spacing="10" Margin="0 0 10 0">
-            <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
-            <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
-            <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
-        </StackPanel>
 
         </Grid>
 

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using DevHome.Common.Extensions;
 using DevHome.PI.Controls;
@@ -135,6 +136,25 @@ public partial class BarWindowHorizontal : WindowEx
         SetDefaultPosition();
 
         SetRegionsForTitleBar();
+
+        PopulateCommandBar();
+    }
+
+    public void PopulateCommandBar()
+    {
+        foreach (ExternalTool tool in ExternalToolsHelper.Instance.FilteredExternalTools)
+        {
+            AppBarButton button = new AppBarButton
+            {
+                Label = tool.Name,
+                Tag = tool,
+            };
+
+            button.Icon = tool.MenuIcon;
+
+            button.Click += _viewModel.ExternalToolButton_Click;
+            MyCommandBar.PrimaryCommands.Add(button);
+        }
     }
 
     public void SetRegionsForTitleBar()
@@ -321,6 +341,9 @@ public partial class BarWindowHorizontal : WindowEx
     private void MainPanel_SizeChanged(object sender, SizeChangedEventArgs e)
     {
         SetRegionsForTitleBar();
+        Debug.WriteLine(ToolColumn.ActualWidth);
+
+        MyCommandBar.Width = ToolColumn.ActualWidth;
     }
 
     // workaround as AppWindow TitleBar doesn't update caption button colors correctly when changed while app is running

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -172,12 +172,11 @@ public partial class BarWindowHorizontal : WindowEx
         button.Click += _viewModel.ExternalToolButton_Click;
 
         MenuFlyout menu = new MenuFlyout();
-
         menu.Items.Add(tool.IsPinned ? CreateUnPinMenuItem(tool) : CreatePinMenuItem(tool));
         menu.Items.Add(CreateUnregisterMenuItem(tool));
-
         button.ContextFlyout = menu;
 
+        // If a tool is pinned, we'll add it to the primary commands list, otherwise the secondary commands list
         if (tool.IsPinned)
         {
             MyCommandBar.PrimaryCommands.Add(button);
@@ -204,6 +203,7 @@ public partial class BarWindowHorizontal : WindowEx
                 menu.Items.Add(CreateUnregisterMenuItem(tool));
                 button.ContextFlyout = menu;
 
+                // If a tool is pinned, we'll add it to the primary commands list, otherwise the secondary commands list
                 if (tool.IsPinned)
                 {
                     MyCommandBar.SecondaryCommands.Remove(button);
@@ -234,7 +234,7 @@ public partial class BarWindowHorizontal : WindowEx
         // If we don't have any more primary commands, move the Manage Tools Option from the secondary commands to the primary commands
         else if (MyCommandBar.PrimaryCommands.Count == 0)
         {
-            // The first two items in the secondary commands list should be the app management button and a separator
+            // The first two items in the secondary commands list should be the tool management button and a separator
             Debug.Assert(MyCommandBar.SecondaryCommands.Count >= 2 && MyCommandBar.SecondaryCommands[0] is AppBarButton toolsBtn && toolsBtn.Command == _viewModel.ManageExternalToolsButtonCommand, "Where did tools button go?");
             Debug.Assert(MyCommandBar.SecondaryCommands.Count >= 2 && MyCommandBar.SecondaryCommands[1] is AppBarSeparator, "Where did the separator go?");
 

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -154,6 +154,14 @@ public partial class BarWindowHorizontal : WindowEx
 
             button.Click += _viewModel.ExternalToolButton_Click;
             MyCommandBar.PrimaryCommands.Add(button);
+
+            tool.PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == nameof(ExternalTool.MenuIcon))
+                {
+                    button.Icon = tool.MenuIcon;
+                }
+            };
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request

This started with an attempted fix to handle the case where we have more external tools "pinned" that what would fit on the visible bar. After playing around with this, the WinUI team suggested I use the CommandBar control... so here we go.

![image](https://github.com/microsoft/devhome/assets/49733346/0d582876-9100-48ab-b887-cc23e491b9bf)


## References and relevant issues

## Detailed description of the pull request / Additional comments

When there aren't any pinned external tools, I'll show the "manage tools" button in the bar. 

![image](https://github.com/microsoft/devhome/assets/49733346/f54ed9e3-3398-49e4-8b43-09c11cffc0b2)


Otherwise, I'll move the "manage tools" button to the secondary menu.....

![image](https://github.com/microsoft/devhome/assets/49733346/8aa5a357-ce3a-4877-bd51-224f6417f0a2)


I have not updated the vertical bar yet.... (unfortunately there isn't an Orientation property on a Command Bar, so it might be a bit more involved). As you'll see in the PR, I hit a few issues with CommandBar that I'll be following up with the WinUI3 team on. Not sure if they are issues with my code or not.


## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
