### PR TITLE
Allow CoreWidgetProvider to be disposed

### DIFF
--- a/common/Services/IExtensionService.cs
+++ b/common/Services/IExtensionService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.AppExtensions;
 
 namespace DevHome.Common.Services;
 
@@ -16,11 +15,9 @@ public interface IExtensionService
 
     Task<IEnumerable<IExtensionWrapper>> GetInstalledExtensionsAsync(Microsoft.Windows.DevHome.SDK.ProviderType providerType, bool includeDisabledExtensions = false);
 
-    Task<IEnumerable<IExtensionWrapper>> GetAllExtensionsAsync();
+    IExtensionWrapper? GetInstalledExtension(string extensionUniqueId);
 
     Task SignalStopExtensionsAsync();
-
-    Task<IEnumerable<AppExtension>> GetInstalledAppExtensionsAsync();
 
     public event EventHandler OnExtensionsChanged;
 

--- a/src/Models/ExtensionWrapper.cs
+++ b/src/Models/ExtensionWrapper.cs
@@ -107,11 +107,12 @@ public class ExtensionWrapper : IExtensionWrapper
                     try
                     {
                         var hr = PInvoke.CoCreateInstance(Guid.Parse(ExtensionClassId), null, CLSCTX.CLSCTX_LOCAL_SERVER, typeof(IExtension).GUID, out var extensionObj);
-                        extensionPtr = Marshal.GetIUnknownForObject(extensionObj);
                         if (hr < 0)
                         {
                             Marshal.ThrowExceptionForHR(hr);
                         }
+
+                        extensionPtr = Marshal.GetIUnknownForObject(extensionObj);
 
                         _extensionObject = MarshalInterface<IExtension>.FromAbi(extensionPtr);
                     }

--- a/src/Services/ExtensionService.cs
+++ b/src/Services/ExtensionService.cs
@@ -9,12 +9,10 @@ using DevHome.Models;
 using DevHome.Telemetry;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
-using Newtonsoft.Json.Linq;
 using Serilog;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.AppExtensions;
 using Windows.Foundation.Collections;
-using YamlDotNet.Core.Tokens;
 using static DevHome.Common.Helpers.ManagementInfrastructureHelper;
 
 namespace DevHome.Services;
@@ -37,11 +35,9 @@ public class ExtensionService : IExtensionService, IDisposable
     private const string CreateInstanceProperty = "CreateInstance";
     private const string ClassIdProperty = "@ClassId";
 
-#pragma warning disable IDE0044 // Add readonly modifier
-    private static List<IExtensionWrapper> _installedExtensions = new();
-    private static List<IExtensionWrapper> _enabledExtensions = new();
-    private static List<string> _installedWidgetsPackageFamilyNames = new();
-#pragma warning restore IDE0044 // Add readonly modifier
+    private static readonly List<IExtensionWrapper> _installedExtensions = new();
+    private static readonly List<IExtensionWrapper> _enabledExtensions = new();
+    private static readonly List<string> _installedWidgetsPackageFamilyNames = new();
 
     public ExtensionService(ILocalSettingsService settingsService)
     {
@@ -158,7 +154,7 @@ public class ExtensionService : IExtensionService, IDisposable
         return (devHomeProvider, classIds);
     }
 
-    public async Task<IEnumerable<AppExtension>> GetInstalledAppExtensionsAsync()
+    private async Task<IEnumerable<AppExtension>> GetInstalledAppExtensionsAsync()
     {
         return await AppExtensionCatalog.Open("com.microsoft.devhome").FindAllAsync();
     }
@@ -227,6 +223,12 @@ public class ExtensionService : IExtensionService, IDisposable
         }
     }
 
+    public IExtensionWrapper? GetInstalledExtension(string extensionUniqueId)
+    {
+        var extension = _installedExtensions.Where(extension => extension.ExtensionUniqueId == extensionUniqueId);
+        return extension.First() ?? null;
+    }
+
     private async Task<IEnumerable<string>> GetInstalledWidgetExtensionsAsync()
     {
         await _getInstalledWidgetsLock.WaitAsync();
@@ -257,20 +259,6 @@ public class ExtensionService : IExtensionService, IDisposable
         var ids = devHomeExtensionWrappers.Select(x => x.PackageFamilyName).Intersect(widgetExtensionWrappers).ToList();
 
         return ids;
-    }
-
-    public async Task<IEnumerable<IExtensionWrapper>> GetAllExtensionsAsync()
-    {
-        var installedExtensions = await GetInstalledExtensionsAsync();
-        foreach (var installedExtension in installedExtensions)
-        {
-            if (!installedExtension.IsRunning())
-            {
-                await installedExtension.StartExtensionAsync();
-            }
-        }
-
-        return installedExtensions;
     }
 
     public async Task SignalStopExtensionsAsync()

