### PR TITLE
Pinned WinGet packages are not loaded in Dev Home

### DIFF
--- a/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
@@ -94,7 +94,7 @@ internal sealed class WinGetPackage : IWinGetPackage
             return package.GetPackageVersionInfo(package.AvailableVersions[0]);
         }
 
-        throw new ArgumentException("Package does not have any versions");
+        throw new ArgumentException($"Package {package.Name} does not have any versions");
     }
 
     /// <summary>

--- a/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
@@ -28,8 +28,8 @@ internal sealed class WinGetPackage : IWinGetPackage
         // longer running).
         _logger = logger;
         Id = package.Id;
-        CatalogId = package.DefaultInstallVersion.PackageCatalog.Info.Id;
-        CatalogName = package.DefaultInstallVersion.PackageCatalog.Info.Name;
+        CatalogId = GetPackageVersionInfo(package).PackageCatalog.Info.Id;
+        CatalogName = GetPackageVersionInfo(package).PackageCatalog.Info.Name;
         UniqueKey = new(Id, CatalogId);
         Name = package.Name;
         AvailableVersions = package.AvailableVersions.Select(v => v.Version).ToList();
@@ -81,6 +81,22 @@ internal sealed class WinGetPackage : IWinGetPackage
         return new(CatalogName, Id, uriOptions);
     }
 
+    private PackageVersionInfo GetPackageVersionInfo(CatalogPackage package)
+    {
+        // Pinned packages do not have a default install version set
+        if (package.DefaultInstallVersion != null)
+        {
+            return package.DefaultInstallVersion;
+        }
+
+        if (package.AvailableVersions.Count > 0)
+        {
+            return package.GetPackageVersionInfo(package.AvailableVersions[0]);
+        }
+
+        throw new ArgumentException("Package does not have any versions");
+    }
+
     /// <summary>
     /// Gets the package metadata from the current culture name (e.g. 'en-US')
     /// </summary>
@@ -94,7 +110,7 @@ internal sealed class WinGetPackage : IWinGetPackage
         try
         {
             var locale = Thread.CurrentThread.CurrentCulture.Name;
-            var metadata = package.DefaultInstallVersion.GetCatalogPackageMetadata(locale);
+            var metadata = GetPackageVersionInfo(package).GetCatalogPackageMetadata(locale);
             return metadataFunction(metadata);
         }
         catch


### PR DESCRIPTION
## Summary of the pull request
- Pinned packages do not set the `DefaultInstallVersion` property in the [COM API](https://github.com/microsoft/winget-cli/blob/542759707d980a1068145283b821568bc45593c7/src/Microsoft.Management.Deployment/PackageManager.idl#L532). So instead, get the catalog information from the first available version.

### Steps
```ps
winget pin add Microsoft.VisualStudioCode
```

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/f6aaee2f-89c3-4fcb-86a4-2d2ddcea27f7" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/10b7ab40-7d3f-42e4-a945-45f6bcef1f5b" />
</td>
</tr>
</table>

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3458
- [ ] Tests added/passed
- [ ] Documentation updated
