### PR TITLE
[File Explorer Source Control Integration] Add subheading and open folder in File Explorer functionality

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -389,7 +389,7 @@
     <value>A restart may be required for long path changes to take effect.</value>
     <comment>Message instructing the user to restart their machine to apply changes</comment>
   </data>
-   <data name="AddRepositoriesTextBlock.Text" xml:space="preserve">
+  <data name="AddRepositoriesTextBlock.Text" xml:space="preserve">
     <value>Add repositories</value>
     <comment>Header for the add repositories user experience for file explorer source control integration</comment>
   </data>
@@ -410,15 +410,15 @@
     <comment>Default value for provider selector</comment>
   </data>
   <data name="RemoveFolder.Text" xml:space="preserve">
-    <value>Remove</value>
+    <value>Remove from list</value>
     <comment>Click to remove a folder path from source control integration</comment>
   </data>
   <data name="MenuFlyoutUnregisteredRepository_Content" xml:space="preserve">
     <value>Unassigned</value>
     <comment>This is the content string displayed when a repository is added in the File Explorer Settings page but no source control provider has been selected. </comment>
   </data>
-  <data name="RemoveRepository.Text" xml:space="preserve">
-    <value>Enter path to remove an enhanced repository</value>
-    <comment>The text for removing a repository from source control integration</comment>
+  <data name="OpenFolderInFileExplorer.Text" xml:space="preserve">
+    <value>Open in File Explorer</value>
+    <comment>Click to open the folder path inside File Explorer </comment>
   </data>
 </root>

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -29,7 +29,7 @@
                 <DataTemplate>
                     <ctControls:SettingsCard 
                         Header="{Binding RepositoryRootPath}"
-                        Description ="{Binding SourceControlProviderDisplayName}"
+                        Description="{Binding SourceControlProviderDisplayName}"
                         Margin="0">
                         <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon 

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -29,6 +29,7 @@
                 <DataTemplate>
                     <ctControls:SettingsCard 
                         Header="{Binding RepositoryRootPath}"
+                        Description ="{Binding SourceControlProviderDisplayName}"
                         Margin="0">
                         <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon 
@@ -63,6 +64,9 @@
                                         <MenuFlyoutItem
                                             x:Uid="RemoveFolder"
                                             Click="RemoveFolderButton_Click" />
+                                        <MenuFlyoutItem
+                                            x:Uid="OpenFolderInFileExplorer"
+                                            Click="OpenFolderInFileExplorer_Click" />
                                     </MenuFlyout>
                                 </Button.Flyout>
                             </Button>

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
@@ -49,8 +49,8 @@ public sealed partial class AddRepositoriesView : UserControl
 
     public void OpenFolderInFileExplorer_Click(object sender, RoutedEventArgs e)
     {
-        MenuFlyoutItem menuItem = (MenuFlyoutItem)sender;
-        if (menuItem.DataContext is RepositoryInformation repoInfo)
+        MenuFlyoutItem? menuItem = sender as MenuFlyoutItem;
+        if (menuItem?.DataContext is RepositoryInformation repoInfo)
         {
             try
             {

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
@@ -1,17 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using DevHome.Common.Extensions;
-using DevHome.Common.Services;
 using DevHome.Customization.Models;
 using DevHome.Customization.ViewModels;
+using DevHome.FileExplorerSourceControlIntegration.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Serilog;
 
 namespace DevHome.Customization.Views;
 
 public sealed partial class AddRepositoriesView : UserControl
 {
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(AddRepositoriesView));
+
     public FileExplorerViewModel ViewModel
     {
         get;
@@ -40,6 +44,30 @@ public sealed partial class AddRepositoriesView : UserControl
         if (menuItem.DataContext is RepositoryInformation repoInfo)
         {
             ViewModel.AssignSourceControlProviderToRepository(menuItem.Text, repoInfo.RepositoryRootPath);
+        }
+    }
+
+    public void OpenFolderInFileExplorer_Click(object sender, RoutedEventArgs e)
+    {
+        // Extract relevant data from view and give to view model for assign
+        MenuFlyoutItem menuItem = (MenuFlyoutItem)sender;
+        if (menuItem.DataContext is RepositoryInformation repoInfo)
+        {
+            try
+            {
+                // Open folder in file explorer
+                System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    Arguments = repoInfo.RepositoryRootPath,
+                };
+
+                System.Diagnostics.Process.Start(startInfo);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to open folder in file explorer");
+            }
         }
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
@@ -49,7 +49,6 @@ public sealed partial class AddRepositoriesView : UserControl
 
     public void OpenFolderInFileExplorer_Click(object sender, RoutedEventArgs e)
     {
-        // Extract relevant data from view and give to view model for assign
         MenuFlyoutItem menuItem = (MenuFlyoutItem)sender;
         if (menuItem.DataContext is RepositoryInformation repoInfo)
         {


### PR DESCRIPTION
## Summary of the pull request
UX changes

## References and relevant issues

## Detailed description of the pull request / Additional comments
This PR adds a subheading that specifies the source control extension the repository path is registered to (if any). This PR also adds a menu option to open the repository root path in File Explorer. 

<img width="758" alt="image" src="https://github.com/user-attachments/assets/e651557f-9db1-41b1-98c8-e2db9968c20d">


## Validation steps performed
Build of msix package
Validated UX functionality

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
