### PR TITLE
Adds toggle settings for the File Explorer Source Control Integration feature

### DIFF
--- a/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
+++ b/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
@@ -39,6 +39,7 @@
     <None Remove="Views\GeneralSystemView.xaml" />
     <None Remove="Views\MainPage.xaml" />
     <None Remove="Views\MainPageView.xaml" />
+    <None Remove="Views\VersionControlIntegrationSettingsView.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -78,5 +79,11 @@
 
   <ItemGroup>
     <Resource Remove="Views\AddRepositoriesView.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Views\VersionControlIntegrationSettingsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 </Project>

--- a/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
+++ b/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
@@ -67,6 +67,10 @@
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
+    <Page Update="Views\VersionControlIntegrationSettingsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -81,9 +85,4 @@
     <Resource Remove="Views\AddRepositoriesView.xaml" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Page Update="Views\VersionControlIntegrationSettingsView.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
 </Project>

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -389,7 +389,7 @@
     <value>A restart may be required for long path changes to take effect.</value>
     <comment>Message instructing the user to restart their machine to apply changes</comment>
   </data>
-   <data name="AddRepositoriesTextBlock.Text" xml:space="preserve">
+  <data name="AddRepositoriesTextBlock.Text" xml:space="preserve">
     <value>Add repositories</value>
     <comment>Header for the add repositories user experience for file explorer source control integration</comment>
   </data>
@@ -420,5 +420,33 @@
   <data name="RemoveRepository.Text" xml:space="preserve">
     <value>Enter path to remove an enhanced repository</value>
     <comment>The text for removing a repository from source control integration</comment>
+  </data>
+  <data name="EnableVersionControlIntegrationCard.Description" xml:space="preserve">
+    <value>Allow Dev Home to enhance your File Explorer view for known repositories</value>
+    <comment>The description for the settings card that allows user to enable or disable File Explorer Version Control Integration</comment>
+  </data>
+  <data name="EnableVersionControlIntegrationCard.Header" xml:space="preserve">
+    <value>Enable File Explorer Version Control Integration</value>
+    <comment>The header for the settings card that allows user to enable or disable File Explorer Version Control Integration</comment>
+  </data>
+  <data name="FileExplorerSettingsTextBlock.Text" xml:space="preserve">
+    <value>File Explorer + Version Control</value>
+    <comment>The text for the File Explorer Settings toggle</comment>
+  </data>
+   <data name="ShowVersionControlInfoCard.Description" xml:space="preserve">
+    <value>See version control columns for enhanced repositories like "Code Status", "Last Change Date", "Last Change Message"</value>
+    <comment>The description for the settings card that allows user to enable or disable displayment of version control property information inside File Explorer</comment>
+  </data>
+  <data name="ShowVersionControlInfoCard.Header" xml:space="preserve">
+    <value>Show version control information</value>
+    <comment>The header for the settings card that allows user to enable or disable displayment of version control property information inside File Explorer</comment>
+  </data>
+  <data name="ShowRepositoryStatusCard.Description" xml:space="preserve">
+    <value>See useful repository statuses provided by relevant version control extension like current branch and remote origin (if applicable)</value>
+    <comment>The description for the settings card that allows user to enable or disable displayment of repository status inside File Explorer</comment>
+  </data>
+  <data name="ShowRepositoryStatusCard.Header" xml:space="preserve">
+    <value>Show the repository status</value>
+    <comment>The header for the settings card that allows user to enable or disable displayment of repository status inside File Explorer</comment>
   </data>
 </root>

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -433,9 +433,9 @@
     <value>File Explorer + Version Control</value>
     <comment>The text for the File Explorer Settings toggle</comment>
   </data>
-   <data name="ShowVersionControlInfoCard.Description" xml:space="preserve">
+  <data name="ShowVersionControlInfoCard.Description" xml:space="preserve">
     <value>See version control columns for enhanced repositories like "Code Status", "Last Change Date", "Last Change Message"</value>
-    <comment>The description for the settings card that allows user to enable or disable displayment of version control property information inside File Explorer</comment>
+    <comment>The description for the settings card that allows user to enable or disable display of version control property information inside File Explorer</comment>
   </data>
   <data name="ShowVersionControlInfoCard.Header" xml:space="preserve">
     <value>Show version control information</value>
