### PR TITLE
Project Ironsides - Fix various sizing issues 

### DIFF
--- a/common/TelemetryEvents/SetupFlow/SummaryPage/CloneRepoNextStepEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/SummaryPage/CloneRepoNextStepEvent.cs
@@ -15,7 +15,7 @@ public class CloneRepoNextStepEvent : EventBase
 
     public string RepoName { get; }
 
-    public override PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServicePerformance;
+    public override PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
 
     public CloneRepoNextStepEvent(string operation, string repoName)
     {

--- a/tools/PI/DevHome.PI/App.config
+++ b/tools/PI/DevHome.PI/App.config
@@ -54,11 +54,14 @@
             </ArrayOfString>
           </value>
         </setting>
-        <setting name="ExpandedLargeSize" serializeAs="String">
-          <value>0, 0</value>
+        <setting name="ExpandedWindowHeight" serializeAs="String">
+          <value>0</value>
         </setting>
         <setting name="ApplyAppFilteringToData" serializeAs="String">
           <value>True</value>
+        </setting>
+        <setting name="WindowWidth" serializeAs="String">
+          <value>0</value>
         </setting>
       </DevHome.PI.Properties.Settings>
     </userSettings>

--- a/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
+++ b/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
@@ -195,13 +195,13 @@ namespace DevHome.PI.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0, 0")]
-        public global::System.Drawing.Size ExpandedLargeSize {
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int ExpandedWindowHeight {
             get {
-                return ((global::System.Drawing.Size)(this["ExpandedLargeSize"]));
+                return ((int)(this["ExpandedWindowHeight"]));
             }
             set {
-                this["ExpandedLargeSize"] = value;
+                this["ExpandedWindowHeight"] = value;
             }
         }
         
@@ -214,6 +214,18 @@ namespace DevHome.PI.Properties {
             }
             set {
                 this["ApplyAppFilteringToData"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int WindowWidth {
+            get {
+                return ((int)(this["WindowWidth"]));
+            }
+            set {
+                this["WindowWidth"] = value;
             }
         }
     }

--- a/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
+++ b/tools/PI/DevHome.PI/Properties/Settings.Designer.cs
@@ -196,9 +196,9 @@ namespace DevHome.PI.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int ExpandedWindowHeight {
+        public double ExpandedWindowHeight {
             get {
-                return ((int)(this["ExpandedWindowHeight"]));
+                return ((double)(this["ExpandedWindowHeight"]));
             }
             set {
                 this["ExpandedWindowHeight"] = value;
@@ -220,9 +220,9 @@ namespace DevHome.PI.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int WindowWidth {
+        public double WindowWidth {
             get {
-                return ((int)(this["WindowWidth"]));
+                return ((double)(this["WindowWidth"]));
             }
             set {
                 this["WindowWidth"] = value;

--- a/tools/PI/DevHome.PI/Properties/Settings.settings
+++ b/tools/PI/DevHome.PI/Properties/Settings.settings
@@ -48,11 +48,14 @@
   &lt;string&gt;DevEnv&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
-    <Setting Name="ExpandedLargeSize" Type="System.Drawing.Size" Scope="User">
-      <Value Profile="(Default)">0, 0</Value>
+    <Setting Name="ExpandedWindowHeight" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="ApplyAppFilteringToData" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="WindowWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/tools/PI/DevHome.PI/Properties/Settings.settings
+++ b/tools/PI/DevHome.PI/Properties/Settings.settings
@@ -48,13 +48,13 @@
   &lt;string&gt;DevEnv&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
-    <Setting Name="ExpandedWindowHeight" Type="System.Int32" Scope="User">
+    <Setting Name="ExpandedWindowHeight" Type="System.Double" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="ApplyAppFilteringToData" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="WindowWidth" Type="System.Int32" Scope="User">
+    <Setting Name="WindowWidth" Type="System.Double" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
   </Settings>

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -27,7 +27,7 @@
         </Grid.RowDefinitions>
 
         <!--Chrome buttons for a horizontal bar -->
-        <Grid x:Name="HorizontalBar" Background="Transparent" VerticalAlignment="Center" Height="31" Grid.Row="0" LayoutUpdated="{x:Bind SetRegionsForTitleBar}">
+        <Grid x:Name="HorizontalBar" Background="Transparent" VerticalAlignment="Center" Height="31" Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="LeftPaddingColumn" Width="0"/>
                 <ColumnDefinition x:Name="ExtraSystemButtons" Width="*"/>
@@ -35,14 +35,14 @@
             </Grid.ColumnDefinitions>
 
             <TextBlock x:Uid="Title" Grid.Column="1" Style="{StaticResource CaptionTextBlockStyle}" Margin="10,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" />
-            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Background="Transparent" Grid.Column="1" >
+            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}" LayoutUpdated="{x:Bind TitlebarLayoutUpdate}">
                 <Button
                     x:Uid="SnapButton" 
                     Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}"
                     x:Name="SnapButton" Style="{StaticResource ChromeButton}" 
                     FontSize="{StaticResource CaptionTextBlockFontSize}"
                     Command="{x:Bind _viewModel.ToggleSnapCommand}" 
-                    HorizontalAlignment="Left" 
+                    HorizontalAlignment="Left"
                     IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}"
                     ToolTipService.ToolTip="{x:Bind _viewModel.CurrentSnapToolTip, Mode=OneWay}">
                     <TextBlock x:Name="SnapButtonText" Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -12,6 +12,7 @@
     Title="" MinHeight="90" MinWidth="700" Height="90" Width="700" MaxHeight="90"
     TaskBarIcon="Images/pi.ico"
     Activated="Window_Activated"
+    WindowStateChanged="WindowEx_WindowStateChanged"
     Closed="WindowEx_Closed">
 
     <Window.SystemBackdrop>

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -19,7 +19,7 @@
         <MicaBackdrop/>
     </Window.SystemBackdrop>
 
-    <Grid x:Name="MainPanel" Loaded="MainPanel_Loaded" SizeChanged="MainPanel_SizeChanged">
+    <Grid x:Name="MainPanel" Loaded="MainPanel_Loaded">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -27,15 +27,15 @@
         </Grid.RowDefinitions>
 
         <!--Chrome buttons for a horizontal bar -->
-        <Grid x:Name="HorizontalBar" Background="Transparent" VerticalAlignment="Center" Height="31" Grid.Row="0">
+        <Grid x:Name="HorizontalBar" Background="Transparent" VerticalAlignment="Center" Height="31" Grid.Row="0" LayoutUpdated="{x:Bind SetRegionsForTitleBar}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition x:Name="LeftPaddingColumn" Width="0"/>
                 <ColumnDefinition x:Name="ExtraSystemButtons" Width="*"/>
                 <ColumnDefinition x:Name="RightPaddingColumn" Width="0"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock x:Uid="Title" Grid.Column="1" Style="{StaticResource CaptionTextBlockStyle}" Margin="10,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}">
+            <TextBlock x:Uid="Title" Grid.Column="1" Style="{StaticResource CaptionTextBlockStyle}" Margin="10,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" />
+            <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Background="Transparent" Grid.Column="1" >
                 <Button
                     x:Uid="SnapButton" 
                     Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}"

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -72,6 +72,8 @@ public partial class BarWindowHorizontal : WindowEx
 
     private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
 
+    private float _previousCustomTitleBarOffset;
+
     public BarWindowHorizontal(BarWindowViewModel model)
     {
         _viewModel = model;
@@ -365,13 +367,23 @@ public partial class BarWindowHorizontal : WindowEx
         EvaluateLocationOfManageToolsButton();
     }
 
-    public void SetRegionsForTitleBar()
+    public void TitlebarLayoutUpdate()
     {
         if (AppWindow is null)
         {
             return;
         }
 
+        if (_previousCustomTitleBarOffset != ChromeButtonPanel.ActualOffset.X)
+        {
+            // If the offset has changed, we need to update the regions for the title bar
+            SetRegionsForTitleBar();
+            _previousCustomTitleBarOffset = ChromeButtonPanel.ActualOffset.X;
+        }
+    }
+
+    public void SetRegionsForTitleBar()
+    {
         var scaleAdjustment = MainPanel.XamlRoot.RasterizationScale;
 
         RightPaddingColumn.Width = new GridLength(AppWindow.TitleBar.RightInset / scaleAdjustment);

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -62,22 +62,11 @@ public partial class BarWindowHorizontal : WindowEx
     // Constants that control window sizes
     private const int WindowPositionOffsetY = 30;
     private const int FloatingHorizontalBarHeight = 90;
-    private const int FloatingHorizontalBarHeightWithExpandedCommandBar = 130;
-    private const int DefaultExpandedViewTop = 30;
-    private const int DefaultExpandedViewLeft = 100;
-    private const int RightSideGap = 10;
+
+    // Default size of the expanded view as a percentage of the screen size
+    private const float DefaultExpandedViewHeightofScreen = 0.9f;
 
     private RECT _monitorRect;
-
-    private RestoreState _restoreState = new()
-    {
-        Top = DefaultExpandedViewTop,
-        Left = DefaultExpandedViewLeft,
-        BarOrientation = Orientation.Horizontal,
-        IsLargePanelVisible = true,
-    };
-
-    private double _dpiScale = 1.0;
 
     internal HWND ThisHwnd { get; private set; }
 
@@ -97,12 +86,6 @@ public partial class BarWindowHorizontal : WindowEx
         ExtendsContentIntoTitleBar = true;
         AppWindow.TitleBar.IconShowOptions = IconShowOptions.HideIconAndSystemMenu;
 
-        // Get the default window size. We grab this in the constructor, as
-        // we may try and set our window size before our main panel gets
-        // loaded (and we call SetDefaultPosition)
-        var settingSize = Settings.Default.ExpandedLargeSize;
-        _restoreState.Height = settingSize.Height;
-        _restoreState.Width = settingSize.Width;
         ExpandCollapseLayoutButtonText.Text = _viewModel.ShowingExpandedContent ? CollapseButtonText : ExpandButtonText;
 
         // Precreate the brushes for the caption buttons
@@ -159,11 +142,7 @@ public partial class BarWindowHorizontal : WindowEx
         ThemeName t = ThemeName.Themes.First(t => t.Name == _settings.CurrentTheme);
         SetRequestedTheme(t.Theme);
 
-        // Calculate the DPI scale.
-        _dpiScale = GetDpiScaleForWindow(ThisHwnd);
-
         SetDefaultPosition();
-
         SetRegionsForTitleBar();
 
         PopulateCommandBar();
@@ -408,33 +387,47 @@ public partial class BarWindowHorizontal : WindowEx
 
     private void SetDefaultPosition()
     {
+        // Calculate the DPI scale.
+        var dpiScale = GetDpiScaleForWindow(ThisHwnd);
+
         // If attached to an app it should show up on the monitor that the app is on
         _monitorRect = GetMonitorRectForWindow(_viewModel.ApplicationHwnd ?? TryGetParentProcessHWND() ?? ThisHwnd);
         var screenWidth = _monitorRect.right - _monitorRect.left;
         this.Move(
-            (int)((screenWidth - (Width * _dpiScale)) / 2) + _monitorRect.left,
+            (int)((screenWidth - (Width * dpiScale)) / 2) + _monitorRect.left,
             (int)WindowPositionOffsetY + _monitorRect.top);
 
         // Get the saved settings for the ExpandedView size. On first run, this will be
         // the default 0,0, so we'll set the size proportional to the monitor size.
         // Subsequently, it will be whatever size the user sets.
-        var settingSize = Settings.Default.ExpandedLargeSize;
-        if (settingSize.Width == 0)
+        var settingWidth = Settings.Default.WindowWidth;
+        if (settingWidth == 0)
         {
-            settingSize.Width = (int)((_monitorRect.Width * 2) / (3 * _dpiScale));
+            settingWidth = (int)((_monitorRect.Width * 2) / 3);
+            Settings.Default.WindowWidth = settingWidth;
         }
 
-        if (settingSize.Height == 0)
+        var settingHeight = Settings.Default.ExpandedWindowHeight;
+        if (settingHeight == 0)
         {
-            settingSize.Height = (int)((_monitorRect.Height * 3) / (4 * _dpiScale));
+            settingHeight = (int)((_monitorRect.Height * 3) / 4);
+            Settings.Default.ExpandedWindowHeight = settingHeight;
         }
 
-        Settings.Default.ExpandedLargeSize = settingSize;
-        Settings.Default.Save();
+        // Set the default window width
+        Width = Settings.Default.WindowWidth / dpiScale;
 
-        // Set the default restore state for the ExpandedView size to the (adjusted) settings size.
-        _restoreState.Height = settingSize.Height;
-        _restoreState.Width = settingSize.Width;
+        // And set the default window height
+        if (LargeContentPanel is not null &&
+            LargeContentPanel.Visibility == Visibility.Visible &&
+            this.WindowState != WindowState.Maximized)
+        {
+            Height = Settings.Default.ExpandedWindowHeight / dpiScale;
+        }
+        else
+        {
+            Height = FloatingHorizontalBarHeight / dpiScale;
+        }
     }
 
     internal void UpdatePositionFromHwnd(HWND hwnd)
@@ -448,11 +441,17 @@ public partial class BarWindowHorizontal : WindowEx
     {
         ClipboardMonitor.Instance.Stop();
 
-        if (LargeContentPanel is not null &&
-            LargeContentPanel.Visibility == Visibility.Visible &&
-            this.WindowState != WindowState.Maximized)
+        // Save window size if we're not maximized
+        if (this.WindowState != WindowState.Maximized)
         {
-            CacheRestoreState();
+            if (LargeContentPanel is not null &&
+                LargeContentPanel.Visibility == Visibility.Visible)
+            {
+                Settings.Default.ExpandedWindowHeight = (int)Height;
+            }
+
+            Settings.Default.WindowWidth = (int)Width;
+            Settings.Default.Save();
         }
 
         if (!_isClosing)
@@ -503,21 +502,6 @@ public partial class BarWindowHorizontal : WindowEx
         }
     }
 
-    private void CacheRestoreState()
-    {
-        _restoreState = new()
-        {
-            Left = AppWindow.Position.X,
-            Top = AppWindow.Position.Y,
-            Width = Width,
-            Height = Height,
-            IsLargePanelVisible = LargeContentPanel.Visibility == Visibility.Visible,
-        };
-
-        Settings.Default.ExpandedLargeSize = new System.Drawing.Size((int)Width, (int)Height);
-        Settings.Default.Save();
-    }
-
     private void ExpandLargeContentPanel()
     {
         // We're expanding.
@@ -528,26 +512,31 @@ public partial class BarWindowHorizontal : WindowEx
         var monitorRect = GetMonitorRectForWindow(ThisHwnd);
         var dpiScale = GetDpiScaleForWindow(ThisHwnd);
 
-        // Expand the window but keep the x,y coordinates of top-left most corner of the window the same so it doesn't
-        // jump around the screen.
-        var availableWidth = monitorRect.Width - Math.Abs(AppWindow.Position.X - monitorRect.left) - RightSideGap;
-        _restoreState.Width = (int)((double)availableWidth / dpiScale);
+        // If we're maximized, we need to set the height to the monitor height
+        if (WindowState == WindowState.Maximized)
+        {
+            Height = monitorRect.Height / dpiScale;
+        }
+        else
+        {
+            // Expand the window but keep the x,y coordinates of top-left most corner of the window the same so it doesn't
+            // jump around the screen.
+            var availableHeight = monitorRect.Height - Math.Abs(AppWindow.Position.Y - monitorRect.top);
+            var targetHeight = (int)((double)availableHeight / dpiScale * DefaultExpandedViewHeightofScreen);
 
-        Width = _restoreState.Width;
-
-        var availableHeight = monitorRect.Height - Math.Abs(AppWindow.Position.Y - monitorRect.top);
-
-        _restoreState.Height = (int)((double)availableHeight / dpiScale);
-
-        this.MoveAndResize(
-            AppWindow.Position.X, AppWindow.Position.Y, _restoreState.Width, _restoreState.Height);
+            // Set the height to the smaller of either the cached height or the computed size
+            Height = Math.Min(targetHeight, Settings.Default.ExpandedWindowHeight);
+        }
     }
 
     private void CollapseLargeContentPanel()
     {
         // Make sure we cache the state before switching to collapsed bar.
-        CacheRestoreState();
+        Settings.Default.ExpandedWindowHeight = (int)Height;
         LargeContentPanel.Visibility = Visibility.Collapsed;
+        this.Height = FloatingHorizontalBarHeight;
+        this.MaxHeight = FloatingHorizontalBarHeight;
+        this.MinHeight = FloatingHorizontalBarHeight;
     }
 
     internal void NavigateTo(Type viewModelType)
@@ -628,6 +617,22 @@ public partial class BarWindowHorizontal : WindowEx
             SnapButtonText.Foreground = brush;
             ExpandCollapseLayoutButtonText.Foreground = brush;
             RotateLayoutButtonText.Foreground = brush;
+        }
+    }
+
+    private void WindowEx_WindowStateChanged(object sender, WindowState e)
+    {
+        if (e.Equals(WindowState.Normal))
+        {
+            if (Height == FloatingHorizontalBarHeight)
+            {
+                // If we were in collapsed mode, then maximized, then expanded, then restored, be sure to set the height back to the expanded height
+                // (by default, Windows will set us to the collapsed height)
+                if (_viewModel.ShowingExpandedContent && Height == FloatingHorizontalBarHeight)
+                {
+                    Height = Settings.Default.ExpandedWindowHeight;
+                }
+            }
         }
     }
 }

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -66,8 +66,6 @@ public partial class BarWindowHorizontal : WindowEx
     // Default size of the expanded view as a percentage of the screen size
     private const float DefaultExpandedViewHeightofScreen = 0.9f;
 
-    private RECT _monitorRect;
-
     internal HWND ThisHwnd { get; private set; }
 
     internal ClipboardMonitor? ClipboardMonitor { get; private set; }
@@ -399,11 +397,11 @@ public partial class BarWindowHorizontal : WindowEx
         // Be sure to grab the DPI for that monitor
         var dpiScale = GetDpiScaleForWindow(_viewModel.ApplicationHwnd ?? TryGetParentProcessHWND() ?? ThisHwnd);
 
-        _monitorRect = GetMonitorRectForWindow(_viewModel.ApplicationHwnd ?? TryGetParentProcessHWND() ?? ThisHwnd);
-        var screenWidth = _monitorRect.right - _monitorRect.left;
+        RECT monitorRect = GetMonitorRectForWindow(_viewModel.ApplicationHwnd ?? TryGetParentProcessHWND() ?? ThisHwnd);
+        var screenWidth = monitorRect.right - monitorRect.left;
         this.Move(
-            (int)((screenWidth - (Width * dpiScale)) / 2) + _monitorRect.left,
-            (int)WindowPositionOffsetY + _monitorRect.top);
+            (int)((screenWidth - (Width * dpiScale)) / 2) + monitorRect.left,
+            (int)WindowPositionOffsetY + monitorRect.top);
     }
 
     internal void SetDefaultWidthAndHeight()
