### PR TITLE
Fix duplicate classIDs for different builds

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -21,7 +21,7 @@ parameters:
 
 variables:
  # MSIXVersion's second part should always be odd to account for stub app's version
-  MSIXVersion: '0.1601'
+  MSIXVersion: '0.1701'
   VersionOfSDK: '0.700'
   solution: '**/DevHome.sln'
   appxPackageDir: 'AppxPackages'

--- a/build/scripts/CreateBuildInfo.ps1
+++ b/build/scripts/CreateBuildInfo.ps1
@@ -6,7 +6,7 @@ Param(
 )
 
 $Major = "0"
-$Minor = "16"
+$Minor = "17"
 $Patch = "99" # default to 99 for local builds
 
 $versionSplit = $Version.Split(".");

--- a/common/Helpers/CommonConstants.cs
+++ b/common/Helpers/CommonConstants.cs
@@ -5,9 +5,19 @@ namespace DevHome.Common.Helpers;
 
 public static class CommonConstants
 {
+#if CANARY_BUILD
+    public const string HyperVExtensionClassId = "6B219EF0-E238-434C-952E-4DF3D452AC83";
+    
+    public const string WSLExtensionClassId = "EF2342AC-FF53-433D-9EDE-D395500F3B3E";
+#elif STABLE_BUILD
     public const string HyperVExtensionClassId = "F8B26528-976A-488C-9B40-7198FB425C9E";
-
+    
     public const string WSLExtensionClassId = "121253AB-BA5D-4E73-99CF-25A2CB8BF173";
+#else
+    public const string HyperVExtensionClassId = "28DD4098-162D-483C-9ED0-FB3887A22F61";
+
+    public const string WSLExtensionClassId = "7F572DC5-F40E-440F-B660-F579168B69B8";
+#endif
 
     public const string HyperVWindowsOptionalFeatureName = "Microsoft-Hyper-V";
 }

--- a/extensions/CoreWidgetProvider/Widgets/CoreExtension.cs
+++ b/extensions/CoreWidgetProvider/Widgets/CoreExtension.cs
@@ -8,7 +8,13 @@ using Serilog;
 namespace CoreWidgetProvider;
 
 [ComVisible(true)]
+#if CANARY_BUILD
+[Guid("AED8A076-3C29-4783-8CFB-F629A5ADB748")]
+#elif STABLE_BUILD
 [Guid("426A52D6-8007-4894-A946-CF80F39507F1")]
