### PR TITLE
Refresh accounts on logout failure

### DIFF
--- a/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/AccountsProviderViewModel.cs
@@ -51,7 +51,6 @@ public partial class AccountsProviderViewModel : ObservableObject
             if (providerOperationResult.Status == ProviderOperationStatus.Failure)
             {
                 _log.Error($"{providerOperationResult.DisplayMessage} - {providerOperationResult.DiagnosticText}");
-                return;
             }
         }
 


### PR DESCRIPTION
## Summary of the pull request
Ensures we always refresh the view of the accounts, even if a remove operation fails. This should keep the view consistent with the data in the case of partial success of errors during removal.

## References and relevant issues
Closes #3357 

## Detailed description of the pull request / Additional comments
On failed developerId logout, the page will not refresh. This fixes it so that we will always refresh, even if there is a failure.

## Validation steps performed
Unable to repro logout failure, but the code change is trivial and straightforward.

## PR checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
- [x] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
