### PR TITLE
Telemetry tagging fix for CloneRepoNextStepsEvent

### DIFF
--- a/common/TelemetryEvents/SetupFlow/SummaryPage/CloneRepoNextStepEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/SummaryPage/CloneRepoNextStepEvent.cs
@@ -15,7 +15,7 @@ public class CloneRepoNextStepEvent : EventBase
 
     public string RepoName { get; }
 
-    public override PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServicePerformance;
+    public override PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
 
     public CloneRepoNextStepEvent(string operation, string repoName)
     {


### PR DESCRIPTION
## Summary of the pull request
This event is currently reported in CloneRepoSummaryInformationFileViewModel.cs in direct response to user clicks to run or view repo config files and hence should be re-tagged as ProductAndServiceUsage

## References and relevant issues
#3438

## PR checklist
- [X] Closes #3438
- [ ] Tests added/passed
- [ ] Documentation updated
- [X] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
