### PR TITLE
Project property updates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
 <!--
@@ -31,6 +32,14 @@
     <BuildRing Condition="'$(BuildRing)'==''">Dev</BuildRing>
     <DefineConstants Condition="'$(BuildRing)'=='Canary'">$(DefineConstants);CANARY_BUILD</DefineConstants>
     <DefineConstants Condition="'$(BuildRing)'=='Stable'">$(DefineConstants);STABLE_BUILD</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
+    <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
     <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug_FailFast'">
     <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\codeAnalysis\StyleCop.json" Link="StyleCop.json" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug_FailFast'">
     <DisableXbfLineInfo>False</DisableXbfLineInfo>
   </PropertyGroup>
 

--- a/common/DevHome.Common.csproj
+++ b/common/DevHome.Common.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <DevHomeSDKVersion Condition="$(DevHomeSDKVersion) == ''">$(DevHomeSDKVersion)</DevHomeSDKVersion>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)ToolingVersions.props" />
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <!-- Debug builds produce a console app; otherwise a Windows app -->
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
+++ b/extensions/CoreWidgetProvider/CoreWidgetProvider.csproj
@@ -2,11 +2,9 @@
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <OutputType>WinExe</OutputType>

--- a/extensions/GitExtension/FileExplorerGitIntegration/FileExplorerGitIntegration.csproj
+++ b/extensions/GitExtension/FileExplorerGitIntegration/FileExplorerGitIntegration.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)ToolingVersions.props" />
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <!-- Debug builds produce a console app; otherwise a Windows app -->
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/extensions/GitExtension/FileExplorerGitIntegration/FileExplorerGitIntegration.csproj
+++ b/extensions/GitExtension/FileExplorerGitIntegration/FileExplorerGitIntegration.csproj
@@ -2,11 +2,9 @@
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <OutputType>WinExe</OutputType>
@@ -38,8 +36,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/extensions/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
+++ b/extensions/HyperVExtension/src/DevSetupAgent/DevSetupAgent.csproj
@@ -8,7 +8,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile Condition="'$(BuildingInsideVisualStudio)' != 'True'">Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfile>
     <SelfContained>true</SelfContained>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <!--

--- a/extensions/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
+++ b/extensions/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <!-- Debug builds produce a console app; otherwise a Windows app -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/extensions/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
+++ b/extensions/HyperVExtension/src/DevSetupEngine/DevSetupEngine.csproj
@@ -3,11 +3,9 @@
   <!-- Debug builds produce a console app; otherwise a Windows app -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <OutputType>WinExe</OutputType>

--- a/extensions/HyperVExtension/src/DevSetupEngineProjection/DevSetupEngineProjection.csproj
+++ b/extensions/HyperVExtension/src/DevSetupEngineProjection/DevSetupEngineProjection.csproj
@@ -5,7 +5,6 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/HyperVExtension/src/HyperVExtension.Common/HyperVExtension.Common.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension.Common/HyperVExtension.Common.csproj
@@ -4,7 +4,6 @@
     <RootNamespace>HyperVExtension.Common</RootNamespace>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/HyperVExtension/src/HyperVExtension.HostGuestCommunication/HyperVExtension.HostGuestCommunication.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension.HostGuestCommunication/HyperVExtension.HostGuestCommunication.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtension/HyperVExtension.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <BuildRing Condition="'$(BuildRing)'==''">Dev</BuildRing>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Scripts\DevSetupAgent.ps1" />

--- a/extensions/HyperVExtension/src/HyperVExtensionServer/HyperVExtensionServer.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtensionServer/HyperVExtensionServer.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <!-- Debug builds produce a console app; otherwise a Windows app -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/extensions/HyperVExtension/src/HyperVExtensionServer/HyperVExtensionServer.csproj
+++ b/extensions/HyperVExtension/src/HyperVExtensionServer/HyperVExtensionServer.csproj
@@ -3,11 +3,9 @@
   <!-- Debug builds produce a console app; otherwise a Windows app -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <OutputType>WinExe</OutputType>

