### PR TITLE
Basic Telemetry for File Explorer Source Control Integration feature inside Dev Home

### DIFF
--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents.SourceControlIntegration;
+
+[EventData]
+
+public class SourceControlIntegrationEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public string RepositoryRootPath
+    {
+        get;
+    }
+
+    public SourceControlIntegrationEvent(string sourceControlProviderClassId, string repositoryRootPath)
+    {
+        RepositoryRootPath = SourceControlIntegrationHelper.GetSafeRootPath(repositoryRootPath);
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // The only sensitive strings is the repository root path. GetSafeRootPath is used to hash the root path.
+    }
+}

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
@@ -10,7 +10,6 @@ using Microsoft.Diagnostics.Telemetry.Internal;
 namespace DevHome.Common.TelemetryEvents.SourceControlIntegration;
 
 [EventData]
-
 public class SourceControlIntegrationEvent : EventBase
 {
     public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
@@ -19,9 +19,15 @@ public class SourceControlIntegrationEvent : EventBase
         get;
     }
 
-    public SourceControlIntegrationEvent(string sourceControlProviderClassId, string repositoryRootPath)
+    public int TrackedRepositoryCount
+    {
+        get;
+    }
+
+    public SourceControlIntegrationEvent(string sourceControlProviderClassId, string repositoryRootPath, int trackedRepositoryCount)
     {
         RepositoryRootPath = SourceControlIntegrationHelper.GetSafeRootPath(repositoryRootPath);
+        TrackedRepositoryCount = trackedRepositoryCount;
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Tracing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationEvent.cs
@@ -26,6 +26,7 @@ public class SourceControlIntegrationEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // The only sensitive strings is the repository root path. GetSafeRootPath is used to hash the root path.
+        // The only sensitive strings is the repository root path. GetSafeRootPath is used to potentially remove PII and
+        // keep last part of path.
     }
 }

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationHelper.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationHelper.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+
+namespace DevHome.Common.TelemetryEvents.SourceControlIntegration;
+
+public static class SourceControlIntegrationHelper
+{
+    private static readonly string[] Separator = new[] { "//" };
+
+    public static string GetSafeRootPath(string rootPath)
+    {
+        var parts = rootPath.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        return parts.LastOrDefault() ?? string.Empty;
+    }
+}

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationHelper.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationHelper.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Linq;
 
 namespace DevHome.Common.TelemetryEvents.SourceControlIntegration;
 
 public static class SourceControlIntegrationHelper
 {
-    private static readonly string[] Separator = new[] { "//" };
-
     public static string GetSafeRootPath(string rootPath)
     {
-        var parts = rootPath.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        var parts = rootPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
         return parts.LastOrDefault() ?? string.Empty;
     }
 }

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
@@ -26,6 +26,7 @@ public class SourceControlIntegrationUserEvent : EventBase
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
     {
-        // The only sensitive strings is the repository root path. GetSafeRootPath is used to hash the root path.
+        // The only sensitive strings is the repository root path. GetSafeRootPath is used to potentially remove PII and
+        // keep last part of path.
     }
 }

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents.SourceControlIntegration;
+
+[EventData]
+
+public class SourceControlIntegrationUserEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public string RepositoryRootPath
+    {
+        get;
+    }
+
+    public SourceControlIntegrationUserEvent(string sourceControlProviderClassId, string repositoryRootPath)
+    {
+        RepositoryRootPath = SourceControlIntegrationHelper.GetSafeRootPath(repositoryRootPath);
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // The only sensitive strings is the repository root path. GetSafeRootPath is used to hash the root path.
+    }
+}

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
@@ -19,9 +19,15 @@ public class SourceControlIntegrationUserEvent : EventBase
         get;
     }
 
