### PR TITLE
Detect renamed files and report commit log of original filename

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
@@ -94,12 +94,18 @@ public class GitLocalRepositoryProviderUnitTests
         GitLocalRepository repo = new GitLocalRepository(RepoPath);
         var result = repo.GetProperties(properties, relativePath);
         Assert.IsNotNull(result);
+
+        // Oddity: When sorting the full commit graph by time, the HEAD is a merge with two parents:
+        // 1. Third a/a1; f73b9567; Apr 7 15:31:13 2005 -0700
+        // 2. Fourth a/a1; d0114ab8; Apr 7 15:30:13 2005 -0700
+        // It would appear that commmit is older, but for some reason, this is the one that was found by LibGit2Sharp.
+        // Commit 1. is "the most recent", and is the commit shown by "git log" and on the GitHub repo.
         Assert.AreEqual(result["System.VersionControl.Status"], string.Empty);
-        Assert.AreEqual(result["System.VersionControl.LastChangeDate"], new System.DateTimeOffset(2005, 4, 7, 15, 31, 13, new System.TimeSpan(-7, 0, 0)));
-        Assert.AreEqual(result["System.VersionControl.LastChangeMessage"], "Fourth a/a1");
+        Assert.AreEqual(result["System.VersionControl.LastChangeDate"], new System.DateTimeOffset(2005, 4, 7, 15, 30, 13, new System.TimeSpan(-7, 0, 0)));
+        Assert.AreEqual(result["System.VersionControl.LastChangeMessage"], "Third a/a1");
         Assert.AreEqual(result["System.VersionControl.LastChangeAuthorEmail"], "a.u.thor@example.com");
         Assert.AreEqual(result["System.VersionControl.LastChangeAuthorName"], "A U Thor");
-        Assert.AreEqual(result["System.VersionControl.LastChangeID"], "d0114ab8ac326bab30e3a657a0397578c5a1af88");
+        Assert.AreEqual(result["System.VersionControl.LastChangeID"], "f73b95671f326616d66b2afb3bdfcdbbce110b44");
         Assert.AreEqual(result["System.VersionControl.CurrentFolderStatus"], "Branch: master ≡ | +0 ~0 -0 | +0 ~0 -0");
     }
 
@@ -150,32 +156,49 @@ public class GitLocalRepositoryProviderUnitTests
     public void DetectFileRename()
     {
         const string statusProperty = "System.VersionControl.Status";
+        const string lastChangeMessageProperty = "System.VersionControl.LastChangeMessage";
         var properties = new string[]
         {
             statusProperty,
+            lastChangeMessageProperty,
         };
         var localRepo = new GitLocalRepository(RepoPath);
         var relativeFromPath = Path.Join("a", "a1");
         var relativeToPath = Path.Join("a", "a1_renamed");
 
+        // Get initial properties
         var result = localRepo.GetProperties(properties, relativeFromPath);
         Assert.AreEqual(result[statusProperty], string.Empty);
+        Assert.AreEqual(result[lastChangeMessageProperty], "Third a/a1");
         result = localRepo.GetProperties(properties, relativeToPath);
-        Assert.IsNull(result[statusProperty]);
+        Assert.AreEqual(result[statusProperty], string.Empty);
+        result.TryGetValue(lastChangeMessageProperty, out var lastChangeMessage);
+        Assert.IsNull(lastChangeMessage);
 
+        // Rename
         var modifiedRepo = new Repository(RepoPath);
         Commands.Move(modifiedRepo, relativeFromPath, relativeToPath);
         Commands.Stage(modifiedRepo, relativeFromPath);
         Commands.Stage(modifiedRepo, relativeToPath);
-        result = localRepo.GetProperties(properties, relativeFromPath);
-        Assert.IsNull(result[statusProperty]);
-        result = localRepo.GetProperties(properties, relativeToPath);
-        Assert.AreEqual(result[statusProperty], "Staged rename");
 
-        modifiedRepo.Reset(ResetMode.Hard);
+        // Get old and new properties
         result = localRepo.GetProperties(properties, relativeFromPath);
         Assert.AreEqual(result[statusProperty], string.Empty);
+        Assert.AreEqual(result[lastChangeMessageProperty], "Third a/a1");
         result = localRepo.GetProperties(properties, relativeToPath);
-        Assert.IsNull(result[statusProperty]);
+        Assert.AreEqual(result[statusProperty], "Staged rename");
+        Assert.AreEqual(result[lastChangeMessageProperty], "Third a/a1");
+
+        // Reset
+        modifiedRepo.Reset(ResetMode.Hard);
+
+        // Get old and new properties
+        result = localRepo.GetProperties(properties, relativeFromPath);
+        Assert.AreEqual(result[statusProperty], string.Empty);
+        Assert.AreEqual(result[lastChangeMessageProperty], "Third a/a1");
+        result = localRepo.GetProperties(properties, relativeToPath);
+        Assert.AreEqual(result[statusProperty], string.Empty);
+        result.TryGetValue(lastChangeMessageProperty, out lastChangeMessage);
+        Assert.IsNull(lastChangeMessage);
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
@@ -98,7 +98,7 @@ public class GitLocalRepositoryProviderUnitTests
         // Oddity: When sorting the full commit graph by time, the HEAD is a merge with two parents:
         // 1. Third a/a1; f73b9567; Apr 7 15:31:13 2005 -0700
         // 2. Fourth a/a1; d0114ab8; Apr 7 15:30:13 2005 -0700
-        // It would appear that commmit is older, but for some reason, this is the one that was found by LibGit2Sharp.
+        // It would appear that commit is older, but for some reason, this is the one that was found by LibGit2Sharp.
         // Commit 1. is "the most recent", and is the commit shown by "git log" and on the GitHub repo.
         Assert.AreEqual(result["System.VersionControl.Status"], string.Empty);
         Assert.AreEqual(result["System.VersionControl.LastChangeDate"], new System.DateTimeOffset(2005, 4, 7, 15, 30, 13, new System.TimeSpan(-7, 0, 0)));

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -101,6 +101,11 @@ internal sealed class CommitLogCache
         }
 
         var parts = result.Output.Split('\n');
