### PR TITLE
Fixing accessibility bugs

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/StringResourceKey.cs
@@ -70,6 +70,7 @@ public static class StringResourceKey
     public static readonly string PackageDescriptionTwoParts = nameof(PackageDescriptionTwoParts);
     public static readonly string PackageInstalledTooltip = nameof(PackageInstalledTooltip);
     public static readonly string PackageNameTooltip = nameof(PackageNameTooltip);
+    public static readonly string PackageInstalledAnnouncement = nameof(PackageInstalledAnnouncement);
     public static readonly string PackagePublisherNameTooltip = nameof(PackagePublisherNameTooltip);
     public static readonly string PackageSourceTooltip = nameof(PackageSourceTooltip);
     public static readonly string PackageVersionTooltip = nameof(PackageVersionTooltip);

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -2007,14 +2007,6 @@
     <value>Error: {0}</value>
     <comment>Locked={"{0}"} Error message with additional details in {0} shown when we failed to generate the project.</comment>
   </data>
-  <data name="VersionComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Version</value>
-    <comment>Name for the version combo box</comment>
-  </data>
-  <data name="VersionComboBox.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Version</value>
-    <comment>Name for the version combo box</comment>
-  </data>
   <data name="SummaryPage_InstallationNotes.Text" xml:space="preserve">
     <value>Installation Notes</value>
     <comment>Text to introduce installation notes in the summary screen.</comment>

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -625,6 +625,10 @@
     <value>Already installed</value>
     <comment>Label for a package/application that already exists on the user's machine.</comment>
   </data>
+  <data name="PackageInstalledAnnouncement" xml:space="preserve">
+    <value>{0}. Already installed</value>
+    <comment>{Locked="{0}","."}Text announced for a package/application that already exists on the user's machine. {0} is replaced by the package name. A period (.) is used to add a pause for the narrator.</comment>
+  </data>
   <data name="PackageNameTooltip" xml:space="preserve">
     <value>Name: {0}</value>
     <comment>{Locked="{0}"} Label for a package name displayed on a tooltip. {0} is replaced by the package name.</comment>

--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/AppManagement_ThemeResources.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/AppManagement_ThemeResources.xaml
@@ -81,7 +81,8 @@
                 </controls:PackageDetailsSettingsCard.HeaderIcon>
                 <StackPanel Orientation="Horizontal" Spacing="10">
                     <ComboBox
-                        x:Uid="VersionComboBox"
+                        AutomationProperties.Name="{Binding TooltipVersion}"
+                        ToolTipService.ToolTip="{Binding TooltipVersion}"
                         Visibility="{Binding ShowVersionList}"
                         BorderThickness="0"
                         FontSize="{ThemeResource CaptionTextBlockFontSize}"

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/PackageViewModel.cs
@@ -119,6 +119,8 @@ public partial class PackageViewModel : ObservableObject
 
     public string PackageTitle => Name;
 
+    public string PackageAnnouncement => IsInstalled ? _stringResource.GetLocalized(StringResourceKey.PackageInstalledAnnouncement, Name) : Name;
+
     public string TooltipName => _stringResource.GetLocalized(StringResourceKey.PackageNameTooltip, Name);
 
     public string TooltipVersion => _stringResource.GetLocalized(StringResourceKey.PackageVersionTooltip, SelectedVersion);

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/AppManagementView.xaml
@@ -180,7 +180,7 @@
             <ListView Grid.Row="2" ItemsSource="{x:Bind ViewModel.SelectedPackages, Mode=OneWay}" SelectionMode="None">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="viewmodels:PackageViewModel">
-                        <controls:PackageDetailsSettingsCard AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="{Binding PackageTitle}">
+                        <controls:PackageDetailsSettingsCard AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="{Binding PackageAnnouncement}">
                             <ToolTipService.ToolTip>
                                 <controls:PackageDetailsTooltip Package="{Binding}" />
                             </ToolTipService.ToolTip>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/ConfigurationFileView.xaml
@@ -59,6 +59,7 @@
                             <Setter Property="Padding" Value="0" />
                             <Setter Property="MinHeight" Value="0" />
                             <Setter Property="MinWidth" Value="0" />
+                            <Setter Property="IsTabStop" Value="False" />
                         </Style>
                     </Setter.Value>
                 </Setter>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogListView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageCatalogListView.xaml
@@ -69,7 +69,7 @@
             <ListView Margin="0,0,8,0" Grid.Row="1" ItemsSource="{x:Bind ViewModel.ViewAllCatalog.Packages, Mode=OneWay}" SelectionMode="None">
                 <ListView.ItemTemplate>
                     <DataTemplate>
