### PR TITLE
Add heading levels to Extensions page

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -199,4 +199,7 @@
   <data name="AvailableFromStoreStackPanel.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Available in the Microsoft Store</value>
   </data>
+  <data name="AvailableFromStoreItemsRepeater.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Available in the Microsoft Store</value>
+  </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -194,12 +194,9 @@
     <comment>ToolTip of the button that brings up the "More options" menu</comment>
   </data>
   <data name="InstalledItemsStackPanel.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Installed</value>
+    <value>Installed Items Stack Panel Name</value>
   </data>
   <data name="AvailableFromStoreStackPanel.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Available in the Microsoft Store</value>
-  </data>
-  <data name="AvailableFromStoreItemsRepeater.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Available in the Microsoft Store</value>
+    <value>Available in the Microsoft Store Automation Properties Name</value>
   </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Strings/en-us/Resources.resw
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -133,5 +192,11 @@
   <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>More options</value>
     <comment>ToolTip of the button that brings up the "More options" menu</comment>
+  </data>
+  <data name="InstalledItemsStackPanel.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Installed</value>
+  </data>
+  <data name="AvailableFromStoreStackPanel.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Available in the Microsoft Store</value>
   </data>
 </root>

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -48,7 +48,7 @@
                                     Margin="0,0,0,28" />
 
                 <!-- Installed items -->
-                <StackPanel x:Uid="InstalledItemsStackPanel" IsTabStop="True">
+                <StackPanel x:Uid="InstalledItemsStackPanel">
                     <Grid Margin="{StaticResource SettingsPageSubTitleMargin}">
                         <TextBlock x:Uid="InstalledTextBlock"
                                Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
@@ -112,7 +112,7 @@
                     
                 </StackPanel>
                 <!-- Available items -->
-                <StackPanel x:Uid="AvailableFromStoreStackPanel" IsTabStop="True">
+                <StackPanel x:Uid="AvailableFromStoreStackPanel">
                     <TextBlock x:Uid="AvailableFromStoreTextBlock"
                                Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
                                Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -52,7 +52,8 @@
                     <Grid Margin="{StaticResource SettingsPageSubTitleMargin}">
                         <TextBlock x:Uid="InstalledTextBlock"
                                Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-                               VerticalAlignment="Center"/>
+                               VerticalAlignment="Center"
+                               AutomationProperties.HeadingLevel="2"/>
                         <Button x:Uid="GetUpdatesButton"
                             AutomationProperties.AutomationId="GetUpdatesButton"
                             HorizontalAlignment="Right"
@@ -115,8 +116,9 @@
                 <StackPanel x:Uid="AvailableFromStoreStackPanel">
                     <TextBlock x:Uid="AvailableFromStoreTextBlock"
                                Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-                               Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />
-                    <ItemsRepeater ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
+                               Margin="{StaticResource ExtensionLibrarySubTitleMargin}" 
+                               AutomationProperties.HeadingLevel="2"/>
+                    <ItemsRepeater x:Uid="AvailableFromStoreItemsRepeater" ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="viewmodels:StorePackageViewModel">
                                 <ctControls:SettingsCard Header="{x:Bind Title}"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -48,107 +48,111 @@
                                     Margin="0,0,0,28" />
 
                 <!-- Installed items -->
-                <Grid Margin="{StaticResource SettingsPageSubTitleMargin}">
-                    <TextBlock x:Uid="InstalledTextBlock"
+                <StackPanel x:Uid="InstalledItemsStackPanel" IsTabStop="True">
+                    <Grid Margin="{StaticResource SettingsPageSubTitleMargin}">
+                        <TextBlock x:Uid="InstalledTextBlock"
                                Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
                                VerticalAlignment="Center"/>
-                    <Button x:Uid="GetUpdatesButton"
+                        <Button x:Uid="GetUpdatesButton"
                             AutomationProperties.AutomationId="GetUpdatesButton"
                             HorizontalAlignment="Right"
                             Style="{ThemeResource AccentButtonStyle}"
                             Visibility="{x:Bind ViewModel.InstalledPackagesList.Count, Converter={StaticResource InverseCountToVisibilityConverter}, Mode=OneWay}"
                             Command="{x:Bind ViewModel.GetUpdatesButtonCommand}"/>
