### PR TITLE
Add "More options" tooltip to Widget

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
+++ b/tools/Dashboard/DevHome.Dashboard/Strings/en-us/Resources.resw
@@ -161,6 +161,10 @@
     <value>More options</value>
     <comment>Name of the button that brings up the "More options" menu</comment>
   </data>
+  <data name="WidgetMoreOptionsButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>More options</value>
+    <comment>Name of the button that brings up the "More options" menu</comment>
+  </data>
   <data name="LargeWidgetMenuText" xml:space="preserve">
     <value>Large</value>
     <comment>The size of a large widget</comment>


### PR DESCRIPTION
## Summary of the pull request
Add a tooltip to the "..." (more options) menu in the corner of the widget.

## References and relevant issues
https://task.ms/53363439

## Detailed description of the pull request / Additional comments

## Validation steps performed
Validated manually.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
