### PR TITLE
Fix action center regression in Setup flow where interactable items are always disabled

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -257,6 +257,11 @@
                 Margin="0,0,0,5"
                 ItemsSource="{x:Bind ViewModel.ActionCenterItems, Mode=OneWay}"
                 SelectionMode="None">
+                <!-- 
+                    Make item container not recieve a tab stop by default since
+                    we don't want the container to recieve the tab stop. We only 
+                    want the controls within the ItemTemplate itself to get a TabStop.
+                -->
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="IsTabStop" Value="False"/>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/LoadingView.xaml
@@ -20,7 +20,7 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary>
                     <converters:EmptyObjectToObjectConverter
-                        x:Key="EmptyObjectToObjectConverter"
+                        x:Key="EmptyObjectToVisibilityConverter"
                         EmptyValue="Collapsed"
                         NotEmptyValue="Visible" />
                     <Style x:Key="DevHomeBorderStyle" TargetType="Border">
@@ -255,9 +255,13 @@
             <ListView
                 Grid.Row="1"
                 Margin="0,0,0,5"
-                IsEnabled="False"
                 ItemsSource="{x:Bind ViewModel.ActionCenterItems, Mode=OneWay}"
                 SelectionMode="None">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="IsTabStop" Value="False"/>
+                    </Style>
+                </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="commonModels:ActionCenterMessages">
                         <Grid>
@@ -269,9 +273,10 @@
                                 Grid.Row="0"
                                 Margin="0,0,0,10"
                                 Padding="20"
+                                IsTabStop="False"
                                 Background="{ThemeResource CardBackgroundFillColorDefault}"
                                 CornerRadius="10"
-                                Visibility="{x:Bind PrimaryMessage, Converter={StaticResource EmptyObjectToObjectConverter}}">
+                                Visibility="{x:Bind PrimaryMessage, Converter={StaticResource EmptyObjectToVisibilityConverter}}">
                                 <TextBlock
                                     IsTextSelectionEnabled="True"
                                     Style="{StaticResource BodyStrongTextBlockStyle}"
@@ -280,10 +285,12 @@
                             </StackPanel>
                             <ContentControl
                                 Grid.Row="1"
+                                IsTabStop="False"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
                                 VerticalContentAlignment="Stretch"
+                                Visibility="{x:Bind ExtensionAdaptiveCardPanel, Converter={StaticResource EmptyObjectToVisibilityConverter}}"
                                 Content="{x:Bind ExtensionAdaptiveCardPanel}"
                                 CornerRadius="10"
                                 Unloaded="ContentControl_Unloaded" />


### PR DESCRIPTION
## Summary of the pull request
This PR fixes a regression in the latest Dev Home Canary build in the setup flow's loading page. The issue is that any interactable control e.g Adaptive cards that appear in the action center can no longer be interacted with because its parent ListView control had its enablement state set to `IsEnabled=False`. The original intent of changing the ListView's enablement state was to prevent non-interactive items like textblocks that appear in the action center from being focusable see PR #3510 for details. This change removes the need for using the ListView's `IsEnabled` attribute in the action center in favor of using the `IsTabStop` attribute.

Video of issue in current Canary build:

https://github.com/user-attachments/assets/69a2c3bb-7ca1-4a43-ba32-536ba6b20fd8


Video of Fix with non-interactable text in the action center:

https://github.com/user-attachments/assets/831a65cf-cb55-4583-9c4b-e4df43bbd0d2

Video of fix with interactable text in the action center (Notice I can tab into the adaptive card without issues now. In the video I cancel the adaptive card which make a regular error textblock in Dev Home appear, which you will see is now still non-interactable): 


https://github.com/user-attachments/assets/9202cc94-b87e-4792-b39e-b3fac8cf2cb4



## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