--- a/extensions/HyperVExtension/src/Telemetry/HyperVExtension.Telemetry.csproj
+++ b/extensions/HyperVExtension/src/Telemetry/HyperVExtension.Telemetry.csproj
@@ -5,7 +5,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/extensions/HyperVExtension/test/DevSetupAgent.Test/DevSetupAgent.Test.csproj
+++ b/extensions/HyperVExtension/test/DevSetupAgent.Test/DevSetupAgent.Test.csproj
@@ -7,7 +7,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/HyperVExtension/test/DevSetupEngine.Test/DevSetupEngine.Test.csproj
+++ b/extensions/HyperVExtension/test/DevSetupEngine.Test/DevSetupEngine.Test.csproj
@@ -7,7 +7,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/extensions/HyperVExtension/test/HyperVExtension/HyperVExtension.UnitTest.csproj
+++ b/extensions/HyperVExtension/test/HyperVExtension/HyperVExtension.UnitTest.csproj
@@ -10,7 +10,6 @@
     <UseWinUI>true</UseWinUI>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/extensions/WSLExtension/WSLExtension.csproj
+++ b/extensions/WSLExtension/WSLExtension.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)ToolingVersions.props" />
   <!-- Debug builds produce a console app; otherwise a Windows app -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/extensions/WSLExtension/WSLExtension.csproj
+++ b/extensions/WSLExtension/WSLExtension.csproj
@@ -3,11 +3,9 @@
   <!-- Debug builds produce a console app; otherwise a Windows app -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <OutputType>WinExe</OutputType>

--- a/settings/DevHome.Settings/DevHome.Settings.csproj
+++ b/settings/DevHome.Settings/DevHome.Settings.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -63,12 +62,4 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -22,7 +22,6 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <!-- To build with the correct logo assets, only include the ones for the current build ring.
@@ -163,14 +162,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
-  </PropertyGroup>
 
   <!-- Third party notice file -->
   <ItemGroup>

--- a/telemetry/DevHome.Telemetry/DevHome.Telemetry.csproj
+++ b/telemetry/DevHome.Telemetry/DevHome.Telemetry.csproj
@@ -7,7 +7,6 @@
     <UseWinUI>true</UseWinUI>
     <!-- DefineConstants is removed in Unstub.ps1-->
     <DefineConstants>TELEMETRYEVENTSOURCE_PUBLIC</DefineConstants>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />

--- a/test/DevHome.Test.csproj
+++ b/test/DevHome.Test.csproj
@@ -10,7 +10,6 @@
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
+++ b/tools/Customization/DevHome.Customization/DevHome.Customization.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -67,14 +66,6 @@
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <Resource Remove="Views\AddRepositoriesView.xaml" />

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/DevHome.FileExplorerSourceControlIntegration.csproj
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/DevHome.FileExplorerSourceControlIntegration.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)ToolingVersions.props" />
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <!-- Debug builds produce a console app; otherwise a Windows app -->
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/DevHome.FileExplorerSourceControlIntegration.csproj
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/DevHome.FileExplorerSourceControlIntegration.csproj
@@ -32,8 +32,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.Dashboard.UnitTest.csproj
+++ b/tools/Dashboard/DevHome.Dashboard.UnitTest/DevHome.Dashboard.UnitTest.csproj
@@ -10,7 +10,6 @@
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
+++ b/tools/Dashboard/DevHome.Dashboard/DevHome.Dashboard.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <CsWinRTIncludes>Microsoft.Windows.Widgets.Hosts</CsWinRTIncludes>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -63,12 +62,4 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/tools/Environments/DevHome.Environments/DevHome.Environments.csproj
+++ b/tools/Environments/DevHome.Environments/DevHome.Environments.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Experiments/src/DevHome.Experiments.csproj
+++ b/tools/Experiments/src/DevHome.Experiments.csproj
@@ -5,7 +5,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Views\TestExperimentPage.xaml" />

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/DevHome.ExtensionLibrary.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,12 +29,4 @@
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_FailFast'">
-    <DefineConstants>$(DefineConstants);DEBUG;DEBUG_FAILFAST</DefineConstants>
-  </PropertyGroup>
 </Project>

--- a/tools/PI/DevHome.PI/DevHome.PI.csproj
+++ b/tools/PI/DevHome.PI/DevHome.PI.csproj
@@ -16,7 +16,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
     <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection/DevHome.QuietBackgroundProcesses.ElevatedServer.Projection.csproj
