### PR TITLE
Fix focus transition issues related to dialogs and UAC in Virtualization

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -317,11 +317,11 @@
     <value>Apply</value>
     <comment>Apply changes to feature state.</comment>
   </data>
-  <data name="CommittingChangesTitle" xml:space="preserve">
+  <data name="ModifyFeaturesDialog.Title" xml:space="preserve">
     <value>Committing changes</value>
     <comment>Title displayed during the process of applying changes</comment>
   </data>
-  <data name="CommittingChangesMessage" xml:space="preserve">
+  <data name="ModifyFeaturesDialogMessage.Text" xml:space="preserve">
     <value>Please wait for the changes to take effect.</value>
     <comment>Message indicating the user should wait for the changes to be applied</comment>
   </data>
@@ -329,11 +329,15 @@
     <value>Restart now</value>
     <comment>Button text to restart the system immediately</comment>
   </data>
-  <data name="CancelButtonText" xml:space="preserve">
+  <data name="ModifyFeaturesDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Restart now</value>
+    <comment>Button text to restart the system immediately</comment>
+  </data>
+  <data name="ModifyFeaturesDialog.SecondaryButtonText" xml:space="preserve">
     <value>Cancel</value>
     <comment>Button text to cancel the current operation</comment>
   </data>
-  <data name="RestartRequiredTitle" xml:space="preserve">
+  <data name="RestartDialog.Title" xml:space="preserve">
     <value>Restart required</value>
     <comment>Title displayed when a restart is required to apply changes</comment>
   </data>
@@ -341,7 +345,15 @@
     <value>Please restart your machine for your applied changes to take effect.</value>
     <comment>Message instructing the user to restart their machine to apply changes</comment>
   </data>
-  <data name="DontRestartNowButtonText" xml:space="preserve">
+  <data name="RestartRequiredDialogMessage.Text" xml:space="preserve">
+    <value>Please restart your machine for your applied changes to take effect.</value>
+    <comment>Message instructing the user to restart their machine to apply changes</comment>
+  </data>
+  <data name="RestartDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Restart now</value>
+    <comment>Button text to restart the system immediately</comment>
+  </data>
+  <data name="RestartDialog.SecondaryButtonText" xml:space="preserve">
     <value>Don't restart now</value>
     <comment>Button text to postpone system restart</comment>
   </data>

--- a/tools/Customization/DevHome.Customization/ViewModels/ModifyFeaturesDialogViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/ModifyFeaturesDialogViewModel.cs
@@ -3,102 +3,20 @@
 
 using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using DevHome.Common.Helpers;
