### PR TITLE
Catching exceptions when selecting a folder.

### DIFF
--- a/common/Windows/FileDialog/WindowOpenFolderDialog.cs
+++ b/common/Windows/FileDialog/WindowOpenFolderDialog.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
-using Serilog;
 using Windows.Storage;
 using Windows.Win32;
 using Windows.Win32.System.Com;
@@ -14,8 +13,6 @@ namespace DevHome.Common.Windows.FileDialog;
 
 public class WindowOpenFolderDialog : WindowFileDialog
 {
-    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(WindowOpenFolderDialog));
-
     /// <inheritdoc />
     private protected override IFileDialog CreateInstance()
     {
@@ -31,21 +28,11 @@ public class WindowOpenFolderDialog : WindowFileDialog
 
     public async Task<StorageFolder?> ShowAsync(Window window)
     {
-        try
+        if (ShowOk(window))
         {
-            if (ShowOk(window))
-            {
-                FileDialog.GetResult(out var shellItem);
-                var folderPath = GetDisplayName(shellItem);
-
-                // GetFolderFromPathAsync will throw if the user does not have access to the
-                // folder.  One such example is a hidden folder.
-                return await StorageFolder.GetFolderFromPathAsync(folderPath).AsTask();
-            }
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex.ToString());
+            FileDialog.GetResult(out var shellItem);
+            var folderPath = GetDisplayName(shellItem);
+            return await StorageFolder.GetFolderFromPathAsync(folderPath).AsTask();
         }
 
         return null;

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -23,6 +23,7 @@ using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using Windows.Storage;
 
 namespace DevHome.Customization.ViewModels;
 
@@ -163,7 +164,17 @@ public partial class FileExplorerViewModel : ObservableObject
             await Task.Run(async () =>
             {
                 using var folderDialog = new WindowOpenFolderDialog();
-                var repoRootfolder = await folderDialog.ShowAsync(Application.Current.GetService<Window>());
+                StorageFolder? repoRootfolder = null;
+
+                try
+                {
+                    repoRootfolder = await folderDialog.ShowAsync(Application.Current.GetService<Window>());
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, $"Error occured when selecting a folder for adding a repository.");
+                }
+
                 if (repoRootfolder != null && repoRootfolder.Path.Length > 0)
                 {
                     _log.Information($"Selected '{repoRootfolder.Path}' as location to register");


### PR DESCRIPTION
## Summary of the pull request
[GetFolderFromPathAsync](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfolderfrompathasync?view=winrt-26100) can throw and will crash DevHome if not caught.  

One example is giving The File Explorer integration "Add Repository" button a path to a hidden folder. (I used the .git folder of a repository).


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Manually with the repro steps above.


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
