### PR TITLE
Add error message for when the virtual machine platform feature isn't enabled for WSL creation

### DIFF
--- a/extensions/WSLExtension/Models/WslInstallDistributionOperation.cs
+++ b/extensions/WSLExtension/Models/WslInstallDistributionOperation.cs
@@ -93,6 +93,7 @@ public class WslInstallDistributionOperation : ICreateComputeSystemOperation
             }
             catch (Exception ex)
             {
+                _log.Error(ex, $"Unable to install {_definition.FriendlyName} due to exception");
                 var errorMsg = _stringResource.GetLocalized("WSLInstallationFailedWithException", _definition.FriendlyName, ex.Message);
                 return new CreateComputeSystemResult(ex, errorMsg, ex.Message);
             }

--- a/extensions/WSLExtension/Strings/en-US/Resources.resw
+++ b/extensions/WSLExtension/Strings/en-US/Resources.resw
@@ -135,15 +135,19 @@
     <comment>{Locked="{0}"} Text message to display when a wsl distribution is installing. {0} is the name of the distribution</comment>
   </data>
   <data name="WSLInstallationFailedWithException" xml:space="preserve">
-    <value>Unable to install and register {0} due to error: {1}. Try using {wsl.exe} to install it manually. See {aka.ms/wslinstall}</value>
+    <value>Unable to install and register {0} due to error: {1}. Try using wsl.exe to install it manually. See aka.ms/wslinstall</value>
     <comment>{Locked="{0}", "{1}", "{wsl.exe}", {aka.ms/wslinstall}} Text message to display when we failed to install a wsl distribution. {0} is the name of the distribution and {1} is the error message.</comment>
   </data>
   <data name="WSLInstallationFailedTimeOut" xml:space="preserve">
-    <value>Installation timed out, unable to install and register {0}. Try using {wsl.exe} to install manually. See {aka.ms/wslinstall}</value>
-    <comment>{Locked="{0}", "{wsl.exe}", {aka.ms/wslinstall}} Text message to display when we failed to install a wsl distribution. {0} is the name of the distribution</comment>
+    <value>Installation timed out, unable to install and register {0}. Try using wsl.exe to install manually. See aka.ms/wslinstall</value>
+    <comment>{Locked="{0}", "{wsl.exe}", "{aka.ms/wslinstall}"} Text message to display when we failed to install a wsl distribution. {0} is the name of the distribution</comment>
   </data>
   <data name="WSLInstallationCompletedSuccessfully" xml:space="preserve">
     <value>Successfully installed and registered {0}</value>
     <comment>{Locked="{0}"} Text message to display when we successfully installed a wsl distribution. {0} is the name of the distribution</comment>
+  </data>
+  <data name="VirtualMachinePlatformNotInstalled" xml:space="preserve">
+    <value>The Virtual Machine Platform feature is needed for the WSL extension to function properly. The feature can be enabled in Dev Home's Windows customization page, under the virtualization feature management option. Enabling the feature will require a reboot. For more information on WSL requirements visit aka.ms/wslinstall</value>
+    <comment>{Locked="{Windows}", "{WSL}", "{aka.ms/wslinstall}", "{Dev Home}"} Text message to display when the virtual machine platform Windows optional component is not enabled.</comment>
   </data>
 </root>

--- a/extensions/WSLExtension/WSLExtension.csproj
+++ b/extensions/WSLExtension/WSLExtension.csproj
@@ -46,6 +46,7 @@
         <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
         <PackageReference Include="YamlDotNet" Version="15.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+		<PackageReference Include="System.Management" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -294,7 +294,7 @@ public static class StringResourceKey
     public static readonly string EnvironmentCreationReviewExpanderDescription = nameof(EnvironmentCreationReviewExpanderDescription);
     public static readonly string CreateEnvironmentButtonText = nameof(CreateEnvironmentButtonText);
     public static readonly string SetupShellReviewPageDescriptionForEnvironmentCreation = nameof(SetupShellReviewPageDescriptionForEnvironmentCreation);
