### PR TITLE
Change Windows customization Nav Icon to 'Developer Tools' icon (EC7A)

### DIFF
--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -31,7 +31,7 @@
             "assembly": "DevHome.Customization",
             "viewFullName": "DevHome.Customization.Views.MainPage",
             "viewModelFullName": "DevHome.Customization.ViewModels.MainPageViewModel",
-            "icon": "e9f5"
+            "icon": "EC7A"
           },
           {
             "identity": "DevHome.Utilities",


### PR DESCRIPTION
## Summary of the pull request
![image](https://github.com/user-attachments/assets/5e331c26-83b3-4b86-8a58-b6bfea78f0ce)

## References and relevant issues
#3413 

## Detailed description of the pull request / Additional comments
Changed the Windows Customization navigation icon to 'Developer Tools' icon

## Validation steps performed
* Open Dev Home
* Check that Windows customization navigation icon is 'Developer Tools' icon, not settings cog icon
![image](https://github.com/user-attachments/assets/10ace42e-ebeb-496c-ae2b-313e8619797c)


## PR checklist
- [X] Closes #3413 
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
