### PR TITLE
Remove const from c++ constructors

### DIFF
--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/GetLocalRepositoryResult.h
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/GetLocalRepositoryResult.h
@@ -7,8 +7,8 @@ namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
     {
         GetLocalRepositoryResult() = default;
 
-        const explicit GetLocalRepositoryResult(winrt::Microsoft::Windows::DevHome::SDK::ILocalRepository const& repository);
-        const GetLocalRepositoryResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
+        explicit GetLocalRepositoryResult(winrt::Microsoft::Windows::DevHome::SDK::ILocalRepository const& repository);
+        GetLocalRepositoryResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
         winrt::Microsoft::Windows::DevHome::SDK::ILocalRepository Repository();
         winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult Result();
 


### PR DESCRIPTION
## Summary of the pull request
New msbuild version points out the error in having const constructors (`error C7731: 'const' is not allowed on a constructor declaration`). Fix the constructors.