-                </Grid>
-                <ItemsRepeater ItemsSource="{x:Bind ViewModel.InstalledPackagesList, Mode=OneWay}">
-                    <ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="viewmodels:InstalledPackageViewModel">
-                            <ctControls:SettingsExpander Header="{x:Bind DisplayName}"
+                    </Grid>
+                    <ItemsRepeater ItemsSource="{x:Bind ViewModel.InstalledPackagesList, Mode=OneWay}">
+                        <ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="viewmodels:InstalledPackageViewModel">
+                                <ctControls:SettingsExpander Header="{x:Bind DisplayName}"
                                                    Description="{x:Bind GeneratePackageDetails(Version,Publisher , InstalledDate), Mode=OneWay}"
                                                    Margin="{ThemeResource SettingsCardMargin}"
                                                    ItemsSource="{x:Bind InstalledExtensionsList}"
                                                    IsExpanded="False">
-                                <ctControls:SettingsExpander.HeaderIcon>
-                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
-                                </ctControls:SettingsExpander.HeaderIcon>
-                                <StackPanel>
-                                    <!-- This StackPanel is a workaround for the bug https://github.com/CommunityToolkit/Windows/issues/396 -->
-                                    <Button x:Uid="MoreOptionsButton"
+                                    <ctControls:SettingsExpander.HeaderIcon>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
+                                    </ctControls:SettingsExpander.HeaderIcon>
+                                    <StackPanel>
+                                        <!-- This StackPanel is a workaround for the bug https://github.com/CommunityToolkit/Windows/issues/396 -->
+                                        <Button x:Uid="MoreOptionsButton"
                                             AutomationProperties.AutomationId="{x:Bind AutomationMoreOptionsPfn}"
                                             Content="&#xe712;"
                                             Height="36" MinWidth="36"
                                             FontFamily="{StaticResource SymbolThemeFontFamily}" 
                                             Background="Transparent"
                                             BorderThickness="0">
-                                        <Button.Flyout>
-                                            <MenuFlyout>
-                                                <MenuFlyoutItem
+                                            <Button.Flyout>
+                                                <MenuFlyout>
+                                                    <MenuFlyoutItem
                                                     x:Uid="UninstallItem"
                                                     Command="{x:Bind UninstallButtonCommand}">
-                                                </MenuFlyoutItem>
-                                            </MenuFlyout>
-                                        </Button.Flyout>
-                                    </Button>
-                                </StackPanel>
-                                <ctControls:SettingsExpander.ItemTemplate>
-                                    <DataTemplate x:DataType="viewmodels:InstalledExtensionViewModel">
-                                        <ctControls:SettingsCard Header="{x:Bind DisplayName}"
+                                                    </MenuFlyoutItem>
+                                                </MenuFlyout>
+                                            </Button.Flyout>
+                                        </Button>
+                                    </StackPanel>
+                                    <ctControls:SettingsExpander.ItemTemplate>
+                                        <DataTemplate x:DataType="viewmodels:InstalledExtensionViewModel">
+                                            <ctControls:SettingsCard Header="{x:Bind DisplayName}"
                                                            CornerRadius="0,0,3,3"
                                                            IsClickEnabled="{x:Bind HasSettingsProvider}"
                                                            Command="{x:Bind NavigateSettingsCommand}">
-                                            <ToggleSwitch IsOn="{x:Bind IsExtensionEnabled, Mode=TwoWay}"/>
-                                        </ctControls:SettingsCard>
-                                    </DataTemplate>
-                                </ctControls:SettingsExpander.ItemTemplate>
-                            </ctControls:SettingsExpander>
-                        </DataTemplate>
-                    </ItemsRepeater.ItemTemplate>
-                </ItemsRepeater>
-                <!-- No extensions message -->
-                <TextBlock x:Uid="NoExtensionsAdded"
+                                                <ToggleSwitch IsOn="{x:Bind IsExtensionEnabled, Mode=TwoWay}"/>
+                                            </ctControls:SettingsCard>
+                                        </DataTemplate>
+                                    </ctControls:SettingsExpander.ItemTemplate>
+                                </ctControls:SettingsExpander>
+                            </DataTemplate>
+                        </ItemsRepeater.ItemTemplate>
+                    </ItemsRepeater>
+                    <!-- No extensions message -->
+                    <TextBlock x:Uid="NoExtensionsAdded"
                            Visibility="{x:Bind ViewModel.InstalledPackagesList.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}"
                            Margin="0,50" 
                            HorizontalAlignment="Center" />
-
+                    
+                </StackPanel>
                 <!-- Available items -->