@@ -411,17 +409,19 @@ public partial class BarWindowHorizontal : WindowEx
         // Get the saved settings for the ExpandedView size. On first run, this will be
         // the default 0,0, so we'll set the size proportional to the monitor size.
         // Subsequently, it will be whatever size the user sets.
+        RECT monitorRect = GetMonitorRectForWindow(_viewModel.ApplicationHwnd ?? TryGetParentProcessHWND() ?? ThisHwnd);
+
         var settingWidth = Settings.Default.WindowWidth;
         if (settingWidth == 0)
         {
-            settingWidth = (int)((_monitorRect.Width * 2) / 3);
+            settingWidth = monitorRect.Width * 2 / 3;
             Settings.Default.WindowWidth = settingWidth;
         }
 
         var settingHeight = Settings.Default.ExpandedWindowHeight;
         if (settingHeight == 0)
         {
-            settingHeight = (int)((_monitorRect.Height * 3) / 4);
+            settingHeight = monitorRect.Height * 3 / 4;
             Settings.Default.ExpandedWindowHeight = settingHeight;
         }
 


### PR DESCRIPTION
## Summary of the pull request

Lots of bug fixes around window sizing around expanding/collapsing bar, remembering height/widths, DPIs, etc. 

## References and relevant issues

## Detailed description of the pull request / Additional comments

- Separated the persisted Width and Height sizes. Width is saved regardless of if the bar is expanded or not, height only applies to the expanded bar
- If the bar is maximized and then expanded, be sure the expanded view covers the whole screen
- If the bar is maximized, then expanded, then restored, don't restore back to the bar height. Use the previous non-maximized expanded window height instead
- When expanding the bar, don't change the width, just change the height
- SetRegionsForTitleBar wasn't getting invoked after the final layout pass on non-DPI 100% monitors. This resulted in our custom chrome items to not be clickable. Unfortunately to fix this, I moved from Size Changed events to Layout Changed events, which is *much* more chatty, but also lets us adjust the clickable regions in the titlebar appropriately.

## Validation steps performed

## PR checklist
- [ ] Closes #3401
- [ ] Closes #3392 
- [ ] Closes #3055
- [ ] Closes #3038
- [ ] Tests added/passed
- [ ] Documentation updated
