### PR TITLE
Add events for core telemetry

### DIFF
--- a/common/TelemetryEvents/PageLoadedEvent.cs
+++ b/common/TelemetryEvents/PageLoadedEvent.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Common.Helpers;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents;
+
+[EventData]
+public class PageLoadedEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public Guid DeploymentIdentifier { get; }
+
+    public string PageName { get; }
+
+    public PageLoadedEvent(string pageName)
+    {
+        DeploymentIdentifier = Deployment.Identifier;
+        PageName = pageName;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -22,6 +22,7 @@ using DevHome.Settings.Extensions;
 using DevHome.SetupFlow.Extensions;
 using DevHome.SetupFlow.Services;
 using DevHome.Telemetry;
+using DevHome.TelemetryEvents;
 using DevHome.Utilities.Extensions;
 using DevHome.ViewModels;
 using DevHome.Views;
@@ -178,6 +179,9 @@ public partial class App : Application, IApp
 
         UnhandledException += App_UnhandledException;
         AppInstance.GetCurrent().Activated += OnActivated;
+
+        TelemetryFactory.Get<ITelemetry>().Log("DevHome_Started_Event", LogLevel.Critical, new DevHomeStartedEvent());
+        Log.Information("Dev Home Started.");
     }
 
     public void ShowMainWindow()
@@ -209,7 +213,7 @@ public partial class App : Application, IApp
         Environment.FailFast(e.Message, e.Exception);
     }
 
