### PR TITLE
Enabling selection on enter, not movement.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/SelectEnvironmentProviderViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/SelectEnvironmentProviderViewModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -14,10 +13,8 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.Services;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
-using Windows.System;
 
 namespace DevHome.SetupFlow.ViewModels.Environments;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/SelectEnvironmentProviderViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/SelectEnvironmentProviderViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -13,8 +14,10 @@ using DevHome.Common.Environments.Models;
 using DevHome.Common.Services;
 using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.Services;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using Windows.System;
 
 namespace DevHome.SetupFlow.ViewModels.Environments;
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/SelectEnvironmentProviderView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/SelectEnvironmentProviderView.xaml
@@ -75,6 +75,7 @@
                     Foreground="{ThemeResource TextFillColorSecondary}" />
 
                 <!--  - List of Compute system providers the user can choose from when they're loaded.  -->
+                <!-- Use negative 5 on bottom-margin to offset manual spacing of the items.-->
                 <ListView
                     x:Name="ComputeSystemProviderViewModelsList"
                     Grid.Row="1"
@@ -83,7 +84,8 @@
                     ItemsSource="{x:Bind ViewModel.ProvidersViewModels, Mode=OneWay}"
                     SelectionMode="Single"
                     SingleSelectionFollowsFocus="False"
-                    Visibility="{x:Bind ViewModel.AreProvidersLoaded, Mode=OneWay}">
+                    Visibility="{x:Bind ViewModel.AreProvidersLoaded, Mode=OneWay}"
+                    Margin="0, 0, 0, -5">
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="SelectionChanged">
                             <ic:InvokeCommandAction Command="{Binding ItemsViewSelectionChangedCommand, Mode=OneWay}" CommandParameter="{Binding SelectedItem, ElementName=ComputeSystemProviderViewModelsList, Mode=OneWay}" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/SelectEnvironmentProviderView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/SelectEnvironmentProviderView.xaml
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <UserControl
     x:Class="DevHome.SetupFlow.Views.Environments.SelectEnvironmentProviderView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:EnvironmentViewModels="using:DevHome.SetupFlow.ViewModels.Environments"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:setupControls="using:DevHome.SetupFlow.Controls"
     xmlns:toolKit="using:CommunityToolkit.WinUI.Controls"
-    xmlns:EnvironmentViewModels="using:DevHome.SetupFlow.ViewModels.Environments"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:winUIBehaviors="using:CommunityToolkit.WinUI.Behaviors"
     Loaded="OnLoaded">
     <UserControl.Resources>
@@ -16,9 +16,12 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///DevHome.Common/Environments/Templates/EnvironmentsTemplates.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <converters:BoolToVisibilityConverter x:Key="CollapsedWhenTrueBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+            <converters:BoolToVisibilityConverter
+                x:Key="CollapsedWhenTrueBoolToVisibilityConverter"
+                FalseValue="Visible"
+                TrueValue="Collapsed" />
 
-            <!-- 
+            <!--
                 Override SettingsCard default resources. This is used because the default
                 SettingsCardHeaderIconMaxSize value for settings cards is 20. This makes
                 the icons sent from extensions in the creation flow appear too small and pixelated.
@@ -26,72 +29,67 @@
             -->
             <x:Double x:Key="SettingsCardHeaderIconMaxSize">40</x:Double>
 
-            <!-- Template for the compute system providers that we were able to retrieve from all the extensions -->
+            <!--  Template for the compute system providers that we were able to retrieve from all the extensions  -->
             <DataTemplate x:Key="ProviderItemTemplate" x:DataType="EnvironmentViewModels:ComputeSystemProviderViewModel">
-                <ItemContainer
-                    AutomationProperties.Name="{x:Bind DisplayName, Mode=OneWay}"
-                    IsSelected="{x:Bind IsSelected}">
+                <ItemContainer AutomationProperties.Name="{x:Bind DisplayName, Mode=OneWay}" IsTabStop="False">
                     <toolKit:SettingsCard
+                        Margin="0,0,0,5"
                         HorizontalAlignment="Stretch"
+                        Header="{x:Bind DisplayName}"
                         HeaderIcon="{x:Bind Icon}"
-                        Header="{x:Bind DisplayName}">
-                    </toolKit:SettingsCard>
+                        IsTabStop="False" />
                 </ItemContainer>
             </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <!--- Show the Select environment header on the page. -->
+    <!--  - Show the Select environment header on the page.  -->
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <setupControls:SetupShell 
-            Title="{x:Bind ViewModel.PageTitle}"
+        <setupControls:SetupShell
             x:Uid="SelectEnvironmentPage"
-            Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}"
-            Foreground="{ThemeResource TextFillColorSecondary}" 
+            Title="{x:Bind ViewModel.PageTitle}"
             Grid.Row="0"
-            ContentVisibility="Collapsed">
-        </setupControls:SetupShell>
-        <ScrollViewer 
+            ContentVisibility="Collapsed"
+            Foreground="{ThemeResource TextFillColorSecondary}"
+            Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}" />
+        <ScrollViewer
+            Grid.Row="1"
             MaxWidth="{ThemeResource MaxPageContentWidth}"
