### PR TITLE
[Environments] Changed UI to match Setup flow

### DIFF
--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -359,16 +359,4 @@
     <value>Provides services and environments for running native user-mode Linux shells and tools on Windows.</value>
     <comment>Description for the Containers-Microsoft-Windows-Subsystem-Linux optional feature.</comment>
   </data>
-  <data name="EnvironmentAlternativeName" xml:space="preserve">
-    <value>Environment Alternative Name</value>
-    <comment>Narrator's text to read out for environment's alternative name</comment>
-  </data>
-  <data name="EnvironmentName" xml:space="preserve">
-    <value>Environment Name</value>
-    <comment>Narrator's text to read out for environment's name</comment>
-  </data>
-  <data name="EnvironmentState" xml:space="preserve">
-    <value>Environment Current State</value>
-    <comment>Narrator's text to read out for environment's current state</comment>
-  </data>
 </root>

--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -359,4 +359,16 @@
     <value>Provides services and environments for running native user-mode Linux shells and tools on Windows.</value>
     <comment>Description for the Containers-Microsoft-Windows-Subsystem-Linux optional feature.</comment>
   </data>
+  <data name="EnvironmentAlternativeName" xml:space="preserve">
+    <value>Environment Alternative Name</value>
+    <comment>Narrator's text to read out for environment's alternative name</comment>
+  </data>
+  <data name="EnvironmentName" xml:space="preserve">
+    <value>Environment Name</value>
+    <comment>Narrator's text to read out for environment's name</comment>
+  </data>
+  <data name="EnvironmentState" xml:space="preserve">
+    <value>Environment Current State</value>
+    <comment>Narrator's text to read out for environment's current state</comment>
+  </data>
 </root>

--- a/tools/Environments/DevHome.Environments/Selectors/CardItemTemplateSelector.cs
+++ b/tools/Environments/DevHome.Environments/Selectors/CardItemTemplateSelector.cs
@@ -11,7 +11,7 @@ public class CardItemTemplateSelector : DataTemplateSelector
 {
     public DataTemplate? CreateComputeSystemOperationTemplate { get; set; }
 
-    public DataTemplate? ComputeSystemTemplate { get; set; }
+    public DataTemplate? PerProviderComputeSystemTemplate { get; set; }
 
     protected override DataTemplate? SelectTemplateCore(object item)
     {
@@ -35,7 +35,7 @@ public class CardItemTemplateSelector : DataTemplateSelector
         }
         else
         {
-            return ComputeSystemTemplate;
+            return PerProviderComputeSystemTemplate;
         }
     }
 }

--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -173,10 +173,6 @@
     <value>Name: Ascending</value>
     <comment>Text for sorting in ascending order of name</comment>
   </data>
-  <data name="SortByAltName.Content" xml:space="preserve">
-    <value>Secondary Name: Ascending</value>
-    <comment>Text for sorting by secondary name</comment>
-  </data>
   <data name="SortByTextBlock.Text" xml:space="preserve">
     <value>Sort:</value>
     <comment>Text labelling sort by text block</comment>
@@ -224,10 +220,6 @@
   <data name="SortByNameDesc.Content" xml:space="preserve">
     <value>Name: Descending</value>
     <comment>Text for sorting in descending order of name</comment>
-  </data>
-  <data name="SortByAltNameDesc.Content" xml:space="preserve">
-    <value>Secondary Name: Descending</value>
-    <comment>Text for sorting by secondary name in descending order</comment>
   </data>
   <data name="SortByLastConnected.Content" xml:space="preserve">
     <value>Last Connected</value>

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -81,7 +81,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
             description.Append(AlternativeName);
         }
 
