### PR TITLE
Only retry and summary buttons can get tab order.

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -181,6 +181,7 @@
                 <ListView
                     x:Name="NonExecutingTasks"
                     Grid.Row="0"
+                    IsEnabled="False"
                     ItemsSource="{x:Bind ViewModel.NonExecutingMessages, Mode=OneWay}"
                     SelectionMode="Single">
                     <ListView.ItemTemplate>
@@ -208,6 +209,7 @@
                 <ListView
                     x:Name="ExecutingTasks"
                     Grid.Row="1"
+                    IsEnabled="False"
                     ItemsSource="{x:Bind ViewModel.ExecutingMessages, Mode=OneWay}"
                     SelectionMode="None">
                     <ListView.ItemTemplate>
@@ -253,6 +255,7 @@
             <ListView
                 Grid.Row="1"
                 Margin="0,0,0,5"
+                IsEnabled="False"
                 ItemsSource="{x:Bind ViewModel.ActionCenterItems, Mode=OneWay}"
                 SelectionMode="None">
                 <ListView.ItemTemplate>


### PR DESCRIPTION
## Summary of the pull request
Removing the two list views from the tab order because they aren't interactable.  This is done by making them diabled.

It does not change the UI. :)


## References and relevant issues

https://task.ms/50310086

## Detailed description of the pull request / Additional comments

## Validation steps performed
Ran through the loading screen.


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

Movie!
https://github.com/user-attachments/assets/58690874-f652-47e0-9c32-4dca4363c706