@@ -443,10 +443,10 @@
   </data>
   <data name="ShowRepositoryStatusCard.Description" xml:space="preserve">
     <value>See useful repository statuses provided by relevant version control extension like current branch and remote origin (if applicable)</value>
-    <comment>The description for the settings card that allows user to enable or disable displayment of repository status inside File Explorer</comment>
+    <comment>The description for the settings card that allows user to enable or disable display of repository status inside File Explorer</comment>
   </data>
   <data name="ShowRepositoryStatusCard.Header" xml:space="preserve">
     <value>Show the repository status</value>
-    <comment>The header for the settings card that allows user to enable or disable displayment of repository status inside File Explorer</comment>
+    <comment>The header for the settings card that allows user to enable or disable display of repository status inside File Explorer</comment>
   </data>
 </root>

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -246,11 +246,21 @@ public partial class FileExplorerViewModel : ObservableObject
 
     public async void OnToggledVersionControlInformationSettingAsync(bool value)
     {
+        if (!value)
+        {
+            _log.Information("The user has disabled display of version control information in File Explorer");
+        }
+
         await LocalSettingsService!.SaveSettingAsync("ShowVersionControlInformation", value);
     }
 
     public async void OnToggledRepositoryStatusSettingAsync(bool value)
     {
+        if (!value)
+        {
+            _log.Information("The user has disabled display or repository status in File Explorer");
+        }
+
         await LocalSettingsService!.SaveSettingAsync("ShowRepositoryStatus", value);
     }
 }

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -27,7 +27,7 @@ using Serilog;
 
 namespace DevHome.Customization.ViewModels;
 
-public partial class FileExplorerViewModel : ObservableObject, INotifyPropertyChanged
+public partial class FileExplorerViewModel : ObservableObject
 {
     private readonly ShellSettings _shellSettings;
 
@@ -58,8 +58,6 @@ public partial class FileExplorerViewModel : ObservableObject, INotifyPropertyCh
     [ObservableProperty]
     private bool _showRepositoryStatus;
 
-    public bool IsFileExplorerIntegrationSettingOn { get; set; }
-
     public FileExplorerViewModel(IExperimentationService experimentationService, IExtensionService extensionService, ILocalSettingsService localSettingsService)
     {
         _shellSettings = new ShellSettings();
@@ -84,7 +82,6 @@ public partial class FileExplorerViewModel : ObservableObject, INotifyPropertyCh
             IsVersionControlIntegrationEnabled = CalculateEnabled("VersionControlIntegration");
             ShowVersionControlInformation = CalculateEnabled("ShowVersionControlInformation");
             ShowRepositoryStatus = CalculateEnabled("ShowRepositoryStatus");
-            IsFileExplorerIntegrationSettingOn = true;
         }
     }
 

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -49,15 +48,6 @@ public partial class FileExplorerViewModel : ObservableObject
 
     public bool IsFeatureEnabled => ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration") && ExtraFolderPropertiesWrapper.IsSupported();
 
-    [ObservableProperty]
-    private bool _isVersionControlIntegrationEnabled;
-
-    [ObservableProperty]
-    private bool _showVersionControlInformation;
-
-    [ObservableProperty]
-    private bool _showRepositoryStatus;
-
     public FileExplorerViewModel(IExperimentationService experimentationService, IExtensionService extensionService, ILocalSettingsService localSettingsService)
     {
         _shellSettings = new ShellSettings();
@@ -71,18 +61,7 @@ public partial class FileExplorerViewModel : ObservableObject
             new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
             new(stringResource.GetLocalized("FileExplorer_Header"), typeof(FileExplorerViewModel).FullName!)
         ];
-        LoadFileExplorerSettings();
         RefreshTrackedRepositories();
