### PR TITLE
Fix issues where launching an external tool that requires elevation.

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/ExternalTool.cs
+++ b/tools/PI/DevHome.PI/Helpers/ExternalTool.cs
@@ -187,7 +187,7 @@ public partial class ExternalTool : ObservableObject
                     {
                         FileName = finalExecutable,
                         Arguments = finalArguments,
-                        UseShellExecute = false,
+                        UseShellExecute = true,
                     };
                     process = Process.Start(startInfo);
                 }


### PR DESCRIPTION
## Summary of the pull request
Utlizes shellexecute to launch external tools and this solves the issue with executables that require elevation in their sxs manifest.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated elevated and non-elevated tools successfully launch in PI.

## PR checklist
- [x] Closes #3423 
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