-        description.Append(_stringResourceCommon.GetLocalized($"ComputeSystem {State}"));
+        description.Append(_stringResourceCommon.GetLocalized($"ComputeSystem{State}"));
         return description.ToString();
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -74,7 +74,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public override string ToString()
     {
-        StringBuilder description = new(Name);
+        var description = new StringBuilder(Name);
 
         if (!string.IsNullOrEmpty(AlternativeName))
         {

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -60,7 +60,9 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public string ComputeSystemId { get; protected set; } = string.Empty;
 
-    private StringResource _stringResource = new("DevHome.Environments.pri", "DevHome.Environments/Resources");
+    private readonly StringResource _stringResource = new("DevHome.Environments.pri", "DevHome.Environments/Resources");
+
+    private readonly StringResource _stringResourceCommon = new("DevHome.Common.pri", "DevHome.Common/Resources");
 
     [ObservableProperty]
     private string _uiMessageToDisplay = string.Empty;
@@ -72,17 +74,14 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public override string ToString()
     {
-        StringBuilder description = new(_stringResource.GetLocalized("EnvironmentName"));
-        description.Append(Name);
+        StringBuilder description = new(Name);
 
         if (!string.IsNullOrEmpty(AlternativeName))
         {
-            description.Append(_stringResource.GetLocalized("EnvironmentAlternativeName"));
             description.Append(AlternativeName);
         }
 
-        description.Append(_stringResource.GetLocalized("EnvironmentState"));
-        description.Append(State.ToString());
+        description.Append(_stringResourceCommon.GetLocalized($"ComputeSystem{State}"));
         return description.ToString();
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Services;
@@ -59,18 +60,30 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public string ComputeSystemId { get; protected set; } = string.Empty;
 
+    private StringResource _stringResource = new("DevHome.Environments.pri", "DevHome.Environments/Resources");
+
     [ObservableProperty]
     private string _uiMessageToDisplay = string.Empty;
 
     public ComputeSystemCardBase()
     {
-        var stringResource = new StringResource("DevHome.Environments.pri", "DevHome.Environments/Resources");
-        _moreOptionsButtonName = stringResource.GetLocalized("MoreOptionsButtonName");
+        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptionsButtonName");
     }
 
     public override string ToString()
     {
-        return $"{Name} {AlternativeName}";
+        StringBuilder description = new(_stringResource.GetLocalized("EnvironmentName"));
+        description.Append(Name);
+
+        if (!string.IsNullOrEmpty(AlternativeName))
+        {
+            description.Append(_stringResource.GetLocalized("EnvironmentAlternativeName"));
+            description.Append(AlternativeName);
+        }
+
+        description.Append(_stringResource.GetLocalized("EnvironmentState"));
+        description.Append(State.ToString());
+        return description.ToString();
     }
 
     /// <summary>

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -81,7 +81,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
             description.Append(AlternativeName);
         }
 
-        description.Append(_stringResourceCommon.GetLocalized($"ComputeSystem{State}"));
+        description.Append(_stringResourceCommon.GetLocalized($"ComputeSystem {State}"));
         return description.ToString();
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -371,9 +371,24 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     [RelayCommand]
     public void SearchHandler(string query)
     {
-        foreach (var providerViewModel in PerProviderViewModels)
+        var dontShow = new List<int>();
+        for (var i = 0; i < PerProviderViewModels.Count; i++)
         {
+            var providerViewModel = PerProviderViewModels[i];
             providerViewModel.SearchHandler(query);
+            if (!providerViewModel.IsVisible)
+            {
+                dontShow.Add(i);
+            }
+        }
+
+        // Move all dontShow indexes to the end of the list
+        // so that the visible providers are only shown.
+        foreach (var index in dontShow)
+        {
+            var temp = PerProviderViewModels[index];
+            PerProviderViewModels.RemoveAt(index);
+            PerProviderViewModels.Add(temp);
         }
     }
 
@@ -383,6 +398,26 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     [RelayCommand]
     public void ProviderHandler(int selectedIndex)
     {
+        // Swap positions of the selected provider and the first provider in the list
+        // so that the selected provider is always at the top of the list and no extra
+        // UI space is shown.
+        if (selectedIndex != 0)
+        {
+            var actualIndex = -1;
+            for (var i = 0; i < PerProviderViewModels.Count; i++)
+            {
+                if (PerProviderViewModels[i].ProviderName.Equals(Providers[selectedIndex], StringComparison.OrdinalIgnoreCase))
+                {
+                    actualIndex = i;
+                    break;
+                }
+            }
+
+            var temp = PerProviderViewModels[0];
+            PerProviderViewModels[0] = PerProviderViewModels[actualIndex];
+            PerProviderViewModels[actualIndex] = temp;
+        }
+
         var currentProvider = Providers[selectedIndex];
         foreach (var providerViewModel in PerProviderViewModels)
         {

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -79,7 +79,14 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _shouldShowCreationHeader;
 
-    private const int DefaultSortIndex = 2;
+    private enum SortOptions
+    {
+        Alphabetical,
+        AlphabeticalDescending,
+        LastConnected,
+    }
+
+    private const int DefaultSortIndex = (int)SortOptions.LastConnected;
 
     public ObservableCollection<string> Providers { get; set; }
 
@@ -371,24 +378,31 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     [RelayCommand]
     public void SearchHandler(string query)
     {
-        var dontShow = new List<int>();
-        for (var i = 0; i < PerProviderViewModels.Count; i++)
+        var currentProviders = PerProviderViewModels.ToList();
+        PerProviderViewModels.Clear();
+
+        var dontShowIndices = new List<int>();
+        for (var i = 0; i < currentProviders.Count; i++)
         {
-            var providerViewModel = PerProviderViewModels[i];
+            var providerViewModel = currentProviders[i];
             providerViewModel.SearchHandler(query);
+
             if (!providerViewModel.IsVisible)
             {
-                dontShow.Add(i);
+                dontShowIndices.Add(i);
+            }
+            else
+            {
+                PerProviderViewModels.Add(providerViewModel);
             }
         }
 
-        // Move all dontShow indexes to the end of the list
+        // Move all don't show indices to the end of the list
         // so that the visible providers are only shown.
-        foreach (var index in dontShow)
+        // Add all the hidden providers
+        foreach (var index in dontShowIndices)
         {
-            var temp = PerProviderViewModels[index];
-            PerProviderViewModels.RemoveAt(index);
-            PerProviderViewModels.Add(temp);
+            PerProviderViewModels.Add(currentProviders[index]);
         }
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -264,7 +264,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
         _log.Information($"Adding any new create compute system operations to computeSystemCards list");
         var curOperations = _computeSystemManager.GetRunningOperationsForCreation();
 
-        var providerViewModel = PerProviderViewModels.FirstOrDefault(provider => provider.ProviderName.Equals(_computeSystemManager.ComputeSystemSetupItem?.AssociatedProvider.DisplayName, StringComparison.OrdinalIgnoreCase));
+        var providerViewModel = PerProviderViewModels.FirstOrDefault(provider => provider.ProviderID.Equals(_computeSystemManager.ComputeSystemSetupItem?.AssociatedProvider.Id, StringComparison.OrdinalIgnoreCase));
 
         if (providerViewModel == null)
         {
@@ -354,7 +354,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
                     tempComputeSystemViewModels.Add(computeSystemViewModel);
                 }
 
-                PerProviderViewModels.Add(new PerProviderViewModel(provider.DisplayName, loginId ?? string.Empty, tempComputeSystemViewModels, _mainWindow));
+                PerProviderViewModels.Add(new PerProviderViewModel(provider.DisplayName, provider.Id, loginId ?? string.Empty, tempComputeSystemViewModels, _mainWindow));
             }
             catch (Exception ex)
             {
@@ -415,7 +415,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
             }
 
             ComputeSystemCardBase? viewModel = default;
-            var providerViewModel = PerProviderViewModels.FirstOrDefault(provider => provider.ProviderName.Equals(computeSystemViewModel.ProviderDisplayName, StringComparison.OrdinalIgnoreCase));
+            var providerViewModel = PerProviderViewModels.FirstOrDefault(provider => provider.ProviderID.Equals(computeSystemViewModel.AssociatedProviderId, StringComparison.OrdinalIgnoreCase));
             if (providerViewModel != null)
             {
                 var computeSystemCards = providerViewModel.ComputeSystems;
@@ -443,7 +443,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
     private bool RemoveComputeSystemCard(ComputeSystemCardBase computeSystemCard)
     {
-        var providerViewModel = PerProviderViewModels.FirstOrDefault(provider => provider.ProviderName.Equals(computeSystemCard.ProviderDisplayName, StringComparison.OrdinalIgnoreCase));
+        var providerViewModel = PerProviderViewModels.FirstOrDefault(provider => provider.ProviderID.Equals(computeSystemCard.AssociatedProviderId, StringComparison.OrdinalIgnoreCase));
 
         if (providerViewModel == null)
         {

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -79,7 +79,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _shouldShowCreationHeader;
 
-    private const int SortUnselected = -1;
+    private const int DefaultSortIndex = 2;
 
     public ObservableCollection<string> Providers { get; set; }
 
@@ -98,7 +98,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
 
         _stringResource = new StringResource("DevHome.Environments.pri", "DevHome.Environments/Resources");
 
-        SelectedSortIndex = SortUnselected;
+        SelectedSortIndex = DefaultSortIndex;
         Providers = new() { _stringResource.GetLocalized("AllProviders") };
         _lastSyncTime = _stringResource.GetLocalized("MomentsAgo");
     }
@@ -112,7 +112,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
     public async Task SyncButton()
     {
         // Reset the sort and filter
-        SelectedSortIndex = SortUnselected;
+        SelectedSortIndex = DefaultSortIndex;
         Providers = new ObservableCollection<string> { _stringResource.GetLocalized("AllProviders") };
         SelectedProviderIndex = 0;
         _wasSyncButtonClicked = true;

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -435,12 +435,6 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
                 ComputeSystemCardsView.SortDescriptions.Add(new SortDescription("Name", SortDirection.Descending));
                 break;
             case 2:
-                ComputeSystemCardsView.SortDescriptions.Add(new SortDescription("AlternativeName", SortDirection.Ascending));
-                break;
-            case 3:
-                ComputeSystemCardsView.SortDescriptions.Add(new SortDescription("AlternativeName", SortDirection.Descending));
-                break;
-            case 4:
                 ComputeSystemCardsView.SortDescriptions.Add(new SortDescription("LastConnected", SortDirection.Ascending));
                 break;
         }

--- a/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/LandingPageViewModel.cs
@@ -354,7 +354,7 @@ public partial class LandingPageViewModel : ObservableObject, IDisposable
                     tempComputeSystemViewModels.Add(computeSystemViewModel);
                 }
 
-                PerProviderViewModels.Add(new PerProviderViewModel(provider.DisplayName, loginId ?? string.Empty, tempComputeSystemViewModels));
+                PerProviderViewModels.Add(new PerProviderViewModel(provider.DisplayName, loginId ?? string.Empty, tempComputeSystemViewModels, _mainWindow));
             }
             catch (Exception ex)
             {

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
+using System.Xml.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Collections;
@@ -121,5 +123,17 @@ public partial class PerProviderViewModel : ObservableObject
 
             return false;
         };
+    }
+
+    public override string ToString()
+    {
+        StringBuilder description = new(ProviderName);
+
+        if (!string.IsNullOrEmpty(DecoratedDevID))
+        {
+            description.Append(DecoratedDevID);
+        }
+
+        return description.ToString();
     }
 }

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -26,8 +26,6 @@ public partial class PerProviderViewModel : ObservableObject
 
     private readonly StringResource _stringResource;
 
-    private const int SortUnselected = -1;
-
     private readonly Window _mainWindow;
 
     [ObservableProperty]
@@ -89,12 +87,6 @@ public partial class PerProviderViewModel : ObservableObject
     public void SortHandler(int selectedSortIndex)
     {
         ComputeSystemAdvancedView.SortDescriptions.Clear();
-
-        if (selectedSortIndex == SortUnselected)
-        {
-            ComputeSystemAdvancedView.SortDescriptions.Add(new SortDescription("LastConnected", SortDirection.Ascending));
-        }
-
         switch (selectedSortIndex)
         {
             case 0:

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -18,6 +18,8 @@ public partial class PerProviderViewModel : ObservableObject
 {
     public string ProviderName { get; }
 
+    public string ProviderID { get; }
+
     public string DecoratedDevID { get; }
 
     public ObservableCollection<ComputeSystemCardBase> ComputeSystems { get; }
@@ -31,9 +33,10 @@ public partial class PerProviderViewModel : ObservableObject
     [ObservableProperty]
     private bool _isVisible = true;
 
-    public PerProviderViewModel(string providerName, string associatedDevID, List<ComputeSystemCardBase> computeSystems, Window mainWindow)
+    public PerProviderViewModel(string name, string id, string associatedDevID, List<ComputeSystemCardBase> computeSystems, Window mainWindow)
     {
-        ProviderName = providerName;
+        ProviderName = name;
+        ProviderID = id;
         DecoratedDevID = associatedDevID.Length > 0 ? '(' + associatedDevID + ')' : string.Empty;
         ComputeSystems = new ObservableCollection<ComputeSystemCardBase>(computeSystems);
         _mainWindow = mainWindow;

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -5,13 +5,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Collections;
 using DevHome.Common.Services;
+using Microsoft.UI.Xaml;
 
 namespace DevHome.Environments.ViewModels;
 
 // View model representing a compute system provider and its associated compute systems.
-public class PerProviderViewModel
+public partial class PerProviderViewModel : ObservableObject
 {
     public string ProviderName { get; }
 
@@ -25,11 +28,17 @@ public class PerProviderViewModel
 
     private const int SortUnselected = -1;
 
-    public PerProviderViewModel(string providerName, string associatedDevID, List<ComputeSystemCardBase> computeSystems)
+    private readonly Window _mainWindow;
+
+    [ObservableProperty]
+    private bool _isVisible = true;
+
+    public PerProviderViewModel(string providerName, string associatedDevID, List<ComputeSystemCardBase> computeSystems, Window mainWindow)
     {
         ProviderName = providerName;
         DecoratedDevID = associatedDevID.Length > 0 ? '(' + associatedDevID + ')' : string.Empty;
         ComputeSystems = new ObservableCollection<ComputeSystemCardBase>(computeSystems);
+        _mainWindow = mainWindow;
 
         _stringResource = new StringResource("DevHome.Environments.pri", "DevHome.Environments/Resources");
         ComputeSystemAdvancedView = new AdvancedCollectionView(ComputeSystems);
@@ -57,6 +66,18 @@ public class PerProviderViewModel
 
             return false;
         };
+
+        _mainWindow.DispatcherQueue.EnqueueAsync(() =>
+        {
+            if (ComputeSystemAdvancedView.Count == 0)
+            {
+                IsVisible = false;
+            }
+            else
+            {
+                IsVisible = true;
+            }
+        });
     }
 
     /// <summary>

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -123,6 +123,11 @@ public partial class PerProviderViewModel : ObservableObject
 
             return false;
         };
+
+        _mainWindow.DispatcherQueue.EnqueueAsync(() =>
+        {
+            IsVisible = ComputeSystemAdvancedView.Count > 0;
+        });
     }
 
     public override string ToString()

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -70,14 +70,7 @@ public partial class PerProviderViewModel : ObservableObject
 
         _mainWindow.DispatcherQueue.EnqueueAsync(() =>
         {
-            if (ComputeSystemAdvancedView.Count == 0)
-            {
-                IsVisible = false;
-            }
-            else
-            {
-                IsVisible = true;
-            }
+            IsVisible = ComputeSystemAdvancedView.Count > 0;
         });
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace DevHome.Environments.ViewModels;
+
+// View model representing a compute system provider and its associated compute systems.
+public class PerProviderViewModel
+{
+    public string ProviderName { get; }
+
+    public string DecoratedDevID { get; }
+
+    public ObservableCollection<ComputeSystemCardBase> ComputeSystems { get; }
+
+    public PerProviderViewModel(string providerName, string associatedDevID, List<ComputeSystemCardBase> computeSystems)
+    {
+        ProviderName = providerName;
+        DecoratedDevID = associatedDevID.Length > 0 ? '(' + associatedDevID + ')' : string.Empty;
+        ComputeSystems = new ObservableCollection<ComputeSystemCardBase>(computeSystems);
+    }
+}

--- a/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/PerProviderViewModel.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using CommunityToolkit.WinUI.Collections;
+using DevHome.Common.Services;
 
 namespace DevHome.Environments.ViewModels;
 
@@ -16,10 +19,98 @@ public class PerProviderViewModel
 
     public ObservableCollection<ComputeSystemCardBase> ComputeSystems { get; }
 
+    public AdvancedCollectionView ComputeSystemAdvancedView { get; set; }
+
+    private readonly StringResource _stringResource;
+
+    private const int SortUnselected = -1;
+
     public PerProviderViewModel(string providerName, string associatedDevID, List<ComputeSystemCardBase> computeSystems)
     {
         ProviderName = providerName;
         DecoratedDevID = associatedDevID.Length > 0 ? '(' + associatedDevID + ')' : string.Empty;
         ComputeSystems = new ObservableCollection<ComputeSystemCardBase>(computeSystems);
+
+        _stringResource = new StringResource("DevHome.Environments.pri", "DevHome.Environments/Resources");
+        ComputeSystemAdvancedView = new AdvancedCollectionView(ComputeSystems);
+        ComputeSystemAdvancedView.SortDescriptions.Add(new SortDescription("IsCardCreating", SortDirection.Descending));
+    }
+
+    /// <summary>
+    /// Updates the view model to show only the compute systems that match the search criteria.
+    /// </summary>
+    public void SearchHandler(string query)
+    {
+        ComputeSystemAdvancedView.Filter = system =>
+        {
+            if (system is CreateComputeSystemOperationViewModel createComputeSystemOperationViewModel)
+            {
+                return createComputeSystemOperationViewModel.EnvironmentName.Contains(query, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (system is ComputeSystemViewModel computeSystemViewModel)
+            {
+                var systemName = computeSystemViewModel.ComputeSystem!.DisplayName.Value;
+                var systemAltName = computeSystemViewModel.ComputeSystem.SupplementalDisplayName.Value;
+                return systemName.Contains(query, StringComparison.OrdinalIgnoreCase) || systemAltName.Contains(query, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        };
+    }
+
+    /// <summary>
+    /// Updates the view model to sort the compute systems according to the sort criteria.
+    /// </summary>
+    /// <remarks>
+    /// New SortDescription property names should be added as new properties to <see cref="ComputeSystemCardBase"/>
+    /// </remarks>
+    public void SortHandler(int selectedSortIndex)
+    {
+        ComputeSystemAdvancedView.SortDescriptions.Clear();
+
+        if (selectedSortIndex == SortUnselected)
+        {
+            ComputeSystemAdvancedView.SortDescriptions.Add(new SortDescription("LastConnected", SortDirection.Ascending));
+        }
+
+        switch (selectedSortIndex)
+        {
+            case 0:
+                ComputeSystemAdvancedView.SortDescriptions.Add(new SortDescription("Name", SortDirection.Ascending));
+                break;
+            case 1:
+                ComputeSystemAdvancedView.SortDescriptions.Add(new SortDescription("Name", SortDirection.Descending));
+                break;
+            case 2:
+                ComputeSystemAdvancedView.SortDescriptions.Add(new SortDescription("LastConnected", SortDirection.Ascending));
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Updates the view model to filter the compute systems according to the provider.
+    /// </summary>
+    public void ProviderHandler(string currentProvider)
+    {
+        ComputeSystemAdvancedView.Filter = system =>
+        {
+            if (currentProvider.Equals(_stringResource.GetLocalized("AllProviders"), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (system is CreateComputeSystemOperationViewModel createComputeSystemOperationViewModel)
+            {
+                return createComputeSystemOperationViewModel.ProviderDisplayName.Equals(currentProvider, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (system is ComputeSystemViewModel computeSystemViewModel)
+            {
+                return computeSystemViewModel.ProviderDisplayName.Equals(currentProvider, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        };
     }
 }

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -257,8 +257,6 @@
                           SelectedIndex="{x:Bind ViewModel.SelectedSortIndex, Mode=TwoWay}">
                     <ComboBoxItem x:Uid="SortByName"/>
                     <ComboBoxItem x:Uid="SortByNameDesc"/>
-                    <ComboBoxItem x:Uid="SortByAltName"/>
-                    <ComboBoxItem x:Uid="SortByAltNameDesc"/>
                     <ComboBoxItem x:Uid="SortByLastConnected"/>
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="SelectionChanged">

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -289,7 +289,7 @@
                 <ComboBox x:Uid="SortSelectionComboBox"
                           x:Name="SortSelectionComboBox"
                           Margin="0 3 0 0"
-                          MinWidth="236"
+                          MinWidth="167"
                           SelectedIndex="{x:Bind ViewModel.SelectedSortIndex, Mode=TwoWay}">
                     <ComboBoxItem x:Uid="SortByName"/>
                     <ComboBoxItem x:Uid="SortByNameDesc"/>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -238,7 +238,7 @@
                           x:Name="ProviderSelectionComboBox"
                           Margin="0 3 0 0"
                           MinWidth="180"
-                          ItemsSource="{x:Bind ViewModel.Providers, Mode=OneWay}" 
+                          ItemsSource="{x:Bind ViewModel.Providers, Mode=OneWay}"
                           SelectedIndex="{x:Bind ViewModel.SelectedProviderIndex, Mode=TwoWay}">
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="SelectionChanged">
@@ -290,9 +290,9 @@
             </StackPanel>
         </Grid>
 
-        <!-- Per VM/Compute System card -->
         <ScrollViewer Grid.Row="3" Style="{StaticResource EnvironmentScrollViewerStyle}" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <Grid>
+                <!-- Per Compute System card -->
                 <StackPanel>
                     <ListView
                         MaxWidth="{ThemeResource MaxPageContentWidth}"
@@ -305,6 +305,8 @@
                             </ItemsPanelTemplate>
                         </ListView.ItemsPanel>
                     </ListView>
+
+                    <!-- Shimmer -->
                     <StackPanel
                         Visibility="{x:Bind ViewModel.ShowLoadingShimmer, Mode=OneWay}">
                         <ContentControl
@@ -312,24 +314,26 @@
                             ContentTemplate="{StaticResource ComputeSystemLoadingTemplate}"/>
                     </StackPanel>
                 </StackPanel>
-                <StackPanel 
+
+                <!-- No extension found, show link to extensions page-->
+                <StackPanel
                     Visibility="{x:Bind ViewModel.CallToActionText, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
                     VerticalAlignment="Center"
                     HorizontalAlignment="Center"
                     Margin="0,0,0,250">
-                    <TextBlock 
+                    <TextBlock
                         Text="{x:Bind ViewModel.CallToActionText, Mode=OneWay}"
-                        HorizontalAlignment="Center" 
-                        TextWrapping="WrapWholeWords" 
+                        HorizontalAlignment="Center"
+                        TextWrapping="WrapWholeWords"
                         HorizontalTextAlignment="Center" />
-                    <views:AddCreateHyperlinkButton 
-                        Grid.Column="3" 
+                    <views:AddCreateHyperlinkButton
+                        Grid.Column="3"
                         HorizontalAlignment="Center"
                         Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                         Content="{x:Bind ViewModel.CallToActionHyperLinkButtonText, Mode=OneWay}"
                         Command="{x:Bind ViewModel.CallToActionInvokeButtonCommand}" />
-                    <HyperlinkButton 
-                        Grid.Column="3" 
+                    <HyperlinkButton
+                        Grid.Column="3"
                         HorizontalAlignment="Center"
                         Visibility="{x:Bind ViewModel.ShouldNavigateToExtensionsPage, Mode=OneWay}"
                         Content="{x:Bind ViewModel.CallToActionHyperLinkButtonText, Mode=OneWay}"
@@ -337,6 +341,8 @@
                 </StackPanel>
             </Grid>
         </ScrollViewer>
+
+        <!-- Notification panel -->
         <Grid Grid.Row="3" MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
             <InfoBar MaxWidth="600"
                 Margin="24"

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -61,7 +61,7 @@
                 </Grid>
             </DataTemplate>
 
-            <!-- Three Dot Button For create compute system operation template -->
+            <!-- Three Dot Button for create compute system operation template -->
             <DataTemplate x:Key="ThreeDotsButtonForCreation" x:DataType="vm:CreateComputeSystemOperationViewModel">
                 <Grid>
                     <Button
@@ -74,7 +74,7 @@
                 </Grid>
             </DataTemplate>
 
-            <!-- Properties template for the compute system properties that appear within a horizontal card.-->
+            <!-- Properties template for the compute system properties that appear within a horizontal card -->
             <DataTemplate x:Key="BottomRowProperties" x:DataType="commonModels:CardProperty">
                 <Grid
                     HorizontalAlignment="Stretch"
@@ -159,6 +159,41 @@
                 </Grid>
             </DataTemplate>
 
+            <!-- Per Provider Card Template -->
+            <DataTemplate x:Key="PerProviderComputeSystemTemplate" x:DataType="vm:PerProviderViewModel">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="0" Orientation="Horizontal">
+                        <TextBlock
+                            Text="{x:Bind ProviderName, Mode=OneWay}"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Margin="0 0 0 3"
+                            IsTextSelectionEnabled="True"/>
+                        <TextBlock
+                            Text="{x:Bind DecoratedDevID, Mode=OneWay}"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Margin="5 0 0 3"
+                            IsTextSelectionEnabled="True"/>
+                    </StackPanel>
+                    <Grid Grid.Row="1">
+                        <ListView
+                            ItemsSource="{x:Bind ComputeSystems, Mode=OneWay}"
+                            SelectionMode="None"
+                            ItemTemplate="{StaticResource ComputeSystemTemplate}"
+                            ItemContainerStyle="{StaticResource HorizontalCardListViewItemContainerForManagementPageStyle}">
+                            <ListView.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel></StackPanel>
+                                </ItemsPanelTemplate>
+                            </ListView.ItemsPanel>
+                        </ListView>
+                    </Grid>
+                </Grid>
+            </DataTemplate>
+
             <DataTemplate x:Key="CreateComputeSystemOperationTemplate" x:DataType="vm:CreateComputeSystemOperationViewModel">
                 <Grid Style="{StaticResource HorizontalCardRootForEnvironmentsPage}">
                     <Grid.RowDefinitions>
@@ -184,7 +219,7 @@
             </DataTemplate>
 
             <selectors:CardItemTemplateSelector x:Key="CardItemTemplateSelector"
-                ComputeSystemTemplate="{StaticResource ComputeSystemTemplate}"
+                PerProviderComputeSystemTemplate="{StaticResource PerProviderComputeSystemTemplate}"
                 CreateComputeSystemOperationTemplate="{StaticResource CreateComputeSystemOperationTemplate}"/>
 
         </Grid.Resources>
@@ -296,7 +331,7 @@
                 <StackPanel>
                     <ListView
                         MaxWidth="{ThemeResource MaxPageContentWidth}"
-                        ItemsSource="{x:Bind ViewModel.ComputeSystemCardsView}" SelectionMode="None"
+                        ItemsSource="{x:Bind ViewModel.PerProviderViewModels}" SelectionMode="None"
                         ItemTemplateSelector="{StaticResource CardItemTemplateSelector}"
                         ItemContainerStyle="{StaticResource HorizontalCardListViewItemContainerForManagementPageStyle}">
                         <ListView.ItemsPanel>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -161,19 +161,20 @@
 
             <!-- Per Provider Card Template -->
             <DataTemplate x:Key="PerProviderComputeSystemTemplate" x:DataType="vm:PerProviderViewModel">
-                <Grid>
+                <Grid
+                    Visibility="{x:Bind IsVisible, Mode=OneWay}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <StackPanel Grid.Row="0" Orientation="Horizontal">
                         <TextBlock
-                            Text="{x:Bind ProviderName, Mode=OneWay}"
+                            Text="{x:Bind ProviderName}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Margin="0 0 0 3"
                             IsTextSelectionEnabled="True"/>
                         <TextBlock
-                            Text="{x:Bind DecoratedDevID, Mode=OneWay}"
+                            Text="{x:Bind DecoratedDevID}"
                             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                             Margin="5 0 0 3"
                             IsTextSelectionEnabled="True"/>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -180,7 +180,7 @@
                     </StackPanel>
                     <Grid Grid.Row="1">
                         <ListView
-                            ItemsSource="{x:Bind ComputeSystems, Mode=OneWay}"
+                            ItemsSource="{x:Bind ComputeSystemAdvancedView, Mode=OneWay}"
                             SelectionMode="None"
                             ItemTemplate="{StaticResource ComputeSystemTemplate}"
                             ItemContainerStyle="{StaticResource HorizontalCardListViewItemContainerForManagementPageStyle}">

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.WinUI;
 using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
+using DevHome.Common.Services;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.Windows.DevHome.SDK;
@@ -58,6 +59,8 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 
     [ObservableProperty]
     private Lazy<string> _accessibilityName;
+
+    private readonly StringResource _stringResourceCommon = new("DevHome.Common.pri", "DevHome.Common/Resources");
 
     public ObservableCollection<CardProperty> ComputeSystemProperties { get; set; }
 
@@ -129,7 +132,8 @@ public partial class ComputeSystemCardViewModel : ObservableObject
     {
         var stringBuilder = new StringBuilder();
         stringBuilder.AppendLine(CultureInfo.CurrentCulture, $"{ComputeSystemTitle}");
-        stringBuilder.AppendLine(CultureInfo.CurrentCulture, $"{CardState}");
+        var state = _stringResourceCommon.GetLocalized($"ComputeSystem{CardState}");
+        stringBuilder.AppendLine(string.Format(CultureInfo.CurrentCulture, "{0}", state));
 
         foreach (var property in ComputeSystemProperties)
         {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -26,6 +26,8 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ComputeSystemCardViewModel));
 
+    private readonly StringResource _stringResourceCommon = new("DevHome.Common.pri", "DevHome.Common/Resources");
+
     private readonly DispatcherQueue _dispatcherQueue;
 
     private readonly IComputeSystemManager _computeSystemManager;
@@ -59,8 +61,6 @@ public partial class ComputeSystemCardViewModel : ObservableObject
 
     [ObservableProperty]
     private Lazy<string> _accessibilityName;
-
-    private readonly StringResource _stringResourceCommon = new("DevHome.Common.pri", "DevHome.Common/Resources");
 
     public ObservableCollection<CardProperty> ComputeSystemProperties { get; set; }
 


### PR DESCRIPTION
## Summary of the pull request
This PR makes multiple small changes to make the Environments page closer to the machine configuration flow as asked by the PMs.
1. Fixes narrator not reading the status of compute systems
2. Removes alternative sorting
3. Adds provider-based classification
4. Makes 'Last connected' the default sort option
![image](https://github.com/microsoft/devhome/assets/16077119/69fbc30b-0135-4e5c-9238-a713c4162b76)


## Validation steps performed
Manually checked narrator, sorting, filtering including with new environment creation flow

## PR checklist
- [ ] Closes #2831 
- [ ] Closes #2558 
- [ ] Closes #2557
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
