### PR TITLE
Render links as hyperlinks in TextBlock

### DIFF
--- a/common/Behaviors/RenderWebHyperlinksBehavior.cs
+++ b/common/Behaviors/RenderWebHyperlinksBehavior.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.Xaml.Interactivity;
+
+namespace DevHome.Common.Behaviors;
+
+/// <summary>
+/// A behavior that renders http and https hyperlinks in a <see cref="TextBlock"/>.
+/// </summary>
+public partial class RenderWebHyperlinksBehavior : Behavior<TextBlock>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.Loaded += OnLoaded;
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        AssociatedObject.Loaded -= OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        SetInlineCollection(ToInline(AssociatedObject.Text));
+    }
+
+    private List<Inline> ToInline(string text)
+    {
+        List<Inline> elements = [];
+        if (string.IsNullOrEmpty(text))
+        {
+            return elements;
+        }
+
+        foreach (var part in WebUrlRegex().Split(text))
+        {
+            if (Uri.IsWellFormedUriString(part, UriKind.Absolute))
+            {
+                elements.Add(CreateHyperlink(part));
+            }
+            else
+            {
+                elements.Add(CreateRun(part));
+            }
+        }
+
+        return elements;
+    }
+
+    /// <summary>
+    /// Create a <see cref="Run"/> element.
+    /// </summary>
+    /// <param name="text">The text to display.</param>
+    /// <returns>The <see cref="Run"/> element.</returns>
+    protected Run CreateRun(string text) => new() { Text = text };
+
+    /// <summary>
+    /// Create a <see cref="Hyperlink"/> element.
+    /// </summary>
+    /// <param name="text">The text to display.</param>
+    /// <returns>The <see cref="Hyperlink"/> element.</returns>
+    protected Hyperlink CreateHyperlink(string text)
+    {
+        Hyperlink hyperlink = new()
+        {
+            NavigateUri = new Uri(text),
+        };
+        hyperlink.Inlines.Add(CreateRun(text));
+        return hyperlink;
+    }
+
+    /// <summary>
+    /// Set the <see cref="TextBlock.Inlines"/> collection.
+    /// </summary>
+    /// <param name="inlineCollection">The collection of <see cref="Inline"/> elements.</param>
+    protected void SetInlineCollection(IEnumerable<Inline> inlineCollection)
+    {
+        AssociatedObject.Inlines.Clear();
+        foreach (var inline in inlineCollection)
+        {
+            AssociatedObject.Inlines.Add(inline);
+        }
+    }
+
+    [GeneratedRegex(@"(https?://[^\s]+)")]
+    private static partial Regex WebUrlRegex();
+}

--- a/common/Behaviors/RenderWebHyperlinksBehavior.cs
+++ b/common/Behaviors/RenderWebHyperlinksBehavior.cs
@@ -30,10 +30,15 @@ public partial class RenderWebHyperlinksBehavior : Behavior<TextBlock>
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        SetInlineCollection(ToInline(AssociatedObject.Text));
+        SetInlineCollection(CreateInlines(AssociatedObject.Text));
     }
 
