### PR TITLE
Use helpers package to register repos with OS

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240709-x2135" />
+    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240805-x2200" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -73,7 +73,7 @@
     <!-- Temporarily duplicate the Adaptive Card from DevHome.Common -->
     <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.0-beta" GeneratePathProperty="true" />
     <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.1.0-beta" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240709-x2135" />
+    <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240805-x2200" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -145,13 +145,6 @@ public partial class FileExplorerViewModel : ObservableObject
                 if (repoRootfolder != null && repoRootfolder.Path.Length > 0)
                 {
                     _log.Information($"Selected '{repoRootfolder.Path}' as location to register");
-                    var wrapperResult = ExtraFolderPropertiesWrapper.Register(repoRootfolder.Path, typeof(SourceControlProvider).GUID);
-                    if (!wrapperResult.Succeeded)
-                    {
-                        _log.Error(wrapperResult.ExtendedError, "Failed to register folder for source control integration");
-                        return;
-                    }
-
                     RepoTracker.AddRepositoryPath(_unassigned, repoRootfolder.Path);
                 }
                 else
@@ -180,6 +173,13 @@ public partial class FileExplorerViewModel : ObservableObject
             if (result.Result == ResultType.Failure)
             {
                 _log.Error("Failed to validate source control extension");
+                return;
+            }
+
+            var wrapperResult = ExtraFolderPropertiesWrapper.Register(rootPath, typeof(SourceControlProvider).GUID);
+            if (!wrapperResult.Succeeded)
+            {
+                _log.Error(wrapperResult.ExtendedError, "Failed to register folder for source control integration");
                 return;
             }
 

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -15,7 +15,9 @@ using DevHome.Customization.Helpers;
 using DevHome.Customization.Models;
 using DevHome.Customization.TelemetryEvents;
 using DevHome.FileExplorerSourceControlIntegration.Services;
+using FileExplorerSourceControlIntegration;
 using Microsoft.Internal.Windows.DevHome.Helpers;
+using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
@@ -41,7 +43,7 @@ public partial class FileExplorerViewModel : ObservableObject
 
     public IExtensionService ExtensionService { get; }
 
-    public bool IsFeatureEnabled => ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration");
+    public bool IsFeatureEnabled => ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration") && ExtraFolderPropertiesWrapper.IsSupported();
 
     public FileExplorerViewModel(IExperimentationService experimentationService, IExtensionService extensionService)
     {
@@ -134,7 +136,7 @@ public partial class FileExplorerViewModel : ObservableObject
     [RelayCommand]
     public async Task AddFolderClick()
     {
-        if (ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration"))
+        if (IsFeatureEnabled)
         {
             await Task.Run(async () =>
             {
@@ -143,6 +145,13 @@ public partial class FileExplorerViewModel : ObservableObject
                 if (repoRootfolder != null && repoRootfolder.Path.Length > 0)
                 {
                     _log.Information($"Selected '{repoRootfolder.Path}' as location to register");
+                    var wrapperResult = ExtraFolderPropertiesWrapper.Register(repoRootfolder.Path, typeof(SourceControlProvider).GUID);
+                    if (!wrapperResult.Succeeded)
+                    {
+                        _log.Error(wrapperResult.ExtendedError, "Failed to register folder for source control integration");
+                        return;
+                    }
+
                     RepoTracker.AddRepositoryPath(_unassigned, repoRootfolder.Path);
                 }
                 else
@@ -156,6 +165,7 @@ public partial class FileExplorerViewModel : ObservableObject
 
     public void RemoveTrackedRepositoryFromDevHome(string rootPath)
     {
+        ExtraFolderPropertiesWrapper.Unregister(rootPath);
         RepoTracker.RemoveRepositoryPath(rootPath);
         RefreshTrackedRepositories();
     }

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/DevHome.QuietBackgroundProcesses.ElevatedServer.vcxproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <Import Project="$(SolutionDir)Directory.CppBuild.props" />
-  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
+  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -204,6 +204,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
   </Target>
 </Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/packages.config
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240709-x2135" targetFramework="native" />
+  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240805-x2200" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/DevHome.QuietBackgroundProcesses.Server.vcxproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/DevHome.QuietBackgroundProcesses.Server.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <Language>C++</Language>
   </PropertyGroup>
-  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
+  <Import Project="..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props" Condition="Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" />
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <Import Project="$(SolutionDir)Directory.CppBuild.props" />
   <PropertyGroup Label="Globals">
@@ -196,6 +196,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240709-x2135\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Internal.Windows.DevHome.Helpers.1.0.20240805-x2200\build\native\Microsoft.Internal.Windows.DevHome.Helpers.props'))" />
   </Target>
 </Project>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/packages.config
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.Server/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240709-x2135" targetFramework="native" />
+  <package id="Microsoft.Internal.Windows.DevHome.Helpers" version="1.0.20240805-x2200" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Summary of the pull request
In addition to DevHome internally mapping each repo folder to an extension, we also need to notify Windows to map the repo folder to DevHome's `FileExplorerSourceControlIntegration`.

## Detailed description of the pull request / Additional comments
In early testing we've used a PowerShell script to manually write registry entries. Now that we have support in the `Microsoft.Internal.Windows.DevHome.Helpers` package to do this programatically, it's time to integrate that call into DevHome proper.

## Validation steps performed
Used private build of DevHome to register repo folders in the File Explorer customization page. Verified that the expected registry entries appeared, and verified that the File Explorer version control integration was now enabled for the added repo.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