-                        <ContentControl AutomationProperties.Name="{Binding PackageTitle}"
+                        <ContentControl AutomationProperties.Name="{Binding PackageAnnouncement}"
                                         Template="{ThemeResource AppManagementSelectablePackageTemplate}" />
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
-    AutomationProperties.Name="{Binding PackageTitle}"
+    AutomationProperties.Name="{Binding PackageAnnouncement}"
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/PackageView.xaml
@@ -104,7 +104,8 @@
 
                         <!-- Package version list -->
                         <ComboBox
-                            x:Uid="VersionComboBox"
+                            AutomationProperties.Name="{Binding TooltipVersion}"
+                            ToolTipService.ToolTip="{Binding TooltipVersion}"
                             Grid.Row="1"
                             Visibility="{Binding ShowVersionList}"
                             BorderThickness="0"

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml
@@ -54,14 +54,14 @@
         <ListView
             Name="PackagesListView"
             Grid.Row="1"
-            Loaded="PackagesListView_Loaded"
             ItemsSource="{x:Bind ViewModel.ResultPackages, Mode=OneWay}"
             SelectionMode="None">
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <Setter Property="Template" Value="{ThemeResource AppManagementSelectablePackageTemplate}" />
-                </Style>
-            </ListView.ItemContainerStyle>
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ContentControl AutomationProperties.Name="{Binding PackageAnnouncement}"
+                                    Template="{ThemeResource AppManagementSelectablePackageTemplate}" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
             <ListView.ItemsPanel>
                 <ItemsPanelTemplate>
                     <StackPanel Spacing="20" />

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SearchView.xaml.cs
@@ -16,18 +16,4 @@ public sealed partial class SearchView : UserControl
     {
         this.InitializeComponent();
     }
-
-    private void PackagesListView_Loaded(object sender, RoutedEventArgs e)
-    {
-        if (sender is ListView listView)
-        {
-            for (var i = 0; i < listView.Items.Count; i++)
-            {
-                if (listView.ContainerFromIndex(i) is ListViewItem item && item.Content is PackageViewModel package)
-                {
-                    AutomationProperties.SetName(item, package.PackageTitle);
-                }
-            }
-        }
-    }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryShowAppsAndRepos.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryShowAppsAndRepos.xaml
@@ -105,7 +105,7 @@
                         Padding="0,12"
                         Style="{ThemeResource BodyStrongTextBlockStyle}" />
                 </Expander.Header>
-                <GridView ItemsSource="{Binding AppsDownloaded, Mode=OneWay}" SelectionMode="None">
+                <GridView ItemsSource="{Binding AppsDownloaded, Mode=OneWay}" SelectionMode="None" Loaded="PackagesGridView_Loaded">
                     <GridView.ItemsPanel>
                         <ItemsPanelTemplate>
                             <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal" />
@@ -117,9 +117,6 @@
                                 Width="250"
                                 Padding="5"
                                 AutomationProperties.Name="{x:Bind PackageTitle}">
-                                <ToolTipService.ToolTip>
-                                    <controls:PackageDetailsTooltip Package="{x:Bind}" />
-                                </ToolTipService.ToolTip>
                                 <controls:PackageDetailsSettingsCard.Header>
                                     <TextBlock Style="{ThemeResource AppManagementPackageTitleTextBlock}" Text="{x:Bind PackageTitle}" />
                                 </controls:PackageDetailsSettingsCard.Header>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryShowAppsAndRepos.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryShowAppsAndRepos.xaml.cs
@@ -3,6 +3,7 @@
 
 using AdaptiveCards.Rendering.WinUI3;
 using CommunityToolkit.Mvvm.Messaging;
+using DevHome.SetupFlow.Controls;
 using DevHome.SetupFlow.Models.Environments;
 using DevHome.SetupFlow.ViewModels;
 using Microsoft.UI.Xaml;
@@ -63,5 +64,25 @@ public sealed partial class SummaryShowAppsAndRepos : UserControl, IRecipient<Ne
 
         AdaptiveCardGrid.Children.Clear();
         AdaptiveCardGrid.Children.Add(frameworkElement);
+    }
+
+    private void PackagesGridView_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not GridView gridView)
+        {
+            return;
+        }
+
+        // Set the tooltip for each item in the grid view
+        for (var i = 0; i < gridView.Items.Count; i++)
+        {
+            if (gridView.ContainerFromIndex(i) is GridViewItem item && item.Content is PackageViewModel packageViewModel)
+            {
+                ToolTipService.SetToolTip(item, new PackageDetailsTooltip()
+                {
+                    Package = packageViewModel,
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of the pull request
- Ensure proper descriptive visual labels are associated with ‘Version’ combo box controls for screen reader compatibility.
- Screen reader should announce already installed information when navigating through installed applications using Up/Down arrow keys.
- The tooltip for apps with notes in the summary page should be accessible via keyboard navigation.
- In the Run Config File remove the tab stop inside an expanded item.

## References and relevant issues
- https://task.ms/50154111
- https://task.ms/50153390
- https://task.ms/50153757
- https://task.ms/50309983

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
