### PR TITLE
Initialize cancellation token in DashboardView constructor

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -52,7 +52,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private static DispatcherQueue _dispatcherQueue;
     private readonly ILocalSettingsService _localSettingsService;
     private readonly IWidgetExtensionService _widgetExtensionService;
-    private CancellationTokenSource _initWidgetsCancellationTokenSource;
+    private readonly CancellationTokenSource _initWidgetsCancellationTokenSource;
     private bool _disposedValue;
 
     private const string DraggedWidget = "DraggedWidget";
@@ -67,6 +67,8 @@ public partial class DashboardView : ToolPage, IDisposable
         this.InitializeComponent();
 
         ViewModel.PinnedWidgets.CollectionChanged += OnPinnedWidgetsCollectionChangedAsync;
+
+        _initWidgetsCancellationTokenSource = new();
 
         _dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
         _localSettingsService = Application.Current.GetService<ILocalSettingsService>();
@@ -206,7 +208,6 @@ public partial class DashboardView : ToolPage, IDisposable
                     await _localSettingsService.SaveSettingAsync(WellKnownSettingsKeys.IsNotFirstDashboardRun, true);
                 }
 
-                _initWidgetsCancellationTokenSource = new();
                 try
                 {
                     await InitializePinnedWidgetListAsync(isFirstDashboardRun, _initWidgetsCancellationTokenSource.Token);

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -52,7 +52,7 @@ public partial class DashboardView : ToolPage, IDisposable
     private static DispatcherQueue _dispatcherQueue;
     private readonly ILocalSettingsService _localSettingsService;
     private readonly IWidgetExtensionService _widgetExtensionService;
-    private readonly CancellationTokenSource _initWidgetsCancellationTokenSource;
+    private readonly CancellationTokenSource _initWidgetsCancellationTokenSource = new();
     private bool _disposedValue;
 
     private const string DraggedWidget = "DraggedWidget";
@@ -67,8 +67,6 @@ public partial class DashboardView : ToolPage, IDisposable
         this.InitializeComponent();
 
         ViewModel.PinnedWidgets.CollectionChanged += OnPinnedWidgetsCollectionChangedAsync;
-
-        _initWidgetsCancellationTokenSource = new();
 
         _dispatcherQueue = Application.Current.GetService<DispatcherQueue>();
         _localSettingsService = Application.Current.GetService<ILocalSettingsService>();


### PR DESCRIPTION
## Summary of the pull request
https://github.com/microsoft/devhome/pull/3619#discussion_r1723701139
There's still a race condition because `InitializeDashboard()` does some amount of non-trivial work before initializing `_initWidgetsCancellationTokenSource`. So it's possible that we could see this sequence:
- `OnLoadedAsync()` called, `InitializeDashboard()` starts running, `_initWidgetsCancellationTokenSource` still `null`.
- `OnUnloadedAsync()` called, `_initWidgetsCancellationTokenSource` still `null`, so no call to `Cancel()`.
- `InitializeDashboard()` finally reaches the point where it initializes `_initWidgetsCancellationTokenSource`, but because `OnUnloadedAsync()` is already finished, the cancellation never gets called.

Instead, we should initialize the cancellation token in the constructor, so even in this case `InitializeDashboard` will eventually see the cancellation.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
