### PR TITLE
Define build constants in CoreWidgetExtension

### DIFF
--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -19,6 +19,11 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfileFullPath>
+  </PropertyGroup
+
+  <PropertyGroup>
+    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
+    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -19,7 +19,7 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfileFullPath>
-  </PropertyGroup
+  </PropertyGroup>
 
   <PropertyGroup>
     <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>


### PR DESCRIPTION
## Summary of the pull request
Fixes an issue where Canary (and presumably Preview) CoreWidgetExtension crashed on startup. Widgets from this extension could not be pinned.

#3483 introduced separate class IDs for different build rings of Dev Home. However, the CoreWidgetExtension project did not define constants for different build rings. Therefore, when we tried to use them during extension startup, the Dev class IDs were being used and the wrong objects created. This caused a crash when creating the objects. To fix the issue, we define the constants in the csproj.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated locally building as Canary.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
