### PR TITLE
Deal with CommandBar app labels

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/ExternalTool.cs
+++ b/tools/PI/DevHome.PI/Helpers/ExternalTool.cs
@@ -57,10 +57,6 @@ public partial class ExternalTool : ObservableObject
     [property: JsonIgnore]
     private SoftwareBitmapSource? _toolIcon;
 
-    [ObservableProperty]
-    [property: JsonIgnore]
-    private ImageIcon? _menuIcon;
-
     public ExternalTool(
         string name,
         string executable,
@@ -108,11 +104,6 @@ public partial class ExternalTool : ObservableObject
                     ToolIcon = await GetSoftwareBitmapSourceFromSoftwareBitmapAsync(softwareBitmap);
                 }
             }
-
-            MenuIcon = new ImageIcon
-            {
-                Source = ToolIcon,
-            };
         }
         catch (Exception ex)
         {

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -122,8 +122,7 @@
                 </CommandBar>
             </StackPanel>
 
-            <CommandBar x:Name="MyCommandBar" HorizontalAlignment="Left" IsDynamicOverflowEnabled="True" Grid.Column="1" Opening="MyCommandBar_Opening" Closed="MyCommandBar_Closing" />
-
+            <CommandBar x:Name="MyCommandBar" HorizontalAlignment="Left" IsDynamicOverflowEnabled="False" DefaultLabelPosition="Collapsed" Grid.Column="1" />
 
             <CommandBar Grid.Column="2">
                 <AppBarSeparator/>

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -23,8 +23,6 @@ using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.Shell.Common;
 using WinRT.Interop;
 using WinUIEx;
 using static DevHome.PI.Helpers.CommonHelper;
@@ -34,6 +32,12 @@ namespace DevHome.PI;
 
 public partial class BarWindowHorizontal : WindowEx
 {
+    private enum PinOption
+    {
+        Pin,
+        UnPin,
+    }
+
     private const string ExpandButtonText = "\ue70d"; // ChevronDown
     private const string CollapseButtonText = "\ue70e"; // ChevronUp
     private const string ManageToolsButtonText = "\uec7a"; // ChevronUp
@@ -179,7 +183,7 @@ public partial class BarWindowHorizontal : WindowEx
         }
     }
 
