### PR TITLE
Expect WidgetsPlatformRuntime on Windows 11

### DIFF
--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -54,7 +54,7 @@ public class InitializationViewModel : ObservableObject
         // Install the widget service if we're on Windows 10 and it's not already installed.
         try
         {
-            if (_widgetServiceService.CheckForWidgetServiceAsync())
+            if (_widgetServiceService.CheckForWidgetService())
             {
                 _log.Information("Skipping installing WidgetService, already installed.");
             }

--- a/src/ViewModels/InitializationViewModel.cs
+++ b/src/ViewModels/InitializationViewModel.cs
@@ -3,6 +3,7 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Extensions;
+using DevHome.Common.Helpers;
 using DevHome.Contracts.Services;
 using DevHome.Dashboard.Services;
 using DevHome.Services.Core.Contracts;
@@ -54,13 +55,14 @@ public class InitializationViewModel : ObservableObject
         // Install the widget service if we're on Windows 10 and it's not already installed.
         try
         {
-            if (_widgetServiceService.CheckForWidgetService())
+            var widgetStatus = _widgetServiceService.GetWidgetServiceState();
+            if (widgetStatus != WidgetServiceService.WidgetServiceStates.NotAtMinVersion)
             {
                 _log.Information("Skipping installing WidgetService, already installed.");
             }
             else
             {
-                if (_widgetServiceService.GetWidgetServiceState() == WidgetServiceService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion)
+                if (!RuntimeHelper.IsOnWindows11)
                 {
                     // We're on Windows 10 and don't have the widget service, try to install it.
                     await _widgetServiceService.TryInstallingWidgetService();
@@ -101,6 +103,8 @@ public class InitializationViewModel : ObservableObject
     private bool HasDevHomeGitHubExtensionInstalled()
     {
         var packages = _packageDeploymentService.FindPackagesForCurrentUser(GitHubExtensionPackageFamilyName);
+
+        // Don't check here if the package is ok, we'll do that later on the Dashboard.
         return packages.Any();
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -19,8 +19,8 @@ internal sealed class WidgetHelpers
 {
     public const string WebExperiencePackPackageId = "9MSSGKG348SP";
     public const string WebExperiencePackageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
-    public const string WidgetServiceStorePackageId = "9N3RK8ZV2ZR8";
-    public const string WidgetServicePackageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
+    public const string WidgetPlatformRuntimePackageId = "9N3RK8ZV2ZR8";
+    public const string WidgetPlatformRuntimePackageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
 
     public static readonly string[] DefaultWidgetDefinitionIds =
     {

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
@@ -8,6 +8,10 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetServiceService
 {
+    /// <summary>
+    /// Checks whether a WidgetService is installed on the machine.
+    /// </summary>
+    /// <returns>Returns true if there is a valid WidgetService that meets the minimum required version, otherwise false.</returns>
     public bool CheckForWidgetServiceAsync();
 
     public Task<bool> TryInstallingWidgetService();

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
@@ -12,7 +12,7 @@ public interface IWidgetServiceService
     /// Checks whether a WidgetService is installed on the machine.
     /// </summary>
     /// <returns>Returns true if there is a valid WidgetService that meets the minimum required version, otherwise false.</returns>
-    public bool CheckForWidgetServiceAsync();
+    public bool CheckForWidgetService();
 
     public Task<bool> TryInstallingWidgetService();
 

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetServiceService.cs
@@ -8,12 +8,6 @@ namespace DevHome.Dashboard.Services;
 
 public interface IWidgetServiceService
 {
-    /// <summary>
-    /// Checks whether a WidgetService is installed on the machine.
-    /// </summary>
-    /// <returns>Returns true if there is a valid WidgetService that meets the minimum required version, otherwise false.</returns>
-    public bool CheckForWidgetService();
-
     public Task<bool> TryInstallingWidgetService();
 
     public WidgetServiceStates GetWidgetServiceState();

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -37,15 +37,22 @@ public class WidgetServiceService : IWidgetServiceService
         _msStoreService = msStoreService;
     }
 
+    /// <inheritdoc/>
     public bool CheckForWidgetServiceAsync()
     {
-        // If we're on Windows 11, check if we have the right WebExperiencePack version of the WidgetService.
+        // If we're on Windows 11, check if we have a valid version of the WidgetService.
         if (RuntimeHelper.IsOnWindows11)
         {
             if (HasValidWebExperiencePack())
             {
                 _log.Information("On Windows 11, HasWebExperienceGoodVersion");
                 _widgetServiceState = WidgetServiceStates.HasWebExperienceGoodVersion;
+                return true;
+            }
+            else if (HasValidWidgetServicePackage())
+            {
+                _log.Information("On Windows 11, HasStoreWidgetServiceGoodVersion");
+                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceGoodVersion;
                 return true;
             }
             else

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -38,7 +38,7 @@ public class WidgetServiceService : IWidgetServiceService
     }
 
     /// <inheritdoc/>
-    public bool CheckForWidgetServiceAsync()
+    public bool CheckForWidgetService()
     {
         // If we're on Windows 11, check if we have a valid version of the WidgetService.
         if (RuntimeHelper.IsOnWindows11)

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -8,6 +8,7 @@ using DevHome.Common.Helpers;
 using DevHome.Dashboard.Helpers;
 using DevHome.Services.Core.Contracts;
 using Serilog;
+using Windows.ApplicationModel;
 
 namespace DevHome.Dashboard.Services;
 
@@ -20,14 +21,12 @@ public class WidgetServiceService : IWidgetServiceService
 
     private WidgetServiceStates _widgetServiceState = WidgetServiceStates.Unknown;
 
-    public WidgetServiceStates GetWidgetServiceState() => _widgetServiceState;
-
     public enum WidgetServiceStates
     {
-        HasWebExperienceGoodVersion,
-        HasWebExperienceNoOrBadVersion,
-        HasStoreWidgetServiceGoodVersion,
-        HasStoreWidgetServiceNoOrBadVersion,
+        MeetsMinVersion,
+        NotAtMinVersion,
+        NotOK,
+        Updating,
         Unknown,
     }
 
@@ -37,59 +36,34 @@ public class WidgetServiceService : IWidgetServiceService
         _msStoreService = msStoreService;
     }
 
-    /// <inheritdoc/>
-    public bool CheckForWidgetService()
+    public WidgetServiceStates GetWidgetServiceState()
     {
-        // If we're on Windows 11, check if we have a valid version of the WidgetService.
-        if (RuntimeHelper.IsOnWindows11)
+        // First check for the WidgetPlatformRuntime package. If it's installed and has a valid state, we return that state.
+        var package = GetWidgetPlatformRuntimePackage();
+        _widgetServiceState = ValidatePackage(package);
+        if (_widgetServiceState == WidgetServiceStates.MeetsMinVersion ||
+            _widgetServiceState == WidgetServiceStates.Updating)
         {
-            if (HasValidWebExperiencePack())
-            {
-                _log.Information("On Windows 11, HasWebExperienceGoodVersion");
-                _widgetServiceState = WidgetServiceStates.HasWebExperienceGoodVersion;
-                return true;
-            }
-            else if (HasValidWidgetServicePackage())
-            {
-                _log.Information("On Windows 11, HasStoreWidgetServiceGoodVersion");
-                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceGoodVersion;
-                return true;
-            }
-            else
-            {
-                _log.Information("On Windows 11, HasWebExperienceNoOrBadVersion");
-                _widgetServiceState = WidgetServiceStates.HasWebExperienceNoOrBadVersion;
-                return false;
-            }
+            return _widgetServiceState;
         }
-        else
-        {
-            // If we're on Windows 10, check if we have the store version installed.
-            if (HasValidWidgetServicePackage())
-            {
-                _log.Information("On Windows 10, HasStoreWidgetServiceGoodVersion");
-                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceGoodVersion;
-                return true;
-            }
-            else
-            {
-                _log.Information("On Windows 10, HasStoreWidgetServiceNoOrBadVersion");
-                _widgetServiceState = WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
-                return false;
-            }
-        }
+
+        // If the WidgetPlatformRuntime package is not installed or not high enough version, check for the WebExperience package.
+        package = GetWebExperiencePackPackage();
+        _widgetServiceState = ValidatePackage(package);
+
+        return _widgetServiceState;
     }
 
     public async Task<bool> TryInstallingWidgetService()
     {
         _log.Information("Try installing widget service...");
-        var installedSuccessfully = await _msStoreService.TryInstallPackageAsync(WidgetHelpers.WidgetServiceStorePackageId);
-        _widgetServiceState = installedSuccessfully ? WidgetServiceStates.HasStoreWidgetServiceGoodVersion : WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion;
+        var installedSuccessfully = await _msStoreService.TryInstallPackageAsync(WidgetHelpers.WidgetPlatformRuntimePackageId);
+        _widgetServiceState = ValidatePackage(GetWidgetPlatformRuntimePackage());
         _log.Information($"InstalledSuccessfully == {installedSuccessfully}, {_widgetServiceState}");
         return installedSuccessfully;
     }
 
-    private bool HasValidWebExperiencePack()
+    private Package GetWebExperiencePackPackage()
     {
         var minSupportedVersion400 = new Version(423, 3800);
         var minSupportedVersion500 = new Version(523, 3300);
@@ -100,14 +74,37 @@ public class WidgetServiceService : IWidgetServiceService
             WidgetHelpers.WebExperiencePackageFamilyName,
             (minSupportedVersion400, version500),
             (minSupportedVersion500, null));
-        return packages.Any();
+        return packages.First();
     }
 
-    private bool HasValidWidgetServicePackage()
+    private Package GetWidgetPlatformRuntimePackage()
     {
         var minSupportedVersion = new Version(1, 0, 0, 0);
 
-        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetServicePackageFamilyName, (minSupportedVersion, null));
-        return packages.Any();
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetPlatformRuntimePackageFamilyName, (minSupportedVersion, null));
+        return packages.First();
+    }
+
+    private WidgetServiceStates ValidatePackage(Package package)
+    {
+        var isWindows11String = RuntimeHelper.IsOnWindows11 ? "Windows 11" : "Windows 10";
+        _log.Information($"Validating package {package.DisplayName} on {isWindows11String}");
+
+        if (package == null)
+        {
+            return WidgetServiceStates.NotAtMinVersion;
+        }
+        else if (package.Status.VerifyIsOK())
+        {
+            return WidgetServiceStates.MeetsMinVersion;
+        }
+        else if (package.Status.Servicing == true)
+        {
+            return WidgetServiceStates.Updating;
+        }
+        else
+        {
+            return WidgetServiceStates.NotOK;
+        }
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -197,6 +197,14 @@
     <value>We're having trouble displaying widgets. Restarting Dev Home may help.</value>
     <comment>Message shown when there's no widget service and the user should restart Dev Home.</comment>
   </data>
+  <data name="UpdatingWidgetServiceMessage.Text" xml:space="preserve">
+    <value>The Widget Service is updating. Please try again when the update is complete.</value>
+    <comment>Message shown when the widget service package is updating and the user should try again later.</comment>
+  </data>
+  <data name="NotOKWidgetServiceMessage.Text" xml:space="preserve">
+    <value>The installed Widget Service package is not available for use.</value>
+    <comment>Message shown when the widget service package has a problem and cannot be used.</comment>
+  </data>
   <data name="UpdateWidgetsMessage.Text" xml:space="preserve">
     <value>You do not have the required dependency installed to display widgets. Please install or update the package from the Store and then restart Dev Home.</value>
     <comment>Message shown when no widgets have been added to the Dashboard</comment>

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -126,6 +126,7 @@
                     <ProgressRing x:Name="LoadingWidgetsProgressRing"
                                   Margin="0,150,0,0"
                                   IsActive="True"
+                                  Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}"
                                   HorizontalAlignment="Center"/>
 
                     <!-- Widget grid empty message -->

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml
@@ -145,6 +145,12 @@
                     <StackPanel x:Name="RestartDevHomeMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
                         <TextBlock x:Uid="RestartDevHomeMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
                     </StackPanel>
+                    <StackPanel x:Name="UpdatingWidgetServiceMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                        <TextBlock x:Uid="UpdatingWidgetServiceMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
+                    </StackPanel>
+                    <StackPanel x:Name="NotOKServiceMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
+                        <TextBlock x:Uid="NotOKWidgetServiceMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
+                    </StackPanel>
                     <StackPanel x:Name="UpdateWidgetsMessageStackPanel" HorizontalAlignment="Center" Margin="0,150,0,0" Visibility="Collapsed">
                         <TextBlock x:Uid="UpdateWidgetsMessage" HorizontalAlignment="Center" TextWrapping="WrapWholeWords" HorizontalTextAlignment="Center" />
                         <HyperlinkButton x:Name="UpdateWidgetsMessageLink"

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -199,7 +199,7 @@ public partial class DashboardView : ToolPage, IDisposable
             RunningAsAdminMessageStackPanel.Visibility = Visibility.Visible;
             return false;
         }
-        else if (!ViewModel.WidgetServiceService.CheckForWidgetServiceAsync())
+        else if (!ViewModel.WidgetServiceService.CheckForWidgetService())
         {
             var widgetServiceState = ViewModel.WidgetServiceService.GetWidgetServiceState();
             if (widgetServiceState == WidgetServiceService.WidgetServiceStates.HasStoreWidgetServiceNoOrBadVersion ||


### PR DESCRIPTION
## Summary of the pull request

WidgetsPlatformRuntime is being rolled out to Insiders on Windows 11. We should check for it when initializing Dashboard, instead of only expecting Web Experience Pack on Windows 11.

This change also moves around some code from InitializeDashboard() to make it more straightforward. First, we ValidateDashboardState(), then we InitializeDashboard().

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3680
- [ ] Tests added/passed
- [ ] Documentation updated
