### PR TITLE
Removed non-navigation items from the Navigation panel

### DIFF
--- a/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml
+++ b/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml
@@ -24,147 +24,129 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <StackPanel Orientation="Vertical">
-                    <ListView x:Name="NavLinksList" SelectionMode="Single" VerticalAlignment="Stretch" ItemsSource="{x:Bind viewModel.Links}"
-                         SelectedIndex="{x:Bind viewModel.SelectedNavLinkIndex, Mode=TwoWay}" SelectionChanged="{x:Bind viewModel.Navigate}">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Orientation="Horizontal" Spacing="12">
-                                    <TextBlock Text="{Binding IconText}" Style="{x:Null}"
-                                        FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource CaptionTextBlockFontSize}"
-                                        HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                    <TextBlock Text="{Binding ContentText}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                    <Rectangle x:Name="Separator"
-                        Visibility="{x:Bind viewModel.AppSettingsVisibility, Mode=OneWay}"
-                        RadiusX="{ThemeResource AppBarSeparatorCornerRadius}"
-                        RadiusY="{ThemeResource AppBarSeparatorCornerRadius}"
-                        Height="{ThemeResource AppBarSeparatorWidth}"
-                        Width="{x:Bind NavLinksList.Width, Mode=OneWay}"
-                        Fill="{ThemeResource AppBarSeparatorForegroundThemeBrush}"
-                        Margin="4" />
-                    <Button 
-                        MinWidth="200" 
-                        HorizontalAlignment="Stretch" 
-                        x:Uid="DetachAppButton" 
-                        Visibility="{x:Bind viewModel.AppSettingsVisibility, Mode=OneWay}" 
-                        Command="{x:Bind viewModel.DetachFromProcessCommand}"/>
-                </StackPanel>
-               
-            </Grid>
+            <!-- Navigation panel -->
+            <ListView 
+                x:Name="NavLinksList" 
+                SelectionMode="Single" 
+                VerticalAlignment="Stretch" 
+                ItemsSource="{x:Bind _viewModel.Links}"
+                SelectedIndex="{x:Bind _viewModel.SelectedNavLinkIndex, Mode=TwoWay}" 
+                SelectionChanged="{x:Bind _viewModel.Navigate}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="12">
+                            <TextBlock 
+                                Text="{Binding IconText}" 
+                                Style="{x:Null}"
+                                FontFamily="{StaticResource SymbolThemeFontFamily}" 
+                                FontSize="{StaticResource CaptionTextBlockFontSize}"
+                                HorizontalAlignment="Left" 
+                                VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding ContentText}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
 
             <toolkit:GridSplitter 
                 Grid.Column="1" ResizeBehavior="BasedOnAlignment" ResizeDirection="Auto" PointerPressed="GridSplitter_PointerPressed"/>
 
+            <!-- Page content -->
             <Grid Grid.Column="2" Margin="16,0,0,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <Frame x:Name="PageFrame"/>
 
+                <Expander
+                    x:Name="ClipboardErrorExpander"
+                    Grid.Row="1"
+                    IsExpanded="False" 
+                    ExpandDirection="Up"
+                    HorizontalAlignment="Stretch" 
+                    VerticalAlignment="Top" 
+                    Padding="0,6" 
+                    HorizontalContentAlignment="Stretch">
+                    <Expander.Header>
+                        <TextBlock x:Uid="ClickboardErrorTextBlock" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
+                    </Expander.Header>
+                    <Grid>
+                        <Grid.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
+                                <Setter Property="Margin" Value="12,0,0,0"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                            <Style TargetType="TextBox">
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
+                                <Setter Property="IsReadOnly" Value="True"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="Margin" Value="0,8,0,0"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </Grid.Resources>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="60"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Uid="HexLabelTextBlock"/>
+                        <TextBox x:Name="ErrorHexTextBox" Grid.Column="1" Text="{x:Bind _viewModel.ClipboardContentsHex, Mode=OneWay}"/>
+                        <TextBlock x:Uid="DecLabelTextBlock" Grid.Row="1"/>
+                        <TextBox x:Name="ErrorDecTextBox" Grid.Row="1" Grid.Column="1" Text="{x:Bind _viewModel.ClipboardContentsDec, Mode=OneWay}"/>
+                        <TextBlock x:Uid="CodeLabelTextBlock" Grid.Row="2"/>
+                        <TextBox x:Name="ErrorCodeTextBox" Grid.Row="2" Grid.Column="1" Text="{x:Bind _viewModel.ClipboardContentsCode, Mode=OneWay}"/>
+                        <TextBlock x:Uid="HelpLabelTextBlock" Grid.Row="3"/>
+                        <TextBox x:Name="ErrorHelpTextBox" Grid.Row="3" Grid.Column="1" 
+                         ScrollViewer.HorizontalScrollBarVisibility="Auto" Height="36" Text="{x:Bind _viewModel.ClipboardContentsHelp, Mode=OneWay}"/>
+                    </Grid>
+                </Expander>
+
             </Grid>
         </Grid>
 
