### PR TITLE
Dev Home PI: Create a new BarWindowViewModel with a new BarWindow instance

### DIFF
--- a/tools/PI/DevHome.PI/PIApp.xaml.cs
+++ b/tools/PI/DevHome.PI/PIApp.xaml.cs
@@ -54,7 +54,6 @@ public partial class App : Application, IApp
                 // Views and ViewModels
                 services.AddSingleton<AppDetailsPage>();
                 services.AddSingleton<AppDetailsPageViewModel>();
-                services.AddSingleton<BarWindowViewModel>();
                 services.AddSingleton<InsightsPage>();
                 services.AddSingleton<InsightsPageViewModel>();
                 services.AddSingleton<ModulesPage>();

--- a/tools/PI/DevHome.PI/PIApp.xaml.cs
+++ b/tools/PI/DevHome.PI/PIApp.xaml.cs
@@ -46,6 +46,7 @@ public partial class App : Application, IApp
                 services.AddSingleton<INavigationService, PINavigationService>();
                 services.AddSingleton<TelemetryReporter>();
                 services.AddSingleton<PIAppInfoService>();
+                services.AddSingleton<PIInsightsService>();
                 services.AddSingleton<WERHelper>();
 
                 // Window

--- a/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/InsightsPage.xaml
@@ -20,7 +20,7 @@
 
         <TextBlock x:Uid="InsightsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
-        <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsList}" Grid.Row="1">
+        <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsService.InsightsList}" Grid.Row="1">
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="models:Insight">
                     <Expander ExpandDirection="Down" HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6">

--- a/tools/PI/DevHome.PI/Services/PIInsightsService.cs
+++ b/tools/PI/DevHome.PI/Services/PIInsightsService.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DevHome.PI.Models;
+
+namespace DevHome.PI.Services;
+
+public partial class PIInsightsService : ObservableObject
+{
+    private Process? _targetProcess;
+
+    [ObservableProperty]
+    private int _unreadCount;
+
+    [ObservableProperty]
+    private ObservableCollection<Insight> _insightsList;
+
+    public PIInsightsService()
+    {
+        TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
+        _insightsList = [];
+
+        var process = TargetAppData.Instance.TargetProcess;
+        if (process is not null)
+        {
+            UpdateTargetProcess(process);
+        }
+    }
+
+    public void UpdateTargetProcess(Process process)
+    {
+        if (_targetProcess != process)
+        {
+            _targetProcess = process;
+            InsightsList.Clear();
+        }
+    }
+
+    private void TargetApp_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TargetAppData.TargetProcess))
+        {
+            if (TargetAppData.Instance.TargetProcess is not null)
+            {
+                UpdateTargetProcess(TargetAppData.Instance.TargetProcess);
+            }
+        }
+    }
+
+    internal void AddInsight(Insight insight)
+    {
+        insight.PropertyChanged += (sender, e) =>
+        {
+            if (e.PropertyName == nameof(Insight.HasBeenRead))
+            {
+                UnreadCount = InsightsList.Count(insight => !insight.HasBeenRead);
+            }
+        };
+
+        UnreadCount++;
+        InsightsList.Add(insight);
+    }
+}

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -38,9 +38,7 @@ public partial class BarWindowViewModel : ObservableObject
 
     private readonly ObservableCollection<Button> _externalTools = [];
     private readonly SnapHelper _snapHelper;
-
-    [ObservableProperty]
-    private PIInsightsService _insightsService;
+    private readonly PIInsightsService _insightsService;
 
     [ObservableProperty]
     private string _systemCpuUsage = string.Empty;
@@ -355,7 +353,7 @@ public partial class BarWindowViewModel : ObservableObject
     {
         if (e.PropertyName == nameof(PIInsightsService.UnreadCount))
         {
-            UnreadInsightsCount = InsightsService.UnreadCount;
+            UnreadInsightsCount = _insightsService.UnreadCount;
             InsightsBadgeOpacity = UnreadInsightsCount > 0 ? 1 : 0;
         }
     }

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -298,6 +298,7 @@ public partial class BarWindowViewModel : ObservableObject
 
                 // Conversely, the result chooser is only visible if we're not attached to a result
                 IsProcessChooserVisible = process is null;
+                UnreadInsightsCount = 0;
             });
         }
         else if (e.PropertyName == nameof(TargetAppData.Icon))

--- a/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/BarWindowViewModel.cs
@@ -248,9 +248,6 @@ public partial class BarWindowViewModel : ObservableObject
     [RelayCommand]
     public void ProcessChooser()
     {
-        ToggleExpandedContentVisibility();
-
-        // And navigate to the appropriate page
         var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
         barWindow?.NavigateTo(typeof(ProcessListPageViewModel));
     }