-    }
-
-    public void LoadFileExplorerSettings()
-    {
-        if (ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration"))
-        {
-            IsVersionControlIntegrationEnabled = CalculateEnabled("VersionControlIntegration");
-            ShowVersionControlInformation = CalculateEnabled("ShowVersionControlInformation");
-            ShowRepositoryStatus = CalculateEnabled("ShowRepositoryStatus");
-        }
     }
 
     public void RefreshTrackedRepositories()
@@ -158,6 +137,24 @@ public partial class FileExplorerViewModel : ObservableObject
         }
     }
 
+    public bool IsVersionControlIntegrationEnabled
+    {
+        get => CalculateEnabled("VersionControlIntegration");
+        set => OnToggledVersionControlIntegrationSettingAsync(value);
+    }
+
+    public bool ShowVersionControlInformation
+    {
+        get => CalculateEnabled("ShowVersionControlInformation");
+        set => OnToggledVersionControlInformationSettingAsync(value);
+    }
+
+    public bool ShowRepositoryStatus
+    {
+        get => CalculateEnabled("ShowRepositoryStatus");
+        set => OnToggledRepositoryStatusSettingAsync(value);
+    }
+
     [RelayCommand]
     public async Task AddFolderClick()
     {
@@ -224,13 +221,11 @@ public partial class FileExplorerViewModel : ObservableObject
         return false;
     }
 
-    [RelayCommand]
-    public async Task OnToggledVersionControlIntegrationSettingAsync()
+    public async void OnToggledVersionControlIntegrationSettingAsync(bool value)
     {
-        IsVersionControlIntegrationEnabled = !IsVersionControlIntegrationEnabled;
-        await LocalSettingsService!.SaveSettingAsync("VersionControlIntegration", IsVersionControlIntegrationEnabled);
+        await LocalSettingsService!.SaveSettingAsync("VersionControlIntegration", value);
 
-        if (!IsVersionControlIntegrationEnabled)
+        if (!value)
         {
             _log.Information("The user has disabled version control integration inside Dev Home");
             ExtraFolderPropertiesWrapper.UnregisterAllForCurrentApp();
@@ -249,17 +244,13 @@ public partial class FileExplorerViewModel : ObservableObject
         }
     }
 
-    [RelayCommand]
-    public async Task OnToggledVersionControlInformationSettingAsync()
+    public async void OnToggledVersionControlInformationSettingAsync(bool value)
     {
-        ShowVersionControlInformation = !ShowVersionControlInformation;
-        await LocalSettingsService!.SaveSettingAsync("ShowVersionControlInformation", ShowVersionControlInformation);
+        await LocalSettingsService!.SaveSettingAsync("ShowVersionControlInformation", value);
     }
 
-    [RelayCommand]
-    public async Task OnToggledRepositoryStatusSettingAsync()
+    public async void OnToggledRepositoryStatusSettingAsync(bool value)
     {
-        ShowRepositoryStatus = !ShowRepositoryStatus;
-        await LocalSettingsService!.SaveSettingAsync("ShowRepositoryStatus", ShowRepositoryStatus);
+        await LocalSettingsService!.SaveSettingAsync("ShowRepositoryStatus", value);
     }
 }

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -1,20 +1,29 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Common.Windows.FileDialog;
 using DevHome.Customization.Helpers;
 using DevHome.Customization.Models;
 using DevHome.Customization.TelemetryEvents;
 using DevHome.FileExplorerSourceControlIntegration.Services;
+using DevHome.Services;
+using DevHome.Telemetry;
 using FileExplorerSourceControlIntegration;
 using Microsoft.Internal.Windows.DevHome.Helpers;
 using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
@@ -25,7 +34,7 @@ using WinUIEx;
 
 namespace DevHome.Customization.ViewModels;
 
