### PR TITLE
Allow widgets to be rearranged by keyboard

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/WidgetViewModel.cs
@@ -49,6 +49,9 @@ public partial class WidgetViewModel : ObservableObject
     private readonly WidgetAdaptiveCardRenderingService _renderingService;
     private readonly IScreenReaderService _screenReaderService;
 
+    private readonly AdaptiveElementParserRegistration _elementParser;
+    private readonly AdaptiveActionParserRegistration _actionParser;
+
     private RenderedAdaptiveCard _renderedCard;
 
     [ObservableProperty]
@@ -114,6 +117,12 @@ public partial class WidgetViewModel : ObservableObject
         Widget = widget;
         WidgetSize = widgetSize;
         WidgetDefinition = widgetDefinition;
+
+        // Use custom parser.
+        _elementParser = new AdaptiveElementParserRegistration();
+        _elementParser.Set(LabelGroup.CustomTypeString, new LabelGroupParser());
+        _actionParser = new AdaptiveActionParserRegistration();
+        _actionParser.Set(ChooseFileAction.CustomTypeString, new ChooseFileParser());
     }
 
     public async Task RenderAsync()
@@ -154,14 +163,8 @@ public partial class WidgetViewModel : ObservableObject
                 var context = new EvaluationContext(cardData, hostData);
                 var json = template.Expand(context);
 
-                // Use custom parser.
-                var elementParser = new AdaptiveElementParserRegistration();
-                elementParser.Set(LabelGroup.CustomTypeString, new LabelGroupParser());
-                var actionParser = new AdaptiveActionParserRegistration();
-                actionParser.Set(ChooseFileAction.CustomTypeString, new ChooseFileParser());
-
                 // Create adaptive card.
-                card = AdaptiveCard.FromJsonString(json, elementParser, actionParser);
+                card = AdaptiveCard.FromJsonString(json, _elementParser, _actionParser);
             }
             catch (Exception ex)
             {

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -85,7 +85,9 @@
                               ItemsSource="{x:Bind ViewModel.PinnedWidgets, Mode=OneWay}"
                               CanReorderItems="True"
                               CanDragItems="True"
-                              DragItemsStarting="WidgetGridView_DragItemsStarting">
+                              DragItemsStarting="WidgetGridView_DragItemsStarting"
+                              SelectionMode="Single"
+                              SingleSelectionFollowsFocus="True">
                         <GridView.ItemTemplate>
                             <DataTemplate x:DataType="vm:WidgetViewModel">
                                 <controls:WidgetControl WidgetSource="{x:Bind}"
@@ -99,7 +101,8 @@
                             <ItemsPanelTemplate>
                                 <controls:WidgetBoard XYFocusKeyboardNavigation="Enabled"
                                                       XYFocusRightNavigationStrategy="RectilinearDistance"
-                                                      XYFocusLeftNavigationStrategy="RectilinearDistance"/>
+                                                      XYFocusLeftNavigationStrategy="RectilinearDistance"
+                                                      KeyUp="HandleKeyUpAsync" />
                             </ItemsPanelTemplate>
                         </GridView.ItemsPanel>
                         <GridView.ItemContainerStyle>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -20,6 +20,7 @@ using DevHome.Dashboard.Services;
 using DevHome.Dashboard.TelemetryEvents;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Telemetry;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -28,10 +29,9 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
-using Windows.System;
 using Windows.UI.Core;
 
-using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
+using VirtualKey = Windows.System.VirtualKey;
 
 namespace DevHome.Dashboard.Views;
 
@@ -475,11 +475,11 @@ public partial class DashboardView : ToolPage, IDisposable
     {
         if (RuntimeHelper.IsOnWindows11)
         {
-            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
+            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
         }
         else
         {
-            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
+            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
         }
     }
 
@@ -883,7 +883,7 @@ public partial class DashboardView : ToolPage, IDisposable
             }
 
             var focusedItem = e.OriginalSource as GridViewItem;
-            if (focusedItem == null || focusedItem.Content == null || focusedItem.Content is not WidgetViewModel widgetViewModel)
+            if (focusedItem?.Content is not WidgetViewModel widgetViewModel)
             {
                 return;
             }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -20,13 +20,18 @@ using DevHome.Dashboard.Services;
 using DevHome.Dashboard.TelemetryEvents;
 using DevHome.Dashboard.ViewModels;
 using DevHome.Telemetry;
-using Microsoft.UI.Dispatching;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.Widgets;
 using Microsoft.Windows.Widgets.Hosts;
 using Serilog;
+using Windows.System;
+using Windows.UI.Core;
+
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 
 namespace DevHome.Dashboard.Views;
 
@@ -41,6 +46,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private readonly WidgetViewModelFactory _widgetViewModelFactory;
 
     private readonly SemaphoreSlim _pinnedWidgetsLock = new(1, 1);
+    private readonly SemaphoreSlim _moveWidgetsLock = new(1, 1);
 
     private static DispatcherQueue _dispatcherQueue;
     private readonly ILocalSettingsService _localSettingsService;
@@ -467,13 +473,13 @@ public partial class DashboardView : ToolPage, IDisposable
     [RelayCommand]
     public async Task GoToWidgetsInStoreAsync()
     {
-        if (Common.Helpers.RuntimeHelper.IsOnWindows11)
+        if (RuntimeHelper.IsOnWindows11)
         {
-            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
+            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WebExperiencePackPackageId}"));
         }
         else
         {
-            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
+            await Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetServiceStorePackageId}"));
         }
     }
 
