### PR TITLE
User/laurenciha/fix environment bug

### DIFF
--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -359,4 +359,8 @@
     <value>Set up</value>
     <comment>Value to be shown in the button option to start the configuration flow</comment>
   </data>
+  <data name="MoreOptionsButtonName" xml:space="preserve">
+    <value>More options button</value>
+    <comment>Name for MoreOptionsButton. It's listed as an additional string here because ComputeSystemCardBase can't access MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name (reason unknown)</comment>
+  </data>
 </root>

--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -360,7 +360,7 @@
     <comment>Value to be shown in the button option to start the configuration flow</comment>
   </data>
   <data name="MoreOptionsButtonName" xml:space="preserve">
-    <value>More options button</value>
+    <value>More options</value>
     <comment>Name for MoreOptionsButton. It's listed as an additional string here because ComputeSystemCardBase can't access MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name (reason unknown)</comment>
   </data>
 </root>

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -69,7 +69,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public ComputeSystemCardBase()
     {
-        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptions.AutomationProperties.Name");
+        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptionsButton.AutomationProperties.Name");
     }
 
     public override string ToString()

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemCardBase.cs
@@ -69,7 +69,7 @@ public abstract partial class ComputeSystemCardBase : ObservableObject
 
     public ComputeSystemCardBase()
     {
-        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptionsButton.AutomationProperties.Name");
+        _moreOptionsButtonName = _stringResource.GetLocalized("MoreOptionsButtonName");
     }
 
     public override string ToString()

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -79,8 +79,7 @@
                 <Grid>
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}"
-                        AutomationProperties.Name="{x:Bind MoreOptionsButtonName}"
-                        ToolTipService.ToolTip="{x:Bind MoreOptionsButtonName}">
+                        x:Uid="MoreOptionsButton">
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}" />
                         </Button.Flyout>


### PR DESCRIPTION
## Summary of the pull request
Added back a resource string I thought was unnecessary.

## References and relevant issues
* Undoing #3487

## Detailed description of the pull request / Additional comments

After removing "MoreOptionsButtonName" from the resources file, the following error occurred upon opening the Environments page:

![image](https://github.com/user-attachments/assets/d57ac8f9-8a15-41c4-8125-b1b249bc353e)

I tried updating the NamedResource to:
* MoreOptionsButton.AutomationProperties.Name
* MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name
* "MoreOptionsButton", "AutomationProperties.Name"

but none of them worked.

In order to fix the error, I'm reverting my previous change.

When looking at the Environments page with Accessibility Insights, it looks like "MoreOptionsButtonName" from ComputeSystemCardBase is often overwritten by MoreOptionsButton.AutomationProperties.Name. I'm keeping both values here because I couldn't remove "MoreOptionsButtonName" and it makes sense for the button's AutomationProperties.Name to overwrite the base name.

I also set the automation properties' name and tooltip on the ThreeDotsButton template through the x:Uid instead of setting them within the template. I did this to make the MoreOptionsButton AutomationProperties changes consistent with the ThreeDotsButton.