### PR TITLE
Git extension improvements

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Diagnostics;
@@ -100,6 +100,6 @@ public class GitLocalRepositoryProviderUnitTests
         Assert.AreEqual(result["System.VersionControl.LastChangeAuthorEmail"], "a.u.thor@example.com");
         Assert.AreEqual(result["System.VersionControl.LastChangeAuthorName"], "A U Thor");
         Assert.AreEqual(result["System.VersionControl.LastChangeID"], "d0114ab8ac326bab30e3a657a0397578c5a1af88");
-        Assert.AreEqual(result["System.VersionControl.CurrentFolderStatus"], "master AheadBy: 0 BehindBy: 0");
+        Assert.AreEqual(result["System.VersionControl.CurrentFolderStatus"], "Branch: master ≡ | +0 ~0 -0 | +0 ~0 -0");
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -23,13 +23,17 @@ internal sealed class CommitLogCache : IEnumerable<Commit>
 
     public CommitLogCache(Repository repo)
     {
-        foreach (var commit in repo.Commits)
-        {
-            // For now, greedily get the entire commit log for simplicity.
-            // PRO: No syncronization needed for the enumerator.
-            // CON: May take longer for the initial load and use more memory.
-            _commits.Add(commit);
-        }
+        // For now, greedily get the entire commit log for simplicity.
+        // PRO: No syncronization needed for the enumerator.
+        // CON: May take longer for the initial load and use more memory.
+        // For reference, I tested on my dev machine on a repo with an *enormous* number of commits
+        // https://github.com/python/cpython with > 120k commits. This was a one-time cost of 2-3 seconds, but also
+        // consumed several hundred MB of memory.
+
+        // Often, but not always, the root folder has some boilerplate/doc/config that rarely changes
+        // Therefore, populating the last commit for each file in the root folder often requires a large portion of the commit history anyway.
+        // This somewhat blunts the appeal of trying to load this incrementally.
+        _commits.AddRange(repo.Commits);
     }
 
     public IEnumerator<Commit> GetEnumerator()

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using LibGit2Sharp;
+
+namespace FileExplorerGitIntegration.Models;
+
+// LibGit2Sharp.CommitEnumerator are not reusable as they do not provide a way to reuse libgit2's revwalk object
+// LibGit2's prepare_walk() does the expensive work of traversing and caching the commit graph
+// Unfortunately LibGit2Sharp.CommitEnumerator.Reset() method resets the revwalk, but does not reinitialize the sort/push/hide options
+// This leaves all that work wasted only to be done again.
+// Furthermore, LibGit2 revwalk initialization takes locks on internal data, which causes contention in multithreaded scenarios as threads
+// all scramble to initialize and re-initialize their own revwalk objects.
+// Ideally, LibGit2Sharp improves the API to allow reusing the revwalk object, but that seems unlikely to happen soon.
+internal sealed class CommitLogCache : IEnumerable<Commit>
+{
+    private readonly List<Commit> _commits = new();
+
+    public CommitLogCache(Repository repo)
+    {
+        foreach (var commit in repo.Commits)
+        {
+            // For now, greedily get the entire commit log for simplicity.
+            // PRO: No syncronization needed for the enumerator.
+            // CON: May take longer for the initial load and use more memory.
+            _commits.Add(commit);
+        }
+    }
+
+    public IEnumerator<Commit> GetEnumerator()
+    {
+        return _commits.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
@@ -199,6 +199,10 @@ public sealed class GitLocalRepository : ILocalRepository
         var checkedFirstCommit = false;
         foreach (var currentCommit in repository.GetCommits())
         {
+            // Now that CommitLogCache is caching the result of the revwalk, the next piece that is most expensive
+            // is obtaining relativePath's TreeEntry from the Tree (e.g. currentTree[relativePath].
+            // Digging into the git shows that number of directory entries and/or directory depth may play a factor.
+            // There may also be a lot of redundant lookups happening here, so it may make sense to do some LRU caching.
             var currentTree = currentCommit.Tree;
             var currentTreeEntry = currentTree[relativePath];
             if (currentTreeEntry == null)

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
@@ -29,13 +29,18 @@ public sealed class GitLocalRepository : ILocalRepository
 
     internal GitLocalRepository(string rootFolder, RepositoryCache? cache)
     {
-        if (!Repository.IsValid(rootFolder))
+        RootFolder = rootFolder;
+        _repositoryCache = cache;
+
+        try
+        {
+            // Rather than open the repo from scratch as validation, try to retrieve it from the cache
+            OpenRepository();
+        }
+        catch
         {
             throw new ArgumentException("Invalid repository path");
         }
-
-        RootFolder = rootFolder;
-        _repositoryCache = cache;
     }
 
     private RepositoryWrapper OpenRepository()

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryCache.cs
@@ -11,40 +11,64 @@ namespace FileExplorerGitIntegration.Models;
 internal sealed class RepositoryCache : IDisposable
 {
     private readonly ConcurrentDictionary<string, Repository> _repositoryCache = new();
+    private readonly ConcurrentDictionary<(Repository repo, Commit head), CommitLogCache> _logCache = new();
     private readonly Serilog.ILogger log = Log.ForContext("SourceContext", nameof(RepositoryCache));
     private bool disposedValue;
 
-    public Repository? GetRepository(string rootFolder)
+    public Repository GetRepository(string rootFolder)
     {
         if (_repositoryCache.TryGetValue(rootFolder, out Repository? repo))
         {
             return repo;
         }
 
+        var tempRepo = new Repository(rootFolder);
         try
         {
-            repo = new Repository(rootFolder);
-            if (!_repositoryCache.TryAdd(rootFolder, repo))
+            if (!_repositoryCache.TryAdd(rootFolder, tempRepo))
             {
                 // Another thread beat us here. Dispose of the repo we just created and get the one from the cache.
-                repo.Dispose();
+                tempRepo.Dispose();
                 var result = _repositoryCache.TryGetValue(rootFolder, out repo);
                 Debug.Assert(result, "Failed to get newly added repo from cache");
                 Debug.Assert(repo != null, "Repo from cache should not be null");
             }
-
-            return repo;
-        }
-        catch (Exception ex)
-        {
-            log.Error("RepositoryCache", "Failed to create Repository", ex);
-            if (repo != null)
+            else
             {
-                repo.Dispose();
+                repo = tempRepo;
+                tempRepo = null;
             }
-
-            return null;
         }
+        finally
+        {
+            if (tempRepo != null)
+            {
+                tempRepo.Dispose();
+            }
+        }
+
+        return repo;
+    }
+
+    public CommitLogCache GetCommitLog(Repository repo)
+    {
+        var head = repo.Head.Tip;
+        var key = (repo, head);
+        if (_logCache.TryGetValue(key, out CommitLogCache? cache))
+        {
+            return cache;
+        }
+
+        cache = new CommitLogCache(repo);
+        if (!_logCache.TryAdd(key, cache))
+        {
+            // Another thread beat us here. Dispose of the CommitLogCache we just created and get the one from the cache.
+            var result = _logCache.TryGetValue(key, out cache);
+            Debug.Assert(result, "Failed to get newly added CommitLogCache from cache");
+            Debug.Assert(cache != null, "CommitLogCache from cache should not be null");
+        }
+
+        return cache;
     }
 
     internal void Dispose(bool disposing)

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Management.Automation;
+using LibGit2Sharp;
+using Microsoft.Windows.DevHome.SDK;
+using Serilog;
+
+namespace FileExplorerGitIntegration.Models;
+
+internal sealed class RepositoryWrapper : IDisposable
+{
+    private readonly Repository _repo;
+    private readonly ReaderWriterLockSlim _repoLock = new();
+
+    private readonly string _workingDirectory;
+
+    private Commit? _head;
+    private CommitLogCache? _commits;
+
+    private bool _disposedValue;
+
+    public RepositoryWrapper(string rootFolder)
+    {
+        _repo = new Repository(rootFolder);
+        _workingDirectory = _repo.Info.WorkingDirectory;
+    }
+
+    public IEnumerable<Commit> GetCommits()
+    {
+        // Fast path: if we have an up-to-date commit log, return that
+        if (_head != null && _commits != null)
+        {
+            _repoLock.EnterReadLock();
+            try
+            {
+                if (_repo.Head.Tip == _head)
+                {
+                    return _commits;
+                }
+            }
+            finally
+            {
+                _repoLock?.ExitReadLock();
+            }
+        }
+
+        // Either the commit log hasn't been created yet, or it's out of date
+        _repoLock.EnterWriteLock();
+        try
+        {
+            if (_head == null || _commits == null || _repo.Head.Tip != _head)
+            {
+                _commits = new CommitLogCache(_repo);
+                _head = _repo.Head.Tip;
+            }
+        }
+        finally
+        {
+            _repoLock.ExitWriteLock();
+        }
+
+        return _commits;
+    }
+
+    public string GetRepoStatus()
+    {
+        RepositoryStatus repositoryStatus;
+        string branchName;
+        var branchStatus = string.Empty;
+        try
+        {
+            _repoLock.EnterWriteLock();
+            repositoryStatus = _repo.RetrieveStatus();
+            branchName = _repo.Info.IsHeadDetached ?
+                "Detached: " + _repo.Head.Tip.Sha[..7] :
+                "Branch: " + _repo.Head.FriendlyName;
+            if (_repo.Head.IsTracking)
+            {
+                var behind = _repo.Head.TrackingDetails.BehindBy;
+                var ahead = _repo.Head.TrackingDetails.AheadBy;
+                if (behind == 0 && ahead == 0)
+                {
+                    branchStatus = " ≡";
+                }
+                else if (behind > 0 && ahead > 0)
+                {
+                    branchStatus = " ↓" + behind + " ↑" + ahead;
+                }
+                else if (behind > 0)
+                {
+                    branchStatus = " ↓" + behind;
+                }
+                else if (ahead > 0)
+                {
+                    branchStatus = " ↑" + ahead;
+                }
+            }
+        }
+        finally
+        {
+            _repoLock.ExitWriteLock();
+        }
+
+        var fileStatus = $"| +{repositoryStatus.Added.Count()} ~{repositoryStatus.Staged.Count()} -{repositoryStatus.Removed.Count()} | +{repositoryStatus.Untracked.Count()} ~{repositoryStatus.Modified.Count()} -{repositoryStatus.Missing.Count()}";
+        var conflicted = 0;
+        foreach (var entry in repositoryStatus)
+        {
+            if (entry.State.HasFlag(FileStatus.Conflicted))
+            {
+                ++conflicted;
+            }
+        }
+
+        if (conflicted > 0)
+        {
+            fileStatus += $" !{conflicted}";
+        }
+
+        return branchName + branchStatus + " " + fileStatus;
+    }
+
+    public string GetFileStatus(string relativePath)
+    {
+        // Skip directories while we're getting individual file status.
+        if (File.GetAttributes(Path.Combine(_workingDirectory, relativePath)).HasFlag(FileAttributes.Directory))
+        {
+            return string.Empty;
+        }
+
+        FileStatus status;
+        try
+        {
+            _repoLock.EnterWriteLock();
+            status = _repo.RetrieveStatus(relativePath);
+        }
+        finally
+        {
+            _repoLock.ExitWriteLock();
+        }
+
+        if (status == FileStatus.Unaltered || status.HasFlag(FileStatus.Nonexistent | FileStatus.Ignored))
+        {
+            return string.Empty;
+        }
+        else if (status.HasFlag(FileStatus.Conflicted))
+        {
+            return "Merge conflict";
+        }
+        else if (status.HasFlag(FileStatus.NewInWorkdir))
+        {
+            return "Untracked";
+        }
+
+        var statusString = string.Empty;
+        if (status.HasFlag(FileStatus.NewInIndex) || status.HasFlag(FileStatus.ModifiedInIndex) || status.HasFlag(FileStatus.RenamedInIndex) || status.HasFlag(FileStatus.TypeChangeInIndex))
+        {
+            statusString = "Staged";
+        }
+
+        if (status.HasFlag(FileStatus.ModifiedInWorkdir) || status.HasFlag(FileStatus.RenamedInWorkdir) || status.HasFlag(FileStatus.TypeChangeInWorkdir))
+        {
+            if (statusString == null)
+            {
+                statusString = "Modified";
+            }
+            else
+            {
+                statusString += ", Modified";
+            }
+        }
+
+        return statusString;
+    }
+
+    internal void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _repo.Dispose();
+                _repoLock.Dispose();
+            }
+        }
+
+        _disposedValue = true;
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -105,14 +105,7 @@ internal sealed class RepositoryWrapper : IDisposable
         }
 
         var fileStatus = $"| +{repositoryStatus.Added.Count()} ~{repositoryStatus.Staged.Count()} -{repositoryStatus.Removed.Count()} | +{repositoryStatus.Untracked.Count()} ~{repositoryStatus.Modified.Count()} -{repositoryStatus.Missing.Count()}";
-        var conflicted = 0;
-        foreach (var entry in repositoryStatus)
-        {
-            if (entry.State.HasFlag(FileStatus.Conflicted))
-            {
-                ++conflicted;
-            }
-        }
+        var conflicted = repositoryStatus.Where(x => x.State.HasFlag(FileStatus.Conflicted)).Count();
 
         if (conflicted > 0)
         {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -162,7 +162,7 @@ internal sealed class RepositoryWrapper : IDisposable
 
         if (status.HasFlag(FileStatus.ModifiedInWorkdir) || status.HasFlag(FileStatus.RenamedInWorkdir) || status.HasFlag(FileStatus.TypeChangeInWorkdir))
         {
-            if (statusString == null)
+            if (string.IsNullOrEmpty(statusString))
             {
                 statusString = "Modified";
             }


### PR DESCRIPTION
## Summary of the pull request

This brings several improvements to the Git extension:
- Huge performance increase for fetching latest commit
- Improved file/repo status
- Improved thread safety

## Detailed description of the pull request / Additional comments
For the perf increase, I learned that `LibGit2Sharp.CommitEnumerator` is not reusable, even though the object it wraps, libgit2's `git_revwalk` is documented that "for maximum performance, this revision walker should be reused for different walks". Measurements confirmed that most of the time was being spent in libgit2's `prepare_walk()` where it traverses, sorts, and caches the commit graph in the `git_revwalk`. After this step, walking the commits in the revwalk proceed quickly, which is used for finding a file's latest commit.

To work around this, we grab the whole commit graph up front and cache the list of `LibGit2Sharp.Commit` objects to walk later. When it's time to fetch this cached list, we first check to see if `HEAD` has changed, and retrieve a new list of commits.
- An interesting data point is that fetching the entire commit history appears wasteful, but this is offset by only needing to do it once, and it's far less complex to grab it in one go rather than try to do it incrementally behind some thread locks. Additionally, while many folders in a repo will consist of relatively "recent" files, a small sampling of repos shows that the root folder often contains files that are quite old - license, .gitignore, .gitattribute, and other configuration and boilerplate tend to change infrequently. Since these are in the root, and the root folder is often the starting point for browsing the file tree, we'd frequently have to fetch a significant portion of the commit in the beginning, eroding the potential savings of an incremental approach.

For improved file status, instead of calling `ToString` on LibGit2Sharp's enum values, we now simplify and turn these strings into more intuitive values, like "Modified", "Staged", "Untracked".

For improved repo status, we now obtain the whole-repo status and condense that into a compact string representation we see in other tools.
`<branch name> <branch status> | <file counts>`
Where:
- `<branch name>` is either `"Branch: <name>"` or `"Detached: <sha>"`
- `<branch status>` if the branch is tracking a remote shows either
  - `↑ <ahead # commits>`
  - `↓ <behind # commits>`
  - `↓ <behind # commits> ↑ <ahead # commits>`
  - `≡` (when up-to-date)
- `<file counts>` is `"+<#added> ~<#numstaged> -<#removed> | <#untracked> ~<modified> -<missing>"`
  - If merge conflicts are present it appends `"!<#conflicted>"`

To fix race conditions, I moved the `LibGit2Sharp.Repository` object into a new `RepositoryWrapper` class that will manage access to the Repository objects to eliminate concurrent access.

## Validation steps performed
Built extension and browsed the PowerToys repo, refreshing the view while checking out branches back and forth to cause contention on fetching status and commits. Not only does this run much faster than before, but the infrequent instances where the extension would sometimes hang or crash have disappeared.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
