### PR TITLE
Define Stable and Canary build constants universally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <_PropertySheetDisplayName>DevHome.Root.Props</_PropertySheetDisplayName>
     <ForceImportBeforeCppProps>$(MsbuildThisFileDirectory)\Cpp.Build.props</ForceImportBeforeCppProps>
+    <BuildRing Condition="'$(BuildRing)'==''">Dev</BuildRing>
     <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
     <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,8 @@
   <PropertyGroup>
     <_PropertySheetDisplayName>DevHome.Root.Props</_PropertySheetDisplayName>
     <ForceImportBeforeCppProps>$(MsbuildThisFileDirectory)\Cpp.Build.props</ForceImportBeforeCppProps>
+    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
+    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -113,9 +113,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
-  <PropertyGroup>
-    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
-    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -21,11 +21,6 @@
     <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfileFullPath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
-    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />

--- a/extensions/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
+++ b/extensions/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
@@ -4,7 +4,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-DevSetupAgent-674f51cd-70a6-4b78-8376-66efbf84c412</UserSecretsId>
-    <BuildRing Condition="'$(BuildRing)'==''">Dev</BuildRing>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfile>
@@ -26,12 +25,6 @@
 
   <PropertyGroup Condition="$(PlatformTarget)=='arm64'">
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
-  </PropertyGroup>
-
-
-  <PropertyGroup>
-    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
-    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/WSLExtension/WSLExtension.csproj
+++ b/extensions/WSLExtension/WSLExtension.csproj
@@ -12,20 +12,15 @@
     <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
         <OutputType>WinExe</OutputType>
     </PropertyGroup>
-	
+
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <StartupObject>WSLExtension.Program</StartupObject>
-		<AssemblyName>WSLExtensionServer</AssemblyName>
-		<PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfileFullPath>
-	</PropertyGroup>
-    <PropertyGroup>
-        <BuildRing Condition="'$(BuildRing)'==''">Dev</BuildRing>
-		<DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
-		<DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
+        <AssemblyName>WSLExtensionServer</AssemblyName>
+        <PublishProfileFullPath Condition="'$(BuildingInsideVisualStudio)' != 'True'">$(SolutionDir)\src\Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfileFullPath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -45,8 +40,8 @@
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
         <PackageReference Include="YamlDotNet" Version="15.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-		<PackageReference Include="System.Management" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="System.Management" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -164,11 +164,6 @@
     </Content>
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
-    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
   </PropertyGroup>

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -71,9 +71,4 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
     <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
-    <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
@@ -5,7 +5,6 @@
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <BuildRing Condition="'$(BuildRing)'==''">Dev</BuildRing>
     <ApplicationIcon Condition="'$(BuildRing)'=='Dev'">$(SolutionDir)\src\Assets\Dev\DevHome_Dev.ico</ApplicationIcon>
     <ApplicationIcon Condition="'$(BuildRing)'=='Canary'">$(SolutionDir)\src\Assets\Canary\DevHome_Canary.ico</ApplicationIcon>
     <ApplicationIcon Condition="'$(BuildRing)'=='Stable'">$(SolutionDir)\src\Assets\Preview\DevHome_Preview.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary of the pull request
More than one project has been burned by forgetting to define the build ring constants individually in their project. This change defines those constants at a global level so it _just_ _works_.
## References and relevant issues
#3569 

## Detailed description of the pull request / Additional comments
Moved the definition of these constants into the root Directory.Build.props.
Removed duplicate definitions from sub-projects to keep things consolidated into one place.

## Validation steps performed
* Passed `-AzureBuildingBranch staging` to Build.ps1 to create a local Canary build.
* Disassembled selected assemblies with conditional constants (aka Guid attributes to verify the Canary values appeared).
* Installed canary MSIX and launched it, excercising functionality that depends on these values (aka enable File Explorer integration, and then register a repository - this requires an activation of the Git extension CLSID, and registers the Guid of the SourceControlIntegrationServer CLSID with the system, both of which are defined using conditional constants).

## PR checklist
- [ ] Closes #3569 

