### PR TITLE
Show error if no accounts can access a repository

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProvider.cs
@@ -135,7 +135,7 @@ internal sealed class RepositoryProvider
     /// <remarks>
     /// Can be null if the provider can't parse the Uri.
     /// </remarks>
-    public IRepository GetRepositoryFromUri(Uri uri, IDeveloperId developerId = null)
+    public RepositoryResult GetRepositoryFromUri(Uri uri, IDeveloperId developerId = null)
     {
         RepositoryResult getResult;
         if (developerId == null)
@@ -147,14 +147,7 @@ internal sealed class RepositoryProvider
             getResult = _repositoryProvider.GetRepositoryFromUriAsync(uri, developerId).AsTask().Result;
         }
 
-        if (getResult.Result.Status == ProviderOperationStatus.Failure)
-        {
-            _log.Information("Could not get repo from Uri.");
-            _log.Information(getResult.Result.DisplayMessage);
-            return null;
-        }
-
-        return getResult.Repository;
+        return getResult;
     }
 
     /// <summary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProviders.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/RepositoryProviders.cs
@@ -105,12 +105,18 @@ internal sealed class RepositoryProviders
         {
             provider.Value.StartIfNotRunning();
             _log.Information($"Attempting to parse using provider {provider.Key}");
-            var repository = provider.Value.GetRepositoryFromUri(uri);
-            if (repository != null)
+            var repositoryResult = provider.Value.GetRepositoryFromUri(uri);
+
+            if (repositoryResult.Result.Status == ProviderOperationStatus.Failure)
             {
-                _log.Information($"Repository parsed to {repository.DisplayName} owned by {repository.OwningAccountName}");
-                return (provider.Value.DisplayName, repository);
+                _log.Information("Could not get repo from Uri.");
+                _log.Information(repositoryResult.Result.DisplayMessage);
+                return (string.Empty, null);
             }
+
+            var repository = repositoryResult.Repository;
+            _log.Information($"Repository parsed to {repository.DisplayName} owned by {repository.OwningAccountName}");
+            return (provider.Value.DisplayName, repository);
         }
 
         return (string.Empty, null);

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -1286,6 +1286,10 @@ public partial class AddRepoViewModel : ObservableObject
 
             return;
         }
+        else
+        {
+            ShouldShowUrlError = true;
+        }
     }
 
     /// <summary>
@@ -1309,10 +1313,11 @@ public partial class AddRepoViewModel : ObservableObject
         }
 
         // Repo may be public.  Try that.
-        var repo = provider.GetRepositoryFromUri(uri);
-        if (repo != null)
+        var repositoryResult = provider.GetRepositoryFromUri(uri);
+
+        if (repositoryResult.Result.Status == ProviderOperationStatus.Success)
         {
-            var cloningInformation = new CloningInformation(repo);
+            var cloningInformation = new CloningInformation(repositoryResult.Repository);
             cloningInformation.RepositoryProvider = provider.GetProvider();
             cloningInformation.ProviderName = provider.DisplayName;
             cloningInformation.CloningLocation = new DirectoryInfo(cloneLocation);
@@ -1326,10 +1331,10 @@ public partial class AddRepoViewModel : ObservableObject
         {
             foreach (var loggedInAccount in loggedInAccounts)
             {
-                repo = provider.GetRepositoryFromUri(uri, loggedInAccount);
-                if (repo != null)
+                repositoryResult = provider.GetRepositoryFromUri(uri, loggedInAccount);
+                if (repositoryResult.Result.Status == ProviderOperationStatus.Success)
                 {
-                    var cloningInformation = new CloningInformation(repo);
+                    var cloningInformation = new CloningInformation(repositoryResult.Repository);
                     cloningInformation.RepositoryProvider = provider.GetProvider();
                     cloningInformation.ProviderName = provider.DisplayName;
                     cloningInformation.CloningLocation = new DirectoryInfo(cloneLocation);
@@ -1338,6 +1343,14 @@ public partial class AddRepoViewModel : ObservableObject
                     return cloningInformation;
                 }
             }
+        }
+
+        // If no accounts can log in, or the user did not log in.
+        if (repositoryResult.Result.Status == ProviderOperationStatus.Failure)
+        {
+            _log.Information("Could not get repo from Uri.");
+            _log.Information(repositoryResult.Result.DisplayMessage);
+            UrlParsingError = _stringResource.GetLocalized(StringResourceKey.UrlNoAccountsHaveAccess);
         }
 
         return null;


### PR DESCRIPTION
## Summary of the pull request
Fixing a regression.  If no accounts can access a repository a message is displayed in the repo dialog.  The message is "No accounts have access to this repository." and it is localized.

## References and relevant issues

N/A

## Detailed description of the pull request / Additional comments

## Validation steps performed
Added different URLs.
1. Valid public (org and non-org)
2. Valid private (org and non-org)
3. Valid private but no access.

All scenarios were successful and returned the correct error message if one was encountered.


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