-public partial class FileExplorerViewModel : ObservableObject
+public partial class FileExplorerViewModel : ObservableObject, INotifyPropertyChanged
 {
     private readonly ShellSettings _shellSettings;
 
@@ -43,13 +52,27 @@ public partial class FileExplorerViewModel : ObservableObject
 
     public IExtensionService ExtensionService { get; }
 
+    public static ILocalSettingsService? LocalSettingsService { get; set; }
+
     public bool IsFeatureEnabled => ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration") && ExtraFolderPropertiesWrapper.IsSupported();
 
-    public FileExplorerViewModel(IExperimentationService experimentationService, IExtensionService extensionService)
+    [ObservableProperty]
+    private bool _isVersionControlIntegrationEnabled;
+
+    [ObservableProperty]
+    private bool _showVersionControlInformation;
+
+    [ObservableProperty]
+    private bool _showRepositoryStatus;
+
+    public bool IsFileExplorerIntegrationSettingOn { get; set; }
+
+    public FileExplorerViewModel(IExperimentationService experimentationService, IExtensionService extensionService, ILocalSettingsService localSettingsService)
     {
         _shellSettings = new ShellSettings();
         ExperimentationService = experimentationService;
         ExtensionService = extensionService;
+        LocalSettingsService = localSettingsService;
 
         var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
         Breadcrumbs =
@@ -57,7 +80,19 @@ public partial class FileExplorerViewModel : ObservableObject
             new(stringResource.GetLocalized("MainPage_Header"), typeof(MainPageViewModel).FullName!),
             new(stringResource.GetLocalized("FileExplorer_Header"), typeof(FileExplorerViewModel).FullName!)
         ];
+        LoadFileExplorerSettings();
         RefreshTrackedRepositories();
+    }
+
+    public void LoadFileExplorerSettings()
+    {
+        if (ExperimentationService.IsFeatureEnabled("FileExplorerSourceControlIntegration"))
+        {
+            IsVersionControlIntegrationEnabled = CalculateEnabled("VersionControlIntegration");
+            ShowVersionControlInformation = CalculateEnabled("ShowVersionControlInformation");
+            ShowRepositoryStatus = CalculateEnabled("ShowRepositoryStatus");
+            IsFileExplorerIntegrationSettingOn = true;
+        }
     }
 
     public void RefreshTrackedRepositories()
@@ -186,5 +221,48 @@ public partial class FileExplorerViewModel : ObservableObject
             RepoTracker.ModifySourceControlProviderForTrackedRepository(extensionCLSID, rootPath);
         });
         RefreshTrackedRepositories();
+    }
+
+    public bool CalculateEnabled(string settingName)
+    {
+        if (LocalSettingsService!.HasSettingAsync(settingName).Result)
+        {
+            return LocalSettingsService.ReadSettingAsync<bool>(settingName).Result;
+        }
+
+        // Settings disabled by default
+        return false;
+    }
+
+    [RelayCommand]
+    public async Task OnToggledVersionControlIntegrationSettingAsync()
+    {
+        IsVersionControlIntegrationEnabled = !IsVersionControlIntegrationEnabled;
+        await LocalSettingsService!.SaveSettingAsync("VersionControlIntegration", IsVersionControlIntegrationEnabled);
+        _log.Information("Saved FE Enable setting");
+
+        if (!IsVersionControlIntegrationEnabled)
+        {
+            _log.Information("Saved FE Enable setting: false");
+            IsFileExplorerIntegrationSettingOn = false;
+        }
+        else
+        {
+            IsFileExplorerIntegrationSettingOn = true;
+        }
+    }
+
+    [RelayCommand]
+    public async Task OnToggledVersionControlInformationSettingAsync()
+    {
+        ShowVersionControlInformation = !ShowVersionControlInformation;
+        await LocalSettingsService!.SaveSettingAsync("ShowVersionControlInformation", ShowVersionControlInformation);
+    }
+
+    [RelayCommand]
+    public async Task OnToggledRepositoryStatusSettingAsync()
+    {
+        ShowRepositoryStatus = !ShowRepositoryStatus;
+        await LocalSettingsService!.SaveSettingAsync("ShowRepositoryStatus", ShowRepositoryStatus);
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:commonViews="using:DevHome.Common.Views"
     xmlns:behaviors="using:DevHome.Common.Behaviors"
-    xmlns:views="using:DevHome.Customization.Views" 
+    xmlns:views="using:DevHome.Customization.Views"
     behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
     behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
 
@@ -12,6 +12,7 @@
         <Grid>
             <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <views:FileExplorerView />
+                <views:VersionControlIntegrationSettingsView />
                 <views:AddRepositoriesView Visibility="{x:Bind ViewModel.IsFeatureEnabled}"/>
             </StackPanel>
         </Grid>

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -12,7 +12,7 @@
         <Grid>
             <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
                 <views:FileExplorerView />
-                <views:VersionControlIntegrationSettingsView />
+                <views:VersionControlIntegrationSettingsView Visibility="{x:Bind ViewModel.IsFeatureEnabled}"/>
                 <views:AddRepositoriesView Visibility="{x:Bind ViewModel.IsFeatureEnabled}"/>
             </StackPanel>
         </Grid>

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
@@ -19,19 +19,19 @@
         <ctControls:SettingsCard
             x:Uid="EnableVersionControlIntegrationCard"
             Margin="{ThemeResource SettingsCardMargin}">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.IsVersionControlIntegrationEnabled, Mode=TwoWay}" Grid.Column="1"></ToggleSwitch>
