### PR TITLE
[DevInsights] - Update Watson page to use AdvancedCollectionView

### DIFF
--- a/tools/DevInsights/DevHome.DevInsights/Pages/WERPage.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/WERPage.xaml
@@ -65,8 +65,8 @@
             GridLinesVisibility="None"
             HeadersVisibility="Column"
             SelectionChanged="WERDataGrid_SelectionChanged"
-            Sorting="WERDataGrid_Sorting"
-            ItemsSource="{x:Bind ViewModel.DisplayedReports, Mode=OneWay}">
+            Sorting="{x:Bind ViewModel.SortReports}"
+            ItemsSource="{x:Bind ViewModel.ReportsView, Mode=OneWay}">
             <controls:DataGrid.Columns>
                 <controls:DataGridTextColumn Tag="DateTime" x:Uid="WERTimeGeneratedColumn" Binding="{Binding Report.TimeGenerated}" Width="180" IsReadOnly="True"/>
                 <controls:DataGridTextColumn Tag="FaultingExecutable" x:Uid="WERFaultingExecutableColumn" Binding="{Binding Report.Executable}" Width="180" IsReadOnly="True"/>

--- a/tools/DevInsights/DevHome.DevInsights/Pages/WERPage.xaml.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Pages/WERPage.xaml.cs
@@ -132,48 +132,6 @@ public sealed partial class WERPage : Page
         }
     }
 
-    private void WERDataGrid_Sorting(object sender, DataGridColumnEventArgs e)
-    {
-        if (e.Column.Tag is not null)
-        {
-            bool sortAscending = e.Column.SortDirection == DataGridSortDirection.Ascending;
-
-            // Flip the sort direction
-            sortAscending = !sortAscending;
-
-            string? tag = e.Column.Tag.ToString();
-            Debug.Assert(tag is not null, "Why is the tag null?");
-
-            if (tag == "DateTime")
-            {
-                ViewModel.SortByDateTime(sortAscending);
-            }
-            else if (tag == "FaultingExecutable")
-            {
-                ViewModel.SortByFaultingExecutable(sortAscending);
-            }
-            else if (tag == "WERBucket")
-            {
-                ViewModel.SortByWERBucket(sortAscending);
-            }
-            else if (tag == "CrashDumpPath")
-            {
-                ViewModel.SortByCrashDumpPath(sortAscending);
-            }
-
-            e.Column.SortDirection = sortAscending ? DataGridSortDirection.Ascending : DataGridSortDirection.Descending;
-
-            // Clear the sort direction for the other columns
-            foreach (DataGridColumn column in WERDataGrid.Columns)
-            {
-                if (column != e.Column)
-                {
-                    column.SortDirection = null;
-                }
-            }
-        }
-    }
-
     private void LocalDumpCollection_Toggled(object sender, RoutedEventArgs e)
     {
         ViewModel.ChangeLocalCollectionForApp(LocalDumpCollectionToggle.IsOn);


### PR DESCRIPTION
## Summary of the pull request
1. Update Watson page to use AdvancedCollectionView for sorting and filtering. 
2. Removed the _displayedReports ObservableCollection. It is a duplicate copy of werAnalyzer.WERAnalysisReports. This can be done by setting werAnalyzer.WERAnalysisReports as the source of _reportsView and calling _reportsView.Refresh() from a dispatcher thread whenever a collection change notification is received.

## Validation steps performed
1. launch DevInsights
2. Go to WER page
3. Toggle target app specific data on and off
4. Check the sorting works for every column
5. Crash an app and make sure a new report is added to the list