### PR TITLE
Update AdaptiveCards

### DIFF
--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.0-beta" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.1.0-beta" />
-    <PackageReference Include="AdaptiveCards.Templating" Version="1.5.0" />
+    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.1-beta" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.2.1-beta" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="2.0.2" />
     <PackageReference Include="CommunityToolkit.Common" Version="8.2.2" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Shimmer" Version="0.1.230830" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.700.544" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />

--- a/common/Models/ExtensionAdaptiveCard.cs
+++ b/common/Models/ExtensionAdaptiveCard.cs
@@ -24,7 +24,9 @@ public class ExtensionAdaptiveCard : IExtensionAdaptiveCard
 
     public string TemplateJson { get; private set; }
 
-    public ExtensionAdaptiveCard(AdaptiveElementParserRegistration? elementParserRegistration = null, AdaptiveActionParserRegistration? actionParserRegistration = null)
+    public ExtensionAdaptiveCard(
+        AdaptiveElementParserRegistration? elementParserRegistration = null,
+        AdaptiveActionParserRegistration? actionParserRegistration = null)
     {
         TemplateJson = new JsonObject().ToJsonString();
         DataJson = new JsonObject().ToJsonString();
@@ -37,18 +39,18 @@ public class ExtensionAdaptiveCard : IExtensionAdaptiveCard
     public ProviderOperationResult Update(string templateJson, string dataJson, string state)
     {
         var template = new AdaptiveCardTemplate(templateJson ?? TemplateJson);
-
-        // Need to use Newtonsoft.Json here because System.Text.Json is missing a set of wrapping brackets
-        // which causes AdaptiveCardTemplate.Expand to fail.  System.Text.Json also does not support parsing
-        // an empty string.
-        var adaptiveCardString = template.Expand(Newtonsoft.Json.JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(dataJson ?? DataJson));
+        var adaptiveCardString = template.Expand(dataJson ?? DataJson);
 
         var parseResult = AdaptiveCard.FromJsonString(adaptiveCardString, _elementParserRegistration, _actionParserRegistration);
 
         if (parseResult.AdaptiveCard is null)
         {
             Log.Error($"ExtensionAdaptiveCard.Update(): AdaptiveCard is null - templateJson: {templateJson} dataJson: {dataJson} state: {state}");
-            return new ProviderOperationResult(ProviderOperationStatus.Failure, new ArgumentNullException(null), "AdaptiveCard is null", $"templateJson: {templateJson} dataJson: {dataJson} state: {state}");
+            return new ProviderOperationResult(
+                ProviderOperationStatus.Failure,
+                new ArgumentNullException(null),
+                "AdaptiveCard is null",
+                $"templateJson: {templateJson} dataJson: {dataJson} state: {state}");
         }
 
         TemplateJson = templateJson ?? TemplateJson;
@@ -57,6 +59,10 @@ public class ExtensionAdaptiveCard : IExtensionAdaptiveCard
 
         UiUpdate?.Invoke(this, parseResult.AdaptiveCard);
 
-        return new ProviderOperationResult(ProviderOperationStatus.Success, null, "IExtensionAdaptiveCard.Update succeeds", "IExtensionAdaptiveCard.Update succeeds");
+        return new ProviderOperationResult(
+            ProviderOperationStatus.Success,
+            null,
+            "IExtensionAdaptiveCard.Update succeeds",
+            "IExtensionAdaptiveCard.Update succeeds");
     }
 }

--- a/common/Services/LocalSettingsService.cs
+++ b/common/Services/LocalSettingsService.cs
@@ -75,7 +75,7 @@ public class LocalSettingsService : ILocalSettingsService
         {
             if (ApplicationData.Current.LocalSettings.Values.TryGetValue(key, out var obj))
             {
-                return await Json.ToObjectAsync<T>((string)obj);
+                return await Helpers.Json.ToObjectAsync<T>((string)obj);
             }
         }
         else
@@ -84,7 +84,7 @@ public class LocalSettingsService : ILocalSettingsService
 
             if (_settings != null && _settings.TryGetValue(key, out var obj))
             {
-                return await Json.ToObjectAsync<T>((string)obj);
+                return await Helpers.Json.ToObjectAsync<T>((string)obj);
             }
         }
 