--- a/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
@@ -14,7 +14,6 @@ namespace DevHome.PI.ViewModels;
 
 public partial class InsightsPageViewModel : ObservableObject
 {
-    private readonly BarWindowViewModel _barWindowViewModel;
     private Process? _targetProcess;
 
     [ObservableProperty]
@@ -25,8 +24,6 @@ public partial class InsightsPageViewModel : ObservableObject
 
     public InsightsPageViewModel()
     {
-        _barWindowViewModel = Application.Current.GetService<BarWindowViewModel>();
-
         TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
         _insightsList = [];
 
@@ -44,7 +41,10 @@ public partial class InsightsPageViewModel : ObservableObject
             _targetProcess = process;
             InsightsList.Clear();
             UnreadCount = 0;
-            _barWindowViewModel.UpdateUnreadInsightsCount(0);
+
+            var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
+            Debug.Assert(barWindow != null, "BarWindow should not be null.");
+            barWindow.UpdateUnreadInsightsCount(0);
         }
     }
 
@@ -61,17 +61,20 @@ public partial class InsightsPageViewModel : ObservableObject
 
     internal void AddInsight(Insight insight)
     {
+        var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
+        Debug.Assert(barWindow != null, "BarWindow should not be null.");
+
         insight.PropertyChanged += (sender, e) =>
         {
             if (e.PropertyName == nameof(Insight.HasBeenRead))
             {
                 UnreadCount = InsightsList.Count(insight => !insight.HasBeenRead);
-                _barWindowViewModel.UpdateUnreadInsightsCount(UnreadCount);
+                barWindow.UpdateUnreadInsightsCount(UnreadCount);
             }
         };
 
         UnreadCount++;
-        _barWindowViewModel.UpdateUnreadInsightsCount(UnreadCount);
+        barWindow.UpdateUnreadInsightsCount(UnreadCount);
         InsightsList.Add(insight);
     }
 }

--- a/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
@@ -17,6 +17,5 @@ public partial class InsightsPageViewModel : ObservableObject
     public InsightsPageViewModel()
     {
         _insightsService = Application.Current.GetService<PIInsightsService>();
-        Debug.Assert(_insightsService != null, "InsightsService should not be null.");
     }
 }

--- a/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
@@ -1,71 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
-using DevHome.PI.Models;
+using DevHome.PI.Services;
 using Microsoft.UI.Xaml;
 
 namespace DevHome.PI.ViewModels;
 
 public partial class InsightsPageViewModel : ObservableObject
 {
-    private Process? _targetProcess;
-
     [ObservableProperty]
-    private ObservableCollection<Insight> _insightsList;
+    private PIInsightsService _insightsService;
 
     public InsightsPageViewModel()
     {
-        TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
-        _insightsList = [];
-
-        var process = TargetAppData.Instance.TargetProcess;
-        if (process is not null)
-        {
-            UpdateTargetProcess(process);
-        }
-    }
-
-    public void UpdateTargetProcess(Process process)
-    {
-        if (_targetProcess != process)
-        {
-            _targetProcess = process;
-            InsightsList.Clear();
-        }
-    }
-
-    private void TargetApp_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(TargetAppData.TargetProcess))
-        {
-            if (TargetAppData.Instance.TargetProcess is not null)
-            {
-                UpdateTargetProcess(TargetAppData.Instance.TargetProcess);
-            }
-        }
-    }
-
-    internal void AddInsight(Insight insight)
-    {
-        var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
-        Debug.Assert(barWindow != null, "BarWindow should not be null.");
-
-        insight.PropertyChanged += (sender, e) =>
-        {
-            if (e.PropertyName == nameof(Insight.HasBeenRead))
-            {
-                var count = InsightsList.Count(insight => !insight.HasBeenRead);
-                barWindow.UpdateUnreadInsightsCount(count);
-            }
-        };
-
-        barWindow.IncreaseUnreadInsightsCount();
-        InsightsList.Add(insight);
+        _insightsService = Application.Current.GetService<PIInsightsService>();
+        Debug.Assert(_insightsService != null, "InsightsService should not be null.");
     }
 }

--- a/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/InsightsPageViewModel.cs
@@ -19,9 +19,6 @@ public partial class InsightsPageViewModel : ObservableObject
     [ObservableProperty]
     private ObservableCollection<Insight> _insightsList;
 
-    [ObservableProperty]
-    private int _unreadCount;
-
     public InsightsPageViewModel()
     {
         TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
@@ -40,11 +37,6 @@ public partial class InsightsPageViewModel : ObservableObject
         {
             _targetProcess = process;
             InsightsList.Clear();
-            UnreadCount = 0;
-
-            var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
-            Debug.Assert(barWindow != null, "BarWindow should not be null.");
-            barWindow.UpdateUnreadInsightsCount(0);
         }
     }
 
@@ -68,13 +60,12 @@ public partial class InsightsPageViewModel : ObservableObject
         {
             if (e.PropertyName == nameof(Insight.HasBeenRead))
             {
-                UnreadCount = InsightsList.Count(insight => !insight.HasBeenRead);
-                barWindow.UpdateUnreadInsightsCount(UnreadCount);
+                var count = InsightsList.Count(insight => !insight.HasBeenRead);
+                barWindow.UpdateUnreadInsightsCount(count);
             }
         };
 
