### PR TITLE
Wrap Commit result and fetch from the command line

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -95,7 +95,7 @@ internal sealed class CommitLogCache
     private CommitWrapper? FindLastCommitUsingCommandLine(string relativePath)
     {
         var result = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), _workingDirectory, $"log -n 1 --pretty=format:%s%n%an%n%ae%n%aI%n%H -- {relativePath}");
-        if (result.Status != Microsoft.Windows.DevHome.SDK.ProviderOperationStatus.Success || result.Output == null)
+        if ((result.Status != Microsoft.Windows.DevHome.SDK.ProviderOperationStatus.Success) || (result.Output is null))
         {
             return null;
         }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -20,20 +20,111 @@ namespace FileExplorerGitIntegration.Models;
 internal sealed class CommitLogCache : IEnumerable<Commit>
 {
     private readonly List<Commit> _commits = new();
+    private readonly bool _useCommandLine = true;
+    private readonly GitDetect _gitDetect = new();
+    private readonly bool _gitInstalled;
+    private readonly string _workingDirectory;
 
     public CommitLogCache(Repository repo)
     {
-        // For now, greedily get the entire commit log for simplicity.
-        // PRO: No syncronization needed for the enumerator.
-        // CON: May take longer for the initial load and use more memory.
-        // For reference, I tested on my dev machine on a repo with an *enormous* number of commits
-        // https://github.com/python/cpython with > 120k commits. This was a one-time cost of 2-3 seconds, but also
-        // consumed several hundred MB of memory.
+        _workingDirectory = repo.Info.WorkingDirectory;
+        if (_useCommandLine)
+        {
+            _gitInstalled = _gitDetect.DetectGit();
+        }
+        else
+        {
+            // For now, greedily get the entire commit log for simplicity.
+            // PRO: No syncronization needed for the enumerator.
+            // CON: May take longer for the initial load and use more memory.
+            // For reference, I tested on my dev machine on a repo with an *enormous* number of commits
+            // https://github.com/python/cpython with > 120k commits. This was a one-time cost of 2-3 seconds, but also
+            // consumed several hundred MB of memory.
 
-        // Often, but not always, the root folder has some boilerplate/doc/config that rarely changes
-        // Therefore, populating the last commit for each file in the root folder often requires a large portion of the commit history anyway.
-        // This somewhat blunts the appeal of trying to load this incrementally.
-        _commits.AddRange(repo.Commits);
+            // Often, but not always, the root folder has some boilerplate/doc/config that rarely changes
+            // Therefore, populating the last commit for each file in the root folder often requires a large portion of the commit history anyway.
+            // This somewhat blunts the appeal of trying to load this incrementally.
+            _commits.AddRange(repo.Commits);
+        }
+    }
+
+    public CommitWrapper? FindLastCommit(string relativePath)
+    {
+        if (_useCommandLine)
+        {
+            return FindLastCommitUsingCommandLine(relativePath);
+        }
+        else
+        {
+            return FindLastCommitUsingLibGit2Sharp(relativePath);
+        }
+    }
+
+    private CommitWrapper? FindLastCommitUsingCommandLine(string relativePath)
+    {
+        var result = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), _workingDirectory, $"log -n 1 --pretty=format:%s%n%an%n%ae%n%aI%n%H -- {relativePath}");
+        if (result.Status != Microsoft.Windows.DevHome.SDK.ProviderOperationStatus.Success || result.Output == null)
+        {
+            return null;
+        }
+
+        var parts = result.Output.Split();
+        string message = parts[0];
+        string authorName = parts[1];
+        string authorEmail = parts[2];
+        DateTimeOffset authorWhen = DateTimeOffset.Parse(parts[3], null, System.Globalization.DateTimeStyles.RoundtripKind);
+        string sha = parts[4];
+        return new CommitWrapper(message, authorName, authorEmail, authorWhen, sha);
+    }
+
+    private CommitWrapper? FindLastCommitUsingLibGit2Sharp(string relativePath)
+    {
+        var checkedFirstCommit = false;
+        foreach (var currentCommit in _commits)
+        {
+            // Now that CommitLogCache is caching the result of the revwalk, the next piece that is most expensive
+            // is obtaining relativePath's TreeEntry from the Tree (e.g. currentTree[relativePath].
+            // Digging into the git shows that number of directory entries and/or directory depth may play a factor.
+            // There may also be a lot of redundant lookups happening here, so it may make sense to do some LRU caching.
+            var currentTree = currentCommit.Tree;
+            var currentTreeEntry = currentTree[relativePath];
+            if (currentTreeEntry == null)
+            {
+                if (checkedFirstCommit)
+                {
+                    continue;
+                }
+                else
+                {
+                    // If this file isn't present in the most recent commit, then it's of no interest
+                    return null;
+                }
+            }
+
+            checkedFirstCommit = true;
+            var parents = currentCommit.Parents;
+            var count = parents.Count();
+            if (count == 0)
+            {
+                return new CommitWrapper(currentCommit);
+            }
+            else if (count > 1)
+            {
+                // Multiple parents means a merge. Ignore.
+                continue;
+            }
+            else
+            {
+                var parentTree = parents.First();
+                var parentTreeEntry = parentTree[relativePath];
+                if (parentTreeEntry == null || parentTreeEntry.Target.Id != currentTreeEntry.Target.Id)
+                {
+                    return new CommitWrapper(currentCommit);
+                }
+            }
+        }
+
+        return null;
     }
 
     public IEnumerator<Commit> GetEnumerator()

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -68,7 +68,7 @@ internal sealed class CommitLogCache : IEnumerable<Commit>
             return null;
         }
 