-                <TextBlock x:Uid="AvailableFromStoreTextBlock"
-                           Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-                           Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />
-                <ItemsRepeater ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
-                    <ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="viewmodels:StorePackageViewModel">
-                            <ctControls:SettingsCard Header="{x:Bind Title}"
-                                               Description="{x:Bind Publisher}"
-                                               Margin="{ThemeResource SettingsCardMargin}"
-                                               CornerRadius="3"
-                                               AutomationProperties.Name="{x:Bind Title}"
-                                               IsClickEnabled="False">
-                                <ctControls:SettingsCard.HeaderIcon>
-                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
-                                </ctControls:SettingsCard.HeaderIcon>
-                                <Button x:Uid="GetButton"
+                <StackPanel x:Uid="AvailableFromStoreStackPanel" IsTabStop="True">
+                    <TextBlock x:Uid="AvailableFromStoreTextBlock"
+                               Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
+                               Margin="{StaticResource ExtensionLibrarySubTitleMargin}" />
+                    <ItemsRepeater ItemsSource="{x:Bind ViewModel.StorePackagesList, Mode=OneWay}">
+                        <ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="viewmodels:StorePackageViewModel">
+                                <ctControls:SettingsCard Header="{x:Bind Title}"
+                                                Description="{x:Bind Publisher}"
+                                                Margin="{ThemeResource SettingsCardMargin}"
+                                                CornerRadius="3"
+                                                AutomationProperties.Name="{x:Bind Title}"
+                                                IsClickEnabled="False">
+                                    <ctControls:SettingsCard.HeaderIcon>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xea86;"/>
+                                    </ctControls:SettingsCard.HeaderIcon>
+                                    <Button x:Uid="GetButton"
                                         AutomationProperties.AutomationId="{x:Bind AutomationInstallPfn}"
                                         Padding="25 4 25 6"
                                         MinWidth="118"
                                         Command="{x:Bind LaunchStoreButtonCommand}"
                                         CommandParameter="{x:Bind ProductId}" />
-                            </ctControls:SettingsCard>
-                        </DataTemplate>
-                    </ItemsRepeater.ItemTemplate>
-                </ItemsRepeater>
-                <!-- No available items messages -->
-                <TextBlock x:Uid="NoAvailableExtensions"
-                           Visibility="{x:Bind ViewModel.GetNoAvailablePackagesVisibility(ViewModel.StorePackagesList.Count, ViewModel.ShouldShowStoreError), Mode=OneWay}"
-                           Margin="0,20,0,48"
-                           HorizontalAlignment="Center" />
-                <StackPanel Visibility="{x:Bind ViewModel.ShouldShowStoreError, Mode=OneWay}" HorizontalAlignment="Center">
-                    <TextBlock x:Uid="StoreErrorMessage"
-                               Foreground="{ThemeResource SystemFillColorCautionBrush}"
-                               Margin="0,50,0,0"
-                               HorizontalAlignment="Center" />
-                    <HyperlinkButton x:Uid="SendFeedback"
-                                     HorizontalAlignment="Center"
-                                     Command="{x:Bind ViewModel.SendFeedbackClickCommand}">
-                    </HyperlinkButton>
+                                </ctControls:SettingsCard>
+                            </DataTemplate>
+                        </ItemsRepeater.ItemTemplate>
+                    </ItemsRepeater>
+                    <!-- No available items messages -->
+                    <TextBlock x:Uid="NoAvailableExtensions"
+                            Visibility="{x:Bind ViewModel.GetNoAvailablePackagesVisibility(ViewModel.StorePackagesList.Count, ViewModel.ShouldShowStoreError), Mode=OneWay}"
+                            Margin="0,20,0,48"
+                            HorizontalAlignment="Center" />
+                    <StackPanel Visibility="{x:Bind ViewModel.ShouldShowStoreError, Mode=OneWay}" HorizontalAlignment="Center">
+                        <TextBlock x:Uid="StoreErrorMessage"
+                                Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                Margin="0,50,0,0"
+                                HorizontalAlignment="Center" />
+                        <HyperlinkButton x:Uid="SendFeedback"
+                                        HorizontalAlignment="Center"
+                                        Command="{x:Bind ViewModel.SendFeedbackClickCommand}">
+                        </HyperlinkButton>
+                    </StackPanel>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
## Summary of the pull request
I enabled the narrator in scan mode to read the heading levels of the "Installed" and "Available in the Microsoft Store" headings on the Dev Home Extensions page by adding Automation.HeadingLevel properties to each text block. 

## References and relevant issues

https://task.ms/52443515

## Detailed description of the pull request / Additional comments

#### Before:

https://github.com/user-attachments/assets/41702b43-b71a-4c46-9541-f9f86f11a9a1

#### After changes:

https://github.com/user-attachments/assets/f3cac5e5-8bd8-4347-94ae-896b02cbc1d7

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