@@ -95,13 +95,13 @@ public class LocalSettingsService : ILocalSettingsService
     {
         if (RuntimeHelper.IsMSIX)
         {
-            ApplicationData.Current.LocalSettings.Values[key] = await Json.StringifyAsync(value!);
+            ApplicationData.Current.LocalSettings.Values[key] = await Helpers.Json.StringifyAsync(value!);
         }
         else
         {
             await InitializeAsync();
 
-            _settings[key] = await Json.StringifyAsync(value!);
+            _settings[key] = await Helpers.Json.StringifyAsync(value!);
 
             await Task.Run(() => _fileService.Save(_applicationDataFolder, _localSettingsFile, _settings));
         }

--- a/extensions/CoreWidgetProvider/Helpers/ChartHelper.cs
+++ b/extensions/CoreWidgetProvider/Helpers/ChartHelper.cs
@@ -64,9 +64,7 @@ internal sealed class ChartHelper
     public static string CreateImageUrl(List<float> chartValues, ChartType type)
     {
         var chartStr = CreateChart(chartValues, type);
-        var bytes = Encoding.UTF8.GetBytes(chartStr);
-        var b64String = Convert.ToBase64String(bytes);
-        return "data:image/svg+xml;base64," + b64String;
+        return "data:image/svg+xml;utf8," + chartStr;
     }
 
     /// <summary>

--- a/extensions/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
+++ b/extensions/CoreWidgetProvider/Widgets/Templates/SSHWalletConfigurationTemplate.json
@@ -1,7 +1,7 @@
 {
   "type": "AdaptiveCard",
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.5",
+  "version": "1.6",
   "body": [
     {
       "type": "Input.Text",
@@ -18,36 +18,24 @@
     {
       "type": "ColumnSet",
       "spacing": "Medium",
+      "horizontalAlignment": "center",
       "columns": [
-        {
-          "type": "Column",
-          "width": "stretch"
-        },
         {
           "type": "Column",
           "width": "auto",
           "items": [
             {
-              "type": "Container",
-              "items": [
+              "type": "ActionSet",
+              "actions": [
                 {
-                  "type": "ActionSet",
-                  "actions": [
-                    {
-                      "type": "Action.Execute",
-                      "title": "%Widget_Template_Button/Preview%",
-                      "verb": "CheckPath",
-                      "associatedInputs": "Auto"
-                    }
-                  ]
+                  "type": "Action.Execute",
+                  "title": "%Widget_Template_Button/Preview%",
+                  "verb": "CheckPath",
+                  "associatedInputs": "Auto"
                 }
               ]
             }
           ]
-        },
-        {
-          "type": "Column",
-          "width": "stretch"
         }
       ]
     },
@@ -93,11 +81,8 @@
     {
       "type": "ColumnSet",
       "spacing": "Large",
+      "horizontalAlignment": "center",
       "columns": [
-        {
-          "type": "Column",
-          "width": "stretch"
-        },
         {
           "type": "Column",
           "width": "auto",
@@ -125,10 +110,6 @@
               ]
             }
           ]
-        },
-        {
-          "type": "Column",
-          "width": "stretch"
         }
       ]
     }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/LruCacheDictionary.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/LruCacheDictionary.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
-using Newtonsoft.Json.Linq;
 
 namespace FileExplorerGitIntegration.Models;
 

--- a/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
@@ -42,7 +42,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.700.544" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/extensions/WSLExtension/WSLExtension.csproj
+++ b/extensions/WSLExtension/WSLExtension.csproj
@@ -30,7 +30,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.DevHome.SDK" Version="0.700.544" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -71,8 +71,8 @@
 
   <ItemGroup>
     <!-- Temporarily duplicate the Adaptive Card from DevHome.Common -->
-    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.0-beta" GeneratePathProperty="true" />
-    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.1.0-beta" GeneratePathProperty="true" />
+    <PackageReference Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.1-beta" GeneratePathProperty="true" />
+    <PackageReference Include="AdaptiveCards.Rendering.WinUI3" Version="2.2.1-beta" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Internal.Windows.DevHome.Helpers" Version="1.0.20240805-x2200" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">


### PR DESCRIPTION
## Summary of the pull request
Update AdaptiveCards rendering, object model, and templating.
* Use svg string directly instead of converting it to base64 in widget charts (enabled by https://github.com/microsoft/AdaptiveCards/pull/8880)
* Use string-based templating APIs instead of Newtonsoft (enabled by https://github.com/microsoft/AdaptiveCards/pull/8919).
* Remove last remaining references to Newtonsoft
* In widget template, use ColumnSet's horizontalAlignment instead of empty column workaround (enabled by https://github.com/microsoft/AdaptiveCards/pull/8936)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
