### PR TITLE
Added tooltip for the "More button (. . .)" in the added environments list item

### DIFF
--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -344,11 +344,19 @@
     <comment>Text for when the environment page in Dev Home is empty and the user has no extensions installed that support environments</comment>
   </data>
   <data name="MoreOptionsButtonName" xml:space="preserve">
-    <value>More Options</value>
+    <value>More options</value>
     <comment>The text narrator should say for the ... button</comment>
   </data>
   <data name="SyncEnvironmentsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sync</value>
     <comment>Accessible name for the button to sync environments.</comment>
+  </data>
+  <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>More options</value>
+    <comment>ToolTip for the button that displays "More Options" menu</comment>
+  </data>
+  <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>More options</value>
+    <comment>Name of the button that brings up the "More options" menu</comment>
   </data>
 </root>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -65,9 +65,8 @@
             <DataTemplate x:Key="ThreeDotsButton" x:DataType="vm:ComputeSystemViewModel">
                 <Grid>
                     <Button
-                        Style="{StaticResource HorizontalThreeDotsStyle}"
-                        AutomationProperties.Name="{x:Bind MoreOptionsButtonName}"
-                        ToolTipService.ToolTip="{x:Bind MoreOptionsButtonName}"> 
+                        x:Uid="MoreOptionsButton"
+                        Style="{StaticResource HorizontalThreeDotsStyle}"> 
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}"/>
                         </Button.Flyout>

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -66,7 +66,8 @@
                 <Grid>
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}"
-                        AutomationProperties.Name="{x:Bind MoreOptionsButtonName}">
+                        AutomationProperties.Name="{x:Bind MoreOptionsButtonName}"
+                        ToolTipService.ToolTip="{x:Bind MoreOptionsButtonName}"> 
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}"/>
                         </Button.Flyout>
@@ -79,7 +80,8 @@
                 <Grid>
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}"
-                        AutomationProperties.Name="{x:Bind MoreOptionsButtonName}">
+                        AutomationProperties.Name="{x:Bind MoreOptionsButtonName}"
+                        ToolTipService.ToolTip="{x:Bind MoreOptionsButtonName}">
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}" />
                         </Button.Flyout>


### PR DESCRIPTION
## Summary of the pull request
Added tooltip for the "More button (. . .)" in the added environments list item

## References and relevant issues
https://task.ms/52448403
#3012 

## Detailed description of the pull request / Additional comments
Added a tooltip to the Three Dots Button template in LandingPage.xaml. I changed the MoreOptionsButtonName from "More Options" to "More options" to match a similar change made in #3012 

## Validation steps performed
1. Open Dev Home
2. Click on Environments tab on the navigation bar
3. If there are no environments on the page, add enough so there is one of each type
For each environment type:
4. Hover over the "..." button in the upper right corner
5. Verify that there is a tooltip saying "More options"

## PR checklist
- [ ] Closes N/A
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
