### PR TITLE
Ensure that PI shows up in the foreground when Win-F12 is hit.

### DIFF
--- a/tools/PI/DevHome.PI/Views/BarWindow.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindow.cs
@@ -32,7 +32,7 @@ public partial class BarWindow
     {
         get
         {
-            if (_horizontalWindow.Visible)
+            if (_viewModel.BarOrientation == Orientation.Horizontal)
             {
                 return _horizontalWindow.ThisHwnd;
             }

--- a/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.UI.Xaml;
 using Windows.System;
 using Windows.Win32;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
+using Windows.Win32.UI.WindowsAndMessaging;
 using WinUIEx;
 using static DevHome.PI.Helpers.WindowHelper;
 
@@ -46,6 +47,8 @@ public sealed partial class PrimaryWindow : WindowEx
         }
         else
         {
+            PInvoke.ShowWindow(DBarWindow.CurrentHwnd, SHOW_WINDOW_CMD.SW_RESTORE);
+
             // Activate is unreliable so use SetForegroundWindow
             PInvoke.SetForegroundWindow(DBarWindow.CurrentHwnd);
         }
@@ -98,6 +101,6 @@ public sealed partial class PrimaryWindow : WindowEx
             TargetAppData.Instance.SetNewAppData(process, hWnd);
         }
 
-        DBarWindow ??= new();
+        ShowBarWindow();
     }
 }


### PR DESCRIPTION
## Summary of the pull request
PI would not come to foreground if the PI window is minimized or obscured when the hotkey (Win-F12) is pressed.
This change now causes PI to restore itself prior to setting its window as foreground.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Launched PI via a variety of mechanisms and validated it came to the foreground.
This included via commandline, Dev Home utility page and hotkey.

## PR checklist
- [x] Closes #3414 
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
