### PR TITLE
Added tooltips to all DevInsights pages

### DIFF
--- a/tools/DevInsights/DevHome.DevInsights/Helpers/CountToVisibilityConverter.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Helpers/CountToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace DevHome.DevInsights.Helpers;
+
+public class CountToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var count = (int)value;
+        return count > 0 ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tools/DevInsights/DevHome.DevInsights/Pages/AppDetailsPage.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/AppDetailsPage.xaml
@@ -33,7 +33,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock x:Uid="AppDetailsTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+            <TextBlock x:Uid="AppDetailsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
             <Button 
                 Grid.Column="1"
                 x:Uid="DetachAppButton" 

--- a/tools/DevInsights/DevHome.DevInsights/Pages/InsightsPage.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/InsightsPage.xaml
@@ -11,16 +11,25 @@
     xmlns:models="using:DevHome.DevInsights.Models"
     mc:Ignorable="d"
     NavigationCacheMode="Enabled">
+    <Page.Resources>
+        <helpers:CountToVisibilityConverter x:Key="CountToVisibilityConverter"/>
+    </Page.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <TextBlock x:Uid="InsightsHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <TextBlock 
+            x:Uid="InsightsPlaceholderTextBlock" 
+            Grid.Row="1" 
+            Margin="0,0,0,8" 
+            Visibility="{x:Bind ViewModel.InsightsService.InsightsList.Count, Converter={StaticResource CountToVisibilityConverter}, Mode=OneWay}"/>
 
-        <ItemsControl ItemsSource="{x:Bind ViewModel.InsightsService.InsightsList}" Grid.Row="1">
+        <ItemsControl x:Name="InsightsItemsControl" ItemsSource="{x:Bind ViewModel.InsightsService.InsightsList}" Grid.Row="2">
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="models:Insight">
                     <Expander ExpandDirection="Down" HorizontalAlignment="Stretch" VerticalAlignment="Top" Padding="0,6">
@@ -39,7 +48,6 @@
                                     Style="{StaticResource SuccessIconInfoBadgeStyle}">
                                 </controls:InfoBadge>
                             </Grid>
-
                         </Expander.Header>
                         <RichTextBlock TextWrapping="Wrap" Margin="12,0,12,0" HorizontalAlignment="Left">
                             <Paragraph>

--- a/tools/DevInsights/DevHome.DevInsights/Pages/ModulesPage.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/ModulesPage.xaml
@@ -23,12 +23,14 @@
         </Grid.RowDefinitions>
 
         <TextBlock x:Uid="ModulesHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}"/>
+        
         <Button Grid.Row="1" Visibility="{x:Bind ViewModel.RunAsAdminVisibility, Mode=OneWay}" Command="{x:Bind ViewModel.RunAsAdminCommand}">
             <StackPanel Orientation="Horizontal" Spacing="10">
                 <SymbolIcon Symbol="Admin"/>
                 <TextBlock x:Uid="RunElevatedButton" Margin="0"/>
             </StackPanel>
         </Button>
+        
         <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.GridVisibility, Mode=OneWay}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="220"/>

--- a/tools/DevInsights/DevHome.DevInsights/Pages/ResourceUsagePage.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/ResourceUsagePage.xaml
@@ -20,6 +20,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock x:Uid="ResourceUsageHeaderTextBlock" FontSize="{StaticResource SubtitleTextBlockFontSize}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+
         <Grid x:Name="ResourceUsagePanel" Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>

--- a/tools/DevInsights/DevHome.DevInsights/Pages/WERPage.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/WERPage.xaml
@@ -48,7 +48,6 @@
             </Grid>
         </StackPanel>
 
-
         <controls:DataGrid
             x:Name="WERDataGrid" Grid.Row="1" Margin="0,6,0,0"
             VerticalScrollBarVisibility="Visible"

--- a/tools/DevInsights/DevHome.DevInsights/Services/DIInsightsService.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Services/DIInsightsService.cs
@@ -39,6 +39,7 @@ public partial class DIInsightsService : ObservableObject
         {
             _targetProcess = process;
             InsightsList.Clear();
+            UnreadCount = 0;
         }
     }
 

--- a/tools/DevInsights/DevHome.DevInsights/Strings/en-us/Resources.resw
+++ b/tools/DevInsights/DevHome.DevInsights/Strings/en-us/Resources.resw
@@ -165,7 +165,7 @@
     <value>Failed to launch: {0}</value>
     <comment>{Locked="{0}"} Text for when there was an error launching an external tool. {0} is the name of an executable(.exe) file.</comment>
   </data>
-  <data name="AppDetailsTextBlock.Text" xml:space="preserve">
+  <data name="AppDetailsHeaderTextBlock.Text" xml:space="preserve">
     <value>App details</value>
     <comment>The contents of a text block referring to details about an application.</comment>
   </data>