@@ -9,7 +9,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <MdmergeMergedDir>$(CppBaseOutDir)\DevHome.QuietBackgroundProcesses.Common\</MdmergeMergedDir>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/DevHome.QuietBackgroundProcesses.UI.csproj
+++ b/tools/QuietBackgroundProcesses/DevHome.QuietBackgroundProcesses.UI/DevHome.QuietBackgroundProcesses.UI.csproj
@@ -7,7 +7,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/SampleTool/src/SampleTool.csproj
+++ b/tools/SampleTool/src/SampleTool.csproj
@@ -5,7 +5,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="SampleToolPage.xaml" />

--- a/tools/SampleTool/unittest/SampleTool.UnitTest.csproj
+++ b/tools/SampleTool/unittest/SampleTool.UnitTest.csproj
@@ -10,7 +10,6 @@
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />

--- a/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.Common/DevHome.SetupFlow.Common.csproj
@@ -6,7 +6,6 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>disable</Nullable>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent.Projection/DevHome.SetupFlow.ElevatedComponent.Projection.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent.Projection/DevHome.SetupFlow.ElevatedComponent.Projection.csproj
@@ -9,7 +9,6 @@
     <Nullable>enable</Nullable>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <!-- CsWinRT properties -->

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/DevHome.SetupFlow.ElevatedComponent.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedComponent/DevHome.SetupFlow.ElevatedComponent.csproj
@@ -8,7 +8,6 @@
     <Nullable>enable</Nullable>
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <!-- CsWinRT properties -->

--- a/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.ElevatedServer/DevHome.SetupFlow.ElevatedServer.csproj
@@ -14,7 +14,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>DevHome.SetupFlow.ElevatedServer.Program</StartupObject>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/SetupFlow/DevHome.SetupFlow.UnitTest/DevHome.SetupFlow.UnitTest.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow.UnitTest/DevHome.SetupFlow.UnitTest.csproj
@@ -10,7 +10,6 @@
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Update="TestAssets\*.json">

--- a/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
+++ b/tools/SetupFlow/DevHome.SetupFlow/DevHome.SetupFlow.csproj
@@ -5,7 +5,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Utilities/EnvVariablesUtility/DevHome.EnvironmentVariables.csproj
+++ b/tools/Utilities/EnvVariablesUtility/DevHome.EnvironmentVariables.csproj
@@ -13,7 +13,6 @@
     <EnableMsixTooling>false</EnableMsixTooling>
     <ProjectPriFileName>DevHome.EnvironmentVariables.pri</ProjectPriFileName>
     <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Page Remove="EnvironmentVariablesApp.xaml" />

--- a/tools/Utilities/HostsUtility/DevHome.HostsFileEditor.csproj
+++ b/tools/Utilities/HostsUtility/DevHome.HostsFileEditor.csproj
@@ -13,7 +13,6 @@
     <EnableMsixTooling>false</EnableMsixTooling>
     <ProjectPriFileName>DevHome.HostsFileEditor.pri</ProjectPriFileName>
     <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Settings\HostsUtilitySettingsWindow.xaml" />

--- a/tools/Utilities/RegPreviewUtility/DevHome.RegistryPreview.csproj
+++ b/tools/Utilities/RegPreviewUtility/DevHome.RegistryPreview.csproj
@@ -13,7 +13,6 @@
     <EnableMsixTooling>false</EnableMsixTooling>
     <ProjectPriFileName>DevHome.RegistryPreview.pri</ProjectPriFileName>
     <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Utilities/src/DevHome.Utilities.csproj
+++ b/tools/Utilities/src/DevHome.Utilities.csproj
@@ -5,7 +5,6 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Views\UtilitiesMainPageView.xaml" />

--- a/uitest/DevHome.UITest.csproj
+++ b/uitest/DevHome.UITest.csproj
@@ -10,7 +10,6 @@
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ProjectPriFileName>resources.pri</ProjectPriFileName>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\Test.runsettings</RunSettingsFilePath>
-    <Configurations>Debug;Release;Debug_FailFast</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="NativeMethods.json" />


### PR DESCRIPTION
## Summary of the pull request
* Move `<Configurations>Debug;Release;Debug_FailFast</Configurations>` into `Directory.Build.props` so that each individual project doesn't need to specify it
* Move the defined constants for `Debug` and `Debug_FailFast` configurations into `Directory.Build.props` so that each individual project doesn't need to specify it but can rely on it (similar to #3574)
* COM servers built with `Debug_FailFast` were building as a Windows app (not writing to separate cmd window) since the condition was being overwritten. Change how we specify when to build as console app and when to build as Windows app to check for Release configuration, rather than Debug

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