+            <ToggleSwitch IsOn="{x:Bind ViewModel.IsVersionControlIntegrationEnabled, Mode=TwoWay}"/>
         </ctControls:SettingsCard>
 
         <ctControls:SettingsCard
             x:Uid="ShowVersionControlInfoCard"
             Margin="{ThemeResource SettingsCardMargin}">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowVersionControlInformation, Mode=TwoWay}" Grid.Column="1"></ToggleSwitch>
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowVersionControlInformation, Mode=TwoWay}"/>
         </ctControls:SettingsCard>
 
         <ctControls:SettingsCard
             x:Uid="ShowRepositoryStatusCard"
             Margin="{ThemeResource SettingsCardMargin}">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRepositoryStatus, Mode=TwoWay}" Grid.Column="1"></ToggleSwitch>
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRepositoryStatus, Mode=TwoWay}"/>
         </ctControls:SettingsCard>
 
     </StackPanel>

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
@@ -32,8 +32,7 @@
         <ctControls:SettingsCard
             x:Uid="ShowVersionControlInfoCard"
             Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible"
-            IsEnabled="{x:Bind ViewModel.IsFileExplorerIntegrationSettingOn, Mode=TwoWay}">
+            Visibility="Visible">
             <ToggleSwitch IsOn="{x:Bind ViewModel.ShowVersionControlInformation, Mode=OneWay}" Grid.Column="1">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="Toggled">
@@ -46,8 +45,7 @@
         <ctControls:SettingsCard
             x:Uid="ShowRepositoryStatusCard"
             Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible"
-            IsEnabled="{x:Bind ViewModel.IsFileExplorerIntegrationSettingOn, Mode=TwoWay}">
+            Visibility="Visible">
             <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRepositoryStatus, Mode=OneWay}" Grid.Column="1">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="Toggled">

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
@@ -18,41 +18,20 @@
 
         <ctControls:SettingsCard
             x:Uid="EnableVersionControlIntegrationCard"
-            Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.IsVersionControlIntegrationEnabled, Mode=OneWay}" Grid.Column="1">
-                <i:Interaction.Behaviors>
-                    <ic:EventTriggerBehavior EventName="Toggled">
-                        <ic:InvokeCommandAction Command="{x:Bind ViewModel.ToggledVersionControlIntegrationSettingCommand}"/>
-                    </ic:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-            </ToggleSwitch>
+            Margin="{ThemeResource SettingsCardMargin}">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.IsVersionControlIntegrationEnabled, Mode=TwoWay}" Grid.Column="1"></ToggleSwitch>
         </ctControls:SettingsCard>
 
         <ctControls:SettingsCard
             x:Uid="ShowVersionControlInfoCard"
-            Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowVersionControlInformation, Mode=OneWay}" Grid.Column="1">
-                <i:Interaction.Behaviors>
-                    <ic:EventTriggerBehavior EventName="Toggled">
-                        <ic:InvokeCommandAction Command="{x:Bind ViewModel.ToggledVersionControlInformationSettingCommand}"/>
-                    </ic:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-            </ToggleSwitch>
+            Margin="{ThemeResource SettingsCardMargin}">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowVersionControlInformation, Mode=TwoWay}" Grid.Column="1"></ToggleSwitch>
         </ctControls:SettingsCard>
 
         <ctControls:SettingsCard
             x:Uid="ShowRepositoryStatusCard"
