### PR TITLE
Add narration to Review and Finish page

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -661,7 +661,7 @@
     <value>Generate Configuration file</value>
     <comment>Text for a generating configuration file button</comment>
   </data>
-  <data name="Review_DownloadFileTooltip.Subtitle" xml:space="preserve">
+  <data name="Review_DownloadFileTooltip.Title" xml:space="preserve">
     <value>Generate a WinGet Configuration file (.winget) to repeat this setup in the future or share it with others.</value>
     <comment>{Locked="WinGet",".winget"}Tooltip text about the generated configuration file</comment>
   </data>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -2023,4 +2023,8 @@
     <value>Close</value>
 	<comment>Close button automation name for the login UI dialog</comment>
   </data>
+  <data name="GenerateConfigInfoButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Generate configuration file info</value>
+	<comment>Narration for the informational icon next to the "Generate Configuration file" button</comment>
+  </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -90,7 +90,7 @@
                                 <TeachingTip x:Name="GenerateConfigInfoTeachingTip"
                                              x:Uid="Review_DownloadFileTooltip"
                                              Target="{x:Bind GenerateConfigInfoButton}"
-                                             IsLightDismissEnabled="True"/>
+                                             IsLightDismissEnabled="False"/>
                             </StackPanel>
                         </Grid>
                     </Expander.Header>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ReviewView.xaml
@@ -79,6 +79,7 @@
                                         x:Uid="Review_GenerateConfigurationFileButton"/>
                                 <!-- Info icon -->
                                 <Button Style="{ThemeResource AlternateCloseButtonStyle}"
+                                        x:Uid="GenerateConfigInfoButton"
                                         x:Name="GenerateConfigInfoButton"
                                         PointerEntered="GenerateConfigInfoButton_PointerEntered"
                                         Click="GenerateConfigInfoButton_Click">


### PR DESCRIPTION
## Summary of the pull request

This PR adds two missing narrations to the Review and Finish page.

The first was for the information button next to the "Generate Configuration file" button.

Before changes:

https://github.com/user-attachments/assets/f6443a6b-312e-42d7-9754-ebbb1db1f30c

After changes:

https://github.com/user-attachments/assets/6bc51f3e-9fca-41a2-9081-b992e308f67d


The second was for the content of the TeachingTip on that information button.

Before changes:

https://github.com/user-attachments/assets/9f27fda7-2920-421a-871d-56a97b78e628

After changes:

https://github.com/user-attachments/assets/7cab612d-95dc-43e3-97a9-c8e70aba3e95

## References and relevant issues

Resolves:
* https://task.ms/52587002
* https://task.ms/52588765

Works around:
* https://github.com/microsoft/microsoft-ui-xaml/issues/9601

## Detailed description of the pull request / Additional comments

I had to use a workaround to make the TeachingTip text readable:
* Change the text from a Subtitle to a Title (which is why the text is now bolded)
* Set Light Dismissible to false

Although this makes some minor cosmetic changes, I believe those are worth the additional functionality until the WinUI 3 TeachingTip is updated.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
