### PR TITLE
Fix missed reference to devhome.pi.exe to re-enable launching as admin

### DIFF
--- a/tools/DevInsights/DevHome.DevInsights/Helpers/CommonHelper.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Helpers/CommonHelper.cs
@@ -41,7 +41,7 @@ internal sealed class CommonHelper
         var startInfo = new ProcessStartInfo();
         startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 
-        var aliasSubDirectoryPath = $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}\\devhome.pi.exe";
+        var aliasSubDirectoryPath = $"Microsoft\\WindowsApps\\{Package.Current.Id.FamilyName}\\devhome.devinsights.exe";
         var aliasPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), aliasSubDirectoryPath);
         startInfo.FileName = aliasPath;
 
@@ -65,7 +65,7 @@ internal sealed class CommonHelper
         }
         catch (Win32Exception ex)
         {
-            _log.Error(ex, "Could not run PI as admin");
+            _log.Error(ex, "Could not run Dev Insights as admin");
             if (ex.NativeErrorCode == (int)WIN32_ERROR.ERROR_CANT_ACCESS_FILE)
             {
                 var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
@@ -73,7 +73,7 @@ internal sealed class CommonHelper
             }
             else if (ex.NativeErrorCode == (int)WIN32_ERROR.ERROR_CANCELLED)
             {
-                _log.Error(ex, "UAC to run PI as admin was denied");
+                _log.Error(ex, "UAC to run Dev Insights as admin was denied");
             }
         }
     }


### PR DESCRIPTION
## Summary of the pull request
A missed reference to devhome.pi.exe prevented admin launches from working.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated self-elevation works again.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
