### PR TITLE
Prevent the enumeration of WSL distributions from failing due to the presence of unpackaged WSL distributions

### DIFF
--- a/extensions/WSLExtension/Helpers/PackageHelper.cs
+++ b/extensions/WSLExtension/Helpers/PackageHelper.cs
@@ -76,6 +76,11 @@ public class PackageHelper
 
     public virtual Package? GetPackageFromPackageFamilyName(string packageFamilyName)
     {
+        if (string.IsNullOrEmpty(packageFamilyName))
+        {
+            return null;
+        }
+
         return _packageManager.FindPackagesForUser(string.Empty, packageFamilyName).FirstOrDefault();
     }
 }

--- a/extensions/WSLExtension/Models/WslComputeSystem.cs
+++ b/extensions/WSLExtension/Models/WslComputeSystem.cs
@@ -81,7 +81,12 @@ public class WslComputeSystem : IComputeSystem
         _distribution = distribution;
         _wslManager = wslManager;
         DisplayName = distribution.FriendlyName;
-        _curPackage = _packageHelper.GetPackageFromPackageFamilyName(_distribution.PackageFamilyName!);
+
+        // Only get the package information if it has a package family name
+        if (_distribution.PackageFamilyName != null)
+        {
+            _curPackage = _packageHelper.GetPackageFromPackageFamilyName(_distribution.PackageFamilyName);
+        }
 
         // Use display name of package if there is no friendly name for this distribution
         if (string.IsNullOrEmpty(DisplayName) && _curPackage != null)
@@ -204,9 +209,14 @@ public class WslComputeSystem : IComputeSystem
             {
                 if (string.IsNullOrEmpty(_distribution.Base64StringLogo))
                 {
+                    byte[]? packageFamilyLogo = default;
+                    var familyName = _distribution.PackageFamilyName;
+
                     // No logo for this distribution so we'll use its PackageFamily logo
-                    var packageFamilyLogo =
-                        await _packageHelper.GetPackageIconAsByteArrayAsync(_distribution.PackageFamilyName!);
+                    if (familyName != null)
+                    {
+                        packageFamilyLogo = await _packageHelper.GetPackageIconAsByteArrayAsync(familyName);
+                    }
 
                     if (packageFamilyLogo == null)
                     {

--- a/extensions/WSLExtension/Services/WslManager.cs
+++ b/extensions/WSLExtension/Services/WslManager.cs
@@ -55,7 +55,14 @@ public class WslManager : IWslManager
 
         foreach (var distribution in await GetInformationOnAllRegisteredDistributionsAsync())
         {
-            _registeredWslDistributions.Add(_wslRegisteredDistributionFactory(distribution.Value));
+            try
+            {
+                _registeredWslDistributions.Add(_wslRegisteredDistributionFactory(distribution.Value));
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, $"Unable to add the distribution: {distribution.Key}");
+            }
         }
 
         return _registeredWslDistributions;


### PR DESCRIPTION
## Summary of the pull request
Currently the WSL extension allows users to install packaged distributions in the create environment flow. However, users may have unpackaged distributions already installed on their machines. Right now, the code to enumerate the WSL distributions assume that the distributions are all packaged and throws an exception in the WSLManager when one is not. 
E.g:
```
[2024/19/11 11:19:18.063 ERR] (WslProvider) Failed to retrieve all wsl distributions
System.ArgumentException: The parameter is incorrect.

The package FamilyName parameter was Null. This parameter must not be Null.
```
Happens when the WslManager on this [line](https://github.com/microsoft/devhome/blob/18e772b5d994bd3924c4e54ecea4ae4b62eeba93/extensions/WSLExtension/Services/WslManager.cs#L58), creates a WslComputesystem on this [line](https://github.com/microsoft/devhome/blob/18e772b5d994bd3924c4e54ecea4ae4b62eeba93/extensions/WSLExtension/Models/WslComputeSystem.cs#L84): 

Due to this, an exception is thrown and the WslComputeSystem returns the error back to Dev Home. This change adds checks for when we attempt to use the package family name. If the distribution does not have one, then we don't attempt to use the package family variable in the WslComputeSystem class. 

Also, I've added a try/catch in the enumeration code in the WslManager above, to allow us to continue enumerating all distributions and returning the ones we found. Instead stopping and throwing an exception if there was an issue with one.

Video showing environments page before change:

https://github.com/microsoft/devhome/assets/105318831/da79a390-65b0-4f79-a941-53a49cfa5423



Video showing environments page after change:


https://github.com/microsoft/devhome/assets/105318831/c2701b8a-029f-40be-a713-1c7856abaec5


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Downloaded and installed docker via these instructions: https://docker-docs.uclv.cu/docker-for-windows/wsl/#:~:text=Install%20%F0%9F%94%97%201%20Follow%20the%20usual%20installation%20instructions,WSL%20Integration.%20...%208%20Click%20Apply%20%26%20Restart.

Confirmed that both the packaged ubuntu distribution and this unpackaged docker distribution both now show up.
## PR checklist
- [x] Closes #3415
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
