### PR TITLE
Cancel Dashboard loading when navigating away

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -52,6 +52,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private static DispatcherQueue _dispatcherQueue;
     private readonly ILocalSettingsService _localSettingsService;
     private readonly IWidgetExtensionService _widgetExtensionService;
+    private CancellationTokenSource _initWidgetsCancellationTokenSource;
     private bool _disposedValue;
 
     private const string DraggedWidget = "DraggedWidget";
@@ -143,6 +144,8 @@ public partial class DashboardView : ToolPage, IDisposable
     [RelayCommand]
     private async Task OnUnloadedAsync()
     {
+        _log.Debug($"Unloading Dashboard, cancel any loading.");
+        _initWidgetsCancellationTokenSource.Cancel();
         ViewModel.PinnedWidgets.CollectionChanged -= OnPinnedWidgetsCollectionChangedAsync;
         Bindings.StopTracking();
 
@@ -200,7 +203,15 @@ public partial class DashboardView : ToolPage, IDisposable
                     await _localSettingsService.SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstDashboardRun, true);
                 }
 
-                await InitializePinnedWidgetListAsync(isFirstDashboardRun);
+                _initWidgetsCancellationTokenSource = new();
+                try
+                {
+                    await InitializePinnedWidgetListAsync(isFirstDashboardRun, _initWidgetsCancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException ex)
+                {
+                   _log.Information(ex, "InitializePinnedWidgetListAsync operation was cancelled.");
+                }
             }
             else
             {
@@ -229,7 +240,7 @@ public partial class DashboardView : ToolPage, IDisposable
         ViewModel.IsLoading = false;
     }
 
-    private async Task InitializePinnedWidgetListAsync(bool isFirstDashboardRun)
+    private async Task InitializePinnedWidgetListAsync(bool isFirstDashboardRun, CancellationToken cancellationToken)
     {
         var hostWidgets = await GetPreviouslyPinnedWidgets();
         if ((hostWidgets.Length == 0) && isFirstDashboardRun)
@@ -237,11 +248,11 @@ public partial class DashboardView : ToolPage, IDisposable
             // If it's the first time the Dashboard has been displayed and we have no other widgets pinned to a
             // different version of Dev Home, pin some default widgets.
             _log.Information($"Pin default widgets");
-            await PinDefaultWidgetsAsync();
+            await PinDefaultWidgetsAsync(cancellationToken);
         }
         else
         {
-            await RestorePinnedWidgetsAsync(hostWidgets);
+            await RestorePinnedWidgetsAsync(hostWidgets, cancellationToken);
         }
     }
 
@@ -274,7 +285,7 @@ public partial class DashboardView : ToolPage, IDisposable
         return [.. comSafeHostWidgets];
     }
 
-    private async Task RestorePinnedWidgetsAsync(ComSafeWidget[] hostWidgets)
+    private async Task RestorePinnedWidgetsAsync(ComSafeWidget[] hostWidgets, CancellationToken cancellationToken)
     {
         var restoredWidgetsWithPosition = new SortedDictionary<int, ComSafeWidget>();
         var restoredWidgetsWithoutPosition = new SortedDictionary<int, ComSafeWidget>();
@@ -289,6 +300,12 @@ public partial class DashboardView : ToolPage, IDisposable
         // append it at the end. If a position is missing, just show the next widget in order.
         foreach (var widget in hostWidgets)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _log.Debug($"CancellationRequested during RestorePinnedWidgetsAsync going through hostWidgets");
+                return;
+            }
+
             try
             {
                 var stateStr = await widget.GetCustomStateAsync();
@@ -381,7 +398,13 @@ public partial class DashboardView : ToolPage, IDisposable
         {
             var comSafeWidget = orderedWidget.Value;
             var size = await comSafeWidget.GetSizeAsync();
-            await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, finalPlace++);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _log.Debug($"CancellationRequested during RestorePinnedWidgetsAsync inserting into PinnedWidgets");
+                return;
+            }
+
+            await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, finalPlace++, cancellationToken);
         }
 
         // Go through the newly created list of pinned widgets and update any positions that may have changed.
