### PR TITLE
Fix unlocalized strings in widget definitions

### DIFF
--- a/src/Package-Can.appxmanifest
+++ b/src/Package-Can.appxmanifest
@@ -160,14 +160,14 @@
                         <Icon Path="Widgets\Assets\icons\ssh_keychain_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotLight.png" DisplayAltText="SSH Keychain widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplaySSKeychain" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\ssh_keychain_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotDark.png" DisplayAltText="SSH Keychain widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplaySSKeychain" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -190,14 +190,14 @@
                         <Icon Path="Widgets\Assets\icons\mem_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotLight.png" DisplayAltText="Memory widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayMemory" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\mem_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotDark.png" DisplayAltText="Memory widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayMemory" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -220,14 +220,14 @@
                         <Icon Path="Widgets\Assets\icons\net_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotLight.png" DisplayAltText="Network widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayNetwork" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\net_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotDark.png" DisplayAltText="Network widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayNetwork" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -250,14 +250,14 @@
                         <Icon Path="Widgets\Assets\icons\gpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotLight.png" DisplayAltText="GPU widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayGPU" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\gpu_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotDark.png" DisplayAltText="GPU widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayGPU" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -280,14 +280,14 @@
                         <Icon Path="Widgets\Assets\icons\cpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotLight.png" DisplayAltText="CPU widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayCPU" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\cpu_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotDark.png" DisplayAltText="CPU widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayCPU" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />

--- a/src/Package-Dev.appxmanifest
+++ b/src/Package-Dev.appxmanifest
@@ -160,14 +160,14 @@
                         <Icon Path="Widgets\Assets\icons\ssh_keychain_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotLight.png" DisplayAltText="SSH Keychain widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplaySSKeychain" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\ssh_keychain_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotDark.png" DisplayAltText="SSH Keychain widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplaySSKeychain" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -190,14 +190,14 @@
                         <Icon Path="Widgets\Assets\icons\mem_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotLight.png" DisplayAltText="Memory widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayMemory" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\mem_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotDark.png" DisplayAltText="Memory widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayMemory" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -220,14 +220,14 @@
                         <Icon Path="Widgets\Assets\icons\net_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotLight.png" DisplayAltText="Network widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayNetwork" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\net_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotDark.png" DisplayAltText="Network widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayNetwork" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -250,14 +250,14 @@
                         <Icon Path="Widgets\Assets\icons\gpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotLight.png" DisplayAltText="GPU widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayGPU" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\gpu_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotDark.png" DisplayAltText="GPU widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayGPU" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -280,14 +280,14 @@
                         <Icon Path="Widgets\Assets\icons\cpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotLight.png" DisplayAltText="CPU widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayCPU" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\cpu_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotDark.png" DisplayAltText="CPU widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayCPU" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />

--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -160,14 +160,14 @@
                         <Icon Path="Widgets\Assets\icons\ssh_keychain_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotLight.png" DisplayAltText="SSH Keychain widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplaySSKeychain" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\ssh_keychain_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotDark.png" DisplayAltText="SSH Keychain widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\SSHScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplaySSKeychain" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -190,14 +190,14 @@
                         <Icon Path="Widgets\Assets\icons\mem_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotLight.png" DisplayAltText="Memory widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayMemory" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\mem_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotDark.png" DisplayAltText="Memory widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\MemoryScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayMemory" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -220,14 +220,14 @@
                         <Icon Path="Widgets\Assets\icons\net_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotLight.png" DisplayAltText="Network widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayNetwork" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\net_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotDark.png" DisplayAltText="Network widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\NetworkScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayNetwork" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -250,14 +250,14 @@
                         <Icon Path="Widgets\Assets\icons\gpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotLight.png" DisplayAltText="GPU widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayGPU" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\gpu_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotDark.png" DisplayAltText="GPU widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\GPUScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayGPU" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />
@@ -280,14 +280,14 @@
                         <Icon Path="Widgets\Assets\icons\cpu_icon_light.png" />
                       </Icons>
                       <Screenshots>
-                        <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotLight.png" DisplayAltText="CPU widget preview image" />
+                        <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotLight.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayCPU" />
                       </Screenshots>
                       <DarkMode>
                         <Icons>
                           <Icon Path="Widgets\Assets\icons\cpu_icon_dark.png" />
                         </Icons>
                         <Screenshots>
-                          <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotDark.png" DisplayAltText="CPU widget preview image" />
+                          <Screenshot Path="Widgets\Assets\screenshots\CPUScreenshotDark.png" DisplayAltText="ms-resource:WidgetScreenshotAltDisplayCPU" />
                         </Screenshots>
                       </DarkMode>
                       <LightMode />

--- a/src/Strings/en-us/Resources.resw
+++ b/src/Strings/en-us/Resources.resw
@@ -318,4 +318,19 @@
     <value>Windows Subsystem for Linux</value>
     <comment>{Locked="Windows", "Linux"} Extension Description</comment>
   </data>
+  <data name="WidgetScreenshotAltDisplayCPU" xml:space="preserve">
+    <value>CPU widget preview image</value>
+  </data>
+  <data name="WidgetScreenshotAltDisplayGPU" xml:space="preserve">
+    <value>GPU widget preview image</value>
+  </data>
+  <data name="WidgetScreenshotAltDisplayMemory" xml:space="preserve">
+    <value>Memory widget preview image</value>
+  </data>
+  <data name="WidgetScreenshotAltDisplayNetwork" xml:space="preserve">
+    <value>Network widget preview image</value>
+  </data>
+  <data name="WidgetScreenshotAltDisplaySSKeychain" xml:space="preserve">
+    <value>SSH Keychain widget preview image</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Core widgets had unlocalized alt display text for the screenshots. This isn't visible to the user but could be an issue with screen readers in non-English locales if the alt text is required.

## References and relevant issues

## Detailed description of the pull request / Additional comments
* Added alt display strings for the widgets to the string table and referenced them.

## Validation steps performed
Built and pinned widgets

## PR checklist
- [x] Closes #3529 
- [x] Tests added/passed
- [x] Documentation updated