-    protected async override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+    protected async override void OnLaunched(LaunchActivatedEventArgs args)
     {
         base.OnLaunched(args);
         await Task.WhenAll(

--- a/src/TelemetryEvents/DevHomeClosedEvent.cs
+++ b/src/TelemetryEvents/DevHomeClosedEvent.cs
@@ -13,15 +13,9 @@ namespace DevHome.TelemetryEvents;
 [EventData]
 public class DevHomeClosedEvent : EventBase
 {
-    public double ElapsedTime
-    {
-        get;
-    }
+    public double ElapsedTime { get; }
 
-    public Guid DeploymentIdentifier
-    {
-        get;
-    }
+    public Guid DeploymentIdentifier { get; }
 
     public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServiceUsage;
 

--- a/src/TelemetryEvents/DevHomeInitializationEndedEvent.cs
+++ b/src/TelemetryEvents/DevHomeInitializationEndedEvent.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+using DevHome.Common.Helpers;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+using Serilog;
+
+namespace DevHome.TelemetryEvents;
+
+[EventData]
+public class DevHomeInitializationEndedEvent : EventBase
+{
+    public Guid DeploymentIdentifier { get; }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public DevHomeInitializationEndedEvent()
+    {
+        DeploymentIdentifier = Deployment.Identifier;
+        var log = Log.ForContext("SourceContext", nameof(DevHomeInitializationEndedEvent));
+        log.Debug($"DevHome Initialization Started Event, Identifier: {DeploymentIdentifier}");
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/src/TelemetryEvents/DevHomeInitializationStartedEvent.cs
+++ b/src/TelemetryEvents/DevHomeInitializationStartedEvent.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+using DevHome.Common.Helpers;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+using Serilog;
+
+namespace DevHome.TelemetryEvents;
+
+[EventData]
+public class DevHomeInitializationStartedEvent : EventBase
+{
+    public Guid DeploymentIdentifier { get; }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public DevHomeInitializationStartedEvent()
+    {
+        DeploymentIdentifier = Deployment.Identifier;
+        var log = Log.ForContext("SourceContext", nameof(DevHomeInitializationStartedEvent));
+        log.Debug($"DevHome Initialization Started Event, Identifier: {DeploymentIdentifier}");
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/src/TelemetryEvents/DevHomeShellLoadedEvent.cs
+++ b/src/TelemetryEvents/DevHomeShellLoadedEvent.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+using DevHome.Common.Helpers;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+using Microsoft.Windows.AppLifecycle;
+using Serilog;
+
+namespace DevHome.TelemetryEvents;
+
+[EventData]
+public class DevHomeShellLoadedEvent : EventBase
+{
+    public Guid DeploymentIdentifier { get; }
+
+    public ExtendedActivationKind ActivationKind { get; }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public DevHomeShellLoadedEvent(ExtendedActivationKind activationKind)
+    {
+        ActivationKind = activationKind;
+        DeploymentIdentifier = Deployment.Identifier;
+        var log = Log.ForContext("SourceContext", nameof(DevHomeShellLoadedEvent));
+        log.Debug($"DevHome Startup Event, Identifier: {DeploymentIdentifier}");
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/src/TelemetryEvents/DevHomeStartedEvent.cs
+++ b/src/TelemetryEvents/DevHomeStartedEvent.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.Tracing;
+using DevHome.Common.Helpers;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+using Serilog;
+
+namespace DevHome.TelemetryEvents;
+
+[EventData]
+public class DevHomeStartedEvent : EventBase
+{
+    public Guid DeploymentIdentifier { get; }
+
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public DevHomeStartedEvent()
+    {
+        DeploymentIdentifier = Deployment.Identifier;
+        var log = Log.ForContext("SourceContext", nameof(DevHomeStartedEvent));
+        log.Debug($"DevHome Launched Event, Identifier: {DeploymentIdentifier}");
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // No sensitive strings to replace.
+    }
+}

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -6,6 +6,8 @@ using DevHome.Common.Extensions;
 using DevHome.Contracts.Services;
 using DevHome.Dashboard.Services;
 using DevHome.Services.Core.Contracts;
+using DevHome.Telemetry;
+using DevHome.TelemetryEvents;
 using DevHome.Views;
 using Microsoft.UI.Xaml;
 using Serilog;
@@ -46,6 +48,9 @@ public class InitializationViewModel : ObservableObject
 
     public async void OnPageLoaded()
     {
+        TelemetryFactory.Get<ITelemetry>().Log("DevHome_Initialization_Started_Event", LogLevel.Critical, new DevHomeInitializationStartedEvent());
+        _log.Information("Dev Home Initialization starting.");
+
         // Install the widget service if we're on Windows 10 and it's not already installed.
         try
         {
@@ -88,6 +93,9 @@ public class InitializationViewModel : ObservableObject
         App.MainWindow.Content = Application.Current.GetService<ShellPage>();
 
         _themeSelector.SetRequestedTheme();
+
+        TelemetryFactory.Get<ITelemetry>().Log("DevHome_Initialization_Ended_Event", LogLevel.Critical, new DevHomeInitializationEndedEvent());
+        _log.Information("Dev Home Initialization ended.");
     }
 
     private bool HasDevHomeGitHubExtensionInstalled()

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -6,8 +6,11 @@ using DevHome.Common.Contracts;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
 using DevHome.Contracts.Services;
+using DevHome.Telemetry;
+using DevHome.TelemetryEvents;
 using Microsoft.UI.Xaml.Navigation;
 using Microsoft.Windows.AppLifecycle;
+using Serilog;
 
 namespace DevHome.ViewModels;
 
@@ -52,7 +55,11 @@ public partial class ShellViewModel : ObservableObject
 
     public async Task OnLoaded()
     {
-        switch (AppInstance.GetCurrent().GetActivatedEventArgs().Kind)
+        var activationKind = AppInstance.GetCurrent().GetActivatedEventArgs().Kind;
+        Log.Information($"Activated with kind {activationKind}");
+        TelemetryFactory.Get<ITelemetry>().Log("DevHome_Shell_Loaded_Event", LogLevel.Critical, new DevHomeShellLoadedEvent(activationKind));
+
+        switch (activationKind)
         {
             case ExtendedActivationKind.File:
                 // Allow the file activation handler to navigate to the appropriate page.

--- a/src/Views/InitializationPage.xaml.cs
+++ b/src/Views/InitializationPage.xaml.cs
@@ -7,9 +7,6 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Views;
 
-/// <summary>
-/// An empty page that can be used on its own or navigated to within a Frame.
-/// </summary>
 public sealed partial class InitializationPage : Page
 {
     public InitializationViewModel ViewModel

--- a/src/Views/WhatsNewPage.xaml.cs
+++ b/src/Views/WhatsNewPage.xaml.cs
@@ -83,6 +83,11 @@ public sealed partial class WhatsNewPage : DevHomePage
         ViewModel.NumberOfBigCards = whatsNewBigCards.Count();
 
         MoveBigCardsIfNeeded(this.ActualWidth);
+
+        TelemetryFactory.Get<ITelemetry>().Log(
+            "Page_Loaded_Event",
+            LogLevel.Critical,
+            new PageLoadedEvent(GetType().Name));
     }
 
     private async void Button_ClickAsync(object sender, RoutedEventArgs e)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -12,6 +12,7 @@ using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Common.Views;
 using DevHome.Dashboard.ComSafeWidgetObjects;
 using DevHome.Dashboard.Controls;
@@ -133,6 +134,10 @@ public partial class DashboardView : ToolPage, IDisposable
     private async Task OnLoadedAsync()
     {
         await InitializeDashboard();
+        TelemetryFactory.Get<ITelemetry>().Log(
+            "Page_Loaded_Event",
+            LogLevel.Critical,
+            new PageLoadedEvent(GetType().Name));
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary of the pull request
Add events for measuring:
- % devices with Dev Home crashes
  - adds DevHomeStartedEvent to replace placeholder currently used
- Dev Home regular startup success rate
  - New event: DevHomeStartedEvent
  - New event: DevHomeShellLoadedEvent
  - New event: PageLoadedEvent
  - We'll measure only instances where DevHomeShellLoaded tells us we started with a "Launch" activation kind, and measure if we successfully got to PageLoadedEvent for Dashboard or What's New page.
- Dev Home regular startup boot time
  - Time from DevHomeStartedEvent to PageLoadedEvent. Exclude any time taken by store download, measured between DevHomeInitializationStartedEvent and DevHomeInitializationEndedEvent.

## References and relevant issues
https://task.ms/52413149

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