--- a/src/Services/ExtensionService.cs
+++ b/src/Services/ExtensionService.cs
@@ -225,8 +225,8 @@ public class ExtensionService : IExtensionService, IDisposable
 
     public IExtensionWrapper? GetInstalledExtension(string extensionUniqueId)
     {
-        var extension = _installedExtensions.Where(extension => extension.ExtensionUniqueId == extensionUniqueId);
-        return extension.First() ?? null;
+        var extension = _installedExtensions.Where(extension => extension.ExtensionUniqueId.Equals(extensionUniqueId, StringComparison.Ordinal));
+        return extension.FirstOrDefault();
     }
 
     private async Task<IEnumerable<string>> GetInstalledWidgetExtensionsAsync()
@@ -369,13 +369,13 @@ public class ExtensionService : IExtensionService, IDisposable
 
     public void EnableExtension(string extensionUniqueId)
     {
-        var extension = _installedExtensions.Where(extension => extension.ExtensionUniqueId == extensionUniqueId);
+        var extension = _installedExtensions.Where(extension => extension.ExtensionUniqueId.Equals(extensionUniqueId, StringComparison.Ordinal));
         _enabledExtensions.Add(extension.First());
     }
 
     public void DisableExtension(string extensionUniqueId)
     {
-        var extension = _enabledExtensions.Where(extension => extension.ExtensionUniqueId == extensionUniqueId);
+        var extension = _enabledExtensions.Where(extension => extension.ExtensionUniqueId.Equals(extensionUniqueId, StringComparison.Ordinal));
         _enabledExtensions.Remove(extension.First());
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Extensions/ServiceExtensions.cs
@@ -29,6 +29,7 @@ public static class ServiceExtensions
         services.AddSingleton<IWidgetIconService, WidgetIconService>();
         services.AddSingleton<IWidgetScreenshotService, WidgetScreenshotService>();
         services.AddSingleton<WidgetAdaptiveCardRenderingService>();
+        services.AddSingleton<IWidgetExtensionService, WidgetExtensionService>();
 
         return services;
     }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetExtensionService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetExtensionService.cs
@@ -7,7 +7,11 @@ namespace DevHome.Dashboard.Services;
 
 internal interface IWidgetExtensionService
 {
-    bool IsCoreWidgetExtension(string providerDefinitionId);
+    /// <summary>
+    /// Gets whether the given providerDefinitionId represents a CoreWidgetProvider of any build ring
+    /// </summary>
+    /// <returns>True if the given providerDefinitionId represents a CoreWidgetProvider, otherwise false.</returns>
+    bool IsCoreWidgetProvider(string providerDefinitionId);
 
     Task EnsureCoreWidgetExtensionStarted(string providerDefinitionId);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetExtensionService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetExtensionService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+
+namespace DevHome.Dashboard.Services;
+
+internal interface IWidgetExtensionService
+{
+    bool IsCoreWidgetExtension(string providerDefinitionId);
+
+    Task EnsureCoreWidgetExtensionStarted(string providerDefinitionId);
+}

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetExtensionService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetExtensionService.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using DevHome.Common.Services;
+
+namespace DevHome.Dashboard.Services;
+
+internal sealed class WidgetExtensionService : IWidgetExtensionService
+{
+    private const string ExtensionUniqueIdStable = "Microsoft.Windows.DevHome_8wekyb3d8bbwe!App!PG-SP-ID1";
+    private const string ExtensionUniqueIdCanary = "Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe!App!PG-SP-ID1";
+    private const string ExtensionUniqueIdDev = "Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe!App!PG-SP-ID1";
+
+    private const string ProviderDefinitionStable = "Microsoft.Windows.DevHome_8wekyb3d8bbwe!App!!CoreWidgetProvider";
+    private const string ProviderDefinitionCanary = "Microsoft.Windows.DevHome.Canary_8wekyb3d8bbwe!App!!CoreWidgetProvider";
+    private const string ProviderDefinitionDev = "Microsoft.Windows.DevHome.Dev_8wekyb3d8bbwe!App!!CoreWidgetProvider";
+
+    private readonly IExtensionService _extensionService;
+
+    public WidgetExtensionService(IExtensionService extensionService)
+    {
+        _extensionService = extensionService;
+    }
+
+    public bool IsCoreWidgetExtension(string providerDefinitionId)
+    {
+        return providerDefinitionId.Equals(ProviderDefinitionStable, StringComparison.Ordinal) ||
+               providerDefinitionId.Equals(ProviderDefinitionCanary, StringComparison.Ordinal) ||
+               providerDefinitionId.Equals(ProviderDefinitionDev, StringComparison.Ordinal);
+    }
+
+    public async Task EnsureCoreWidgetExtensionStarted(string providerDefinitionId)
+    {
+        if (providerDefinitionId.StartsWith(ProviderDefinitionStable, StringComparison.Ordinal))
+        {
+            await EnsureExtensionStarted(ExtensionUniqueIdStable);
+        }
+        else if (providerDefinitionId.StartsWith(ProviderDefinitionCanary, StringComparison.Ordinal))
+        {
+            await EnsureExtensionStarted(ExtensionUniqueIdCanary);
+        }
+        else if (providerDefinitionId.StartsWith(ProviderDefinitionDev, StringComparison.Ordinal))
+        {
+            await EnsureExtensionStarted(ExtensionUniqueIdDev);
+        }
+    }
+
+    private async Task EnsureExtensionStarted(string extensionUniqueId)
+    {
+        var extensionWrapper = _extensionService.GetInstalledExtension(extensionUniqueId);
+        if (!extensionWrapper.IsRunning())
+        {
+            await extensionWrapper.StartExtensionAsync();
+        }
+    }
+}

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetExtensionService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetExtensionService.cs
@@ -24,7 +24,8 @@ internal sealed class WidgetExtensionService : IWidgetExtensionService
         _extensionService = extensionService;
     }
 