-            Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible">
-            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRepositoryStatus, Mode=OneWay}" Grid.Column="1">
-                <i:Interaction.Behaviors>
-                    <ic:EventTriggerBehavior EventName="Toggled">
-                        <ic:InvokeCommandAction Command="{x:Bind ViewModel.ToggledRepositoryStatusSettingCommand}"/>
-                    </ic:EventTriggerBehavior>
-                </i:Interaction.Behaviors>
-            </ToggleSwitch>
+            Margin="{ThemeResource SettingsCardMargin}">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRepositoryStatus, Mode=TwoWay}" Grid.Column="1"></ToggleSwitch>
         </ctControls:SettingsCard>
 
     </StackPanel>

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DevHome.Customization.Views.VersionControlIntegrationSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DevHome.Customization.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls" 
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core" 
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    mc:Ignorable="d">
+
+    <StackPanel>
+        <TextBlock 
+            x:Uid="FileExplorerSettingsTextBlock"
+            Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"/>
+
+        <ctControls:SettingsCard
+            x:Uid="EnableVersionControlIntegrationCard"
+            Margin="{ThemeResource SettingsCardMargin}"
+            Visibility="Visible">
+            <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=OneWay}" Grid.Column="1">
+                <i:Interaction.Behaviors>
+                    <ic:EventTriggerBehavior EventName="Toggled">
+                    </ic:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </ToggleSwitch>
+        </ctControls:SettingsCard>
+
+        <ctControls:SettingsCard
+            x:Uid="ShowVersionControlInfoCard"
+            Margin="{ThemeResource SettingsCardMargin}"
+            Visibility="Visible">
+            <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=OneWay}" Grid.Column="1">
+                <i:Interaction.Behaviors>
+                    <ic:EventTriggerBehavior EventName="Toggled">
+                    </ic:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </ToggleSwitch>
+        </ctControls:SettingsCard>
+
+        <ctControls:SettingsCard
+            x:Uid="ShowRepositoryStatusCard"
+            Margin="{ThemeResource SettingsCardMargin}"
+            Visibility="Visible">
+            <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=OneWay}" Grid.Column="1">
+                <i:Interaction.Behaviors>
+                    <ic:EventTriggerBehavior EventName="Toggled">
+                    </ic:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </ToggleSwitch>
+        </ctControls:SettingsCard>
+
+    </StackPanel>
+</UserControl>

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
@@ -20,9 +20,10 @@
             x:Uid="EnableVersionControlIntegrationCard"
             Margin="{ThemeResource SettingsCardMargin}"
             Visibility="Visible">
-            <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=OneWay}" Grid.Column="1">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.IsVersionControlIntegrationEnabled, Mode=OneWay}" Grid.Column="1">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="Toggled">
+                        <ic:InvokeCommandAction Command="{x:Bind ViewModel.ToggledVersionControlIntegrationSettingCommand}"/>
                     </ic:EventTriggerBehavior>
                 </i:Interaction.Behaviors>
             </ToggleSwitch>
@@ -31,10 +32,12 @@
         <ctControls:SettingsCard
             x:Uid="ShowVersionControlInfoCard"
             Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible">
-            <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=OneWay}" Grid.Column="1">
+            Visibility="Visible"
+            IsEnabled="{x:Bind ViewModel.IsFileExplorerIntegrationSettingOn, Mode=TwoWay}">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowVersionControlInformation, Mode=OneWay}" Grid.Column="1">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="Toggled">
+                        <ic:InvokeCommandAction Command="{x:Bind ViewModel.ToggledVersionControlInformationSettingCommand}"/>
                     </ic:EventTriggerBehavior>
                 </i:Interaction.Behaviors>
             </ToggleSwitch>
@@ -43,10 +46,12 @@
         <ctControls:SettingsCard
             x:Uid="ShowRepositoryStatusCard"
             Margin="{ThemeResource SettingsCardMargin}"
