### PR TITLE
Update admin button contents

### DIFF
--- a/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/AppDetailsPage.xaml
@@ -152,9 +152,14 @@
                 </Grid>
 
                 <Button 
-                    Grid.Row="3" Grid.ColumnSpan="2" x:Uid="RunElevatedButton" Margin="0,12,0,0"
+                    Grid.Row="3" Grid.ColumnSpan="2" Margin="0,12,0,0"
                     Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" 
-                    Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
+                    Command="{x:Bind ViewModel.RunAsAdminCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <SymbolIcon Symbol="Admin"/>
+                        <TextBlock x:Uid="RunElevatedButton" Margin="0"/>
+                    </StackPanel>
+                </Button>
             </Grid>
         </ScrollViewer>
     </Grid>

--- a/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/ModulesPage.xaml
@@ -23,7 +23,12 @@
         </Grid.RowDefinitions>
 
         <TextBlock x:Uid="ModulesHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
-        <Button Grid.Row="1" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
+        <Button Grid.Row="1" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <SymbolIcon Symbol="Admin"/>
+                <TextBlock x:Uid="RunElevatedButton" Margin="0"/>
+            </StackPanel>
+        </Button>
         <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="220"/>

--- a/tools/PI/DevHome.PI/Pages/WERPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WERPage.xaml
@@ -40,7 +40,7 @@
                     <Button Visibility="{x:Bind ViewModel.AllowElevationOption}" Command="{x:Bind ViewModel.RunAsAdminCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="10">
                             <SymbolIcon Symbol="Admin"/>
-                            <TextBlock x:Uid="RunElevatedButton" Margin="0"/>
+                            <TextBlock x:Uid="RunElevatedButtonForWER" Margin="0"/>
                         </StackPanel>
                     </Button>
                     <HyperlinkButton x:Uid="LocalDumpMoreInfo" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2279804" />

--- a/tools/PI/DevHome.PI/Pages/WERPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WERPage.xaml
@@ -40,7 +40,7 @@
                     <Button Visibility="{x:Bind ViewModel.AllowElevationOption}" Command="{x:Bind ViewModel.RunAsAdminCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="10">
                             <SymbolIcon Symbol="Admin"/>
-                            <TextBlock x:Uid="RunElevatedButtonForWER" Margin="0"/>
+                            <TextBlock x:Uid="RunElevatedButton" Margin="0"/>
                         </StackPanel>
                     </Button>
                     <HyperlinkButton x:Uid="LocalDumpMoreInfo" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2279804" />

--- a/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
+++ b/tools/PI/DevHome.PI/Pages/WinLogsPage.xaml
@@ -20,7 +20,12 @@
         </Grid.RowDefinitions>
 
         <TextBlock x:Uid="WinLogsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
-        <Button Grid.Row="1" x:Uid="RunElevatedButton" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}"/>
+        <Button Grid.Row="1" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <SymbolIcon Symbol="Admin"/>
+                <TextBlock x:Uid="RunElevatedButton" Margin="0"/>
+            </StackPanel>
+        </Button>
         <StackPanel x:Name="WinLogsOptions" Grid.Row="2" Orientation="Horizontal" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}">
             <CheckBox
                 x:Uid="EtwCheckbox" x:Name="EtwCheckbox" IsChecked="{x:Bind ViewModel.IsETWLogsEnabled, Mode=TwoWay}" Tag="{x:Bind models:WinLogsTool.ETWLogs}"

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -1057,11 +1057,19 @@
     <value>More</value>
     <comment>Label for a link that navigates the user to a location to learn more about WER local dumps</comment>
   </data>
-    <data name="RunElevatedButton.Text" xml:space="preserve">
+  <data name="RunElevatedButtonForWER.Text" xml:space="preserve">
     <value>Change</value>
-    <comment>The contents of a button to allow the user to trigger elevation</comment>
+    <comment>The contents of a button to allow the user to trigger elevation to change WER settings</comment>
   </data>
-    <data name="RunElevatedButton.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="RunElevatedButtonForWER.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Project Ironsides needs to run as Admin in order to modify WER collection for an app.</value>
+    <comment>{Locked="Ironsides"} Tooltip for a button that relaunches Project Ironsides as admin to change WER settings</comment>
+  </data>
+  <data name="RunElevatedButton.Text" xml:space="preserve">
+    <value>Run as admin</value>
+    <comment>The contents of a button to allow the user to run as admin</comment>
+  </data>
+  <data name="RunElevatedButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Project Ironsides needs to run as Admin in order to get more data for an app.</value>
     <comment>{Locked="Ironsides"} Tooltip for a button that relaunches Project Ironsides as admin to get more data</comment>
   </data>

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -1066,8 +1066,8 @@
     <comment>{Locked="Ironsides"} Tooltip for a button that relaunches Project Ironsides as admin to change WER settings</comment>
   </data>
   <data name="RunElevatedButton.Text" xml:space="preserve">
-    <value>Run as admin</value>
-    <comment>The contents of a button to allow the user to run as admin</comment>
+    <value>Get Information</value>
+    <comment>The contents of a button to allow the user to trigger elevation to get more information</comment>
   </data>
   <data name="RunElevatedButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Project Ironsides needs to run as Admin in order to get more data for an app.</value>

--- a/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
+++ b/tools/PI/DevHome.PI/Strings/en-us/Resources.resw
@@ -481,10 +481,6 @@
     <value>Is running as System</value>
     <comment>This refers to whether the application is running as System</comment>
   </data>
-  <data name="RunElevatedButton.Content" xml:space="preserve">
-    <value>Restart Project Ironsides as Admin to get more data</value>
-    <comment>{Locked="Ironsides"} When the user clicks this button we close and relaunch Project Ironsides as admin to get more app details</comment>
-  </data>
   <data name="InsightsButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Go to the key insights</value>
     <comment>The tooltip for a button that takes the user to the key insights page</comment>
@@ -1061,13 +1057,13 @@
     <value>More</value>
     <comment>Label for a link that navigates the user to a location to learn more about WER local dumps</comment>
   </data>
-  <data name="RunElevatedButtonForWER.Text" xml:space="preserve">
+    <data name="RunElevatedButton.Text" xml:space="preserve">
     <value>Change</value>
-    <comment>The contents of a button to allow the user to trigger elevation to change WER settings</comment>
+    <comment>The contents of a button to allow the user to trigger elevation</comment>
   </data>
-  <data name="RunElevatedButtonForWER.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Project Ironsides needs to run as Admin in order to modify WER collection for an app.</value>
-    <comment>{Locked="Ironsides"} Tooltip for a button that relaunches Project Ironsides as admin to change WER settings</comment>
+    <data name="RunElevatedButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Project Ironsides needs to run as Admin in order to get more data for an app.</value>
+    <comment>{Locked="Ironsides"} Tooltip for a button that relaunches Project Ironsides as admin to get more data</comment>
   </data>
   <data name="DumpInfoSelectorItem.Text" xml:space="preserve">
     <value>Dump Info</value>


### PR DESCRIPTION
## Summary of the pull request
Problem: Run as admin button in multiple pages is cut off
![image](https://github.com/user-attachments/assets/3d07ebaa-8515-4e44-bc83-2ab9939bce3f)

Fix: Update the button to have a tooltip similar to the one used in WER page:
<img width="716" alt="image" src="https://github.com/user-attachments/assets/5ca9670f-595f-49e9-8a22-1e1529f55289">

## PR checklist
- [ ] Closes #3032