-    public SourceControlIntegrationUserEvent(string sourceControlProviderClassId, string repositoryRootPath)
+    public int TrackedRepositoryCount
+    {
+        get;
+    }
+
+    public SourceControlIntegrationUserEvent(string sourceControlProviderClassId, string repositoryRootPath, int trackedRepositoryCount)
     {
         RepositoryRootPath = SourceControlIntegrationHelper.GetSafeRootPath(repositoryRootPath);
+        TrackedRepositoryCount = trackedRepositoryCount;
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
@@ -10,7 +10,6 @@ using Microsoft.Diagnostics.Telemetry.Internal;
 namespace DevHome.Common.TelemetryEvents.SourceControlIntegration;
 
 [EventData]
-
 public class SourceControlIntegrationUserEvent : EventBase
 {
     public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;

--- a/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
+++ b/common/TelemetryEvents/SourceControlIntegration/SourceControlIntegrationUserEvent.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Tracing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DevHome.Telemetry;
 using Microsoft.Diagnostics.Telemetry;
 using Microsoft.Diagnostics.Telemetry.Internal;

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -3,6 +3,8 @@
 
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents.SourceControlIntegration;
+using DevHome.Telemetry;
 using Serilog;
 using Windows.Storage;
 
@@ -101,13 +103,16 @@ public class RepositoryTracking
                 log.Warning("Repository root path already registered in the repo store");
             }
         }
+
+        TelemetryFactory.Get<ITelemetry>().Log("EnhanceRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID, rootPath));
     }
 
     public void RemoveRepositoryPath(string rootPath)
     {
+        var extensionCLSID = string.Empty;
         lock (trackRepoLock)
         {
-            TrackedRepositories.TryGetValue(rootPath, out var extensionCLSID);
+            TrackedRepositories.TryGetValue(rootPath, out extensionCLSID);
             TrackedRepositories.Remove(rootPath);
             fileService.Save(RepoStoreOptions.RepoStoreFolderPath, RepoStoreOptions.RepoStoreFileName, TrackedRepositories);
             log.Information("Repository removed from repo store");
@@ -120,6 +125,8 @@ public class RepositoryTracking
                 log.Error(ex, $"Removed event signaling failed: ");
             }
         }
+
+        TelemetryFactory.Get<ITelemetry>().Log("RemoveEnhanceRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID ?? string.Empty, rootPath));
     }
 
     public Dictionary<string, string> GetAllTrackedRepositories()

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -104,7 +104,7 @@ public class RepositoryTracking
             }
         }
 
-        TelemetryFactory.Get<ITelemetry>().Log("EnhanceRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID, rootPath));
+        TelemetryFactory.Get<ITelemetry>().Log("AddEnhancedRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID, rootPath));
     }
 
     public void RemoveRepositoryPath(string rootPath)
@@ -126,7 +126,7 @@ public class RepositoryTracking
             }
         }
 
-        TelemetryFactory.Get<ITelemetry>().Log("RemoveEnhanceRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID ?? string.Empty, rootPath));
+        TelemetryFactory.Get<ITelemetry>().Log("RemoveEnhancedRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID ?? string.Empty, rootPath));
     }
 
     public Dictionary<string, string> GetAllTrackedRepositories()

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/RepositoryTracking.cs
@@ -104,7 +104,7 @@ public class RepositoryTracking
             }
         }
 
-        TelemetryFactory.Get<ITelemetry>().Log("AddEnhancedRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID, rootPath));
+        TelemetryFactory.Get<ITelemetry>().Log("AddEnhancedRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID, rootPath, TrackedRepositories.Count));
     }
 
     public void RemoveRepositoryPath(string rootPath)
@@ -126,7 +126,7 @@ public class RepositoryTracking
             }
         }
 
-        TelemetryFactory.Get<ITelemetry>().Log("RemoveEnhancedRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID ?? string.Empty, rootPath));
+        TelemetryFactory.Get<ITelemetry>().Log("RemoveEnhancedRepository_Event", LogLevel.Critical, new SourceControlIntegrationEvent(extensionCLSID ?? string.Empty, rootPath, TrackedRepositories.Count));
     }
 
     public Dictionary<string, string> GetAllTrackedRepositories()


### PR DESCRIPTION
## Summary of the pull request
Add telemetry around repository add/removal 

## References and relevant issues

## Detailed description of the pull request / Additional comments
For this feature, the telemetry event will be fired when a user adds a repository or removes a repository through the UI flow. As such the event will take two pieces of information i.e. the source control technology provider name and repository root path. The root path will be scrubbed to remove potential PII. 

## Validation steps performed
Built release msix package

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
