### PR TITLE
Prevent extension wrapper's IsRunning() from throwing

### DIFF
--- a/src/Models/ExtensionWrapper.cs
+++ b/src/Models/ExtensionWrapper.cs
@@ -4,6 +4,7 @@
 using System.Runtime.InteropServices;
 using DevHome.Common.Services;
 using Microsoft.Windows.DevHome.SDK;
+using Serilog;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.AppExtensions;
 using Windows.Win32;
@@ -89,7 +90,9 @@ public class ExtensionWrapper : IExtensionWrapper
                 return false;
             }
 
-            throw;
+            // Getting here is unexpected; log the state to handle other errors in the future.
+            Log.Warning(e, $"Unexpected result in IsRunning(): {e.Message}");
+            return false;
         }
 
         return true;


### PR DESCRIPTION
## Summary of the pull request
Extension wrapper call to IsRunning() can throw if the cast fails for any other reason than the one checked for. This throw is unlogged and appears to be uncaught by calling code, which if it happens could lead to a crash. This is a speculative fix to prevent the throw and instead log the warning for the unexpected state so we may identify if this is indeed happening and handle it better in the future.

## References and relevant issues
#3540 

## Detailed description of the pull request / Additional comments
Changed the rethrow in IsRunning() to a warning log and return false.  The Serilog "Log.Warning" call is guaranteed to not throw per Serilog documentation, so this should not result in a problem.

## Validation steps performed
* Built and ran Dev Home. As this is a speculative fix in code which may not be hit I was unable to verify further.

## PR checklist
- [x] Closes #3540
- [x] Tests added/passed
- [x] Documentation updated