-        var parts = result.Output.Split();
+        var parts = result.Output.Split('\n');
         string message = parts[0];
         string authorName = parts[1];
         string authorEmail = parts[2];

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitWrapper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using LibGit2Sharp;
+
+internal sealed class CommitWrapper
+{
+    public string MessageShort { get; private set; }
+
+    public string AuthorName { get; private set; }
+
+    public string AuthorEmail { get; private set; }
+
+    public DateTimeOffset AuthorWhen { get; private set; }
+
+    public string Sha { get; private set; }
+
+    public CommitWrapper(Commit commit)
+    {
+        MessageShort = commit.MessageShort;
+        AuthorName = commit.Author.Name;
+        AuthorEmail = commit.Author.Email;
+        AuthorWhen = commit.Author.When;
+        Sha = commit.Sha;
+    }
+
+    public CommitWrapper(string messageShort, string authorName, string authorEmail, DateTimeOffset authorWhen, string sha)
+    {
+        MessageShort = messageShort;
+        AuthorName = authorName;
+        AuthorEmail = authorEmail;
+        AuthorWhen = authorWhen;
+        Sha = sha;
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -23,6 +23,7 @@ public class GitExecute
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 WorkingDirectory = repositoryDirectory ?? string.Empty,
+                StandardOutputEncoding = System.Text.Encoding.UTF8,
             };
 
             using var process = Process.Start(processStartInfo);

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
@@ -61,7 +61,7 @@ public sealed class GitLocalRepository : ILocalRepository
 
         var repository = OpenRepository();
 
-        if (repository == null)
+        if (repository is null)
         {
             _log.Debug("GetProperties: Repository object is null");
             return result;
@@ -73,7 +73,7 @@ public sealed class GitLocalRepository : ILocalRepository
             {
                 case "System.VersionControl.LastChangeMessage":
                     latestCommit ??= FindLatestCommit(relativePath, repository);
-                    if (latestCommit != null)
+                    if (latestCommit is not null)
                     {
                         result.Add(propName, latestCommit.MessageShort);
                     }
@@ -81,7 +81,7 @@ public sealed class GitLocalRepository : ILocalRepository
                     break;
                 case "System.VersionControl.LastChangeAuthorName":
                     latestCommit ??= FindLatestCommit(relativePath, repository);
-                    if (latestCommit != null)
+                    if (latestCommit is not null)
                     {
                         result.Add(propName, latestCommit.AuthorName);
                     }
@@ -89,7 +89,7 @@ public sealed class GitLocalRepository : ILocalRepository
                     break;
                 case "System.VersionControl.LastChangeDate":
                     latestCommit ??= FindLatestCommit(relativePath, repository);
-                    if (latestCommit != null)
+                    if (latestCommit is not null)
                     {
                         result.Add(propName, latestCommit.AuthorWhen);
                     }
@@ -97,7 +97,7 @@ public sealed class GitLocalRepository : ILocalRepository
                     break;
                 case "System.VersionControl.LastChangeAuthorEmail":
                     latestCommit ??= FindLatestCommit(relativePath, repository);
-                    if (latestCommit != null)
+                    if (latestCommit is not null)
                     {
                         result.Add(propName, latestCommit.AuthorEmail);
                     }
@@ -105,7 +105,7 @@ public sealed class GitLocalRepository : ILocalRepository
                     break;
                 case "System.VersionControl.LastChangeID":
                     latestCommit ??= FindLatestCommit(relativePath, repository);
-                    if (latestCommit != null)
+                    if (latestCommit is not null)
                     {
                         result.Add(propName, latestCommit.Sha);
                     }
@@ -117,7 +117,7 @@ public sealed class GitLocalRepository : ILocalRepository
 
                 case "System.VersionControl.CurrentFolderStatus":
                     var folderStatus = GetFolderStatus(relativePath, repository);
-                    if (folderStatus != null)
+                    if (folderStatus is not null)
                     {
                         result.Add(propName, folderStatus);
                     }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
@@ -57,7 +57,7 @@ public sealed class GitLocalRepository : ILocalRepository
     {
         relativePath = relativePath.Replace('\\', '/');
         var result = new ValueSet();
-        Commit? latestCommit = null;
+        CommitWrapper? latestCommit = null;
 
         var repository = OpenRepository();
 
@@ -72,89 +72,54 @@ public sealed class GitLocalRepository : ILocalRepository
             switch (propName)
             {
                 case "System.VersionControl.LastChangeMessage":
-                    if (latestCommit == null)
+                    latestCommit ??= FindLatestCommit(relativePath, repository);
+                    if (latestCommit != null)
                     {
-                        latestCommit = FindLatestCommit(relativePath, repository);
-                        if (latestCommit != null)
-                        {
-                            result.Add("System.VersionControl.LastChangeMessage", latestCommit.MessageShort);
-                        }
-                    }
-                    else
-                    {
-                        result.Add("System.VersionControl.LastChangeMessage", latestCommit.MessageShort);
+                        result.Add(propName, latestCommit.MessageShort);
                     }
 
                     break;
                 case "System.VersionControl.LastChangeAuthorName":
-                    if (latestCommit == null)
+                    latestCommit ??= FindLatestCommit(relativePath, repository);
+                    if (latestCommit != null)
                     {
-                        latestCommit = FindLatestCommit(relativePath, repository);
-                        if (latestCommit != null)
-                        {
-                            result.Add("System.VersionControl.LastChangeAuthorName", latestCommit.Author.Name);
-                        }
-                    }
-                    else
-                    {
-                        result.Add("System.VersionControl.LastChangeAuthorName", latestCommit.Author.Name);
+                        result.Add(propName, latestCommit.AuthorName);
                     }
 
                     break;
                 case "System.VersionControl.LastChangeDate":
-                    if (latestCommit == null)
+                    latestCommit ??= FindLatestCommit(relativePath, repository);
+                    if (latestCommit != null)
                     {
-                        latestCommit = FindLatestCommit(relativePath, repository);
-                        if (latestCommit != null)
-                        {
-                            result.Add("System.VersionControl.LastChangeDate", latestCommit.Author.When);
-                        }
-                    }
-                    else
-                    {
-                        result.Add("System.VersionControl.LastChangeDate", latestCommit.Author.When);
+                        result.Add(propName, latestCommit.AuthorWhen);
                     }
 
                     break;
                 case "System.VersionControl.LastChangeAuthorEmail":
-                    if (latestCommit == null)
+                    latestCommit ??= FindLatestCommit(relativePath, repository);
+                    if (latestCommit != null)
                     {
-                        latestCommit = FindLatestCommit(relativePath, repository);
-                        if (latestCommit != null)
-                        {
-                            result.Add("System.VersionControl.LastChangeAuthorEmail", latestCommit.Author.Email);
-                        }
-                    }
-                    else
-                    {
-                        result.Add("System.VersionControl.LastChangeAuthorEmail", latestCommit.Author.Email);
+                        result.Add(propName, latestCommit.AuthorEmail);
                     }
 
                     break;
                 case "System.VersionControl.LastChangeID":
-                    if (latestCommit == null)
+                    latestCommit ??= FindLatestCommit(relativePath, repository);
+                    if (latestCommit != null)
                     {
-                        latestCommit = FindLatestCommit(relativePath, repository);
-                        if (latestCommit != null)
-                        {
-                            result.Add("System.VersionControl.LastChangeID", latestCommit.Sha);
-                        }
-                    }
-                    else
-                    {
-                        result.Add("System.VersionControl.LastChangeID", latestCommit.Sha);
+                        result.Add(propName, latestCommit.Sha);
                     }
 
                     break;
                 case "System.VersionControl.Status":
-                    result.Add("System.VersionControl.Status", GetStatus(relativePath, repository));
+                    result.Add(propName, GetStatus(relativePath, repository));
                     break;
 
                 case "System.VersionControl.CurrentFolderStatus":
                     var folderStatus = GetFolderStatus(relativePath, repository);
                     if (folderStatus != null)
                     {
-                        result.Add("System.VersionControl.CurrentFolderStatus", folderStatus);
+                        result.Add(propName, folderStatus);
                     }
 
                     break;
@@ -194,7 +159,7 @@ public sealed class GitLocalRepository : ILocalRepository
         }
     }
 
-    private Commit? FindLatestCommit(string relativePath, RepositoryWrapper repository)
+    private CommitWrapper? FindLatestCommit(string relativePath, RepositoryWrapper repository)
     {
         return repository.FindLastCommit(relativePath);
     }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/LruCacheDictionary.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/LruCacheDictionary.cs
@@ -23,81 +23,6 @@ internal sealed class LruCacheDictionary<TKey, TValue>
         _dict = [];
     }
 
-    public LruCacheDictionary(IEqualityComparer<TKey> comparer, int capacity = DefaultCapacity)
-    {
-        _capacity = capacity;
-        _dict = new Dictionary<TKey, LinkedListNode<(TKey, TValue)>>(comparer);
-    }
-
-    public int Count => _dict.Count;
-
-    public bool IsEmpty => Count == 0;
-
-    public IEqualityComparer<TKey> Comparer => _dict.Comparer;
-
-    public void Clear()
-    {
-        lock (_lock)
-        {
-            _dict.Clear();
-            _lruList.Clear();
-        }
-    }
-
-    public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
-    {
-        lock (_lock)
-        {
-            if (_dict.TryGetValue(key, out var node))
-            {
-                RenewExistingNodeNoLock(node);
-                return updateValueFactory(key, node.Value.Item2);
-            }
-
-            var value = addValueFactory(key);
-            AddAndTrimNoLock(key, value);
-            return value;
-        }
-    }
-
-    public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
-    {
-        lock (_lock)
-        {
-            if (_dict.TryGetValue(key, out var node))
-            {
-                RenewExistingNodeNoLock(node);
-                return updateValueFactory(key, node.Value.Item2);
-            }
-
-            AddAndTrimNoLock(key, addValue);
-            return addValue;
-        }
-    }
-
-    public bool ContainsKey(TKey key)
-    {
-        lock (_lock)
-        {
-            return _dict.ContainsKey(key);
-        }
-    }
-
-    public bool TryAdd(TKey key, TValue value)
-    {
-        lock (_lock)
-        {
-            if (_dict.TryGetValue(key, out var node))
-            {
-                RenewExistingNodeNoLock(node);
-                return false;
-            }
-
-            AddAndTrimNoLock(key, value);
-            return true;
-        }
-    }
-
     public bool TryGetValue(TKey key, out TValue value)
     {
         lock (_lock)
@@ -129,39 +54,6 @@ internal sealed class LruCacheDictionary<TKey, TValue>
         }
     }
 
-    public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
-    {
-        lock (_lock)
-        {
-            if (_dict.TryGetValue(key, out var node))
-            {
-                RenewExistingNodeNoLock(node);
-                return node.Value.Item2;
-            }
-
-            var value = valueFactory(key);
-            AddAndTrimNoLock(key, value);
-            return value;
-        }
-    }
-
-    public bool TryRemove(TKey key, out TValue value)
-    {
-        lock (_lock)
-        {
-            if (_dict.TryGetValue(key, out var node))
-            {
-                _lruList.Remove(node);
-                _dict.Remove(key);
-                value = node.Value.Item2;
-                return true;
-            }
-
-            value = default!;
-            return false;
-        }
-    }
-
     private void AddAndTrimNoLock(TKey key, TValue value)
     {
         var newNode = new LinkedListNode<(TKey, TValue)>((key, value));
@@ -187,17 +79,12 @@ internal sealed class LruCacheDictionary<TKey, TValue>
     {
         if (_lruList.Count > _capacity)
         {
-            RemoveFirstNoLock();
-        }
-    }
-
-    private void RemoveFirstNoLock()
-    {
-        var node = _lruList.First;
-        if (node != null)
-        {
-            _lruList.RemoveFirst();
-            _dict.Remove(node.Value.Item1);
+            var node = _lruList.First;
+            if (node != null)
+            {
+                _lruList.RemoveFirst();
+                _dict.Remove(node.Value.Item1);
+            }
         }
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/LruCacheDictionary.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/LruCacheDictionary.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Newtonsoft.Json.Linq;
+
+namespace FileExplorerGitIntegration.Models;
+
+// A simple LRU cache dictionary implementation.
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "File names for generics are ugly.")]
+internal sealed class LruCacheDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly int _capacity;
+    private const int DefaultCapacity = 512;
+    private readonly object _lock = new();
+    private readonly Dictionary<TKey, LinkedListNode<(TKey, TValue)>> _dict;
+    private readonly LinkedList<(TKey, TValue)> _lruList = new();
+
+    public LruCacheDictionary(int capacity = DefaultCapacity)
+    {
+        _capacity = capacity;
+        _dict = [];
+    }
+
+    public LruCacheDictionary(IEqualityComparer<TKey> comparer, int capacity = DefaultCapacity)
+    {
+        _capacity = capacity;
+        _dict = new Dictionary<TKey, LinkedListNode<(TKey, TValue)>>(comparer);
+    }
+
+    public int Count => _dict.Count;
+
+    public bool IsEmpty => Count == 0;
+
+    public IEqualityComparer<TKey> Comparer => _dict.Comparer;
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _dict.Clear();
+            _lruList.Clear();
+        }
+    }
+
+    public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                RenewExistingNodeNoLock(node);
+                return updateValueFactory(key, node.Value.Item2);
+            }
+
+            var value = addValueFactory(key);
+            AddAndTrimNoLock(key, value);
+            return value;
+        }
+    }
+
+    public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                RenewExistingNodeNoLock(node);
+                return updateValueFactory(key, node.Value.Item2);
+            }
+
+            AddAndTrimNoLock(key, addValue);
+            return addValue;
+        }
+    }
+
+    public bool ContainsKey(TKey key)
+    {
+        lock (_lock)
+        {
+            return _dict.ContainsKey(key);
+        }
+    }
+
+    public bool TryAdd(TKey key, TValue value)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                RenewExistingNodeNoLock(node);
+                return false;
+            }
+
+            AddAndTrimNoLock(key, value);
+            return true;
+        }
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                RenewExistingNodeNoLock(node);
+                value = node.Value.Item2;
+                return true;
+            }
+
+            value = default!;
+            return false;
+        }
+    }
+
+    public TValue GetOrAdd(TKey key, TValue value)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                RenewExistingNodeNoLock(node);
+                return node.Value.Item2;
+            }
+
+            AddAndTrimNoLock(key, value);
+            return value;
+        }
+    }
+
+    public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                RenewExistingNodeNoLock(node);
+                return node.Value.Item2;
+            }
+
+            var value = valueFactory(key);
+            AddAndTrimNoLock(key, value);
+            return value;
+        }
+    }
+
+    public bool TryRemove(TKey key, out TValue value)
+    {
+        lock (_lock)
+        {
+            if (_dict.TryGetValue(key, out var node))
+            {
+                _lruList.Remove(node);
+                _dict.Remove(key);
+                value = node.Value.Item2;
+                return true;
+            }
+
+            value = default!;
+            return false;
+        }
+    }
+
+    private void AddAndTrimNoLock(TKey key, TValue value)
+    {
+        var newNode = new LinkedListNode<(TKey, TValue)>((key, value));
+        AddNewNodeNoLock(newNode);
+        TrimToCapacityNoLock();
+    }
+
+    private void RenewExistingNodeNoLock(LinkedListNode<(TKey, TValue)> node)
+    {
+        Debug.Assert(node.List == _lruList, "Node is not in the list");
+        _lruList.Remove(node);
+        _lruList.AddLast(node);
+    }
+
+    private void AddNewNodeNoLock(LinkedListNode<(TKey, TValue)> node)
+    {
+        Debug.Assert(node.List == null, "Node is already in the list");
+        _lruList.AddLast(node);
+        _dict.Add(node.Value.Item1, node);
+    }
+
+    private void TrimToCapacityNoLock()
+    {
+        if (_lruList.Count > _capacity)
+        {
+            RemoveFirstNoLock();
+        }
+    }
+
+    private void RemoveFirstNoLock()
+    {
+        var node = _lruList.First;
+        if (node != null)
+        {
+            _lruList.RemoveFirst();
+            _dict.Remove(node.Value.Item1);
+        }
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -30,7 +30,13 @@ internal sealed class RepositoryWrapper : IDisposable
         _statusCache = new StatusCache(rootFolder);
     }
 
-    public IEnumerable<Commit> GetCommits()
+    public CommitWrapper? FindLastCommit(string relativePath)
+    {
+        var commitLog = GetCommitLogCache();
+        return commitLog.FindLastCommit(relativePath);
+    }
+
+    private CommitLogCache GetCommitLogCache()
     {
         // Fast path: if we have an up-to-date commit log, return that
         if (_head != null && _commits != null)


### PR DESCRIPTION
## Summary of the pull request
Use the git command line to fetch the latest commit for a file.

## References and relevant issues

## Detailed description of the pull request / Additional comments
In GVFS-enabled repos, while we can walk the entire commit log, parts of it are virualized out and Libgit2 doesn't cause them to appear.
## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
