### PR TITLE
Project Ironsides - Make window snapping more predictable

### DIFF
--- a/tools/PI/DevHome.PI/Helpers/CommonHelper.cs
+++ b/tools/PI/DevHome.PI/Helpers/CommonHelper.cs
@@ -168,4 +168,9 @@ internal sealed class CommonHelper
 
         return valueAsInt;
     }
+
+    public static int MulDiv(int number, int numerator, int denominator)
+    {
+        return (int)((((long)number * numerator) + (denominator >> 1)) / denominator);
+    }
 }

--- a/tools/PI/DevHome.PI/NativeMethods.txt
+++ b/tools/PI/DevHome.PI/NativeMethods.txt
@@ -6,6 +6,7 @@ CombineRgn
 CreateEllipticRgn
 CreateRectRgn
 CreateRoundRectRgn
+DefSubclassProc
 DwmGetWindowAttribute
 DwmSetWindowAttribute
 DwmSetWindowAttribute
@@ -43,6 +44,7 @@ GlobalUnlock
 IsIconic
 IsImmersiveProcess
 IsWindow
+IsWindowArranged
 IsWindowVisible
 IsWow64Process2
 IsZoomed
@@ -68,6 +70,7 @@ SetWindowLong
 SetWindowLong
 SetWindowPos
 SetWindowRgn
+SetWindowSubclass
 SetWinEventHook
 ShowWindow
 SystemParametersInfo
@@ -104,12 +107,13 @@ RM_UNIQUE_PROCESS
 RM_PROCESS_INFO
 RM_REBOOT_REASON
 SECTION_FLAGS
+SUBCLASSPROC
 SW_*
-VIRTUAL_KEY
 VIRTUAL_KEY
 WIN32_ERROR
 WINEVENT_*
 WINEVENT_OUTOFCONTEXT
 WINEVENT_SKIPOWNPROCESS
+WINDOWPOS
 WM_*
 WS_*

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml
@@ -10,7 +10,7 @@
     xmlns:local="using:DevHome.PI.Controls"
     xmlns:helpers="using:DevHome.PI.Helpers"
     mc:Ignorable="d"
-    Title="" MinHeight="90" MinWidth="700" Height="90" Width="700" MaxHeight="90"
+    Title="" MinHeight="90" MinWidth="700" Height="90" Width="700"
     TaskBarIcon="Images/pi.ico"
     Activated="Window_Activated"
     WindowStateChanged="WindowEx_WindowStateChanged"

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -20,6 +20,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Serilog;
 using Windows.Foundation;
 using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
@@ -45,6 +46,7 @@ public partial class BarWindowHorizontal : WindowEx
     private const string ExpandButtonText = "\ue70d"; // ChevronDown
     private const string CollapseButtonText = "\ue70e"; // ChevronUp
     private const string ManageToolsButtonText = "\uec7a"; // DeveloperTools
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(BarWindowHorizontal));
 
     private readonly string _pinMenuItemText = CommonHelper.GetLocalizedString("PinMenuItemText");
     private readonly string _unpinMenuItemText = CommonHelper.GetLocalizedString("UnpinMenuItemRawText");
@@ -671,20 +673,20 @@ public partial class BarWindowHorizontal : WindowEx
                     // Enforce our height limit if we're not showing expanded content and we're not being snapped
                     wndPos.cy = CommonHelper.MulDiv(FloatingHorizontalBarHeight, (int)this.GetDpiForWindow(), 96);
                     Marshal.StructureToPtr(wndPos, lParam, true);