@@ -817,15 +823,33 @@ public partial class DashboardView : ToolPage, IDisposable
 
         var draggedWidgetViewModel = draggedObject as WidgetViewModel;
 
+        await MoveWidgetAsync(draggedWidgetViewModel, draggedIndex, droppedIndex);
+
+        _log.Debug($"Drop ended");
+    }
+
+    private async Task MoveWidgetAsync(WidgetViewModel draggedWidgetViewModel, int draggedIndex, int droppedIndex)
+    {
         // Remove the moved widget then insert it back in the collection at the new location. If the dropped widget was
         // moved from a lower index to a higher one, removing the moved widget before inserting it will ensure that any
         // widgets between the starting and ending indices move up to replace the removed widget. If the widget was
         // moved from a higher index to a lower one, then the order of removal and insertion doesn't matter.
         ViewModel.PinnedWidgets.CollectionChanged -= OnPinnedWidgetsCollectionChangedAsync;
 
-        ViewModel.PinnedWidgets.RemoveAt(draggedIndex);
         var size = await draggedWidgetViewModel.Widget.GetSizeAsync();
-        await InsertWidgetInPinnedWidgetsAsync(draggedWidgetViewModel.Widget, size, droppedIndex);
+
+        // Doing these operations in different orders for different start/end indexes make the animation look a little better.
+        if (draggedIndex < droppedIndex)
+        {
+            ViewModel.PinnedWidgets.RemoveAt(draggedIndex);
+            await InsertWidgetInPinnedWidgetsAsync(draggedWidgetViewModel.Widget, size, droppedIndex);
+        }
+        else
+        {
+            await InsertWidgetInPinnedWidgetsAsync(draggedWidgetViewModel.Widget, size, droppedIndex);
+            ViewModel.PinnedWidgets.RemoveAt(draggedIndex + 1);
+        }
+
         await WidgetHelpers.SetPositionCustomStateAsync(draggedWidgetViewModel.Widget, droppedIndex);
 
         // Update the CustomState Position of any widgets that were moved.
@@ -839,8 +863,70 @@ public partial class DashboardView : ToolPage, IDisposable
         }
 
         ViewModel.PinnedWidgets.CollectionChanged += OnPinnedWidgetsCollectionChangedAsync;
+    }
 
-        _log.Debug($"Drop ended");
+    /// <summary>
+    /// Handle keyboard shortcuts for moving widgets left and right.
+    /// </summary>
+    private async void HandleKeyUpAsync(object sender, KeyRoutedEventArgs e)
+    {
+        _log.Debug($"Key up");
+
+        await _moveWidgetsLock.WaitAsync();
+        try
+        {
+            var key = e.Key;
+            _log.Debug($"e.Key = {key}");
+            if (e.Handled || !(key == VirtualKey.Left || key == VirtualKey.Right))
+            {
+                return;
+            }
+
+            var focusedItem = e.OriginalSource as GridViewItem;
+            if (focusedItem == null || focusedItem.Content == null || focusedItem.Content is not WidgetViewModel widgetViewModel)
+            {
+                return;
+            }
+
+            if (IsAltAndShiftPressed())
+            {
+                var index = ViewModel.PinnedWidgets.IndexOf(widgetViewModel);
+                _log.Information($"Move widget {widgetViewModel.WidgetDisplayTitle} at index {index} {key}");
+
+                if (key == VirtualKey.Left && index > 0)
+                {
+                    await MoveWidgetAsync(widgetViewModel, index, index - 1);
+                    await FocusManager.TryFocusAsync(WidgetGridView.ItemsPanelRoot.Children.ElementAt(index - 1), FocusState.Keyboard);
+                    _log.Debug($"Focus moved to index {index - 1}");
+                }
+                else if (key == VirtualKey.Right && index < (ViewModel.PinnedWidgets.Count - 1))
+                {
+                    // Setting focus before and after the move looks more natural than letting the focus move to the wrong element.
+                    await FocusManager.TryFocusAsync(WidgetGridView.ItemsPanelRoot.Children.ElementAt(index + 1), FocusState.Keyboard);
+                    await MoveWidgetAsync(widgetViewModel, index, index + 1);
+                    await FocusManager.TryFocusAsync(WidgetGridView.ItemsPanelRoot.Children.ElementAt(index + 1), FocusState.Keyboard);
+                    _log.Debug($"Focus moved to index {index + 1}");
+                }
+            }
+
+            e.Handled = true;
+        }
+        finally
+        {
+            _moveWidgetsLock.Release();
+        }
+    }
+
+    private bool IsAltAndShiftPressed()
+    {
+        var downState = CoreVirtualKeyStates.Down;
+
+        // VirtualKeys "Menu" key is also the "Alt" key on the keyboard.
+        var isAltKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu) & downState) == downState;
+        var isShiftKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift) & downState) == downState;
+        _log.Debug($"isAltKeyPressed = {isAltKeyPressed} isShiftKeyPressed = {isShiftKeyPressed}");
+
+        return isAltKeyPressed && isShiftKeyPressed;
     }
 
     public void Dispose()
@@ -856,6 +942,7 @@ public partial class DashboardView : ToolPage, IDisposable
             if (disposing)
             {
                 _pinnedWidgetsLock.Dispose();
+                _moveWidgetsLock.Dispose();
             }
 
             _disposedValue = true;


### PR DESCRIPTION
## Summary of the pull request
Allows widgets to be rearranged via Alt+Shift+LeftArrow and Alt+Shift+RightArrow keyboard commands.

Separately, create widget's ActionParser and ElementParser only once and reuse them, since they never change.

## References and relevant issues
https://task.ms/49658818

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated locally.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
