### PR TITLE
fix hyper-v unit tests

### DIFF
--- a/extensions/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVManagerTest.cs
+++ b/extensions/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVManagerTest.cs
@@ -16,58 +16,24 @@ namespace HyperVExtension.UnitTest.HyperVExtensionTests.Services;
 public class HyperVManagerTest : HyperVExtensionTestsBase
 {
     [TestMethod]
-    [ExpectedException(typeof(HyperVAdminGroupException))]
-    public void StartVirtualMachineManagementServiceFailsWhenUserNotInHyperVAdminGroup()
-    {
-        // Arrange
-        SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
-        var hyperVManager = TestHost.GetService<IHyperVManager>();
-        var identityService = TestHost.GetService<IWindowsIdentityService>() as WindowsIdentityServiceMock;
-        identityService!.SecuritySidIdentifier = string.Empty;
-        SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); });
-
-        // Assert
-        hyperVManager.StartVirtualMachineManagementService();
-    }
-
-    [TestMethod]
-    [ExpectedException(typeof(HyperVModuleNotLoadedException))]
-    public void StartVirtualMachineManagementServiceFailsWhenModuleNotLoaded()
-    {
-        // Arrange
-        SetupHyperVTestMethod(string.Empty, ServiceControllerStatus.Running);
-        var hyperVManager = TestHost.GetService<IHyperVManager>();
-        SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); });
-
-        // Assert
-        hyperVManager.StartVirtualMachineManagementService();
-    }
-
-    [TestMethod]
     public void StartVirtualMachineManagementServiceDoesNotThrowWhenServiceIsRunning()
     {
         // Arrange
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
-        SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); });
 
         // If no exceptions are thrown, the service was started successfully
         hyperVManager.StartVirtualMachineManagementService();
     }
 
     [TestMethod]
-    [ExpectedException(typeof(TimeoutException))]
+    [ExpectedException(typeof(VirtualMachineManagementServiceException))]
     public void StartVirtualMachineManagementServiceThrowsExceptionWhenServiceNotRunning()
     {
         // Make sure the service appears to be stopped the next time we create an instance
         // of the IWindowsServiceController.
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Stopped);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
-        SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); });
 
         // Assert
         hyperVManager.StartVirtualMachineManagementService();
@@ -80,7 +46,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(null); });
 
         // Act
@@ -99,7 +64,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() =>
             {
                 // get two virtual machines.
@@ -125,7 +89,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         var expectedVmGuid = Guid.NewGuid();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() =>
             {
                 // get VM with Id = expectedVmGuid
@@ -147,7 +110,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() =>
             {
                 // VM returned so we can check the state.
@@ -168,7 +130,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() =>
             {
                 // Return VM that is in the off state.
@@ -188,7 +149,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock { State = HyperVState.Saved, }); });
 
         // Act
@@ -205,7 +165,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock { State = HyperVState.Running, }); });
 
         // Act
@@ -222,7 +181,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock { State = HyperVState.Paused, }); });
 
         // Act
@@ -239,7 +197,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock { State = HyperVState.Running, }); });
 
         // Act
@@ -256,7 +213,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock { IsDeleted = true, }); });
 
         // Act
@@ -281,7 +237,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
             ParentCheckpointName = "TestCheckpointParent",
         });
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() =>
             {
                 // Simulate PowerShell returning a checkpoint.
@@ -305,11 +260,10 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         var expectedCheckpointGuid = Guid.NewGuid();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock()); })
             .Returns(() =>
             {
-                // Simulate PowerShell returning a VM whole parent checkpoint Id is now the Checkpoint Id of the one passed in.
+                // Simulate PowerShell returning a VM whose parent checkpoint Id is now the Checkpoint Id of the one passed in.
                 return CreatePSObjectCollection(new PSCustomObjectMock { ParentCheckpointId = expectedCheckpointGuid });
             });
 