-    private void AddToolToCommandBar(ExternalTool tool)
+    private AppBarButton CreateAppBarButton(ExternalTool tool, PinOption pinOption)
     {
         AppBarButton button = new AppBarButton
         {
@@ -187,52 +191,71 @@ public partial class BarWindowHorizontal : WindowEx
             Tag = tool,
         };
 
-        button.Icon = tool.MenuIcon;
+        button.Icon = new ImageIcon
+        {
+            Source = tool.ToolIcon,
+        };
 
         button.Click += _viewModel.ExternalToolButton_Click;
+        button.ContextFlyout = CreateMenuFlyout(tool, pinOption);
 
+        ToolTipService.SetToolTip(button, tool.Name);
+
+        return button;
+    }
+
+    private MenuFlyout CreateMenuFlyout(ExternalTool tool, PinOption pinOption)
+    {
         MenuFlyout menu = new MenuFlyout();
-        menu.Items.Add(tool.IsPinned ? CreateUnPinMenuItem(tool) : CreatePinMenuItem(tool));
+        menu.Items.Add(pinOption == PinOption.Pin ? CreatePinMenuItem(tool) : CreateUnPinMenuItem(tool));
         menu.Items.Add(CreateUnregisterMenuItem(tool));
-        button.ContextFlyout = menu;
 
-        // If a tool is pinned, we'll add it to the primary commands list, otherwise the secondary commands list
+        return menu;
+    }
+
+    private void AddToolToCommandBar(ExternalTool tool)
+    {
+        // We create 2 copies of the button, one for the primary commands list and one for the secondary commands list.
+        // We're not allowed to put the same button in both lists.
+        AppBarButton pinnedButton = CreateAppBarButton(tool, PinOption.UnPin); // The pinned button should always have the unpin option
+        AppBarButton unPinnedButton = CreateAppBarButton(tool, tool.IsPinned ? PinOption.UnPin : PinOption.Pin); // The unpinned button is dynamic
+
+        // If a tool is pinned, we'll add it to the primary commands list.
         if (tool.IsPinned)
         {
-            MyCommandBar.PrimaryCommands.Add(button);
+            MyCommandBar.PrimaryCommands.Add(pinnedButton);
         }
-        else
-        {
-            MyCommandBar.SecondaryCommands.Add(button);
-        }
+
+        // We'll always add all tools to the secondary commands list.
+        MyCommandBar.SecondaryCommands.Add(unPinnedButton);
 
         tool.PropertyChanged += (sender, args) =>
         {
-            if (args.PropertyName == nameof(ExternalTool.MenuIcon))
+            if (args.PropertyName == nameof(ExternalTool.ToolIcon))
             {
-                button.Icon = tool.MenuIcon;
+                // An ImageIcon can only be set once, so we can't share it with both buttons
+                pinnedButton.Icon = new ImageIcon
+                {
+                    Source = tool.ToolIcon,
+                };
+
+                unPinnedButton.Icon = new ImageIcon
+                {
+                    Source = tool.ToolIcon,
+                };
             }
             else if (args.PropertyName == nameof(ExternalTool.IsPinned))
             {
-                // The command bar does not like to be updated when the overflow menu is open, so be sure to close it before manipulating elements.
-                MyCommandBar.IsOpen = false;
-
-                // Flip the menu item from pin to unpin (or vice versa)
-                MenuFlyout menu = new MenuFlyout();
-                menu.Items.Add(tool.IsPinned ? CreateUnPinMenuItem(tool) : CreatePinMenuItem(tool));
-                menu.Items.Add(CreateUnregisterMenuItem(tool));
-                button.ContextFlyout = menu;
-
                 // If a tool is pinned, we'll add it to the primary commands list, otherwise the secondary commands list
+                unPinnedButton.ContextFlyout = CreateMenuFlyout(tool, tool.IsPinned ? PinOption.UnPin : PinOption.Pin);
+
                 if (tool.IsPinned)
                 {
-                    MyCommandBar.SecondaryCommands.Remove(button);
-                    MyCommandBar.PrimaryCommands.Add(button);
+                    MyCommandBar.PrimaryCommands.Add(pinnedButton);
                 }
                 else
                 {
-                    MyCommandBar.PrimaryCommands.Remove(button);
-                    MyCommandBar.SecondaryCommands.Add(button);
+                    MyCommandBar.PrimaryCommands.Remove(pinnedButton);
                 }
 
                 EvaluateLocationOfManageToolsButton();
@@ -345,23 +368,28 @@ public partial class BarWindowHorizontal : WindowEx
                 Debug.Assert(e.OldItems is not null, "Why is old items null");
                 foreach (ExternalTool oldItem in e.OldItems)
                 {
-                    // Find this item in the command bar
-                    AppBarButton? button = MyCommandBar.PrimaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
-                    if (button is not null)
+                    if (oldItem.IsPinned)
                     {
-                        MyCommandBar.PrimaryCommands.Remove(button);
-                    }
-                    else
-                    {
-                        button = MyCommandBar.SecondaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
-                        if (button is not null)
+                        // Find this item in the command bar
+                        AppBarButton? pinnedButton = MyCommandBar.PrimaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
+                        if (pinnedButton is not null)
                         {
-                            MyCommandBar.SecondaryCommands.Remove(button);
+                            MyCommandBar.PrimaryCommands.Remove(pinnedButton);
                         }
                         else
                         {
                             Debug.Assert(false, "Could not find button for tool");
                         }
+                    }
+
+                    AppBarButton? button = MyCommandBar.SecondaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
+                    if (button is not null)
+                    {
+                        MyCommandBar.SecondaryCommands.Remove(button);
+                    }
+                    else
+                    {
+                        Debug.Assert(false, "Could not find button for tool");
                     }
                 }
 
@@ -532,7 +560,6 @@ public partial class BarWindowHorizontal : WindowEx
         // Make sure we cache the state before switching to collapsed bar.
         CacheRestoreState();
         LargeContentPanel.Visibility = Visibility.Collapsed;
-        SetBarToDefaultHeight();
     }
 
     internal void NavigateTo(Type viewModelType)
@@ -614,35 +641,5 @@ public partial class BarWindowHorizontal : WindowEx
             ExpandCollapseLayoutButtonText.Foreground = brush;
             RotateLayoutButtonText.Foreground = brush;
         }
-    }
-
-    private void SetBarToDefaultHeight()
-    {
-        if (!_viewModel.ShowingExpandedContent)
-        {
-            this.Height = FloatingHorizontalBarHeight;
-            this.MaxHeight = FloatingHorizontalBarHeight;
-            this.MinHeight = FloatingHorizontalBarHeight;
-            this.AppWindow.Resize(new Windows.Graphics.SizeInt32(this.AppWindow.Size.Width, FloatingHorizontalBarHeight));
-        }
-    }
-
-    // CommandBar has an issue where, if the overflow menu opens and the app's window size is too small,
-    // the overflow menu will always appear above the app window and will go off screen. Bug has been filed,
-    // but in the meantime, we'll adjust our window's size to when the overflow menu opens, and set it back
-    // to default after it is closed in order to work around this issue.
-    private void MyCommandBar_Opening(object sender, object e)
-    {
-        if (!_viewModel.ShowingExpandedContent)
-        {
-            this.Height = FloatingHorizontalBarHeightWithExpandedCommandBar;
-            this.MaxHeight = FloatingHorizontalBarHeightWithExpandedCommandBar;
-            this.MinHeight = FloatingHorizontalBarHeightWithExpandedCommandBar;
-        }
-    }
-
-    private void MyCommandBar_Closing(object sender, object e)
-    {
-        SetBarToDefaultHeight();
     }
 }

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -207,7 +207,7 @@ public partial class BarWindowHorizontal : WindowEx
     private MenuFlyout CreateMenuFlyout(ExternalTool tool, PinOption pinOption)
     {
         MenuFlyout menu = new MenuFlyout();
-        menu.Items.Add(pinOption == PinOption.Pin ? CreatePinMenuItem(tool) : CreateUnPinMenuItem(tool));
+        menu.Items.Add(CreatePinMenuItem(tool, pinOption));
         menu.Items.Add(CreateUnregisterMenuItem(tool));
 
         return menu;
@@ -217,29 +217,29 @@ public partial class BarWindowHorizontal : WindowEx
     {
         // We create 2 copies of the button, one for the primary commands list and one for the secondary commands list.
         // We're not allowed to put the same button in both lists.
-        AppBarButton pinnedButton = CreateAppBarButton(tool, PinOption.UnPin); // The pinned button should always have the unpin option
-        AppBarButton unPinnedButton = CreateAppBarButton(tool, tool.IsPinned ? PinOption.UnPin : PinOption.Pin); // The unpinned button is dynamic
+        AppBarButton primaryCommandButton = CreateAppBarButton(tool, PinOption.UnPin); // The primary button should always have the unpin option
+        AppBarButton secondaryCommandButton = CreateAppBarButton(tool, tool.IsPinned ? PinOption.UnPin : PinOption.Pin); // The secondary button is dynamic
 
         // If a tool is pinned, we'll add it to the primary commands list.
         if (tool.IsPinned)
         {
-            MyCommandBar.PrimaryCommands.Add(pinnedButton);
+            MyCommandBar.PrimaryCommands.Add(primaryCommandButton);
         }
 
         // We'll always add all tools to the secondary commands list.
-        MyCommandBar.SecondaryCommands.Add(unPinnedButton);
+        MyCommandBar.SecondaryCommands.Add(secondaryCommandButton);
 
         tool.PropertyChanged += (sender, args) =>
         {
             if (args.PropertyName == nameof(ExternalTool.ToolIcon))
             {
                 // An ImageIcon can only be set once, so we can't share it with both buttons
-                pinnedButton.Icon = new ImageIcon
+                primaryCommandButton.Icon = new ImageIcon
                 {
                     Source = tool.ToolIcon,
                 };
 
-                unPinnedButton.Icon = new ImageIcon
+                secondaryCommandButton.Icon = new ImageIcon
                 {
                     Source = tool.ToolIcon,
                 };
@@ -247,15 +247,15 @@ public partial class BarWindowHorizontal : WindowEx
             else if (args.PropertyName == nameof(ExternalTool.IsPinned))
             {
                 // If a tool is pinned, we'll add it to the primary commands list, otherwise the secondary commands list
-                unPinnedButton.ContextFlyout = CreateMenuFlyout(tool, tool.IsPinned ? PinOption.UnPin : PinOption.Pin);
+                secondaryCommandButton.ContextFlyout = CreateMenuFlyout(tool, tool.IsPinned ? PinOption.UnPin : PinOption.Pin);
 
                 if (tool.IsPinned)
                 {
-                    MyCommandBar.PrimaryCommands.Add(pinnedButton);
+                    MyCommandBar.PrimaryCommands.Add(primaryCommandButton);
                 }
                 else
                 {
-                    MyCommandBar.PrimaryCommands.Remove(pinnedButton);
+                    MyCommandBar.PrimaryCommands.Remove(primaryCommandButton);
                 }
 
                 EvaluateLocationOfManageToolsButton();
@@ -310,28 +310,16 @@ public partial class BarWindowHorizontal : WindowEx
         }
     }
 
-    private MenuFlyoutItem CreatePinMenuItem(ExternalTool tool)
+    private MenuFlyoutItem CreatePinMenuItem(ExternalTool tool, PinOption pinOption)
     {
-        MenuFlyoutItem pin = new MenuFlyoutItem
+        MenuFlyoutItem item = new MenuFlyoutItem
         {
-            Text = _pinMenuItemText,
+            Text = pinOption == PinOption.Pin ? _pinMenuItemText : _unpinMenuItemText,
             Command = tool.TogglePinnedStateCommand,
             Icon = new FontIcon() { Glyph = tool.PinGlyph },
         };
 
-        return pin;
-    }
-
-    private MenuFlyoutItem CreateUnPinMenuItem(ExternalTool tool)
-    {
-        MenuFlyoutItem unpin = new MenuFlyoutItem
-        {
-            Text = _unpinMenuItemText,
-            Command = tool.TogglePinnedStateCommand,
-            Icon = new FontIcon() { Glyph = tool.PinGlyph },
-        };
-
-        return unpin;
+        return item;
     }
 
     private MenuFlyoutItem CreateUnregisterMenuItem(ExternalTool tool)


### PR DESCRIPTION
## Summary of the pull request

We were using the standard behavior for the CommandBar to show text labels when the bar was expanded.

![image](https://github.com/user-attachments/assets/491c879d-4438-49d3-b3f1-b5d1c95c7a54)

It kind of looks bad, especially for tool names that take up multiple lines. It also requires the bar to be enlarged to show the text labels, and if the bar isn't enlarged enough, the popup menu goes up (and off the screen) instead of down.

Additionally, using the dynamic overflow feature of the command bar caused the list of tools to be fragmented... a list of pinned tools and a list of non-pinned tools.

This updates the CommandBar to no longer try and put labels on the expanded CommandBar, and turns off dynamic overflow, and will only show one list of External Tools (SecondaryCommands for those looking at the code). The order of these tools should stay consistent, and all tools will show up in the dropdown menu regardless if the tool is pinned or not.

This also adds tooltips to the bar.

![image](https://github.com/user-attachments/assets/385fe76a-011e-4ab5-886f-c3fe46922ef3)

## References and relevant issues

## Detailed description of the pull request / Additional comments

This also removes the MenuIcon property from an ExternalTool. This exposed ImageIcon is good for "1 use only" and is too tempting to just use (and unfortunately there isn't an ImageIcon.Copy() or Clone().

This also lets me remove all of the dynamic resizing of the bar that I had previously added.


## Validation steps performed

## PR checklist
- [ ] Closes #3391 #3380 
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
