### PR TITLE
Setting focus when adding account

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -579,6 +579,8 @@ public partial class AddRepoViewModel : ObservableObject
     [RelayCommand]
     private async Task AddAccountClicked()
     {
+        _addRepoDialog.Focus(FocusState.Programmatic);
+
         // If the user selects repos from account 1, then logs into account 2 and does not save between those two actions
         // _previouslySelectedRepos will be empty.  The result is the repos in account 1 will not be selected if the user navigates
         // to account 1 after logging into account 2.

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -236,9 +236,4 @@ public partial class AddRepoDialog : ContentDialog
         GatheringSearchValuesGrid.Visibility = Visibility.Collapsed;
         ShowingSearchTermsGrid.Visibility = Visibility.Visible;
     }
-
-    public void SetFocusOnSegmentedView()
-    {
-        SwitchViewsSegmentedView.Focus(FocusState.Programmatic);
-    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml.cs
@@ -236,4 +236,9 @@ public partial class AddRepoDialog : ContentDialog
         GatheringSearchValuesGrid.Visibility = Visibility.Collapsed;
         ShowingSearchTermsGrid.Visibility = Visibility.Visible;
     }
+
+    public void SetFocusOnSegmentedView()
+    {
+        SwitchViewsSegmentedView.Focus(FocusState.Programmatic);
+    }
 }


### PR DESCRIPTION
## Summary of the pull request
When the "AddAccount" flyout menu item is clicked focus moves to DevHome code because the flyout turns invisible.

To fix this call Focus on the content dialog.

I am aware this isn't the "best" solution but it is the cleanest.  The other two are
1. Separate AddRepoDialog into templates.  This way code can move to a "Logging in" template.
2. Add more Bools to control parts of the UI.

I spent a few days trying solution 2.  No go.  I decided on this solution.

## References and relevant issues

https://task.ms/51630578

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually verified with clicking the "Add Account" item and pressing "Enter" on the "Add Account" button.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