@@ -278,7 +278,7 @@
     <comment>Refers to how much disk storage (hard drive/solid state drive) the process is utilizing.</comment>
   </data>
   <data name="WERHeaderTextBlock.Text" xml:space="preserve">
-    <value>WER Reports</value>
+    <value>Crash reports</value>
     <comment>The contents of a WER crash dumps.</comment>
   </data>
   <data name="WERTimeGeneratedColumn.Header" xml:space="preserve">
@@ -311,7 +311,7 @@
   </data>
   <data name="WERCheckbox.ToolTipService.ToolTip" xml:space="preserve">
     <value>Entries from the event log for the target app</value>
-    <comment>Tooltip for whether to WER report logs are shown in the log view output.</comment>
+    <comment>Tooltip for whether the WER report logs are shown in the log view output.</comment>
   </data>
   <data name="ClearWinLogsButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Clear the list</value>
@@ -558,7 +558,7 @@
     <comment>{Locked="{0}"} A description to help a user that is dealing with a file locked for exclusive access. {0} is a file name.</comment>
   </data>
   <data name="WERStartErrorMessage" xml:space="preserve">
-    <value>Could not start WER Monitoring</value>
+    <value>Could not start WER crash dump monitoring</value>
     <comment>Refers to being unable to start monitoring the WER error logs.</comment>
   </data>
   <data name="PreferencesTabName" xml:space="preserve">
@@ -1034,7 +1034,7 @@
     <comment>Filter string to specify that the file dialog should include PowerShell files</comment>
   </data>
   <data name="LocalDumpCollectionLabel.Text" xml:space="preserve">
-    <value>Local WER collection for app</value>
+    <value>Local WER crash dump collection for app</value>
     <comment>Label for Windows Error reporting toggle switch</comment>
   </data>
   <data name="LocalDumpCollectionToggle.ToolTipService.ToolTip" xml:space="preserve">
@@ -1050,7 +1050,7 @@
     <comment>The contents of a button to allow the user to trigger elevation to change WER settings</comment>
   </data>
   <data name="RunElevatedButtonForWER.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Dev Insights needs to run as Admin in order to modify WER collection for an app.</value>
+    <value>Dev Insights needs to run as Admin in order to modify WER crash dump collection for an app.</value>
     <comment>Tooltip for a button that relaunches Dev Insights as admin to change WER settings</comment>
   </data>
   <data name="RunElevatedButton.Text" xml:space="preserve">
@@ -1178,11 +1178,11 @@
     <comment>Tooltip for the button text allowing the user to select the type of tool</comment>
   </data>
   <data name="ToolTypeMenuItemDumpAnalyzer.Text" xml:space="preserve">
-    <value>WER Dump Analyzer</value>
+    <value>WER crash dump analyzer</value>
     <comment>Describes type of tool used to analyze WER dumps</comment>
   </data>
   <data name="ToolTypeMenuItemDumpAnalyzer.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Tool that will be used to analyze WER dumps generated on the system</value>
+    <value>Tool that will be used to analyze WER crash dumps generated on the system</value>
     <comment>Tooltip that describes what a WER Dump analyzer does</comment>
   </data>
   <data name="ClipboardMonitorWindowTitle" xml:space="preserve">
@@ -1199,15 +1199,47 @@ Dump File creation time: {1}</value>
     <comment>{Locked="{0}", "{1}"} Created string that contains basic information about a crash dump</comment>
   </data>
   <data name="BucketUsingThisToolString" xml:space="preserve">
-    <value>Use this tool for WER bucketing</value>
+    <value>Use this tool for WER crash dump bucketing</value>
     <comment>Context menu button used to select a tool that is using to bucket WER reports</comment>
   </data>
   <data name="BucketUsingThisToolStringDefault.Text" xml:space="preserve">
-    <value>Use this tool for WER bucketing</value>
+    <value>Use this tool for WER crash dump bucketing</value>
     <comment>Context menu button used to select a tool that is using to bucket WER reports</comment>
   </data>
   <data name="OutputRegularExpressionTextBoxLabel.Text" xml:space="preserve">
-    <value>Regular Expression for WER bucket</value>
+    <value>Regular Expression for WER crash dump bucket</value>
     <comment>Label for a textbox that will contain the regular expression a tool uses to determine the bucketing string of a cab.</comment>
