### PR TITLE
Add background to Extension Settings

### DIFF
--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionSettingsPage.xaml
@@ -14,7 +14,12 @@
 
     <Grid>
         <ScrollViewer VerticalAlignment="Top">
-            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}" Margin="{ThemeResource ContentPageMargin}">
+            <StackPanel MaxWidth="{ThemeResource MaxPageContentWidth}"
+                        Margin="{ThemeResource ContentPageMargin}"
+                        Background="{ThemeResource WidgetCardBackground}"
+                        BorderBrush="{ThemeResource WidgetCardBorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource ControlCornerRadius}">
                 <commonviews:ExtensionAdaptiveCardPanel x:Name="SettingsContent">
                     <i:Interaction.Behaviors>
                         <ic:EventTriggerBehavior EventName="Loaded">


### PR DESCRIPTION
## Summary of the pull request

The layout of the adaptive card provided for an extension settings page has margins, or can otherwise not line up with the header. To improve the look and feel of the page, add a background behind the card. We use the same colors for this background as we do for the widget backgrounds.
![image](https://github.com/user-attachments/assets/42e50758-1397-48e0-9f4f-6f4bad75af4e)

## References and relevant issues
https://github.com/microsoft/devhomegithubextension/issues/252

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
