### PR TITLE
Fix Typo in Experimental Features page

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -574,7 +574,7 @@
     <comment>Name of experimental feature 'FileExplorer SourceControl Integration' on the 'Settings -> Experiments' page where you enable it.</comment>
   </data>
   <data name="FileExplorerSourceControlIntegration_Description" xml:space="preserve">
-    <value>View property information (such as commit status, last commit date etc.) from source control technologies inside FileExplorer</value>
+    <value>View property information (such as commit status, last commit date etc.) from source control technologies inside File Explorer</value>
     <comment>Inline description of the FileExplorerSourceControlIntegration experimental feature on the 'Settings -> Experiments' page where you enable it.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
Fixes typo on File Explorer Integration Setting i.e. FileExplorer -> File Explorer

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Build tested 
<img width="944" alt="image" src="https://github.com/user-attachments/assets/d7f47390-a0cb-4356-aa1f-a2ac2a97a3fa">


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
