### PR TITLE
Removed extra MoreOptionsButtonName

### DIFF
--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -343,10 +343,6 @@
     <value>Go to extensions library</value>
     <comment>Text for when the environment page in Dev Home is empty and the user has no extensions installed that support environments</comment>
   </data>
-  <data name="MoreOptionsButtonName" xml:space="preserve">
-    <value>More options</value>
-    <comment>The text narrator should say for the ... button</comment>
-  </data>
   <data name="SyncEnvironmentsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sync</value>
     <comment>Accessible name for the button to sync environments.</comment>

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -69,7 +69,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public ComputeSystemCardBase()
     {
-        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptionsButtonName");
+        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptions.AutomationProperties.Name");
     }
 
     public override string ToString()


### PR DESCRIPTION
## Summary of the pull request
Removed an extra variable "MoreOptionsButtonName" from the Environments resource file `devhome\tools\Environments\DevHome.Environments\Strings\en-us\Resources.resw`. It was removed because it was only used in one place and could be set to MoreOptions.AutomationProperties.Name, which was used more often in the codebase.

## References and relevant issues
This variable was first discussed in #3442

## Detailed description of the pull request / Additional comments
* If you are unable to see changes to a resource file in a debug build, you may need to rebuild the resource file's project first. 

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