-        <!-- Bottom section -->
-        <StackPanel Orientation="Vertical" Grid.Row="2">
-            <Expander
-                    x:Name="ClipboardErrorExpander"
-                    IsExpanded="False" ExpandDirection="Up"
-                    HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6" 
-                    HorizontalContentAlignment="Stretch">
-            <Expander.Header>
-                <TextBlock x:Uid="ClickboardErrorTextBlock" FontSize="{StaticResource CaptionTextBlockFontSize}"/>
-            </Expander.Header>
-            <Grid>
-                <Grid.Resources>
-                    <Style TargetType="TextBlock">
-                        <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
-                        <Setter Property="Margin" Value="12,0,0,0"/>
-                        <Setter Property="VerticalAlignment" Value="Center"/>
-                    </Style>
-                    <Style TargetType="TextBox">
-                        <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
-                        <Setter Property="IsReadOnly" Value="True"/>
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="Margin" Value="0,8,0,0"/>
-                        <Setter Property="VerticalAlignment" Value="Center"/>
-                    </Style>
-                </Grid.Resources>
+        <!-- Status bar -->
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Grid.Resources>
+                <Style TargetType="TextBlock">
+                    <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
+                    <Setter Property="VerticalAlignment" Value="Center"/>
+                </Style>
+                <Style TargetType="Button">
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Style>
+            </Grid.Resources>
+            <StackPanel Orientation="Horizontal" Grid.Column="0" Spacing="10" Visibility="{x:Bind _viewModel.PerfMarkersVisibility, Mode=OneWay}">
+                <TextBlock x:Uid="ExpandedViewTargetAppPidTextBox"  Text="{x:Bind _viewModel.ApplicationPid, Mode=OneWay}"/>
+                <TextBlock x:Uid="ExpandedViewAppCpuPerf" Text="{x:Bind _viewModel.CpuUsage, Mode=OneWay}"/>
+                <TextBlock x:Uid="ExpandedViewAppMemoryPerf" Text="{x:Bind _viewModel.RamUsage, Mode=OneWay}"/>
+                <TextBlock x:Uid="ExpandedViewAppDiskPerf" Text="{x:Bind _viewModel.DiskUsage, Mode=OneWay}"/>
+            </StackPanel>
 
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="60"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock x:Uid="HexLabelTextBlock"/>
-                <TextBox x:Name="ErrorHexTextBox" Grid.Column="1" Text="{x:Bind viewModel.ClipboardContentsHex, Mode=OneWay}"/>
-                <TextBlock x:Uid="DecLabelTextBlock" Grid.Row="1"/>
-                <TextBox x:Name="ErrorDecTextBox" Grid.Row="1" Grid.Column="1" Text="{x:Bind viewModel.ClipboardContentsDec, Mode=OneWay}"/>
-                <TextBlock x:Uid="CodeLabelTextBlock" Grid.Row="2"/>
-                <TextBox x:Name="ErrorCodeTextBox" Grid.Row="2" Grid.Column="1" Text="{x:Bind viewModel.ClipboardContentsCode, Mode=OneWay}"/>
-                <TextBlock x:Uid="HelpLabelTextBlock" Grid.Row="3"/>
-                <TextBox x:Name="ErrorHelpTextBox" Grid.Row="3" Grid.Column="1" 
-                             ScrollViewer.HorizontalScrollBarVisibility="Auto" Height="36" Text="{x:Bind viewModel.ClipboardContentsHelp, Mode=OneWay}"/>
-            </Grid>
-            </Expander>
+            <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right" Spacing="10" >
+                <TextBlock x:Uid="FilterDataToTargetAppToggleLabel" VerticalAlignment="Center"/>
+                <ToggleSwitch x:Name="ApplyAppFilteringToData" IsOn="{x:Bind _viewModel.ApplyAppFiltering, Mode=TwoWay}" MinWidth="0">
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="Toggled">
+                            <ic:InvokeCommandAction Command="{x:Bind _viewModel.ApplyAppFilteringToDataCommand}" />
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                </ToggleSwitch>
+            </StackPanel>
+        </Grid>
 
