### PR TITLE
[File Explorer SourceControl Integration] Add IsFeaturePresent Check

### DIFF
--- a/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using DevHome.Common.Models;
 using DevHome.Common.Services;
 using DevHome.QuietBackgroundProcesses;
+using Microsoft.Internal.Windows.DevHome.Helpers.FileExplorer;
 
 namespace DevHome.Settings.ViewModels;
 
@@ -48,6 +49,11 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
             {
                 return false;
             }
+        }
+
+        if (string.Equals(experimentalFeature.Id, "FileExplorerSourceControlIntegration", StringComparison.OrdinalIgnoreCase))
+        {
+            return ExtraFolderPropertiesWrapper.IsSupported();
         }
 
         throw new NotImplementedException();

--- a/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
+++ b/settings/DevHome.Settings/ViewModels/ExperimentalFeaturesViewModel.cs
@@ -45,7 +45,7 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
             {
                 return QuietBackgroundProcessesSessionManager.IsFeaturePresent();
             }
-            catch (System.Exception)
+            catch (Exception)
             {
                 return false;
             }
@@ -53,7 +53,14 @@ public partial class ExperimentalFeaturesViewModel : ObservableObject
 
         if (string.Equals(experimentalFeature.Id, "FileExplorerSourceControlIntegration", StringComparison.OrdinalIgnoreCase))
         {
-            return ExtraFolderPropertiesWrapper.IsSupported();
+            try
+            {
+                return ExtraFolderPropertiesWrapper.IsSupported();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         throw new NotImplementedException();

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -74,6 +74,7 @@
     {
       "identity": "FileExplorerSourceControlIntegration",
       "enabledByDefault": false,
+      "needsFeaturePresenceCheck": true,
       "buildTypeOverrides": [
         {
           "buildType": "dev",


### PR DESCRIPTION
## Summary of the pull request
This PR adds the IsFeaturePresent check for FileExplorerSourceControlIntegration experimental feature. 

## References and relevant issues

## Detailed description of the pull request / Additional comments
The toggle for the File Explorer Source Control Integration feature will only be visible on the Dev Home  page if the OS supports the feature. 

## Validation steps performed
Build of msix
Local Validation of return value in supported case
Tested on WIn10 VM to see absent experimental feature toggle as expected. 


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
