### PR TITLE
Fix possible crash navigating away from Dashboard

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -145,7 +145,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private async Task OnUnloadedAsync()
     {
         _log.Debug($"Unloading Dashboard, cancel any loading.");
-        _initWidgetsCancellationTokenSource.Cancel();
+        _initWidgetsCancellationTokenSource?.Cancel();
         ViewModel.PinnedWidgets.CollectionChanged -= OnPinnedWidgetsCollectionChangedAsync;
         Bindings.StopTracking();
 


### PR DESCRIPTION
## Summary of the pull request
If something terrible happens during Dashboard startup and the `_initWidgetsCancellationTokenSource` in not initialized, then cancelling it when we move away from the Dashboard can cause a crash. Check that the object is initialized before trying to use it.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
