### PR TITLE
Close the PI process when WM_ENDSESSION is received

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/ServicingHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/ServicingHelper.cs
@@ -37,11 +37,7 @@ public class ServicingHelper
 
     private void OnWindowMessageReceived(object? sender, WindowMessageEventArgs e)
     {
-        if (e.Message.MessageId == PInvoke.WM_QUERYENDSESSION)
-        {
-            // e.Handled = true;
-        }
-        else if (e.Message.MessageId == PInvoke.WM_ENDSESSION)
+        if (e.Message.MessageId == PInvoke.WM_ENDSESSION)
         {
             _onSessionEnd?.Invoke();
             e.Handled = true;

--- a/tools/PI/DevHome.PI/Helpers/ServicingHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/ServicingHelper.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.UI.Xaml;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using WinUIEx.Messaging;
+
+namespace DevHome.PI.Helpers;
+
+// Note: instead of making this class disposable, we're disposing the WindowMessageMonitor in
+// UnregisterHotKey, and MainWindow calls this in its Closing event handler.
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+public class ServicingHelper
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+{
+    private const string NoWindowHandleException = "Cannot get window handle: are you doing this too early?";
+    private readonly HWND _windowHandle;
+    private readonly WindowMessageMonitor _windowMessageMonitor;
+    private readonly Action _onSessionEnd;
+
+    public ServicingHelper(Window handlerWindow, Action handleSessionEnd)
+    {
+        _onSessionEnd = handleSessionEnd;
+
+        // Set up the window message hook to listen for session end messages.
+        _windowHandle = (HWND)WinRT.Interop.WindowNative.GetWindowHandle(handlerWindow);
+        if (_windowHandle.IsNull)
+        {
+            throw new InvalidOperationException(NoWindowHandleException);
+        }
+
+        _windowMessageMonitor = new WindowMessageMonitor(_windowHandle);
+        _windowMessageMonitor.WindowMessageReceived += OnWindowMessageReceived;
+    }
+
+    private void OnWindowMessageReceived(object? sender, WindowMessageEventArgs e)
+    {
+        if (e.Message.MessageId == PInvoke.WM_QUERYENDSESSION)
+        {
+            // e.Handled = true;
+        }
+        else if (e.Message.MessageId == PInvoke.WM_ENDSESSION)
+        {
+            _onSessionEnd?.Invoke();
+            e.Handled = true;
+        }
+    }
+
+    internal void Unregister()
+    {
+        _windowMessageMonitor?.Dispose();
+    }
+}

--- a/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/PrimaryWindow.xaml.cs
@@ -29,6 +29,8 @@ public sealed partial class PrimaryWindow : WindowEx
 
     private HotKeyHelper? _hotKeyHelper;
 
+    private ServicingHelper? _servicingHelper;
+
     public BarWindow? DBarWindow { get; private set; }
 
     public PrimaryWindow()
@@ -62,6 +64,7 @@ public sealed partial class PrimaryWindow : WindowEx
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
         App.Log("DevHome.PI_MainWindows_Loaded", LogLevel.Measure);
+        _servicingHelper = new(this, HandleSessionEnd);
         _hotKeyHelper = new(this, HandleHotKey);
         _hotKeyHelper.RegisterHotKey(HotKey, KeyModifier);
     }
@@ -70,6 +73,14 @@ public sealed partial class PrimaryWindow : WindowEx
     {
         DBarWindow?.Close();
         _hotKeyHelper?.UnregisterHotKey();
+        _servicingHelper?.Unregister();
+    }
+
+    public void HandleSessionEnd()
+    {
+        App.Log("DevHome.PI_SessionEnd", LogLevel.Info);
+        DBarWindow?.Close();
+        Process.GetCurrentProcess().Kill();
     }
 
     public void HandleHotKey(int keyId)


### PR DESCRIPTION
## Summary of the pull request
PI is necessarily long-running to support hotkey(Win-F12) activation.  When the Dev Home package is serviced for update, all processes must be closed and if they don't close promptly a HANG_QUIESCE Watson report is generated.

## References and relevant issues

## Detailed description of the pull request / Additional comments
To avoid HANG_QUIESCE reports from being generated respond to WM_ENDSESSION by closing the window and terminating the process.

## Validation steps performed
Made a test script to send WM_ENDSESSION, verified before the change PI does not exit and after it does.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
