### PR TITLE
Restore maximized window when a second instance is launched

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -25,16 +25,15 @@ using DevHome.Telemetry;
 using DevHome.Utilities.Extensions;
 using DevHome.ViewModels;
 using DevHome.Views;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Dispatching;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 using Serilog;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace DevHome;
 
@@ -185,14 +184,14 @@ public partial class App : Application, IApp
     {
         _dispatcherQueue.TryEnqueue(() =>
         {
-            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(MainWindow);
-            if (PInvoke.IsIconic(new HWND(hWnd)) && MainWindow.AppWindow.Presenter is OverlappedPresenter overlappedPresenter)
+            var hWnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(MainWindow));
+            if (PInvoke.IsIconic(hWnd))
             {
-                overlappedPresenter.Restore(true);
+                PInvoke.ShowWindow(hWnd, SHOW_WINDOW_CMD.SW_RESTORE);
             }
             else
             {
-                PInvoke.SetForegroundWindow(new HWND(hWnd));
+                PInvoke.SetForegroundWindow(hWnd);
             }
         });
     }

--- a/src/NativeMethods.txt
+++ b/src/NativeMethods.txt
@@ -4,3 +4,4 @@ GetSystemInfo
 CoCreateInstance
 SetForegroundWindow
 IsIconic
+ShowWindow


### PR DESCRIPTION
## Summary of the pull request

## References and relevant issues

#3436

## Detailed description of the pull request / Additional comments

Fixed an issue where maximized state of DevHome window is lost when a second instance is launched with the main one minimized on taskbar.

## Validation steps performed

Manually tested with the main DevHome minimized on taskbar:
- With maximized window
- With a small window

## PR checklist
- [x] Closes #3436
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
