### PR TITLE
Temporary UI to unblock removal of registered repositories

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -309,4 +309,8 @@
     <value>The root path provided is incorrect or is a UNC path. Please check for invalid characters and if the drive exists on the machine.</value>
     <comment>The error message for root path validation</comment>
   </data>
+  <data name="RemoveRepository.Text" xml:space="preserve">
+    <value>Enter path to remove an enhanced repository</value>
+    <comment>The text for removing a repository from source control integration</comment>
+  </data>
 </root>

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -85,6 +86,11 @@ public partial class FileExplorerViewModel : ObservableObject
         }
 
         return false;
+    }
+
+    public void RemoveRepositoryPath(string rootPath)
+    {
+        RepoTracker.RemoveRepositoryPath(rootPath);
     }
 
     public bool ShowFileExtensions

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -67,6 +67,17 @@
                          Severity="Error">
                     </InfoBar>
                 </StackPanel>
+                <StackPanel  x:Name="RemoveRepository" Orientation="Horizontal" Margin="0,20,0,20">
+                    <TextBox x:Name="RemovePathTextBox"
+                             x:Uid="RemovePathTextBox"
+                             PlaceholderText="Enter path to remove an enhanced repository"
+                             MinWidth="300"
+                             VerticalAlignment="Center"
+                             HorizontalAlignment="Left"/>
+                    <Button  Content="Remove" 
+                             Click="RemoveButton_Click" 
+                             Margin="10, 5, 0, 0"/>
+                </StackPanel>
                 <StackPanel x:Name="DisplayTrackRepository" Visibility="Collapsed">
                     <TextBlock Text="Git" Style="{ThemeResource SettingsSectionHeaderTextBlockStyle}"/>
                     <ItemsRepeater ItemsSource="{x:Bind ViewModel.TrackedRepositories}"

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -69,8 +69,7 @@
                 </StackPanel>
                 <StackPanel  x:Name="RemoveRepository" Orientation="Horizontal" Margin="0,20,0,20">
                     <TextBox x:Name="RemovePathTextBox"
-                             x:Uid="RemovePathTextBox"
-                             PlaceholderText="Enter path to remove an enhanced repository"
+                             x:Uid="RemoveRepository"
                              MinWidth="300"
                              VerticalAlignment="Center"
                              HorizontalAlignment="Left"/>

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
@@ -37,6 +37,7 @@ public sealed partial class FileExplorerPage : Page
         {
             TrackRepository.Visibility = Visibility.Visible;
             DisplayTrackRepository.Visibility = Visibility.Visible;
+            RemoveRepository.Visibility = Visibility.Visible;
         }
     }
 
@@ -104,6 +105,16 @@ public sealed partial class FileExplorerPage : Page
             {
                 RootPathErrorBar.IsOpen = true;
             }
+        }
+
+        ViewModel.RefreshTrackedRepositories();
+    }
+
+    private void RemoveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (ValidateRepositoryPath(RemovePathTextBox.Text))
+        {
+            ViewModel.RemoveRepositoryPath(RemovePathTextBox.Text);
         }
 
         ViewModel.RefreshTrackedRepositories();

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml.cs
@@ -112,11 +112,7 @@ public sealed partial class FileExplorerPage : Page
 
     private void RemoveButton_Click(object sender, RoutedEventArgs e)
     {
-        if (ValidateRepositoryPath(RemovePathTextBox.Text))
-        {
-            ViewModel.RemoveRepositoryPath(RemovePathTextBox.Text);
-        }
-
+        ViewModel.RemoveRepositoryPath(RemovePathTextBox.Text);
         ViewModel.RefreshTrackedRepositories();
     }
 }


### PR DESCRIPTION
## Summary of the pull request
This PR adds a text box and a button to allow removing a repository root path registered for source control integration.  

## References and relevant issues

## Detailed description of the pull request / Additional comments
![image](https://github.com/microsoft/devhome/assets/128866445/a6bbef75-7549-4b84-9109-e0ca5828a410)

This will be used to unblock remove functionality for internal testing. 

## Validation steps performed
Local Build and msix release build in Developer Command Prompt
Validated remove functionality in UI


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