-            Margin="{ThemeResource ContentPageMargin}"
-            Grid.Row="1">
+            Margin="{ThemeResource ContentPageMargin}">
             <Grid RowSpacing="10">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="auto"/>
-                    <RowDefinition Height="auto"/>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <!--- Show the Select environment subtitle on the page. -->
+                <!--  - Show the Select environment subtitle on the page.  -->
                 <TextBlock
-                    Grid.Row="0"
-                    x:Uid="SelectEnvironmentSubtitle"
                     x:Name="LabelForItemsView"
-                    Foreground="{ThemeResource TextFillColorSecondary}"/>
+                    x:Uid="SelectEnvironmentSubtitle"
+                    Grid.Row="0"
+                    Foreground="{ThemeResource TextFillColorSecondary}" />
 
-                <!--- List of Compute system providers the user can choose from when they're loaded. -->
-                <ItemsView 
+                <!--  - List of Compute system providers the user can choose from when they're loaded.  -->
+                <ListView
                     x:Name="ComputeSystemProviderViewModelsList"
                     Grid.Row="1"
                     AutomationProperties.LabeledBy="{Binding ElementName=LabelForItemsView, Mode=OneWay}"
-                    ItemsSource="{x:Bind ViewModel.ProvidersViewModels, Mode=OneWay}"
                     ItemTemplate="{StaticResource ProviderItemTemplate}"
+                    ItemsSource="{x:Bind ViewModel.ProvidersViewModels, Mode=OneWay}"
+                    SelectionMode="Single"
+                    SingleSelectionFollowsFocus="False"
                     Visibility="{x:Bind ViewModel.AreProvidersLoaded, Mode=OneWay}">
-                    <ItemsView.Layout>
-                        <StackLayout Spacing="5" />
-                    </ItemsView.Layout>
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="SelectionChanged">
-                            <ic:InvokeCommandAction  
-                                Command="{Binding ItemsViewSelectionChangedCommand, Mode=OneWay}"  
-                                CommandParameter="{Binding SelectedItem, ElementName=ComputeSystemProviderViewModelsList, Mode=OneWay}"/>
+                            <ic:InvokeCommandAction Command="{Binding ItemsViewSelectionChangedCommand, Mode=OneWay}" CommandParameter="{Binding SelectedItem, ElementName=ComputeSystemProviderViewModelsList, Mode=OneWay}" />
                         </ic:EventTriggerBehavior>
                     </i:Interaction.Behaviors>
-                </ItemsView>
+                </ListView>
 
                 <Grid
                     Grid.Row="2"
@@ -99,34 +97,34 @@
                     VerticalAlignment="Center"
                     Visibility="{x:Bind ViewModel.AreProvidersLoaded, Mode=OneWay, Converter={StaticResource CollapsedWhenTrueBoolToVisibilityConverter}}">
                     <ProgressRing
-                        IsActive="True"
                         Width="25"
-                        Height="25"/>
+                        Height="25"
+                        IsActive="True" />
                 </Grid>
 
-                <StackPanel 
+                <StackPanel
                     Grid.Row="2"
-                    Visibility="{x:Bind ViewModel.CallToActionText, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
+                    HorizontalAlignment="Center"
                     VerticalAlignment="Center"
-                    HorizontalAlignment="Center">
-                    <TextBlock 
+                    Visibility="{x:Bind ViewModel.CallToActionText, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        HorizontalTextAlignment="Center"
                         Text="{x:Bind ViewModel.CallToActionText, Mode=OneWay}"
-                        HorizontalAlignment="Center" 
-                        TextWrapping="WrapWholeWords" 
-                        HorizontalTextAlignment="Center" />
-                    <HyperlinkButton 
-                        Grid.Column="3" 
-                        HorizontalAlignment="Center" 
-                        Content="{x:Bind ViewModel.CallToActionHyperLinkButtonText, Mode=OneWay}"
-                        Command="{x:Bind ViewModel.CallToActionButtonCommand}" />
+                        TextWrapping="WrapWholeWords" />
+                    <HyperlinkButton
+                        Grid.Column="3"
+                        HorizontalAlignment="Center"
+                        Command="{x:Bind ViewModel.CallToActionButtonCommand}"
+                        Content="{x:Bind ViewModel.CallToActionHyperLinkButtonText, Mode=OneWay}" />
                 </StackPanel>
 
                 <InfoBar
+                    Grid.Row="3"
                     MaxWidth="480"
                     Margin="24"
                     HorizontalAlignment="Right"
-                    VerticalAlignment="Bottom"
-                    Grid.Row="3">
+                    VerticalAlignment="Bottom">
                     <i:Interaction.Behaviors>
                         <winUIBehaviors:StackedNotificationsBehavior x:Name="NotificationQueue" />
                     </i:Interaction.Behaviors>


### PR DESCRIPTION
## Summary of the pull request
Previous implementation used an ItemsView to get an accented border around an environment. A result is that moving between the environments with the arrows also selected the environment.

This change uses a list view to
1. Get the blue pill
2. Enables selection when the enter key is pressed and only when the enter key is pressed.

## References and relevant issues

https://task.ms/50553395

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
![UsingListViews](https://github.com/user-attachments/assets/83c15869-76e8-4a4a-8c29-62cb1da19fcf)