-    private List<Inline> ToInline(string text)
+    /// <summary>
+    /// Create a collection of <see cref="Inline"/> elements.
+    /// </summary>
+    /// <param name="text">The text to parse.</param>
+    /// <returns>The collection of <see cref="Inline"/> elements.</returns>
+    private List<Inline> CreateInlines(string text)
     {
         List<Inline> elements = [];
         if (string.IsNullOrEmpty(text))
@@ -43,9 +48,9 @@ public partial class RenderWebHyperlinksBehavior : Behavior<TextBlock>
 
         foreach (var part in WebUrlRegex().Split(text))
         {
-            if (Uri.IsWellFormedUriString(part, UriKind.Absolute))
+            if (Uri.TryCreate(part, UriKind.Absolute, out var uri))
             {
-                elements.Add(CreateHyperlink(part));
+                elements.Add(CreateHyperlink(part, uri));
             }
             else
             {
@@ -61,18 +66,19 @@ public partial class RenderWebHyperlinksBehavior : Behavior<TextBlock>
     /// </summary>
     /// <param name="text">The text to display.</param>
     /// <returns>The <see cref="Run"/> element.</returns>
-    protected Run CreateRun(string text) => new() { Text = text };
+    private Run CreateRun(string text) => new() { Text = text };
 
     /// <summary>
     /// Create a <see cref="Hyperlink"/> element.
     /// </summary>
     /// <param name="text">The text to display.</param>
+    /// <param name="uri">The URI to navigate to.</param>
     /// <returns>The <see cref="Hyperlink"/> element.</returns>
-    protected Hyperlink CreateHyperlink(string text)
+    private Hyperlink CreateHyperlink(string text, Uri uri)
     {
         Hyperlink hyperlink = new()
         {
-            NavigateUri = new Uri(text),
+            NavigateUri = uri,
         };
         hyperlink.Inlines.Add(CreateRun(text));
         return hyperlink;
@@ -82,7 +88,7 @@ public partial class RenderWebHyperlinksBehavior : Behavior<TextBlock>
     /// Set the <see cref="TextBlock.Inlines"/> collection.
     /// </summary>
     /// <param name="inlineCollection">The collection of <see cref="Inline"/> elements.</param>
-    protected void SetInlineCollection(IEnumerable<Inline> inlineCollection)
+    private void SetInlineCollection(IEnumerable<Inline> inlineCollection)
     {
         AssociatedObject.Inlines.Clear();
         foreach (var inline in inlineCollection)

--- a/docs/tools/common/Readme.md
+++ b/docs/tools/common/Readme.md
@@ -10,6 +10,9 @@ List of common controls that are generic, customizable and reusable from all pag
 - [CloseButton](./CloseButton.md)
 - [ExperimentControl](./ExperimentControl.md)
 
+## Behaviors
+- [RenderWebHyperlinksBehavior](./RenderWebHyperlinksBehavior.md)
+
 ## File dialog
 > [!NOTE]
 > File picker fails when running the application as admin.

--- a/docs/tools/common/RenderWebHyperlinksBehavior.md
+++ b/docs/tools/common/RenderWebHyperlinksBehavior.md
@@ -1,5 +1,5 @@
 # RenderWebHyperlinksBehavior behavior
-A behavior that can be attached to a `TextBloc`k control to render `http[s]` hyperlinks in the text. The behavior uses a regular expression to find hyperlinks in the text and converts them to clickable hyperlinks.
+A behavior that can be attached to a `TextBlock` control to render `http[s]` hyperlinks in the text. The behavior uses a regular expression to find hyperlinks in the text and converts them to clickable hyperlinks.
 
 ## Example
 ```xml

--- a/docs/tools/common/RenderWebHyperlinksBehavior.md
+++ b/docs/tools/common/RenderWebHyperlinksBehavior.md
@@ -1,0 +1,11 @@
+# RenderWebHyperlinksBehavior behavior
+A behavior that can be attached to a `TextBloc`k control to render `http[s]` hyperlinks in the text. The behavior uses a regular expression to find hyperlinks in the text and converts them to clickable hyperlinks.
+
+## Example
+```xml
+<TextBlock Text="This is a hyperlink: https://www.microsoft.com">
+    <i:Interaction.Behaviors>
+        <behaviors:RenderWebHyperlinksBehavior />
+    </i:Interaction.Behaviors>
+</TextBlock>
+```

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryAppInstallationNotes.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryAppInstallationNotes.xaml
@@ -7,6 +7,8 @@
     xmlns:local="using:DevHome.SetupFlow.Views.Summary"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="using:DevHome.SetupFlow.ViewModels"
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
     mc:Ignorable="d">
 
     <Grid>
@@ -56,7 +58,11 @@
                                     Tag="{Binding ElementName=ViewAllButton}"
                                     Text="{x:Bind InstallationNotes}"
                                     TextTrimming="WordEllipsis"
-                                    TextWrapping="WrapWholeWords" />
+                                    TextWrapping="WrapWholeWords">
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:RenderWebHyperlinksBehavior />
+                                    </i:Interaction.Behaviors>
+                                </TextBlock>
                                 <Button
                                     Name="ViewAllButton"
                                     x:Uid="SummaryPage_ViewAll"

--- a/tools/SetupFlow/DevHome.SetupFlow/Windows/InstallationNotesWindow.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Windows/InstallationNotesWindow.xaml
@@ -5,6 +5,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:windows="using:DevHome.Common.Windows"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:behaviors="using:DevHome.Common.Behaviors"
     IsTopLevel="True"
     MinHeight="385"
     Height="385"
@@ -17,6 +19,10 @@
 
     <StackPanel Padding="24,0">
         <TextBlock Padding="0,8" Style="{ThemeResource SubtitleTextBlockStyle}" Text="{x:Bind PackageTitle}"/>
-        <TextBlock Grid.Row="1" IsTextSelectionEnabled="True" Text="{x:Bind InstallationNotes}" TextWrapping="WrapWholeWords"/>
+        <TextBlock Grid.Row="1" IsTextSelectionEnabled="True" Text="{x:Bind InstallationNotes}" TextWrapping="WrapWholeWords">
+            <i:Interaction.Behaviors>
+                <behaviors:RenderWebHyperlinksBehavior />
+            </i:Interaction.Behaviors>
+        </TextBlock>
     </StackPanel>
 </windows:SecondaryWindow>


### PR DESCRIPTION
## Summary of the pull request
- Added behavior class `RenderWebHyperlinksBehavior` to render http and https links in a `TextBlock`

![image](https://github.com/user-attachments/assets/ac2fb60d-6d16-456b-88de-57173f7abcc3)

## References and relevant issues
- https://task.ms/46550428

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