-            Visibility="Visible">
-            <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=OneWay}" Grid.Column="1">
+            Visibility="Visible"
+            IsEnabled="{x:Bind ViewModel.IsFileExplorerIntegrationSettingOn, Mode=TwoWay}">
+            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRepositoryStatus, Mode=OneWay}" Grid.Column="1">
                 <i:Interaction.Behaviors>
                     <ic:EventTriggerBehavior EventName="Toggled">
+                        <ic:InvokeCommandAction Command="{x:Bind ViewModel.ToggledRepositoryStatusSettingCommand}"/>
                     </ic:EventTriggerBehavior>
                 </i:Interaction.Behaviors>
             </ToggleSwitch>

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Extensions;
+using DevHome.Common.Services;
+using DevHome.Customization.Models;
+using DevHome.Customization.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+namespace DevHome.Customization.Views;
+
+public sealed partial class VersionControlIntegrationSettingsView : UserControl
+{
+    public VersionControlIntegrationSettingsView()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml.cs
@@ -2,14 +2,10 @@
 // Licensed under the MIT License.
 
 using DevHome.Common.Extensions;
-using DevHome.Common.Services;
-using DevHome.Customization.Models;
 using DevHome.Customization.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace DevHome.Customization.Views;
 
 public sealed partial class VersionControlIntegrationSettingsView : UserControl

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml.cs
@@ -14,8 +14,14 @@ namespace DevHome.Customization.Views;
 
 public sealed partial class VersionControlIntegrationSettingsView : UserControl
 {
+    public FileExplorerViewModel ViewModel
+    {
+        get;
+    }
+
     public VersionControlIntegrationSettingsView()
     {
+        ViewModel = Application.Current.GetService<FileExplorerViewModel>();
         this.InitializeComponent();
     }
 }

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/FileExplorerIntegrationUserSettings.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/FileExplorerIntegrationUserSettings.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Models;
+using DevHome.Common.Services;
+using Serilog;
+
+namespace DevHome.FileExplorerSourceControlIntegration.Services;
+
+public class FileExplorerIntegrationUserSettings
+{
+    private readonly LocalSettingsService? _localSettingsService;
+    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(FileExplorerIntegrationUserSettings));
+
+    public FileExplorerIntegrationUserSettings()
+    {
+        try
+        {
+            FileService fileService = new FileService();
+            var options = new Microsoft.Extensions.Options.OptionsWrapper<LocalSettingsOptions>(
+            new LocalSettingsOptions
+            {
+                ApplicationDataFolder = "DevHome/ApplicationData",
+                LocalSettingsFile = "LocalSettings.json",
+            });
+
+            // The LocalSettingsService has to be used and initialized from within the
+            // File Explorer Source Control Integration COM Server
+            _localSettingsService = new LocalSettingsService(fileService, options);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to get LocalSettingsService");
+        }
+    }
+
+    public bool IsFileExplorerVersionControlEnabled()
+    {
+        if (_localSettingsService != null && _localSettingsService.HasSettingAsync("VersionControlIntegration").Result)
+        {
+            return _localSettingsService.ReadSettingAsync<bool>("VersionControlIntegration").Result;
+        }
+
+        // DisabledByDefault
+        return false;
+    }
+
+    public bool ShowFileExplorerVersionControlColumnData()
+    {
+        if (_localSettingsService != null && _localSettingsService.HasSettingAsync("ShowVersionControlInformation").Result)
+        {
+            return _localSettingsService.ReadSettingAsync<bool>("ShowVersionControlInformation").Result;
+        }
+
+        // DisabledByDefault
+        return false;
+    }
+
+    public bool ShowRepositoryStatus()
+    {
+        if (_localSettingsService != null && _localSettingsService.HasSettingAsync("ShowRepositoryStatus").Result)
+        {
+            return _localSettingsService.ReadSettingAsync<bool>("ShowRepositoryStatus").Result;
+        }
+
+        // DisabledByDefault
+        return false;
+    }
+}

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/FileExplorerIntegrationUserSettings.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/FileExplorerIntegrationUserSettings.cs
@@ -10,7 +10,9 @@ namespace DevHome.FileExplorerSourceControlIntegration.Services;
 public class FileExplorerIntegrationUserSettings
 {
     private readonly LocalSettingsService? _localSettingsService;
-    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(FileExplorerIntegrationUserSettings));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(FileExplorerIntegrationUserSettings));
+    private const string DefaultApplicationDataFolder = "DevHome/ApplicationData";
+    private const string DefaultLocalSettingsFile = "LocalSettings.json";
 
     public FileExplorerIntegrationUserSettings()
     {
@@ -20,8 +22,8 @@ public class FileExplorerIntegrationUserSettings
             var options = new Microsoft.Extensions.Options.OptionsWrapper<LocalSettingsOptions>(
             new LocalSettingsOptions
             {
-                ApplicationDataFolder = "DevHome/ApplicationData",
-                LocalSettingsFile = "LocalSettings.json",
+                ApplicationDataFolder = DefaultApplicationDataFolder,
+                LocalSettingsFile = DefaultLocalSettingsFile,
             });
 
             // The LocalSettingsService has to be used and initialized from within the

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/FileExplorerIntegrationUserSettings.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/Services/FileExplorerIntegrationUserSettings.cs
@@ -43,7 +43,7 @@ public class FileExplorerIntegrationUserSettings
             return _localSettingsService.ReadSettingAsync<bool>("VersionControlIntegration").Result;
         }
 