-            <!-- Bottom status bar -->
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <Grid.Resources>
-                    <Style TargetType="TextBlock">
-                        <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
-                        <Setter Property="VerticalAlignment" Value="Center"/>
-                    </Style>
-                    <Style TargetType="Button">
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="Background" Value="Transparent"/>
-                    </Style>
-                </Grid.Resources>
-                <StackPanel Orientation="Horizontal" Grid.Column="0" Spacing="10" Visibility="{x:Bind viewModel.PerfMarkersVisibility, Mode=OneWay}">
-                    <TextBlock x:Uid="ExpandedViewTargetAppPidTextBox"  Text="{x:Bind viewModel.ApplicationPid, Mode=OneWay}"/>
-                    <TextBlock x:Uid="ExpandedViewAppCpuPerf" Text="{x:Bind viewModel.CpuUsage, Mode=OneWay}"/>
-                    <TextBlock x:Uid="ExpandedViewAppMemoryPerf" Text="{x:Bind viewModel.RamUsage, Mode=OneWay}"/>
-                    <TextBlock x:Uid="ExpandedViewAppDiskPerf" Text="{x:Bind viewModel.DiskUsage, Mode=OneWay}"/>
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
-                    <StackPanel Orientation="Horizontal" Spacing="10" >
-                        <TextBlock x:Uid="FilterDataToTargetAppToggleLabel" VerticalAlignment="Center"/>
-                        <ToggleSwitch x:Name="ApplyAppFilteringToData" IsOn="{x:Bind viewModel.ApplyAppFiltering, Mode=TwoWay}" MinWidth="0">
-                            <i:Interaction.Behaviors>
-                                <ic:EventTriggerBehavior EventName="Toggled">
-                                    <ic:InvokeCommandAction Command="{x:Bind viewModel.ApplyAppFilteringToDataCommand}" />
-                                </ic:EventTriggerBehavior>
-                            </i:Interaction.Behaviors>
-                        </ToggleSwitch>
-                    </StackPanel>
-
-                    <Button Click="SettingsButton_Click">
-                        <TextBlock Text="&#xe713;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource CaptionTextBlockFontSize}" />
-                    </Button>
-                </StackPanel>
-            </Grid>
-        </StackPanel>
     </Grid>
 </UserControl>

--- a/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml.cs
+++ b/tools/PI/DevHome.PI/Controls/ExpandedViewControl.xaml.cs
@@ -3,7 +3,6 @@
 
 using System;
 using DevHome.PI.ViewModels;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 
@@ -11,12 +10,12 @@ namespace DevHome.PI.Controls;
 
 public sealed partial class ExpandedViewControl : UserControl
 {
-    private readonly ExpandedViewControlViewModel viewModel = new();
+    private readonly ExpandedViewControlViewModel _viewModel = new();
 
     public ExpandedViewControl()
     {
         InitializeComponent();
-        viewModel.NavigationService.Frame = PageFrame;
+        _viewModel.NavigationService.Frame = PageFrame;
     }
 
     public Frame GetPageFrame()
@@ -26,17 +25,12 @@ public sealed partial class ExpandedViewControl : UserControl
 
     public void NavigateTo(Type viewModelType)
     {
-        viewModel.NavigateTo(viewModelType);
-    }
-
-    private void SettingsButton_Click(object sender, RoutedEventArgs e)
-    {
-        NavigateToSettings(typeof(SettingsPageViewModel).FullName!);
+        _viewModel.NavigateTo(viewModelType);
     }
 
     public void NavigateToSettings(string viewModelType)
     {
-        viewModel.NavigateToSettings(viewModelType);
+        _viewModel.NavigateToSettings(viewModelType);
     }
 
     private void GridSplitter_PointerPressed(object sender, PointerRoutedEventArgs e)

--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -28,9 +28,24 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Uid="AppDetailsTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="AppDetailsTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+            <Button 
+                Grid.Column="1"
+                x:Uid="DetachAppButton" 
+                Height="40"
+                BorderThickness="0"
+                Visibility="{x:Bind ViewModel.AppSettingsVisibility, Mode=OneWay}" 
+                Command="{x:Bind ViewModel.DetachFromProcessCommand}">
+                <TextBlock Text="&#xe894;" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="{StaticResource SubtitleTextBlockFontSize}"/>
+            </Button>
+        </Grid>
 
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,6,0,0">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>

--- a/tools/PI/DevHome.PI/Services/PINavigationService.cs
+++ b/tools/PI/DevHome.PI/Services/PINavigationService.cs
@@ -161,6 +161,6 @@ internal sealed class PINavigationService : INavigationService
 
     public static object? GetPageViewModel(Frame frame)
     {
-        return frame.Content?.GetType().GetProperty("viewModel")?.GetValue(frame.Content, null);
+        return frame.Content?.GetType().GetProperty("_viewModel")?.GetValue(frame.Content, null);
     }
 }

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -917,10 +917,6 @@
     <value>Enable App Execution Alias for Project Ironsides and try again</value>
     <comment>{Locked="Ironsides"} Content Dialog title to enable app execution alias for Project Ironsides</comment>
   </data>
