### PR TITLE
Project Ironsides - Fix the "Manage Tools button" launch

### DIFF
--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -256,20 +256,8 @@ public partial class BarWindowViewModel : ObservableObject
     }
 
     [RelayCommand]
-    public void LaunchInsights()
-    {
-        ToggleExpandedContentVisibility();
-
-        // And navigate to the appropriate page
-        var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
-        barWindow?.NavigateTo(typeof(InsightsPageViewModel));
-    }
-
-    [RelayCommand]
     public void ManageExternalToolsButton()
     {
-        ToggleExpandedContentVisibility();
-
         var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
         barWindow?.NavigateToPiSettings(typeof(AdditionalToolsViewModel).FullName!);
     }

--- a/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
@@ -264,7 +264,7 @@ public partial class ExpandedViewControlViewModel : ObservableObject
 
         if (_additionalNavigationInfo is not null)
         {
-            Debug.Assert(Links[SelectedNavLinkIndex] == _settingsNavLink, "Addition Nav Info currently only supported for Settings");
+            Debug.Assert(Links[SelectedNavLinkIndex] == _settingsNavLink, "Additional Nav Info currently only supported for Settings");
             navigationService.NavigateTo(_additionalNavigationInfo);
             _additionalNavigationInfo = null;
             return;

--- a/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/ExpandedViewControlViewModel.cs
@@ -62,6 +62,8 @@ public partial class ExpandedViewControlViewModel : ObservableObject
     [ObservableProperty]
     private bool _applyAppFiltering;
 
+    private string? _additionalNavigationInfo;
+
     public INavigationService NavigationService { get; }
 
     private readonly PageNavLink _appDetailsNavLink;
@@ -236,7 +238,21 @@ public partial class ExpandedViewControlViewModel : ObservableObject
             var link = Links[i];
             if (link.PageViewModel == viewModelType)
             {
-                SelectedNavLinkIndex = i;
+                if (SelectedNavLinkIndex == i)
+                {
+                    // Navigation between pages is a bit convoluted, as we set SelectedNavLinkIndex, which triggers a change
+                    // event on a ListView that calls Navigate() to perform the actual navigation.
+                    //
+                    // If we're trying to navigate to the same Listview item, we need to call Navigate() directly. ListViewItems != Pages (for example, Settings
+                    // is a ListView Item, but there are several pages under Settings). If we end up navigating to the same page,
+                    // the NavService will no-op it
+                    Navigate();
+                }
+                else
+                {
+                    SelectedNavLinkIndex = i;
+                }
+
                 break;
             }
         }
@@ -244,22 +260,25 @@ public partial class ExpandedViewControlViewModel : ObservableObject
 
     public void Navigate()
     {
-        if (SelectedNavLinkIndex != -1)
+        var navigationService = Application.Current.GetService<INavigationService>();
+
+        if (_additionalNavigationInfo is not null)
         {
-            var navigationService = Application.Current.GetService<INavigationService>();
+            Debug.Assert(Links[SelectedNavLinkIndex] == _settingsNavLink, "Addition Nav Info currently only supported for Settings");
+            navigationService.NavigateTo(_additionalNavigationInfo);
+            _additionalNavigationInfo = null;
+            return;
+        }
+        else
+        {
             navigationService.NavigateTo(Links[SelectedNavLinkIndex]?.PageViewModel?.FullName!);
         }
     }
 
     public void NavigateToSettings(string viewModelType)
     {
-        var navigationService = Application.Current.GetService<INavigationService>();
-        var mainSettingsPage = typeof(SettingsPageViewModel).FullName!;
-        navigationService.NavigateTo(mainSettingsPage);
-        if (!string.Equals(mainSettingsPage, viewModelType, StringComparison.OrdinalIgnoreCase))
-        {
-            navigationService.NavigateTo(viewModelType);
-        }
+        _additionalNavigationInfo = viewModelType;
+        NavigateTo(typeof(SettingsPageViewModel));
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary of the pull request

There was a recent change to make the Settings button a real ListView item in our Expanded control. However, we didn't update the code to handle programmatic launches into Settings pages (like from the Manage Tools button in the title bar) well now that it is a ListView Item.

This fixes that and removes dead code (there were 2 functions to launch the Insights Settings page). This also fixes some flickering when pressing the Manage Tools button when we were already in expanded mode.

## References and relevant issues

## Detailed description of the pull request / Additional comments

This required a little bit more work, as the Settings ListView doesn't have a single Settings page but multiple Settings pages. All of the code was written assuming each ListView item only had 1 page. I've fixed this for Settings for now, but hopefully this will work better when we move to a NavigationView control instead of our current Listview control.

## Validation steps performed

Launch PI, Press the Manage Tools button without first expanding the bar. Verify the bar expands and the Add Tools settings page shows. Click the Manage Tools button again and confirm there is no flicker. Click the other buttons (WER Reports, Insights, etc) and confirm navigation happens. Click on the Settings listview item, then click on the Manage Tools button and confirm the navigation happens. 

## PR checklist
- [ ] Closes #3343 
- [ ] Tests added/passed
- [ ] Documentation updated