-        // DisabledByDefault
+        // If the user has not set the setting, it is disabled by default on page load
         return false;
     }
 
@@ -54,7 +54,7 @@ public class FileExplorerIntegrationUserSettings
             return _localSettingsService.ReadSettingAsync<bool>("ShowVersionControlInformation").Result;
         }
 
-        // DisabledByDefault
+        // If the user has not set the setting, it is disabled by default on page load
         return false;
     }
 
@@ -65,7 +65,7 @@ public class FileExplorerIntegrationUserSettings
             return _localSettingsService.ReadSettingAsync<bool>("ShowRepositoryStatus").Result;
         }
 
-        // DisabledByDefault
+        // If the user has not set the setting, it is disabled by default on page load
         return false;
     }
 }

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
@@ -96,6 +96,7 @@ public class SourceControlProvider :
 internal sealed class RootFolderPropertyProvider : Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer.IPerFolderRootPropertyProvider
 {
     private readonly FileExplorerIntegrationUserSettings _fileExplorerIntegrationUserSettings;
+    private readonly string _repositoryStatusPropertyString = "System.VersionControl.CurrentFolderStatus";
 
     public RootFolderPropertyProvider(ILocalRepository repository)
     {
@@ -116,12 +117,12 @@ internal sealed class RootFolderPropertyProvider : Microsoft.Internal.Windows.De
 
         if (showFileExplorerVersionControlColumnData && !showRepositoryStatus)
         {
-            var filteredPropertyStrings = properties.Where(s => s != "System.VersionControl.CurrentFolderStatus").ToArray();
+            var filteredPropertyStrings = properties.Where(s => s != _repositoryStatusPropertyString).ToArray();
             properties = filteredPropertyStrings;
         }
         else if (!showFileExplorerVersionControlColumnData && showRepositoryStatus)
         {
-            properties = new string[] { "System.VersionControl.CurrentFolderStatus" };
+            properties = new string[] { _repositoryStatusPropertyString };
         }
 
         return _repository.GetProperties(properties, relativePath);


### PR DESCRIPTION
## Summary of the pull request
Adds toggle settings for the File Explorer Source Control Integration feature to allow user customization

## References and relevant issues

## Detailed description of the pull request / Additional comments
Adds toggle settings to:
- enable/disable File Explorer Integration with Version Control Extension
- enable/disable displaying version control information in File Explorer columns
- enable/disable displaying Repository Status on the bottom left of File Explorer


## Validation steps performed
Local build of msix
Tested functionality of user settings end to end in VM 
![image](https://github.com/user-attachments/assets/51b7aa7d-e4d6-47b4-8c1a-d391841cc5ed)
![image](https://github.com/user-attachments/assets/d31fa740-c4bb-4e2a-864c-29c7477e1cf7)
![image](https://github.com/user-attachments/assets/a3e01a9d-0a75-4d51-adb2-5cf0088ae774)


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