+  </data>
+  <data name="ProcessListHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>A list of all running processes. You can select an item from the list to target. You can also type a name in the search box to find that process. The drop-down contains a list of all items that are filtered out by default - you can select any of these to include them in the main list. Another way to select your target process is to bring its window to the foreground and then use the hotkey Windows+F12.</value>
+    <comment>{Locked="Windows+F12"} Description of the Process list page.</comment>
+  </data>
+  <data name="WERHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Recent crash reports available on this machine. By default, this is filtered to your target app (if any). You can select any dump file in the list to open it in a dump analyzer tool of your choice. If you want to change your choice of dump analyzer tool, go to Windows Settings &gt; Apps &gt; Default apps &gt; Set default for ".dmp" file type.</value>
+    <comment>{Locked=".dmp"} Description of the Crash reports page.</comment>
+  </data>
+  <data name="InsightsHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>As Dev Insights gathers context data for your target app, it can analyze the data, and in some cases it can provide insights into the nature of the problem. If Dev Insights does identify insights, they will be listed here. (Note that this is a work in progress, and initially there are very few cases where Dev Insights can provide definitive analysis.)</value>
+    <comment>Description of the Insights page.</comment>
+  </data>
+  <data name="ResourceUsageHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>A list of a wide range of resource usage and sensor items for both your target app (if any), and for the system as a whole.</value>
+    <comment>Description of the Resource usage page.</comment>
+  </data>
+  <data name="ModulesHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>All the modules (DLLs, etc) that have been loaded by your target process.</value>
+    <comment>Description of the Loaded modules page.</comment>
+  </data>
+  <data name="WinLogsHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>As you exercise the features of your target app, this will generate log outputs in various forms. By default, this page tracks Event Tracing for Windows (ETW) logs, the system Event log, and Windows Error Reporting (WER) logs. You can also enable Debug Output tracking, althought this can produce a large amount of output, depending on the app. Dev Insights analyzes log output and in some cases can generate insights.</value>
+    <comment>Description of the Windows logs page.</comment>
+  </data>
+  <data name="AppDetailsHeaderTextBlock.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Information about the current target app.</value>
+    <comment>Description of the App details page.</comment>
+  </data>
+  <data name="InsightsPlaceholderTextBlock.Text" xml:space="preserve">
+    <value>(No insights found)</value>
+    <comment>Placeholder text on the Insights page when the insights list is empty.</comment>
   </data>
 </root>

--- a/tools/DevInsights/DevHome.DevInsights/ViewModels/BarWindowViewModel.cs
+++ b/tools/DevInsights/DevHome.DevInsights/ViewModels/BarWindowViewModel.cs
@@ -301,6 +301,7 @@ public partial class BarWindowViewModel : ObservableObject
                 // Conversely, the result chooser is only visible if we're not attached to a result
                 IsProcessChooserVisible = process is null;
                 UnreadInsightsCount = 0;
+                InsightsBadgeOpacity = 0;
             });
         }
         else if (e.PropertyName == nameof(TargetAppData.Icon))

--- a/tools/DevInsights/DevHome.DevInsights/ViewModels/ExpandedViewControlViewModel.cs
+++ b/tools/DevInsights/DevHome.DevInsights/ViewModels/ExpandedViewControlViewModel.cs
@@ -69,7 +69,7 @@ public partial class ExpandedViewControlViewModel : ObservableObject
         TargetAppData.Instance.PropertyChanged += TargetApp_PropertyChanged;
         PerfCounters.Instance.PropertyChanged += PerfCounterHelper_PropertyChanged;
 
-        _appDetailsNavLink = new PageNavLink("\uE71D", CommonHelper.GetLocalizedString("AppDetailsTextBlock/Text"), typeof(AppDetailsPageViewModel));
+        _appDetailsNavLink = new PageNavLink("\uE71D", CommonHelper.GetLocalizedString("AppDetailsHeaderTextBlock/Text"), typeof(AppDetailsPageViewModel));
         _resourceUsageNavLink = new PageNavLink("\uE950", CommonHelper.GetLocalizedString("ResourceUsageHeaderTextBlock/Text"), typeof(ResourceUsagePageViewModel));
         _modulesNavLink = new PageNavLink("\uE74C", CommonHelper.GetLocalizedString("ModulesHeaderTextBlock/Text"), typeof(ModulesPageViewModel));
         _werNavLink = new PageNavLink("\uE7BA", CommonHelper.GetLocalizedString("WERHeaderTextBlock/Text"), typeof(WERPageViewModel));


### PR DESCRIPTION
## Summary of the pull request

Added a tooltip to the header textblock on each page (apart from Settings), to explain the purpose of the page, and explain any controls within the page. I originally planned to add static text at the top of the page, but a tooltip is less intrusive, and doesn't take up space unless the user wants to see it.

Also added a "no insights found" placeholder text to the Insights page for when there are no insights. Plus, fixed the bug where we weren't hiding the insights info badge when there are no insights (as when we switch target from one app to another). 

Renamed "WER Reports" to "Crash reports" in the page header, and renamed "WER dump" to "WER crash dump" elsewhere, per user feedback.

Closes #3054 
Closes #3699 
Closes #3704 
Closes #3708 