-  <data name="DetachAppButton.Content" xml:space="preserve">
-    <value>Detach from target app</value>
-    <comment>Button in the expanded view to detach from the target app</comment>
-  </data>
   <data name="DetachAppButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Detach from the currently targeted process</value>
     <comment>Used to describe what the DetachAppButton does</comment>

--- a/tools/PI/DevHome.PI/ViewModels/AppDetailsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/AppDetailsPageViewModel.cs
@@ -38,6 +38,9 @@ public partial class AppDetailsPageViewModel : ObservableObject
     [ObservableProperty]
     private Visibility _processPackageVisibility = Visibility.Collapsed;
 
+    [ObservableProperty]
+    private Visibility _appSettingsVisibility = Visibility.Collapsed;
+
     private Process? _targetProcess;
 
     public AppDetailsPageViewModel()
@@ -48,7 +51,12 @@ public partial class AppDetailsPageViewModel : ObservableObject
         var process = TargetAppData.Instance.TargetProcess;
         if (process is not null)
         {
+            AppSettingsVisibility = Visibility.Visible;
             UpdateTargetProcess(process);
+        }
+        else
+        {
+            AppSettingsVisibility = Visibility.Collapsed;
         }
     }
 
@@ -123,7 +131,12 @@ public partial class AppDetailsPageViewModel : ObservableObject
         {
             if (TargetAppData.Instance.TargetProcess is not null)
             {
+                AppSettingsVisibility = Visibility.Visible;
                 UpdateTargetProcess(TargetAppData.Instance.TargetProcess);
+            }
+            else
+            {
+                AppSettingsVisibility = Visibility.Collapsed;
             }
         }
     }
@@ -135,6 +148,12 @@ public partial class AppDetailsPageViewModel : ObservableObject
         {
             CommonHelper.RunAsAdmin(_targetProcess.Id, nameof(AppDetailsPageViewModel));
         }
+    }
+
+    [RelayCommand]
+    public void DetachFromProcess()
+    {
+        TargetAppData.Instance.ClearAppData();
     }
 
     private void GetPackageInfo(ProcessDiagnosticInfo pdi)

