### PR TITLE
Fixes for adding an external tool

### DIFF
--- a/tools/PI/DevHome.PI/Controls/AddToolControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/AddToolControl.xaml
@@ -37,7 +37,13 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Button
-                    x:Name="AppListButton" x:Uid="AppListButton" HorizontalAlignment="Left" VerticalAlignment="Top" MinWidth="100" Click="AppListButton_Click"/>
+                    x:Name="RefreshAppListButton" 
+                    x:Uid="RefreshAppListButton" 
+                    HorizontalAlignment="Left" 
+                    VerticalAlignment="Top" 
+                    MinWidth="100" 
+                    Click="RefreshAppListButton_Click"
+                    IsEnabled="False"/>
                 <ListView 
                     x:Name="AppsListView" 
                     Grid.Column="1" 
@@ -74,7 +80,7 @@
                 <Button 
                     x:Name="ToolBrowseButton" x:Uid="ToolBrowseButton" HorizontalAlignment="Left" MinWidth="100" Click="ToolBrowseButton_Click"/>
                 <TextBox 
-                    x:Name="ToolPathTextBox" Grid.Column="1" MinWidth="800" Margin="8,0,0,0" HorizontalAlignment="Stretch"/>
+                    x:Name="ToolPathTextBox" Grid.Column="1" MinWidth="800" Margin="8,0,0,0" HorizontalAlignment="Stretch" KeyDown="ToolPathTextBox_KeyDown"/>
             </Grid>
 
             <Grid Grid.Row="2" Margin="0,6,0,0">

--- a/tools/PI/DevHome.PI/Pages/AdditionalToolsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AdditionalToolsPage.xaml
@@ -19,7 +19,7 @@
                 </i:Interaction.Behaviors>
             </BreadcrumbBar>
 
-            <ctControls:SettingsExpander x:Uid="SettingsAddToolCard" IsExpanded="False">
+            <ctControls:SettingsExpander x:Name="SettingsAddToolCard" x:Uid="SettingsAddToolCard" IsExpanded="False" Expanded="SettingsAddToolCard_Expanded">
                 <ctControls:SettingsExpander.HeaderIcon>
                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xED0E;"/>
                 </ctControls:SettingsExpander.HeaderIcon>

--- a/tools/PI/DevHome.PI/Pages/AdditionalToolsPage.xaml.cs
+++ b/tools/PI/DevHome.PI/Pages/AdditionalToolsPage.xaml.cs
@@ -17,4 +17,9 @@ public sealed partial class AdditionalToolsPage : Page
         ViewModel = Application.Current.GetService<AdditionalToolsViewModel>();
         InitializeComponent();
     }
+
+    private void SettingsAddToolCard_Expanded(object sender, System.EventArgs e)
+    {
+        AddToolPanel.RefreshAppList();
+    }
 }

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -941,9 +941,9 @@
     <value>Activation</value>
     <comment>Header text for a group of radio buttons indicating the activation type</comment>
   </data>
-  <data name="AppListButton.Content" xml:space="preserve">
-    <value>App list</value>
-    <comment>Text for a button to get a list of apps</comment>
+  <data name="RefreshAppListButton.Content" xml:space="preserve">
+    <value>Refresh</value>
+    <comment>Text for a button to refresh the list of apps</comment>
   </data>
   <data name="AppsDataGridIconColumn.Header" xml:space="preserve">
     <value>Icon</value>


### PR DESCRIPTION
## Summary of the pull request
Fixed the filepath textbox handling to enable the user to type in (or copy/paste) a filepath, in addition to using the fileopen dialog. Validates the path, and strips off any quotes so it can be used directly in later operations (such as getting the icon).

Changed the behavior of the app list, so that this now populates when the user opens the parent expander - instead of forcing the user to open the expander and then also tap the "get app list" button. Changed the "get app list" button to "refresh app list" behavior instead.

Closes #3474, #3472 