### PR TITLE
Remove locking of the "Windows Sandbox" term

### DIFF
--- a/common/Strings/en-us/Resources.resw
+++ b/common/Strings/en-us/Resources.resw
@@ -353,7 +353,7 @@
   </data>
   <data name="WindowsSandboxDescription" xml:space="preserve">
     <value>Enables the dependencies required to run Windows Sandbox scenarios.</value>
-    <comment>Locked="{Windows Sandbox}" Description for the Containers-DisposableClientVM optional feature.</comment>
+    <comment>Description for the Containers-DisposableClientVM optional feature.</comment>
   </data>
   <data name="WindowsSubsystemForLinuxDescription" xml:space="preserve">
     <value>Provides services and environments for running native user-mode Linux shells and tools on Windows.</value>


### PR DESCRIPTION
## Summary of the pull request

We have an internal bug

[Bug 51361901](https://microsoft.visualstudio.com/OS/_workitems/edit/51361901): Locver: Apps: DevHome: Dev rule locks "Windows Sandbox" that is approved for localization in Term Studio

This removes the lock on the localization.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
