### PR TITLE
Align the process list with the page title

### DIFF
--- a/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ProcessListPage.xaml
@@ -25,7 +25,7 @@
 
         <TextBlock x:Uid="ProcessListHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
-        <Grid Margin="16,16,0,0" Grid.Row="1">
+        <Grid Margin="0,16,0,0" Grid.Row="1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -55,7 +55,7 @@
 
         <controls:DataGrid
             x:Uid="ProcessDataGrid"
-            x:Name="ProcessDataGrid" Grid.Row="2" Margin="16,4,0,0"
+            x:Name="ProcessDataGrid" Grid.Row="2" Margin="0,4,0,0"
             VerticalScrollBarVisibility="Visible"
             AlternatingRowBackground="Transparent"
             AlternatingRowForeground="Gray"


### PR DESCRIPTION
## Summary of the pull request

Align the process list with the page title.

## References and relevant issues

Fixes #3324 

## Detailed description of the pull request / Additional comments

Set the process list page grid and datagrid left margins to 0 in order to align the process list with the page title. This maintains consistency with the margins contained on the other pages.

Before:

![process-list-before](https://github.com/user-attachments/assets/1f01ba52-079b-4765-acdf-960c2a3ee23f)

After:

![process-list-after](https://github.com/user-attachments/assets/a137dd34-d360-4910-bbec-4c3586ba3f06)

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
