### PR TITLE
[Environments] Extension Refresh & other fixes

### DIFF
--- a/common/Environments/Helpers/EnvironmentsNotificationHelper.cs
+++ b/common/Environments/Helpers/EnvironmentsNotificationHelper.cs
@@ -201,7 +201,7 @@ public partial class EnvironmentsNotificationHelper
 
         // Add the user to the Hyper-V Administrators group and enable the Hyper-V feature if it is not already enabled.
         // Using a string instead of a file for the script so it can't be manipulated via the file system.
-        startInfo.Arguments = $"-ExecutionPolicy Bypass -Command \"{HyperVSetupScript.SetupFunction}\"";
+        startInfo.Arguments = $"-ExecutionPolicy Bypass -Command \"{HyperVSetupScript.SetupFunction} {user}\"";
         startInfo.UseShellExecute = true;
         startInfo.Verb = "runas";
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/AddRepoViewModel.cs
@@ -666,6 +666,13 @@ public partial class AddRepoViewModel : ObservableObject
 
         ChangeToUrlPage();
 
+        // If the user isn't setting up a local machine, hide the browse button.
+        // Since we can't browse for a folder on a remote machine.
+        if (!_setupFlowOrchestrator.IsSettingUpLocalMachine)
+        {
+            FolderPickerViewModel.HideBrowseButton();
+        }
+
         // override changes ChangeToUrlPage to correctly set the state.
         UrlParsingError = string.Empty;
         ShouldShowUrlError = false;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/FolderPickerViewModel.cs
@@ -50,6 +50,12 @@ public partial class FolderPickerViewModel : ObservableObject
     private bool _isBrowseButtonEnabled;
 
     /// <summary>
+    /// Visually hides the browse button.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showBrowseButton = true;
+
+    /// <summary>
     /// Used to show different content in the textbox based on whether the checkbox is checked or unchecked.
     /// </summary>
     /// <remarks>
@@ -96,6 +102,11 @@ public partial class FolderPickerViewModel : ObservableObject
     public void DisableBrowseButton()
     {
         IsBrowseButtonEnabled = false;
+    }
+
+    public void HideBrowseButton()
+    {
+        ShowBrowseButton = false;
     }
 
     public void SetCloneLocation(string cloneLocation)

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -149,8 +149,7 @@ public partial class SetupFlowViewModel : ObservableObject
         var parameter = args.Parameter?.ToString();
 
         if ((!string.IsNullOrEmpty(parameter)) &&
-            parameter.Contains(_creationFlowNavigationParameter, StringComparison.OrdinalIgnoreCase) &&
-            Orchestrator.CurrentSetupFlowKind != SetupFlowKind.CreateEnvironment)
+            parameter.Contains(_creationFlowNavigationParameter, StringComparison.OrdinalIgnoreCase))
         {
             // We expect that when navigating from anywhere in Dev Home to the create environment page
             // that the arg.Parameter variable be semicolon delimited string with the first value being 'StartCreationFlow'

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
@@ -397,8 +397,8 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
 
         // Remove the mappings that failed to load.
         // The errors are already handled by the notification helper.
-        foreach (var mapping in data.DevIdToComputeSystemMap.Where(map =>
-            map.Value.Result.Status == ProviderOperationStatus.Failure))
+        foreach (var mapping in data.DevIdToComputeSystemMap.Where(kvp =>
+            kvp.Value.Result.Status == ProviderOperationStatus.Failure))
         {
             data.DevIdToComputeSystemMap.Remove(mapping.Key);
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupTargetViewModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -393,6 +394,14 @@ public partial class SetupTargetViewModel : SetupPageViewModelBase
     public async Task UpdateListViewModelList(ComputeSystemsLoadedData data)
     {
         _notificationsHelper?.DisplayComputeSystemEnumerationErrors(data);
+
+        // Remove the mappings that failed to load.
+        // The errors are already handled by the notification helper.
+        foreach (var mapping in data.DevIdToComputeSystemMap.Where(map =>
+            map.Value.Result.Status == ProviderOperationStatus.Failure))
+        {
+            data.DevIdToComputeSystemMap.Remove(mapping.Key);
+        }
 
         var curListViewModel = new ComputeSystemsListViewModel(data);
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AddRepoDialog.xaml
@@ -398,7 +398,8 @@
                     <Button
                         x:Uid="ClonePath_Button"
                         Margin="5,27,0,0"
-                        IsEnabled="{x:Bind AddRepoViewModel.FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay}">
+                        IsEnabled="{x:Bind AddRepoViewModel.FolderPickerViewModel.IsBrowseButtonEnabled, Mode=OneWay}"
+                        Visibility="{x:Bind AddRepoViewModel.FolderPickerViewModel.ShowBrowseButton, Mode=OneWay}">
                         <i:Interaction.Behaviors>
                             <ic:EventTriggerBehavior EventName="Click">
                                 <ic:InvokeCommandAction Command="{x:Bind AddRepoViewModel.OpenFolderPickerCommand}" />


### PR DESCRIPTION
## Summary of the pull request
1. Bug fix - Fixes "Create Environments" button showing cached extension availability. 
Using the button after enabling extensions, didn't refresh the page and didn't show data from the enabled extension. 
The PR removes the caching code and refreshes the page every time navigated to.

2. Bug fix - Fixes adding incorrect user to Hyper - V admin group.
Adding a user to the Hyper-V admin group runs an elevated script. And getting the current user in this script returns the admin. 
The bug was that the admin was being added to the group, not the user who might have initiated the operation. The fix adds the user as a parameter to the script call.

3. Bug fix - Hides browse button under repo manager for remote machines.
Having a browse button, while configuring remote machines, was confusing as it browsed the local machine instead.
The PR hides the button in cases where remote machines are being configured.

4. Bug fix - Machine config page doesn't load extension data
If one of the accounts associated with an extension errored out, an exception caused the rest of the data to be skipped.
The PR removes the data with the errors from the relevant variable, since it has already been handled.

## Validation steps performed
Each fix was tested manually.

## PR checklist
- [ ] Closes #3353 
- [ ] Closes #3112 
- [ ] Closes #3219 
- [ ] Closes #3568 