-        UnreadCount++;
-        barWindow.UpdateUnreadInsightsCount(UnreadCount);
+        barWindow.IncreaseUnreadInsightsCount();
         InsightsList.Add(insight);
     }
 }

--- a/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
@@ -28,6 +28,7 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
     private readonly bool _logMeasures;
     private readonly ObservableCollection<WinLogsEntry> _winLogsOutput;
     private readonly DispatcherQueue _dispatcher;
+    private readonly PIInsightsService _insightsService;
 
     [ObservableProperty]
     private ObservableCollection<WinLogsEntry> _winLogEntries;
@@ -61,6 +62,8 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
 
         _dispatcher = DispatcherQueue.GetForCurrentThread();
         TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
+
+        _insightsService = Application.Current.GetService<PIInsightsService>();
 
         _winLogEntries = [];
         _winLogsOutput = [];
@@ -200,8 +203,7 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
         {
             _dispatcher.TryEnqueue(() =>
             {
-                var insightsService = Application.Current.GetService<PIInsightsService>();
-                insightsService.AddInsight(newInsight);
+                _insightsService.AddInsight(newInsight);
             });
         }
     }

--- a/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
+++ b/tools/PI/DevHome.PI/ViewModels/WinLogsPageViewModel.cs
@@ -14,6 +14,7 @@ using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
 using DevHome.PI.Helpers;
 using DevHome.PI.Models;
+using DevHome.PI.Services;
 using DevHome.PI.TelemetryEvents;
 using DevHome.Telemetry;
 using Microsoft.UI.Dispatching;
@@ -199,8 +200,8 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
         {
             _dispatcher.TryEnqueue(() =>
             {
-                var insightsPageViewModel = Application.Current.GetService<InsightsPageViewModel>();
-                insightsPageViewModel.AddInsight(newInsight);
+                var insightsService = Application.Current.GetService<PIInsightsService>();
+                insightsService.AddInsight(newInsight);
             });
         }
     }

--- a/tools/PI/DevHome.PI/Views/BarWindow.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindow.cs
@@ -176,14 +176,4 @@ public partial class BarWindow
     {
         return _viewModel.IsSnapped;
     }
-
-    public void IncreaseUnreadInsightsCount()
-    {
-        _viewModel.UpdateUnreadInsightsCount(_viewModel.UnreadInsightsCount + 1);
-    }
-
-    public void UpdateUnreadInsightsCount(int count)
-    {
-        _viewModel.UpdateUnreadInsightsCount(count);
-    }
 }

--- a/tools/PI/DevHome.PI/Views/BarWindow.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindow.cs
@@ -26,7 +26,7 @@ public partial class BarWindow
     private readonly Settings _settings = Settings.Default;
     private readonly BarWindowHorizontal _horizontalWindow;
     private readonly BarWindowVertical _verticalWindow;
-    private readonly BarWindowViewModel _viewModel = Application.Current.GetService<BarWindowViewModel>();
+    private readonly BarWindowViewModel _viewModel = new();
 
     internal HWND CurrentHwnd
     {
@@ -175,5 +175,10 @@ public partial class BarWindow
     public bool IsBarSnappedToWindow()
     {
         return _viewModel.IsSnapped;
+    }
+
+    public void UpdateUnreadInsightsCount(int count)
+    {
+        _viewModel.UpdateUnreadInsightsCount(count);
     }
 }

--- a/tools/PI/DevHome.PI/Views/BarWindow.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindow.cs
@@ -177,6 +177,11 @@ public partial class BarWindow
         return _viewModel.IsSnapped;
     }
 
+    public void IncreaseUnreadInsightsCount()
+    {
+        _viewModel.UpdateUnreadInsightsCount(_viewModel.UnreadInsightsCount + 1);
+    }
+
     public void UpdateUnreadInsightsCount(int count)
     {
         _viewModel.UpdateUnreadInsightsCount(count);


### PR DESCRIPTION
## Summary of the pull request
Bug: PI crashes when a user closes the 1st BarWindow and then restarts PI ->click on process list button.
Problem: Toggling expand window status. We try to collapse an already collapsed window.

## Detailed description of the pull request / Additional comments
Since we have BarWindowViewModel as a singleton, when a new BarWindow is created, it reuses the exiting instance of BarWindowViewModel. It is possible the user closed the initial instance of BarWindow in the expanded state. Now when a new instance is started and the user wants to expand the bar, the viewmodel thinks it is already expanded, and tries to collapse it. Also, viewmodel is not in its default state.

Fix: Create a new BarWindowViewModel with every BarWindow instance, so it is in its default state. 

Other fixes:
1. Add a new PIInsightsService, which can be referenced and updated from various view models.
2. Remove ToggleExpandedContentVisibility from ProcessChooser, since NavigateTo handles expanding the window.

## Validation steps performed
1. Launched PI
2. Expanded the window
4. Closed PI
5. Launched PI again
6. Click on process chooser or Insights button
7. Made sure PI doesn't crash
8. Also, added new logs and insights
9. Confirmed the unread insights count is updated
10. Read a few insights and confirmed the unread insights count are correct. 