@@ -390,6 +413,12 @@ public partial class DashboardView : ToolPage, IDisposable
         var updatedPlace = 0;
         foreach (var widget in ViewModel.PinnedWidgets)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _log.Debug($"CancellationRequested during RestorePinnedWidgetsAsync updating custom state");
+                return;
+            }
+
             await WidgetHelpers.SetPositionCustomStateAsync(widget.Widget, updatedPlace++);
         }
 
@@ -410,21 +439,27 @@ public partial class DashboardView : ToolPage, IDisposable
         _log.Information($"After delete, {length} widgets for this host");
     }
 
-    private async Task PinDefaultWidgetsAsync()
+    private async Task PinDefaultWidgetsAsync(CancellationToken cancellationToken)
     {
         var comSafeWidgetDefinitions = await ComSafeHelpers.GetAllOrderedComSafeWidgetDefinitions(ViewModel.WidgetHostingService);
         foreach (var comSafeWidgetDefinition in comSafeWidgetDefinitions)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _log.Debug($"CancellationRequested during PinDefaultWidgetsAsync");
+                return;
+            }
+
             var id = comSafeWidgetDefinition.Id;
             if (WidgetHelpers.DefaultWidgetDefinitionIds.Contains(id))
             {
                 _log.Information($"Found default widget {id}");
-                await PinDefaultWidgetAsync(comSafeWidgetDefinition);
+                await PinDefaultWidgetAsync(comSafeWidgetDefinition, cancellationToken);
             }
         }
     }
 
-    private async Task PinDefaultWidgetAsync(ComSafeWidgetDefinition defaultWidgetDefinition)
+    private async Task PinDefaultWidgetAsync(ComSafeWidgetDefinition defaultWidgetDefinition, CancellationToken cancellationToken)
     {
         try
         {
@@ -467,7 +502,7 @@ public partial class DashboardView : ToolPage, IDisposable
             await comSafeWidget.SetCustomStateAsync(newCustomState);
 
             // Put new widget on the Dashboard.
-            await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, position);
+            await InsertWidgetInPinnedWidgetsAsync(comSafeWidget, size, position, cancellationToken);
             _log.Information($"Inserted default widget {unsafeWidgetId} at position {position}");
         }
         catch (Exception ex)
@@ -580,9 +615,10 @@ public partial class DashboardView : ToolPage, IDisposable
             buttonText: stringResource.GetLocalized("CloseButtonText"));
     }
 
-    private async Task InsertWidgetInPinnedWidgetsAsync(ComSafeWidget widget, WidgetSize size, int index)
+    private async Task InsertWidgetInPinnedWidgetsAsync(ComSafeWidget widget, WidgetSize size, int index, CancellationToken cancellationToken = default)
     {
-        await Task.Run(async () =>
+        await Task.Run(
+            async () =>
         {
             var widgetDefinitionId = widget.DefinitionId;
             var widgetId = widget.Id;
@@ -613,6 +649,12 @@ public partial class DashboardView : ToolPage, IDisposable
                     new ReportPinnedWidgetEvent(comSafeWidgetDefinition.ProviderDefinitionId, widgetDefinitionId));
 
                 var wvm = _widgetViewModelFactory(widget, size, comSafeWidgetDefinition);
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _log.Debug($"CancellationRequested during InsertWidgetInPinnedWidgetsAsync");
+                    return;
+                }
+
                 _dispatcherQueue.TryEnqueue(() =>
                 {
                     try
@@ -631,7 +673,8 @@ public partial class DashboardView : ToolPage, IDisposable
             {
                 await DeleteWidgetWithNoDefinition(widget, widgetDefinitionId);
             }
-        });
+        },
+            cancellationToken);
     }
 
     private async Task DeleteWidgetWithNoDefinition(ComSafeWidget widget, string widgetDefinitionId)


### PR DESCRIPTION
## Summary of the pull request
Navigating away from the Dashboard will clear out PinnedWidgets. However, if the widgets were still being loaded, clearing PinnedWidgets while iterating through it will cause a crash. When we navigate away, we should cancel the loading so we don't hit this scenario.

We do still have work item #1215 to further support concurrency, but this will fix the issue in #3558, which is more likely to be hit than other concurrency scenarios.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3558
- [ ] Tests added/passed
- [ ] Documentation updated
