### PR TITLE
Update DevHome-CI.yml pipeline actions

### DIFF
--- a/.github/workflows/DevHome-CI.yml
+++ b/.github/workflows/DevHome-CI.yml
@@ -27,21 +27,20 @@ jobs:
     env:
       MSIX_VERSION: "0.1"
       SDK_VERSION: "0.1"
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         clean: true
 
     - name: Setup .NET SDK ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.GPR_READ_TOKEN }}
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
       with:
         vs-version: '17.5'
 

--- a/.github/workflows/DevHome-CI.yml
+++ b/.github/workflows/DevHome-CI.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       MSIX_VERSION: "0.1"
       SDK_VERSION: "0.1"
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## Summary of the pull request
Update GitHub actions to ones that use the supported Node20 instead of unsupported Node16.
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