@@ -327,7 +281,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         var initialCheckpointGuid = Guid.NewGuid();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock()); })
             .Returns(() =>
             {
@@ -349,7 +302,6 @@ public class HyperVManagerTest : HyperVExtensionTestsBase
         var hyperVManager = TestHost.GetService<IHyperVManager>();
         var newCheckpointId = Guid.NewGuid();
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() =>
             {
                 // Simulate PowerShell returning the new Checkpoint for the VM.

--- a/extensions/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVProviderTests.cs
+++ b/extensions/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVProviderTests.cs
@@ -61,10 +61,7 @@ public class HyperVProviderTests : HyperVExtensionTestsBase
             });
 
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); }) // first call to load HyperV module
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); }) // second call to load HyperV module
             .Returns(() => { return objectForVirtualMachineHost; })
-            .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock()); }) // call CreateVirtualMachineFromGallery which initially tries to load hyperV module
             .Returns(() => { return objectForVirtualMachine; })
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock()); }) // Calls Set-VMMemory to set VM startup memory but we don't need to check it
             .Returns(() => { return CreatePSObjectCollection(new PSCustomObjectMock()); }); // Calls Set-VMProcessor to set VM processor count but we don't need to check it

--- a/extensions/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVVirtualMachineTest.cs
+++ b/extensions/HyperVExtension/test/HyperVExtension/HyperVExtensionTests/Services/HyperVVirtualMachineTest.cs
@@ -48,8 +48,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Running;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -72,8 +70,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Off;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -96,8 +92,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Off;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -119,7 +113,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         SetupHyperVTestMethod(HyperVStrings.HyperVModuleName, ServiceControllerStatus.Running);
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObjectAfterDeletion);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -142,8 +135,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Saved;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -166,8 +157,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Paused;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -190,8 +179,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Running;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
-            .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -214,7 +201,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Running;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psCheckpointAfterItWasCreated);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
         var hyperVManager = TestHost!.GetService<IHyperVManager>();
@@ -237,7 +223,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         _psVirtualMachineObject.State = HyperVState.Running;
         var expectedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return expectedPsObjectCollection; })
             .Returns(() => { return expectedPsObjectCollection; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;
@@ -262,7 +247,6 @@ public class HyperVVirtualMachineTest : HyperVExtensionTestsBase
         var initialReturnedPsObjectCollection = CreatePSObjectCollection(_psVirtualMachineObject);
         var psObjectCollectionReturnedAfterDeletion = CreatePSObjectCollection(_psVirtualMachineObjectAfterDeletingCheckpoint);
         SetupPowerShellSessionInvokeResults()
-            .Returns(() => { return CreatePSObjectCollection(PowerShellHyperVModule); })
             .Returns(() => { return initialReturnedPsObjectCollection; })
             .Returns(() => { return psObjectCollectionReturnedAfterDeletion; });
         var expectedProviderOperationStatus = ProviderOperationStatus.Success;


### PR DESCRIPTION
## Summary of the pull request
Due to previous changes in the Hyper-V extension the old unit tests needed to be updated. This PR updates the unit tests so that they are all passing now

Changes:
- Before Build 24 we attempted to load the Hyper-V PowerShell twice module before attempting to invoke any Hyper-V PowerShell cmdlet. However, we've since removed that call so the unit tests need to reflect this removal.
- Since we no longer attempt to load the module, the unit tests for loading the module can be removed.
- Also during that time we moved the call to check if the user is in the Hyper-V admin group outside of the [StartVirtualMachineManagementService method](https://github.com/microsoft/devhome/blob/cc8cc56d87366dfa0f1a4cb0f12f726b02660875/extensions/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs#L57). So the unit test that tested it in the StartVirtualMachineManagementService method is removed in this PR.

Validation after running the unit tests in VS test explorer:
![Unit test results 1](https://github.com/user-attachments/assets/3007cb95-7d23-4254-97f4-af087169d340)
![Unit test results 2](https://github.com/user-attachments/assets/e32dede4-7c7f-4986-95c8-29a439af7d85)

## References and relevant issues
Note: In the future we're planning on moving away from PowerShell to WMI via issue #2958  So these unit tests will need to be updated. But for now, its better to make sure they're all still passing before then.
## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
