### PR TITLE
Disallow user from adding widgets if the WidgetService isn't started

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetHostingService.cs
@@ -131,7 +131,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error(ex, "Exception in GetWidgetDefinitionAsync:");
+                _log.Error(ex, "Exception in GetWidgetCatalogAsync:");
                 _widgetCatalog = null;
             }
         }
@@ -161,7 +161,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error(ex, "Exception in GetWidgetDefinitionAsync:");
+                _log.Error(ex, "Exception in GetProviderDefinitionsAsync:");
             }
         }
 
@@ -190,7 +190,7 @@ public class WidgetHostingService : IWidgetHostingService
             }
             catch (Exception ex)
             {
-                _log.Error(ex, "Exception in GetWidgetDefinitionAsync:");
+                _log.Error(ex, "Exception in GetWidgetDefinitionsAsync:");
             }
         }
 

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -25,7 +25,7 @@ public partial class DashboardViewModel : ObservableObject
     private bool _isLoading;
 
     [ObservableProperty]
-    private bool _hasWidgetService;
+    private bool _hasWidgetServiceInitialized;
 
     public DashboardViewModel(
         IWidgetServiceService widgetServiceService,
@@ -43,7 +43,7 @@ public partial class DashboardViewModel : ObservableObject
 
     public Visibility GetNoWidgetMessageVisibility(int widgetCount, bool isLoading)
     {
-        return (widgetCount == 0 && !isLoading && HasWidgetService) ? Visibility.Visible : Visibility.Collapsed;
+        return (widgetCount == 0 && !isLoading && HasWidgetServiceInitialized) ? Visibility.Visible : Visibility.Collapsed;
     }
 
     public bool IsRunningAsAdmin()

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -60,7 +60,7 @@
                     x:Uid="AddWidget"
                     HorizontalAlignment="Right"
                     Command="{x:Bind AddWidgetClickCommand}"
-                    IsEnabled="{x:Bind ViewModel.HasWidgetService, Mode=OneWay}"/>
+                    IsEnabled="{x:Bind ViewModel.HasWidgetServiceInitialized, Mode=OneWay}"/>
             </StackPanel>
         </Grid>
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -195,9 +195,10 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         else if (ViewModel.WidgetServiceService.CheckForWidgetServiceAsync())
         {
-            ViewModel.HasWidgetService = true;
             if (await SubscribeToWidgetCatalogEventsAsync())
             {
+                ViewModel.HasWidgetServiceInitialized = true;
+
                 var isFirstDashboardRun = !(await _localSettingsService.ReadSettingAsync<bool>(WellKnownSettingsKeys.IsNotFirstDashboardRun));
                 _log.Information($"Is first dashboard run = {isFirstDashboardRun}");
                 if (isFirstDashboardRun)

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -86,6 +86,7 @@ public partial class DashboardView : ToolPage, IDisposable
             var widgetCatalog = await ViewModel.WidgetHostingService.GetWidgetCatalogAsync();
             if (widgetCatalog == null)
             {
+                _log.Error("Error in in SubscribeToWidgetCatalogEvents, widgetCatalog == null");
                 return false;
             }
 


### PR DESCRIPTION
## Summary of the pull request
If the WidgetService can't start, then we shouldn't let the user try to add widgets. Instead of checking a variable `HasWidgetService`, change it to `HasWidgetServiceInitialized` which only is true if actual calls to the WidgetService have succeeded.

Also fix the logging on some errors.

## References and relevant issues
Mitigates #3594

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
