### PR TITLE
Project Ironsides - Don't crash when reading unexpected data from the event log

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/CommonHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/CommonHelper.cs
@@ -4,10 +4,10 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management;
-using System.Management.Automation;
 using System.Runtime.InteropServices;
 using DevHome.Common.Extensions;
 using DevHome.Common.Services;
@@ -15,7 +15,6 @@ using Microsoft.UI.Xaml;
 using Serilog;
 using Windows.ApplicationModel;
 using Windows.Wdk.System.Threading;
-using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Threading;
 using PInvokeWdk = Windows.Wdk.PInvoke;
@@ -141,5 +140,32 @@ internal sealed class CommonHelper
         }
 
         return activationArgs;
+    }
+
+    private static readonly Int32Converter _converter = new();
+
+    public static int? ParseStringToInt(string value)
+    {
+        int? valueAsInt;
+
+        try
+        {
+            if (_converter.IsValid(value))
+            {
+                // Int32Converter.ConvertFromString() does a pretty good job of parsing numbers, except when given a hex
+                // number that isn't prefixed with 0x. If it fails, try parsing it using int.Parse().
+                valueAsInt = (int?)_converter.ConvertFromString(value);
+            }
+            else
+            {
+                valueAsInt = int.Parse(value, NumberStyles.HexNumber, CultureInfo.CurrentCulture);
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        return valueAsInt;
     }
 }

--- a/tools/PI/DevHome.PI/Models/ClipboardMonitor.cs
+++ b/tools/PI/DevHome.PI/Models/ClipboardMonitor.cs
@@ -95,29 +95,15 @@ internal sealed class ClipboardMonitor : WindowHooker<ClipboardMonitor>, INotify
 
         // If this text contains a number, show it in different number bases.
         var matches = FindNumbersRegex.Matches(text);
-        var converter = new Int32Converter();
 
         foreach (var match in matches.Cast<Match>())
         {
             var original = match.ToString();
 
             // Assume the number is easily identifable as either base 10 or base 16... convert to int.
-            int? errorAsInt;
+            int? errorAsInt = CommonHelper.ParseStringToInt(original);
 
-            try
-            {
-                if (converter.IsValid(original))
-                {
-                    // Int32Converter.ConvertFromString() does a pretty good job of parsing numbers, except when given a hex
-                    // number that isn't prefixed with 0x. If it fails, try parsing it using int.Parse().
-                    errorAsInt = (int?)converter.ConvertFromString(original);
-                }
-                else
-                {
-                    errorAsInt = int.Parse(original, NumberStyles.HexNumber, CultureInfo.CurrentCulture);
-                }
-            }
-            catch
+            if (errorAsInt is null)
             {
                 // If this ConvertFromString() function fails due to a bad format, update the above regex to ensure
                 // the bad string isn't fed to this function.
@@ -126,29 +112,24 @@ internal sealed class ClipboardMonitor : WindowHooker<ClipboardMonitor>, INotify
             }
 
             newContents.Raw = original;
-            newContents.Hex = errorAsInt is not null ? Convert.ToString((int)errorAsInt, 16) : original;
-            newContents.Dec = errorAsInt is not null ? Convert.ToString((int)errorAsInt, 10) : original;
+            newContents.Hex = Convert.ToString((int)errorAsInt, 16);
+            newContents.Dec = Convert.ToString((int)errorAsInt, 10);
 
-            // Is there an error code on here?
-            // if (ErrorLookupHelper.ContainsErrorCode(text, out var hresult))
-            if (errorAsInt is not null)
+            var errors = ErrorLookupHelper.LookupError((int)errorAsInt);
+            if (errors is not null)
             {
-                var errors = ErrorLookupHelper.LookupError((int)errorAsInt);
-                if (errors is not null)
+                foreach (var error in errors)
                 {
-                    foreach (var error in errors)
+                    // Seperate each error with a space. These errors aren't localized, so we may not need to worry
+                    // about the space being in the wrong place.
+                    if (newContents.Code != string.Empty)
                     {
-                        // Seperate each error with a space. These errors aren't localized, so we may not need to worry
-                        // about the space being in the wrong place.
-                        if (newContents.Code != string.Empty)
-                        {
-                            newContents.Code += " ";
-                            newContents.Help += " ";
-                        }
-
-                        newContents.Code += error.Name;
-                        newContents.Help += error.Help;
+                        newContents.Code += " ";
+                        newContents.Help += " ";
                     }
+
+                    newContents.Code += error.Name;
+                    newContents.Help += error.Help;
                 }
             }
 

--- a/tools/PI/DevHome.PI/Models/WERHelper.cs
+++ b/tools/PI/DevHome.PI/Models/WERHelper.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Threading;
 using DevHome.Common.Helpers;
+using DevHome.PI.Helpers;
 using Microsoft.Win32;
 using Serilog;
 
@@ -250,8 +251,7 @@ internal sealed class WERHelper : IDisposable
 
     private void FindOrCreateWEREntryFromEventLog(string filepath, DateTime timeGenerated, string moduleName, string executable, string eventGuid, string description, string processId)
     {
-        var converter = new Int32Converter();
-        var pid = (int?)converter.ConvertFromString(processId);
+        int? pid = CommonHelper.ParseStringToInt(processId);
 
         // When adding/updating a report, we need to do it on the dispatcher thread
         _dispatcher.TryEnqueue(() =>


### PR DESCRIPTION
## Summary of the pull request
This was a bug reported by a customer. Apparently on their box, their event log had a PIDs being expressed as hex values without a leading "0x", while on my machine they all have the leading "0x". When we'd try and parse "5cd8" we'd crash.

The Clipboard monitor code had parsing logic to handle these cases, so I lifted that parsing logic from the Clipboard monitor, put it in a common helper, and now both the clipboard monitor and the WER logic use that.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3453 
- [ ] Tests added/passed
- [ ] Documentation updated