-    public static readonly string EnvironmentCreationAdaptiveCardLoadingMessage = nameof(EnvironmentCreationAdaptiveCardLoadingMessage);
+    public static readonly string EnvironmentCreationUILoadingMessage = nameof(EnvironmentCreationUILoadingMessage);
 
     // Summary page
     public static readonly string SummaryPageOpenDashboard = nameof(SummaryPageOpenDashboard);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1808,9 +1808,9 @@
     <value>Add options to create your environment</value>
     <comment>Description for the configure environment page</comment>
   </data>
-  <data name="ErrorRetrievingAdaptiveCardSession.Title" xml:space="preserve">
-    <value>There was an error retrieving the adaptive card session from the extension</value>
-    <comment>Error text display when we are unable to retrieve the adaptive card information from an extension</comment>
+  <data name="ErrorLoadingCreationUITitle" xml:space="preserve">
+    <value>There was an error loading the data required to create {0} environments</value>
+    <comment>Locked={"{0}"} Error text display when we are unable to retrieve the creation data for a Dev Home provider. {0} is the name of the provider</comment>
   </data>
   <data name="EnvironmentCreationReviewTabTitle" xml:space="preserve">
     <value>Environment</value>
@@ -1867,9 +1867,9 @@
     <value>We've started creating your environment</value>
     <comment>Text to tell the user that an environment is being created. Environments can be local or cloud virtual machines</comment>
   </data>
-  <data name="EnvironmentCreationAdaptiveCardLoadingMessage" xml:space="preserve">
-    <value>Loading adaptive card from the {0} provider</value>
-    <comment>Text to tell the user that Dev Home is loading the adaptive card content from a specific Dev Home extension provider. {0} is the display name of the provider</comment>
+  <data name="EnvironmentCreationUILoadingMessage" xml:space="preserve">
+    <value>Loading data needed to create {0} environments</value>
+    <comment>Text to tell the user that Dev Home is loading the creation UX from a specific Dev Home extension provider. {0} is the display name of the provider</comment>
   </data>
   <data name="RepoToolNoRepositoriesMessage" xml:space="preserve">
     <value>Added repositories are found in your {0} account and will appear here.</value>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/EnvironmentCreationOptionsView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/EnvironmentCreationOptionsView.xaml
@@ -41,7 +41,7 @@
                     Visibility="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}">
                     <InfoBar
                         IsOpen="True"
-                        x:Uid="ErrorRetrievingAdaptiveCardSession"
+                        Title="{x:Bind ViewModel.SessionErrorTitle, Mode=OneWay}"
                         Severity="Error"
                         Message="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay}" >
                     </InfoBar>


### PR DESCRIPTION
## Summary of the pull request

- Adds error message when the `Virtual Machine Platform` Windows feature is not enabled. This is needed when attempting to install a WSL distribution for the first time. Relates to: #3400 . When `wsl.exe install` is ran for the first time it will install the `Virtual Machine Platform` feature, update wsl.exe and install the selected distribution. However, when this happens even though the distribution is installed it isn't registered until `Virtual Machine Platform` is enabled and the computer is rebooted. Unfortunately there is no way for us to know when both have occurred as they happen in separate processes outside of Dev Homes control, so Dev Home will just show "waiting for <distributions name>'s installation to complete" even though a reboot is needed.

So to fix this, we will show an error and lead the user to enable the `Virtual Machine Platform` feature from the Windows Customization page and reboot, before allowing them to go through the WSL environment creation flow. This should prevent a confusing experience.

Video showing what will happen now that we show the error:

https://github.com/microsoft/devhome/assets/105318831/b956986a-0d6a-436e-aab4-3339a6fb4436


Also removed the verbiage surrounding adaptive cards in the error and loading progress bar in the create environment page.
## References and relevant issues

I noticed that I had to use WMI to check for feature enablement again here. I'm thinking we can add a common service for WMI usage through Dev Home. See: #3381
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [X] Closes #3400
- [X] Closes #3363
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