-    public bool IsCoreWidgetExtension(string providerDefinitionId)
+    /// <inheritdoc/>
+    public bool IsCoreWidgetProvider(string providerDefinitionId)
     {
         return providerDefinitionId.Equals(ProviderDefinitionStable, StringComparison.Ordinal) ||
                providerDefinitionId.Equals(ProviderDefinitionCanary, StringComparison.Ordinal) ||

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -597,7 +597,7 @@ public partial class DashboardView : ToolPage, IDisposable
                 // The WidgetService will start the widget provider, however Dev Home won't know about it and won't be
                 // able to send disposed events when Dev Home closes. Ensure the provider is started here so we can
                 // tell the extension to dispose later.
-                if (_widgetExtensionService.IsCoreWidgetExtension(comSafeWidgetDefinition.ProviderDefinitionId))
+                if (_widgetExtensionService.IsCoreWidgetProvider(comSafeWidgetDefinition.ProviderDefinitionId))
                 {
                     await _widgetExtensionService.EnsureCoreWidgetExtensionStarted(comSafeWidgetDefinition.ProviderDefinitionId);
                 }

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -10,7 +10,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using DevHome.Common.Extensions;
-using DevHome.Common.Helpers;
 using DevHome.Common.Services;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -27,18 +26,18 @@ public partial class ExtensionLibraryViewModel : ObservableObject
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(ExtensionLibraryViewModel));
 
-    private readonly string devHomeProductId = "9N8MHTPHNGVV";
+    private const string DevHomeProductId = "9N8MHTPHNGVV";
 
     private readonly IExtensionService _extensionService;
     private readonly DispatcherQueue _dispatcherQueue;
 
     // All internal Dev Home extensions that should allow users to enable/disable them, should add
     // their class Ids to this set.
-    private readonly HashSet<string> _internalClassIdsToBeShownInExtensionsPage = new()
-    {
+    private readonly HashSet<string> _internalClassIdsToBeShownInExtensionsPage =
+    [
         HyperVExtensionClassId,
         WSLExtensionClassId,
-    };
+    ];
 
     public ObservableCollection<StorePackageViewModel> StorePackagesList { get; set; }
 
@@ -68,7 +67,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     [RelayCommand]
     public async Task LoadedAsync()
     {
-        await GetInstalledExtensionsAsync();
+        await GetInstalledPackagesAndExtensionsAsync();
         GetAvailablePackages();
     }
 
@@ -77,12 +76,12 @@ public partial class ExtensionLibraryViewModel : ObservableObject
         await _dispatcherQueue.EnqueueAsync(async () =>
         {
             ShouldShowStoreError = false;
-            await GetInstalledExtensionsAsync();
+            await GetInstalledPackagesAndExtensionsAsync();
             GetAvailablePackages();
         });
     }
 
-    private async Task GetInstalledExtensionsAsync()
+    private async Task GetInstalledPackagesAndExtensionsAsync()
     {
         var extensionWrappers = await _extensionService.GetInstalledExtensionsAsync(true);
 
@@ -166,7 +165,7 @@ public partial class ExtensionLibraryViewModel : ObservableObject
                 var productId = productObj.GetNamedString("ProductId");
 
                 // Don't show self as available.
-                if (productId == devHomeProductId)
+                if (productId == DevHomeProductId)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary of the pull request
When Dev Home's ExtensionService starts an extension process, it keeps a reference around so that when Dev Home is closed, it can signal to the extension that it can stop. Previously, we have relied on the WidgetService to start the CoreWidgetProvider process. Since it implements no other Dev Home provider, nowhere inside Dev Home was starting it, so we had no way to signal it to stop and it would continue running.

This change starts the CoreWidgetProvider as a Dev Home extension when a core widget it put on the Dashboard (either via Add Widget or having been pinned during a previous run). The WidgetExtensionService is a new service that handles this. Now it can be signaled to stop and does when Dev Home closes.

Core Widgets can still be used in the Windows Widget Board, the WidgetService can still start the process when needed there.

## Detailed description of the pull request / Additional comments
Additional changes:
* In ExtensionService, removed an unused method, made a method that was only used locally private, and added a new method that returns an ExtensionWrapper given an extension's unique ID
* In ExtensionWrapper, if we get a bad HRESULT throw it right away instead of trying to use the bad object.
* ExtensionLibraryViewModel had a method with the same name as one from the ExtensionService. Changed the name of the method in ExtensionLibraryViewModel just to keep things more separate.

## Validation steps performed
Validated locally using Dev and Canary core widgets.

## PR checklist
- [ ] Closes #3411
- [ ] Tests added/passed
- [ ] Documentation updated