+        if (parts.Length != 5)
+        {
+            return null;
+        }
+
         string message = parts[0];
         string authorName = parts[1];
         string authorEmail = parts[2];

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -128,12 +128,6 @@ internal sealed class RepositoryWrapper : IDisposable
 
     public string GetFileStatus(string relativePath)
     {
-        // Skip directories while we're getting individual file status.
-        if (File.GetAttributes(Path.Combine(_workingDirectory, relativePath)).HasFlag(FileAttributes.Directory))
-        {
-            return string.Empty;
-        }
-
         GitStatusEntry? status;
         if (!_statusCache.Status.FileEntries.TryGetValue(relativePath, out status))
         {
@@ -180,11 +174,6 @@ internal sealed class RepositoryWrapper : IDisposable
 
     private string GetOriginalPath(string relativePath)
     {
-        if (File.GetAttributes(Path.Combine(_workingDirectory, relativePath)).HasFlag(FileAttributes.Directory))
-        {
-            return relativePath;
-        }
-
         _statusCache.Status.FileEntries.TryGetValue(relativePath, out var status);
         if (status is null)
         {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -172,6 +172,8 @@ internal sealed class RepositoryWrapper : IDisposable
         return statusString;
     }
 
+    // Detect uncommitted renames and return the original path.
+    // This allows us to get the commit history, because the new path doesn't exist yet.
     private string GetOriginalPath(string relativePath)
     {
         _statusCache.Status.FileEntries.TryGetValue(relativePath, out var status);

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -182,11 +182,7 @@ internal sealed class RepositoryWrapper : IDisposable
             return relativePath;
         }
 
-        if (status.Status.HasFlag(FileStatus.RenamedInIndex))
-        {
-            return status.RenameOldPath ?? relativePath;
-        }
-        else if (status.Status.HasFlag(FileStatus.RenamedInWorkdir))
+        if (status.Status.HasFlag(FileStatus.RenamedInIndex) || status.Status.HasFlag(FileStatus.RenamedInWorkdir))
         {
             return status.RenameOldPath ?? relativePath;
         }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/StatusCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/StatusCache.cs
@@ -262,9 +262,9 @@ internal sealed class StatusCache : IDisposable
                 // For porcelain=v2, "rename" entries have the following format:
                 //   2 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <X><score> <path><sep><origPath>
                 // For now, we only care about the <XY>, <path>, and <origPath> fields.
-                var pieces = line.Split(' ', 9);
+                var pieces = line.Split(' ', 10);
                 var fileStatusString = pieces[1];
-                var newPath = pieces[8];
+                var newPath = pieces[9];
                 var oldPath = parts[++i];
                 FileStatus statusEntry = FileStatus.Unaltered;
                 if (fileStatusString[0] == 'R')


### PR DESCRIPTION
## Detailed description of the pull request / Additional comments
First, we weren't parsing rename status properly, so the new filename was wrong. This caused file status lookups to miss the rename.

Second, renamed files were looking for the commit log for the renamed file, which hasn't been committed yet. So now we first check the current cached status to see if this file is renamed, and if so, use the old name to lookup the commit log.

Finally, added a unit test to validate the behavior.

While fixing up unit tests, also noticed we should fail more gracefully on files that don't have a commit history.

Also we should stop checking File.Attributes to skip folders, since we're no longer using the LibGit2Sharp API that didn't like folders, simplification is good, and I don't want to run the risk of accidentally hydrating anything in a virtualizing repo.

## Validation steps performed
Ran new unit test.
Built a private build and validated that the status and most recent commit appeared correct.

## PR checklist
- [ ] Closes #3576 
- [ ] Tests added/passed
