### PR TITLE
Support single quote in app install protocol

### DIFF
--- a/src/Services/AppInstallActivationHandler.cs
+++ b/src/Services/AppInstallActivationHandler.cs
@@ -108,7 +108,7 @@ public class AppInstallActivationHandler : ActivationHandler<ProtocolActivatedEv
     private string[] SplitAndTrimIdentifiers(string query)
     {
         return query.Split(_separator, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(id => id.Trim(' ', '"'))
+                    .Select(id => id.Trim(' ', '"', '\''))
                     .ToArray();
     }
 


### PR DESCRIPTION
## Summary of the pull request
- Support single quote in app install protocol

Working examples:
- `ms-devhome:add-apps-to-cart?WingetURIs="x-ms-winget://msstore/9NBLGGH4NNS1"`
- `ms-devhome:add-apps-to-cart?WingetURIs='x-ms-winget://msstore/9NBLGGH4NNS1'`
- `ms-devhome:add-apps-to-cart?WingetURIs=x-ms-winget://msstore/9NBLGGH4NNS1`

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3377
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