-                    Debug.WriteLine("WM_WINDOWPOSCHANGING: Enforcing height limit " + _isSnapped + " " + _transitionFromSnapped);
+                    _log.Information("WM_WINDOWPOSCHANGING: Enforcing height limit " + _isSnapped + " " + _transitionFromSnapped);
                 }
                 else if (wndPos.cy <= floatingBarHeight && _viewModel.ShowingExpandedContent && _transitionFromSnapped)
                 {
                     // If we're transitioning from snapped (which always expands our bar) to unsnapped, be sure set our height to the expanded height
                     wndPos.cy = CommonHelper.MulDiv((int)Settings.Default.ExpandedWindowHeight, (int)this.GetDpiForWindow(), 96);
                     Marshal.StructureToPtr(wndPos, lParam, true);
-                    Debug.WriteLine("WM_WINDOWPOSCHANGING: Expanding window size for expanded content " + _isSnapped);
+                    _log.Information("WM_WINDOWPOSCHANGING: Expanding window size for expanded content " + _isSnapped);
                 }
                 else if (wndPos.cy > floatingBarHeight && !_viewModel.ShowingExpandedContent)
                 {
                     // Our window is bigger than the floating bar height, so we should show the expanded content
                     _viewModel.ShowingExpandedContent = true;
-                    Debug.WriteLine("WM_WINDOWPOSCHANGING: enabling expanded content due to large window size " + PInvoke.IsWindowArranged(hWnd));
+                    _log.Information("WM_WINDOWPOSCHANGING: enabling expanded content due to large window size " + PInvoke.IsWindowArranged(hWnd));
                 }
                 else
                 {

--- a/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/PI/DevHome.PI/Views/BarWindowHorizontal.xaml.cs
@@ -21,11 +21,12 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
-using Windows.Graphics;
 using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.UI.Shell;
+using Windows.Win32.UI.WindowsAndMessaging;
 using WinRT.Interop;
 using WinUIEx;
 using static DevHome.PI.Helpers.CommonHelper;
@@ -625,11 +626,11 @@ public partial class BarWindowHorizontal : WindowEx
         }
     }
 
-    private Windows.Win32.UI.Shell.SUBCLASSPROC? _wndProc;
+    private SUBCLASSPROC? _wndProc;
 
     private void HookWndProc()
     {
-        _wndProc = new Windows.Win32.UI.Shell.SUBCLASSPROC(NewWindowProc);
+        _wndProc = new SUBCLASSPROC(NewWindowProc);
         PInvoke.SetWindowSubclass(ThisHwnd, _wndProc, 456, 0);
     }
 
@@ -642,10 +643,10 @@ public partial class BarWindowHorizontal : WindowEx
         {
             case PInvoke.WM_WINDOWPOSCHANGING:
             {
-                Windows.Win32.UI.WindowsAndMessaging.WINDOWPOS wndPos = Marshal.PtrToStructure<Windows.Win32.UI.WindowsAndMessaging.WINDOWPOS>(lParam);
+                WINDOWPOS wndPos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
 
                 // We only care about this message if it's triggering a resize
-                if (wndPos.flags.HasFlag(Windows.Win32.UI.WindowsAndMessaging.SET_WINDOW_POS_FLAGS.SWP_NOSIZE))
+                if (wndPos.flags.HasFlag(SET_WINDOW_POS_FLAGS.SWP_NOSIZE))
                 {
                     break;
                 }


### PR DESCRIPTION
## Summary of the pull request

We were using WindowEx's MaxHeight to prevent the user from resizing the bar when we were in collapsed mode. WindowEx enforced this by responding to the WM_GETMINMAXINFO window message and telling Windows the max height of the window.

However, when in the collapsed state, this caused the snapping system to only snap the window in the collapsed state

![image](https://github.com/user-attachments/assets/bc490a26-9150-4406-9275-71922df9998d)

It was deemed that, when the user snaps the window, we should expand ourselves first. Unfortunately there doesn't appear to be a good way to update our max size via the WM_GETMINMAXINFO prior to the snapping experience being invoked.

Instead, following the advice of the windowing devs, we're now enforcing the window size in the WM_WINDOWPOSCHANGING event.... if the user tries to change the window height when we're in the collapsed mode, we'll enforce the size there.

This also gives us the ability to adjust our allowed window size based on if the window is being snapped or not (via the IsWindowArranged() API). By moving to that, we get the expected snapping behavior...

![image](https://github.com/user-attachments/assets/78cb317b-5742-435d-9514-35ca7d14ffe8)

I've also updated the maximize logic to expand the bar when it is maximized as well.

The rest of the logic is trying to keep a sane state once your restore/unsnap. It felt more natural to me that, even if we were collapsed before we snapped/maximized (which triggers us to go to an expanded state), that we should remain in an expanded state once we restore/unsnap.

At some point it may be worth revisiting the separate collapsed/expanded state vs just resizing the window, but that's a decision for another day.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3037 
- [ ] Tests added/passed
- [ ] Documentation updated
