### PR TITLE
Fix Dev Home hang/crash on registration exception from FileExplorer.ExtraFolderPropertiesWrapper

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -209,7 +209,7 @@ public partial class FileExplorerViewModel : ObservableObject
             }
             catch (Exception ex)
             {
-                _log.Error(ex, "An error occurred while registering folder for File Explorer source control integration");
+                _log.Error(ex, "An exception occurred while registering folder for File Explorer source control integration");
             }
 
             RepoTracker.ModifySourceControlProviderForTrackedRepository(extensionCLSID, rootPath);

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -198,11 +198,18 @@ public partial class FileExplorerViewModel : ObservableObject
                 return;
             }
 
-            var wrapperResult = ExtraFolderPropertiesWrapper.Register(rootPath, typeof(SourceControlProvider).GUID);
-            if (!wrapperResult.Succeeded)
+            try
             {
-                _log.Error(wrapperResult.ExtendedError, "Failed to register folder for source control integration");
-                return;
+                var wrapperResult = ExtraFolderPropertiesWrapper.Register(rootPath, typeof(SourceControlProvider).GUID);
+                if (!wrapperResult.Succeeded)
+                {
+                    _log.Error(wrapperResult.ExtendedError, "Failed to register folder for source control integration");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "An error occurred while registering folder for File Explorer source control integration");
             }
 
             RepoTracker.ModifySourceControlProviderForTrackedRepository(extensionCLSID, rootPath);


### PR DESCRIPTION
## Summary of the pull request
Add try/catch to prevent Dev Home crash

## References and relevant issues

## Detailed description of the pull request / Additional comments
If Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer.ExtraFolderPropertiesWrapper.Register throws an exception, it will cause Dev Home to hang and eventually crash. This PR adds a try/catch to gracefully handle this scenario. 


## Validation steps performed
Build of msix package
Validation of msix in VM

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