--- a/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
@@ -13,93 +13,85 @@ using DevHome.PI.Helpers;
 using DevHome.PI.Models;
 using DevHome.PI.Properties;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.PI.ViewModels;
 
 public partial class ExpandedViewControlViewModel : ObservableObject
 {
-    private readonly Microsoft.UI.Dispatching.DispatcherQueue dispatcher;
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
 
     [ObservableProperty]
-    private Visibility perfMarkersVisibility = Visibility.Collapsed;
+    private Visibility _perfMarkersVisibility = Visibility.Collapsed;
 
     [ObservableProperty]
-    private string applicationPid = string.Empty;
+    private string _applicationPid = string.Empty;
 
     [ObservableProperty]
-    private string applicationName = string.Empty;
+    private string _applicationName = string.Empty;
 
     [ObservableProperty]
-    private string cpuUsage = string.Empty;
+    private string _cpuUsage = string.Empty;
 
     [ObservableProperty]
-    private string ramUsage = string.Empty;
+    private string _ramUsage = string.Empty;
 
     [ObservableProperty]
-    private string diskUsage = string.Empty;
+    private string _diskUsage = string.Empty;
 
     [ObservableProperty]
-    private string clipboardContentsHex = string.Empty;
+    private string _clipboardContentsHex = string.Empty;
 
     [ObservableProperty]
-    private string clipboardContentsDec = string.Empty;
+    private string _clipboardContentsDec = string.Empty;
 
     [ObservableProperty]
-    private string clipboardContentsCode = string.Empty;
+    private string _clipboardContentsCode = string.Empty;
 
     [ObservableProperty]
-    private string clipboardContentsHelp = string.Empty;
+    private string _clipboardContentsHelp = string.Empty;
 
     [ObservableProperty]
-    private string title = string.Empty;
+    private string _title = string.Empty;
 
     [ObservableProperty]
-    private string settingsHeader = string.Empty;
+    private ObservableCollection<PageNavLink> _links;
 
     [ObservableProperty]
-    private ObservableCollection<PageNavLink> links;
-
-    [ObservableProperty]
-    private int selectedNavLinkIndex = 0;
-
-    [ObservableProperty]
-    private Visibility appSettingsVisibility = Visibility.Collapsed;
+    private int _selectedNavLinkIndex = 0;
 
     [ObservableProperty]
     private bool _applyAppFiltering;
 
     public INavigationService NavigationService { get; }
 
-    private readonly PageNavLink appDetailsNavLink;
-    private readonly PageNavLink resourceUsageNavLink;
-    private readonly PageNavLink modulesNavLink;
-    private readonly PageNavLink werNavLink;
-    private readonly PageNavLink winLogsNavLink;
-    private readonly PageNavLink processListNavLink;
-    private readonly PageNavLink insightsNavLink;
+    private readonly PageNavLink _appDetailsNavLink;
+    private readonly PageNavLink _resourceUsageNavLink;
+    private readonly PageNavLink _modulesNavLink;
+    private readonly PageNavLink _werNavLink;
+    private readonly PageNavLink _winLogsNavLink;
+    private readonly PageNavLink _processListNavLink;
+    private readonly PageNavLink _insightsNavLink;
+    private readonly PageNavLink _settingsNavLink;
 
     public ExpandedViewControlViewModel()
     {
-        dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
         PerfCounters.Instance.PropertyChanged += PerfCounterHelper_PropertyChanged;
         ClipboardMonitor.Instance.PropertyChanged += Clipboard_PropertyChanged;
 
-        appDetailsNavLink = new PageNavLink("\uE71D", CommonHelper.GetLocalizedString("AppDetailsTextBlock/Text"), typeof(AppDetailsPageViewModel));
-        resourceUsageNavLink = new PageNavLink("\uE950", CommonHelper.GetLocalizedString("ResourceUsageHeaderTextBlock/Text"), typeof(ResourceUsagePageViewModel));
-        modulesNavLink = new PageNavLink("\uE74C", CommonHelper.GetLocalizedString("ModulesHeaderTextBlock/Text"), typeof(ModulesPageViewModel));
-        werNavLink = new PageNavLink("\uE7BA", CommonHelper.GetLocalizedString("WERHeaderTextBlock/Text"), typeof(WERPageViewModel));
-        winLogsNavLink = new PageNavLink("\uE7C4", CommonHelper.GetLocalizedString("WinLogsHeaderTextBlock/Text"), typeof(WinLogsPageViewModel));
-        processListNavLink = new PageNavLink("\uE8FD", CommonHelper.GetLocalizedString("ProcessListHeaderTextBlock/Text"), typeof(ProcessListPageViewModel));
-        insightsNavLink = new PageNavLink("\uE946", CommonHelper.GetLocalizedString("InsightsHeaderTextBlock/Text"), typeof(InsightsPageViewModel));
+        _appDetailsNavLink = new PageNavLink("\uE71D", CommonHelper.GetLocalizedString("AppDetailsTextBlock/Text"), typeof(AppDetailsPageViewModel));
+        _resourceUsageNavLink = new PageNavLink("\uE950", CommonHelper.GetLocalizedString("ResourceUsageHeaderTextBlock/Text"), typeof(ResourceUsagePageViewModel));
+        _modulesNavLink = new PageNavLink("\uE74C", CommonHelper.GetLocalizedString("ModulesHeaderTextBlock/Text"), typeof(ModulesPageViewModel));
+        _werNavLink = new PageNavLink("\uE7BA", CommonHelper.GetLocalizedString("WERHeaderTextBlock/Text"), typeof(WERPageViewModel));
+        _winLogsNavLink = new PageNavLink("\uE7C4", CommonHelper.GetLocalizedString("WinLogsHeaderTextBlock/Text"), typeof(WinLogsPageViewModel));
+        _processListNavLink = new PageNavLink("\uE8FD", CommonHelper.GetLocalizedString("ProcessListHeaderTextBlock/Text"), typeof(ProcessListPageViewModel));
+        _insightsNavLink = new PageNavLink("\uE946", CommonHelper.GetLocalizedString("InsightsHeaderTextBlock/Text"), typeof(InsightsPageViewModel));
+        _settingsNavLink = new PageNavLink("\uE713", CommonHelper.GetLocalizedString("SettingsToolHeaderTextBlock/Text"), typeof(SettingsPageViewModel));
 
-        links = new();
+        _links = [];
 
         ApplyAppFiltering = Settings.Default.ApplyAppFilteringToData;
-
-        appSettingsVisibility = TargetAppData.Instance.TargetProcess is not null ? Visibility.Visible : Visibility.Collapsed;
-
         AddPagesIfNecessary(TargetAppData.Instance.TargetProcess);
 
         // Initial values
@@ -107,29 +99,27 @@ public partial class ExpandedViewControlViewModel : ObservableObject
         RamUsage = CommonHelper.GetLocalizedString("MemoryPerfTextFormat", PerfCounters.Instance.RamUsageInMB);
         DiskUsage = CommonHelper.GetLocalizedString("DiskPerfTextFormat", PerfCounters.Instance.DiskUsage);
         NavigationService = Application.Current.GetService<INavigationService>();
-
-        SettingsHeader = CommonHelper.GetLocalizedString("SettingsToolHeaderTextBlock/Text");
     }
 
     private void PerfCounterHelper_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(PerfCounters.CpuUsage))
         {
-            dispatcher.TryEnqueue(() =>
+            _dispatcher.TryEnqueue(() =>
             {
                 CpuUsage = CommonHelper.GetLocalizedString("CpuPerfTextFormat", PerfCounters.Instance.CpuUsage);
             });
         }
         else if (e.PropertyName == nameof(PerfCounters.RamUsageInMB))
         {
-            dispatcher.TryEnqueue(() =>
+            _dispatcher.TryEnqueue(() =>
             {
                 RamUsage = CommonHelper.GetLocalizedString("MemoryPerfTextFormat", PerfCounters.Instance.RamUsageInMB);
             });
         }
         else if (e.PropertyName == nameof(PerfCounters.DiskUsage))
         {
-            dispatcher.TryEnqueue(() =>
+            _dispatcher.TryEnqueue(() =>
             {
                 DiskUsage = CommonHelper.GetLocalizedString("DiskPerfTextFormat", PerfCounters.Instance.DiskUsage);
             });
@@ -142,7 +132,7 @@ public partial class ExpandedViewControlViewModel : ObservableObject
         {
             var process = TargetAppData.Instance.TargetProcess;
 
-            dispatcher.TryEnqueue(() =>
+            _dispatcher.TryEnqueue(() =>
             {
                 // The App status bar is only visibile if we're attached to a process
                 PerfMarkersVisibility = process is null ? Visibility.Collapsed : Visibility.Visible;
@@ -151,8 +141,6 @@ public partial class ExpandedViewControlViewModel : ObservableObject
 
                 ApplicationName = process?.ProcessName ?? string.Empty;
                 Title = process?.ProcessName ?? string.Empty;
-
-                AppSettingsVisibility = process is not null ? Visibility.Visible : Visibility.Collapsed;
 
                 if (process is null)
                 {
@@ -168,7 +156,7 @@ public partial class ExpandedViewControlViewModel : ObservableObject
         {
             var newAppName = TargetAppData.Instance.AppName;
 
-            dispatcher.TryEnqueue(() =>
+            _dispatcher.TryEnqueue(() =>
             {
                 ApplicationName = newAppName;
                 Title = newAppName;
@@ -182,7 +170,7 @@ public partial class ExpandedViewControlViewModel : ObservableObject
             var process = TargetAppData.Instance.TargetProcess;
             if (process != null && process.HasExited)
             {
-                dispatcher.TryEnqueue(() =>
+                _dispatcher.TryEnqueue(() =>
                 {
                     Title = CommonHelper.GetLocalizedString("TerminatedText", ApplicationName);
                 });
@@ -193,7 +181,7 @@ public partial class ExpandedViewControlViewModel : ObservableObject
     private void Clipboard_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         var clipboardContents = ClipboardMonitor.Instance.Contents;
-        dispatcher.TryEnqueue(() =>
+        _dispatcher.TryEnqueue(() =>
         {
             ClipboardContentsHex = clipboardContents.Hex;
             ClipboardContentsDec = clipboardContents.Dec;
@@ -204,25 +192,26 @@ public partial class ExpandedViewControlViewModel : ObservableObject
 
     private void AddPagesIfNecessary(Process? process)
     {
-        if (!Links.Contains(processListNavLink))
+        if (!Links.Contains(_processListNavLink))
         {
-            Links.Add(processListNavLink);
-            Links.Add(werNavLink);
-            Links.Add(insightsNavLink);
+            Links.Add(_processListNavLink);
+            Links.Add(_werNavLink);
+            Links.Add(_insightsNavLink);
+            Links.Add(_settingsNavLink);
         }
 
         // If App Details is missing, add all other pages.
-        if (!Links.Contains(appDetailsNavLink))
+        if (!Links.Contains(_appDetailsNavLink))
         {
             if (process is not null)
             {
-                Links.Insert(0, appDetailsNavLink);
-                Links.Insert(1, resourceUsageNavLink);
-                Links.Insert(2, modulesNavLink);
+                Links.Insert(0, _appDetailsNavLink);
+                Links.Insert(1, _resourceUsageNavLink);
+                Links.Insert(2, _modulesNavLink);
 
                 // Process List #3
                 // WER #4
-                Links.Insert(5, winLogsNavLink);
+                Links.Insert(5, _winLogsNavLink);
 
                 // Insights #6;
             }
@@ -232,12 +221,12 @@ public partial class ExpandedViewControlViewModel : ObservableObject
     private void RemoveAppSpecificPages()
     {
         // First navigate to ProcessListPage, then remove all other pages.
-        SelectedNavLinkIndex = Links.IndexOf(processListNavLink);
+        SelectedNavLinkIndex = Links.IndexOf(_processListNavLink);
 
-        Links.Remove(appDetailsNavLink);
-        Links.Remove(resourceUsageNavLink);
-        Links.Remove(modulesNavLink);
-        Links.Remove(winLogsNavLink);
+        Links.Remove(_appDetailsNavLink);
+        Links.Remove(_resourceUsageNavLink);
+        Links.Remove(_modulesNavLink);
+        Links.Remove(_winLogsNavLink);
     }
 
     public void NavigateTo(Type viewModelType)
@@ -264,11 +253,6 @@ public partial class ExpandedViewControlViewModel : ObservableObject
 
     public void NavigateToSettings(string viewModelType)
     {
-        // Because the Settings item isn't part of our NavLink list, when the user selects Settings,
-        // we need to move the list selection so that when they subsequently select an item from
-        // the NavLinks, we'll navigate to the correct page even if that was the previously-selected item.
-        SelectedNavLinkIndex = -1;
-
         var navigationService = Application.Current.GetService<INavigationService>();
         var mainSettingsPage = typeof(SettingsPageViewModel).FullName!;
         navigationService.NavigateTo(mainSettingsPage);
@@ -276,12 +260,6 @@ public partial class ExpandedViewControlViewModel : ObservableObject
         {
             navigationService.NavigateTo(viewModelType);
         }
-    }
-
-    [RelayCommand]
-    public void DetachFromProcess()
-    {
-        TargetAppData.Instance.ClearAppData();
     }
 
     [RelayCommand]


### PR DESCRIPTION
The "Detach from target app" button was in the Navigation panel, but it's not a navigation item. It also only applies if PI is actually associated with a target app. So I moved it to the AppDetails page (which also only applies if there's a target app). Also changed the button content to a Fluent Icons glyph, consistent with other buttons in PI.

Also repositioned the Clipboard error monitoring panel so that it is at the bottom of the main content page, and no longer extends into the Navigation panel.

At the same time, I moved the Settings navigation button from the status bar back into the Navigation panel, as this is a navigation item. As part of this, I made it part of the regular navigation list. Also removed some redundant properties which weren't used anyway. Note issue #3462, which will standardize the Navigation panel itself - at that time we can move Settings item to be a bottom navigation item, which is more common.

Closes #3323
Closes #3321
Closes #3462
