### PR TITLE
Fixed the missing DI icon on the main utilities page

### DIFF
--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -55,7 +55,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 Title = stringResource.GetLocalized("DevInsightsTitle"),
                 Description = stringResource.GetLocalized("DevInsightsDesc"),
                 NavigateUri = "https://go.microsoft.com/fwlink/?linkid=2275140",
-                ImageSource = Path.Combine(AppContext.BaseDirectory, "PI.ico"),
+                ImageSource = Path.Combine(AppContext.BaseDirectory, "DI.ico"),
                 UtilityAutomationId = "DevHome.DevInsights",
             },
         };


### PR DESCRIPTION
## Summary of the pull request
When I replaced all the DevInsights "PI" icons with "DI" icons, I missed the one in the main DevHome Utilities page.