### PR TITLE
[PI] Get correct process for UWP app

### DIFF
--- a/tools/PI/DevHome.PI/Controls/ProcessSelectionButton.cs
+++ b/tools/PI/DevHome.PI/Controls/ProcessSelectionButton.cs
@@ -49,6 +49,7 @@ public class ProcessSelectionButton : Button
         WindowHelper.GetAppInfoUnderMouseCursor(out p, out hwnd);
         if (p != null)
         {
+            WindowHelper.TranslateUWPProcess(hwnd, ref p);
             TargetAppData.Instance.SetNewAppData(p, hwnd);
         }
 

--- a/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/WindowHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;

--- a/tools/PI/DevHome.PI/NativeMethods.txt
+++ b/tools/PI/DevHome.PI/NativeMethods.txt
@@ -9,6 +9,7 @@ CreateRoundRectRgn
 DwmGetWindowAttribute
 DwmSetWindowAttribute
 DwmSetWindowAttribute
+EnumChildWindows
 EnumThreadWindows
 EnumWindows
 GetAncestor

--- a/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
@@ -98,6 +98,7 @@ public sealed partial class PrimaryWindow : WindowEx
                 return;
             }
 
+            TranslateUWPProcess(hWnd, ref process);
             TargetAppData.Instance.SetNewAppData(process, hWnd);
         }
 


### PR DESCRIPTION
## Summary of the pull request

Attach to the correct process instead of `ApplicationFrameHost` when PI targets an UWP app window using shortcut or finder tool.

## References and relevant issues

#3441

## Detailed description of the pull request / Additional comments

Adopted the same logic used in PowerToys Run Window Walker plugin to show correct info for UWP windows.

## Validation steps performed

Manually tested using Windows 10 UWP apps: Photos, Calculator and Feedback Hub.
- Shortcut: PI attach to the correct process
- Finder tool: PI attach to the correct process
- Select `ApplicationFrameHost` from process list: PI attach to `ApplicationFrameHost`

## PR checklist
- [x] Closes #3441
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Telemetry [compliance tasks](https://aka.ms/devhome-telemetry) completed for added/updated events