+#else
+[Guid("1EAF0D53-0628-47F3-9C60-C70943FCA7CE")]
+#endif
 [ComDefaultInterface(typeof(IExtension))]
 public sealed class CoreExtension : IExtension
 {

--- a/extensions/CoreWidgetProvider/Widgets/WidgetProvider.cs
+++ b/extensions/CoreWidgetProvider/Widgets/WidgetProvider.cs
@@ -9,7 +9,13 @@ namespace CoreWidgetProvider.Widgets;
 
 [ComVisible(true)]
 [ClassInterface(ClassInterfaceType.None)]
+#if CANARY_BUILD
+[Guid("3D9C5DCD-FC4D-4B8F-8195-9478891D52E2")]
+#elif STABLE_BUILD
 [Guid("F8B2DBB9-3687-4C6E-99B2-B92C82905937")]
+#else
+[Guid("F20D97D4-CC52-4001-ACF0-8750FB3A2547")]
+#endif
 internal sealed class WidgetProvider : IWidgetProvider, IWidgetProvider2
 {
     private readonly Dictionary<string, IWidgetImplFactory> _widgetDefinitionRegistry = new();

--- a/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.cs
@@ -10,7 +10,13 @@ using Serilog;
 namespace HyperVExtension;
 
 [ComVisible(true)]
+#if CANARY_BUILD
+[Guid("6B219EF0-E238-434C-952E-4DF3D452AC83")]
+#elif STABLE_BUILD
 [Guid("F8B26528-976A-488C-9B40-7198FB425C9E")]
+#else
+[Guid("28DD4098-162D-483C-9ED0-FB3887A22F61")]
+#endif
 [ComDefaultInterface(typeof(IExtension))]
 public sealed class HyperVExtension : IExtension, IDisposable
 {

--- a/extensions/WSLExtension/Services/WslExtension.cs
+++ b/extensions/WSLExtension/Services/WslExtension.cs
@@ -10,7 +10,13 @@ using WSLExtension.ClassExtensions;
 namespace WSLExtension.Services;
 
 [ComVisible(true)]
+#if CANARY_BUILD
+[Guid("EF2342AC-FF53-433D-9EDE-D395500F3B3E")]
+#elif STABLE_BUILD
 [Guid("121253AB-BA5D-4E73-99CF-25A2CB8BF173")]
+#else
+[Guid("7F572DC5-F40E-440F-B660-F579168B69B8")]
+#endif
 [ComDefaultInterface(typeof(IExtension))]
 public sealed class WslExtension : IExtension, IDisposable
 {

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -36,16 +36,25 @@
   <ItemGroup Condition="'$(BuildRing)' == 'Dev'">
     <Content Include="Assets\Dev\**" Link="Assets\Logos\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
     <Content Include="Assets\Dev\DevHome_Dev.ico" Link="Assets\DevHome.ico" CopyToOutputDirectory="Always" />
+    <AppxManifest Include="Package-Dev.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildRing)' == 'Canary'">
     <Content Include="Assets\Canary\**" Link="Assets\Logos\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
     <Content Include="Assets\Canary\DevHome_Canary.ico" Link="Assets\DevHome.ico" CopyToOutputDirectory="Always" />
+    <AppxManifest Include="Package-Can.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildRing)' == 'Stable'">
     <Content Include="Assets\Preview\**" Link="Assets\Logos\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
     <Content Include="Assets\Preview\DevHome_Preview.ico" Link="Assets\DevHome.ico" CopyToOutputDirectory="Always" />
+    <AppxManifest Include="Package.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Package-Can.appxmanifest
+++ b/src/Package-Can.appxmanifest
@@ -9,9 +9,9 @@
       </ProxyStub>
     </Extension>
   </Extensions>
-  <Identity Name="Microsoft.Windows.DevHome" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
+  <Identity Name="Microsoft.Windows.DevHome.Canary" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home (Preview)</DisplayName>
+    <DisplayName>Dev Home (Canary)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\Logos\StoreLogo.png</Logo>
     <desktop6:FileSystemWriteVirtualization>disabled</desktop6:FileSystemWriteVirtualization>
@@ -26,7 +26,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription" BackgroundColor="transparent" Square150x150Logo="Assets\Logos\MedTile.png" Square44x44Logo="Assets\Logos\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameCanary" Description="ms-resource:AppDescription" BackgroundColor="transparent" Square150x150Logo="Assets\Logos\MedTile.png" Square44x44Logo="Assets\Logos\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\Logos\WideTile.png" />
         <uap:SplashScreen Image="Assets\Logos\SplashScreen.png" />
       </uap:VisualElements>
@@ -62,28 +62,28 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="HyperVExtensionServer.exe" Arguments="-RegisterProcessAsComServer" DisplayName="HyperVExtensionServer">
-              <com:Class Id="F8B26528-976A-488C-9B40-7198FB425C9E" DisplayName="HyperVExtensionServer" />
+              <com:Class Id="6B219EF0-E238-434C-952E-4DF3D452AC83" DisplayName="HyperVExtensionServer" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="WslExtensionServer.exe" Arguments="-RegisterProcessAsComServer" DisplayName="WslExtensionServer">
-              <com:Class Id="121253AB-BA5D-4E73-99CF-25A2CB8BF173" DisplayName="WslExtensionServer" />
+              <com:Class Id="EF2342AC-FF53-433D-9EDE-D395500F3B3E" DisplayName="WslExtensionServer" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="CoreWidgetProvider">
-              <com:Class Id="F8B2DBB9-3687-4C6E-99B2-B92C82905937" DisplayName="CoreWidgetProvider" />
+              <com:Class Id="3D9C5DCD-FC4D-4B8F-8195-9478891D52E2" DisplayName="CoreWidgetProvider" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Core Extension">
-              <com:Class Id="426A52D6-8007-4894-A946-CF80F39507F1" DisplayName="Core Extension" />
+              <com:Class Id="AED8A076-3C29-4783-8CFB-F629A5ADB748" DisplayName="Core Extension" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
@@ -92,7 +92,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
+                  <CreateInstance ClassId="AED8A076-3C29-4783-8CFB-F629A5ADB748" />
                 </Activation>
                 <!-- Best practice is to define SupportedInterfaces, even if it is empty -->
                 <SupportedInterfaces />
@@ -105,7 +105,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
+                  <CreateInstance ClassId="6B219EF0-E238-434C-952E-4DF3D452AC83" />
                 </Activation>
                 <SupportedInterfaces>
                   <ComputeSystem />
@@ -119,7 +119,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="121253AB-BA5D-4E73-99CF-25A2CB8BF173" />
+                  <CreateInstance ClassId="EF2342AC-FF53-433D-9EDE-D395500F3B3E" />
                 </Activation>
                 <SupportedInterfaces>
                   <ComputeSystem />
@@ -129,7 +129,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameStable" Id="CoreWidgetProvider" PublicFolder="Public">
+          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameCanary" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>
                 <ProviderIcons>
@@ -137,7 +137,7 @@
                 </ProviderIcons>
                 <Activation>
                   <!-- Apps exports COM interface which implements IWidgetProvider -->
-                  <CreateInstance ClassId="F8B2DBB9-3687-4C6E-99B2-B92C82905937" />
+                  <CreateInstance ClassId="3D9C5DCD-FC4D-4B8F-8195-9478891D52E2" />
                 </Activation>
                 <TrustedPackageFamilyNames>
                   <TrustedPackageFamilyName>Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe</TrustedPackageFamilyName>

--- a/src/Package-Dev.appxmanifest
+++ b/src/Package-Dev.appxmanifest
@@ -9,9 +9,9 @@
       </ProxyStub>
     </Extension>
   </Extensions>
-  <Identity Name="Microsoft.Windows.DevHome" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
+  <Identity Name="Microsoft.Windows.DevHome.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.0.0" />
   <Properties>
-    <DisplayName>Dev Home (Preview)</DisplayName>
+    <DisplayName>Dev Home (Dev)</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\Logos\StoreLogo.png</Logo>
     <desktop6:FileSystemWriteVirtualization>disabled</desktop6:FileSystemWriteVirtualization>
@@ -26,7 +26,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameStable" Description="ms-resource:AppDescription" BackgroundColor="transparent" Square150x150Logo="Assets\Logos\MedTile.png" Square44x44Logo="Assets\Logos\AppList.png">
+      <uap:VisualElements DisplayName="ms-resource:AppDisplayNameDev" Description="ms-resource:AppDescription" BackgroundColor="transparent" Square150x150Logo="Assets\Logos\MedTile.png" Square44x44Logo="Assets\Logos\AppList.png">
         <uap:DefaultTile Wide310x150Logo="Assets\Logos\WideTile.png" />
         <uap:SplashScreen Image="Assets\Logos\SplashScreen.png" />
       </uap:VisualElements>
@@ -62,28 +62,28 @@
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="HyperVExtensionServer.exe" Arguments="-RegisterProcessAsComServer" DisplayName="HyperVExtensionServer">
-              <com:Class Id="F8B26528-976A-488C-9B40-7198FB425C9E" DisplayName="HyperVExtensionServer" />
+              <com:Class Id="28DD4098-162D-483C-9ED0-FB3887A22F61" DisplayName="HyperVExtensionServer" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="WslExtensionServer.exe" Arguments="-RegisterProcessAsComServer" DisplayName="WslExtensionServer">
-              <com:Class Id="121253AB-BA5D-4E73-99CF-25A2CB8BF173" DisplayName="WslExtensionServer" />
+              <com:Class Id="7F572DC5-F40E-440F-B660-F579168B69B8" DisplayName="WslExtensionServer" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="CoreWidgetProvider">
-              <com:Class Id="F8B2DBB9-3687-4C6E-99B2-B92C82905937" DisplayName="CoreWidgetProvider" />
+              <com:Class Id="F20D97D4-CC52-4001-ACF0-8750FB3A2547" DisplayName="CoreWidgetProvider" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:ExeServer Executable="CoreWidgetProvider.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Core Extension">
-              <com:Class Id="426A52D6-8007-4894-A946-CF80F39507F1" DisplayName="Core Extension" />
+              <com:Class Id="1EAF0D53-0628-47F3-9C60-C70943FCA7CE" DisplayName="Core Extension" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
@@ -92,7 +92,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="426A52D6-8007-4894-A946-CF80F39507F1" />
+                  <CreateInstance ClassId="1EAF0D53-0628-47F3-9C60-C70943FCA7CE" />
                 </Activation>
                 <!-- Best practice is to define SupportedInterfaces, even if it is empty -->
                 <SupportedInterfaces />
@@ -105,7 +105,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="F8B26528-976A-488C-9B40-7198FB425C9E" />
+                  <CreateInstance ClassId="28DD4098-162D-483C-9ED0-FB3887A22F61" />
                 </Activation>
                 <SupportedInterfaces>
                   <ComputeSystem />
@@ -119,7 +119,7 @@
             <uap3:Properties>
               <DevHomeProvider>
                 <Activation>
-                  <CreateInstance ClassId="121253AB-BA5D-4E73-99CF-25A2CB8BF173" />
+                  <CreateInstance ClassId="7F572DC5-F40E-440F-B660-F579168B69B8" />
                 </Activation>
                 <SupportedInterfaces>
                   <ComputeSystem />
@@ -129,7 +129,7 @@
           </uap3:AppExtension>
         </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameStable" Id="CoreWidgetProvider" PublicFolder="Public">
+          <uap3:AppExtension Name="com.microsoft.windows.widgets" DisplayName="ms-resource:WidgetProviderDisplayNameDev" Id="CoreWidgetProvider" PublicFolder="Public">
             <uap3:Properties>
               <WidgetProvider>
                 <ProviderIcons>
@@ -137,7 +137,7 @@
                 </ProviderIcons>
                 <Activation>
                   <!-- Apps exports COM interface which implements IWidgetProvider -->
-                  <CreateInstance ClassId="F8B2DBB9-3687-4C6E-99B2-B92C82905937" />
+                  <CreateInstance ClassId="F20D97D4-CC52-4001-ACF0-8750FB3A2547" />
                 </Activation>
                 <TrustedPackageFamilyNames>
                   <TrustedPackageFamilyName>Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe</TrustedPackageFamilyName>


### PR DESCRIPTION
## Summary of the pull request
Stable/Canary/Dev builds all use the same ClassIds in package.appxmanifest.  This causes issues when multiple versions are installed at the same time, notably not being able to determine which version will actually get activated.  This change clones package.appxmanifest into three different versions and changes the ClassIds for Canary/Dev versions (Stable remains the same).

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2451
- [ ] Tests added/passed
- [ ] Documentation updated