-using DevHome.Common.Services;
 
 namespace DevHome.Customization.ViewModels;
 
 public partial class ModifyFeaturesDialogViewModel : ObservableObject
 {
-    private readonly StringResource _stringResource;
-
-    private readonly IAsyncRelayCommand _applyChangesCommand;
-
     private CancellationTokenSource? _cancellationTokenSource;
-
-    public enum State
-    {
-        Initial,
-        CommittingChanges,
-        Complete,
-    }
-
-    [ObservableProperty]
-    private State _currentState = State.Initial;
-
-    public ModifyFeaturesDialogViewModel(IAsyncRelayCommand applyChangedCommand)
-    {
-        _stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
-        _applyChangesCommand = applyChangedCommand;
-    }
-
-    [ObservableProperty]
-    private string _title = string.Empty;
-
-    [ObservableProperty]
-    private string _message = string.Empty;
-
-    [ObservableProperty]
-    private string _primaryButtonText = string.Empty;
-
-    [ObservableProperty]
-    private string _secondaryButtonText = string.Empty;
-
-    [ObservableProperty]
-    private bool _isPrimaryButtonEnabled;
-
-    [ObservableProperty]
-    private bool _isSecondaryButtonEnabled;
-
-    [ObservableProperty]
-    private bool _showProgress;
 
     public void SetCommittingChanges(CancellationTokenSource cancellationTokenSource)
     {
-        CurrentState = State.CommittingChanges;
-
         _cancellationTokenSource = cancellationTokenSource;
-        IsPrimaryButtonEnabled = false;
-        IsSecondaryButtonEnabled = true;
-        ShowProgress = true;
-        Title = _stringResource.GetLocalized("CommittingChangesTitle");
-        Message = _stringResource.GetLocalized("CommittingChangesMessage");
-        PrimaryButtonText = _stringResource.GetLocalized("RestartNowButtonText");
-        SecondaryButtonText = _stringResource.GetLocalized("CancelButtonText");
     }
 
-    public void SetCompleteRestartRequired()
+    internal void HandleCancel()
     {
-        CurrentState = State.Complete;
-
-        _cancellationTokenSource = null;
-        IsPrimaryButtonEnabled = true;
-        IsSecondaryButtonEnabled = true;
-        ShowProgress = false;
-        Title = _stringResource.GetLocalized("RestartRequiredTitle");
-        Message = _stringResource.GetLocalized("RestartRequiredMessage");
-        PrimaryButtonText = _stringResource.GetLocalized("RestartNowButtonText");
-        SecondaryButtonText = _stringResource.GetLocalized("DontRestartNowButtonText");
-    }
-
-    internal void HandlePrimaryButton()
-    {
-        switch (CurrentState)
-        {
-            case State.Complete:
-                RestartHelper.RestartComputer();
-                break;
-        }
-    }
-
-    internal void HandleSecondaryButton()
-    {
-        switch (CurrentState)
-        {
-            case State.CommittingChanges:
-                _cancellationTokenSource?.Cancel();
-                break;
-        }
+        _cancellationTokenSource?.Cancel();
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/ModifyFeaturesDialog.xaml
+++ b/tools/Customization/DevHome.Customization/Views/ModifyFeaturesDialog.xaml
@@ -16,7 +16,7 @@
         MinHeight="40"
         Spacing="20">
         <TextBlock
-             x:Uid="ms-resource:///DevHome.Customization/Resources/ModifyFeaturesDialogMessage"
+            x:Uid="ModifyFeaturesDialogMessage"
             TextWrapping="WrapWholeWords"/>
         <ProgressBar
             IsIndeterminate="True"

--- a/tools/Customization/DevHome.Customization/Views/ModifyFeaturesDialog.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/ModifyFeaturesDialog.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using CommunityToolkit.Mvvm.Input;
 using DevHome.Customization.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 
@@ -11,20 +10,15 @@ public sealed partial class ModifyFeaturesDialog : ContentDialog
 {
     public ModifyFeaturesDialogViewModel ViewModel { get; }
 
-    public ModifyFeaturesDialog(IAsyncRelayCommand applyChangedCommand)
+    public ModifyFeaturesDialog()
     {
-        ViewModel = new ModifyFeaturesDialogViewModel(applyChangedCommand);
+        ViewModel = new ModifyFeaturesDialogViewModel();
         this.InitializeComponent();
         this.DataContext = ViewModel;
     }
 
-    private void OnPrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    private void OnCancelClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        ViewModel.HandlePrimaryButton();
-    }
-
-    private void OnSecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
-    {
-        ViewModel.HandleSecondaryButton();
+        ViewModel.HandleCancel();
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml
+++ b/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml
@@ -17,7 +17,7 @@
         MinHeight="40"
         Spacing="20">
         <TextBlock
-            x:Uid="ms-resource:///DevHome.Customization/Resources/RestartRequiredDialogMessage"
+            x:Uid="RestartRequiredDialogMessage"
             TextWrapping="WrapWholeWords"/>
     </StackPanel>
 </ContentDialog>

--- a/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml
+++ b/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml
@@ -1,13 +1,14 @@
 <ContentDialog
-    x:Class="DevHome.Customization.Views.ModifyFeaturesDialog"
+    x:Class="DevHome.Customization.Views.RestartDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    x:Uid="ms-resource:///DevHome.Customization/Resources/ModifyFeaturesDialog"
+    x:Uid="ms-resource:///DevHome.Customization/Resources/RestartDialog"
     Style="{ThemeResource DefaultContentDialogStyle}"
     DefaultButton="Primary"
     PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
-    IsPrimaryButtonEnabled="False"
-    SecondaryButtonClick="OnCancelClick">
+    IsPrimaryButtonEnabled="True"
+    IsSecondaryButtonEnabled="True"
+    PrimaryButtonClick="OnRestartClick">
     <!-- Give the StackPanel content a min width and height to make the dialog have a consistent
          size whether the ProgressBar is visible or not. -->
     <StackPanel
@@ -16,10 +17,7 @@
         MinHeight="40"
         Spacing="20">
         <TextBlock
-             x:Uid="ms-resource:///DevHome.Customization/Resources/ModifyFeaturesDialogMessage"
+            x:Uid="ms-resource:///DevHome.Customization/Resources/RestartRequiredDialogMessage"
             TextWrapping="WrapWholeWords"/>
-        <ProgressBar
-            IsIndeterminate="True"
-            Height="4"/>
     </StackPanel>
 </ContentDialog>

--- a/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using DevHome.Common.Helpers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DevHome.Customization.Views;
+
+public sealed partial class RestartDialog : ContentDialog
+{
+    public RestartDialog()
+    {
+        this.InitializeComponent();
+    }
+
+    private void OnRestartClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        RestartHelper.RestartComputer();
+    }
+}


### PR DESCRIPTION
## Summary of the pull request
This change ensures the narrator reads the committing changes and restart dialog without manual reapplication of focus.

The progress modal dialog is disrupted by a race with the UAC prompt focusing the narrator. Additionally, having one content dialog that shares two presentations make this difficult to orchestrate with focus and accessibility, to simplify things, the modify features dialog is split:

- One dialog hosts the committing changes and is shown immediately after starting to apply features, removing the race condition with the UAC dialog.
- Another dialog for the restart action is shown after the process completes.


## References and relevant issues
#3639 

## Detailed description of the pull request / Additional comments

## Validation steps performed
Apply a feature with narrator enabled

## PR checklist
- [ ] Closes #3639 
- [ ] Tests added/passed
- [ ] Documentation updated
