### PR TITLE
Add narration for close button on Add Repository Dialog

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -2019,4 +2019,8 @@
     <value>Installation Notes</value>
     <comment>Text to introduce installation notes in the summary screen.</comment>
   </data>
+  <data name="LoginUIDialogCloseButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Close</value>
+	<comment>Close button automation name for the login UI dialog</comment>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -152,7 +152,8 @@
                         VerticalAlignment="Center"
                         Command="{x:Bind AddRepoViewModel.CancelButtonPressedCommand, Mode=OneWay}"
                         DataContext="{x:Bind}"
-                        Style="{ThemeResource AlternateCloseButtonStyle}">
+                        Style="{ThemeResource AlternateCloseButtonStyle}"
+                        AutomationProperties.Name="Close (X)">
                         <Button.Content>
                             <SymbolIcon Symbol="Cancel" />
                         </Button.Content>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -148,12 +148,12 @@
                         HorizontalAlignment="Left"
                         Style="{ThemeResource SubtitleTextBlockStyle}" />
                     <Button
+                        x:Uid="LoginUIDialogCloseButton"
                         Grid.Column="1"
                         VerticalAlignment="Center"
                         Command="{x:Bind AddRepoViewModel.CancelButtonPressedCommand, Mode=OneWay}"
                         DataContext="{x:Bind}"
-                        Style="{ThemeResource AlternateCloseButtonStyle}"
-                        AutomationProperties.Name="Close (X)">
+                        Style="{ThemeResource AlternateCloseButtonStyle}">
                         <Button.Content>
                             <SymbolIcon Symbol="Cancel" />
                         </Button.Content>


### PR DESCRIPTION
## Summary of the pull request
This pull request adds screen reader narration to the close button in the Add Repository Dialog under Machine Configuration in Dev Home.

## References and relevant issues
https://task.ms/52584819

## Detailed description of the pull request / Additional comments

Here's the video of the narration before the change was made:

https://github.com/user-attachments/assets/154e4c3b-fcd9-4b42-9842-fdaec96cc619

Here's a video of the narration after the change:

https://github.com/user-attachments/assets/f1378ee7-b154-46d8-bd6f-ca5d3121497b

## Validation steps performed:

- Sign out of any GitHub accounts in Dev Home
- Turn on Narrator (Win+Ctrl+Enter)
- Open Dev Home app.
- Go to Machine Configuration -> Clone Repository.
- Navigate to "Add Repository" button and activate it.
- Select "Account" tab in "Add Repository" flyout.
- Select Account type as "Dev Home GitHub extension preview".
- Navigate to "Connect" button and activate it.
- Navigate to close (X) button and observe narrator output.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
