### PR TITLE
Standardized the DevInsights toolbar using CommandBars

### DIFF
--- a/extensionsdk/Microsoft.Windows.DevHome.SDK/GetLocalRepositoryResult.h
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK/GetLocalRepositoryResult.h
@@ -7,8 +7,8 @@ namespace winrt::Microsoft::Windows::DevHome::SDK::implementation
     {
         GetLocalRepositoryResult() = default;
 
-        const explicit GetLocalRepositoryResult(winrt::Microsoft::Windows::DevHome::SDK::ILocalRepository const& repository);
-        const GetLocalRepositoryResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
+        explicit GetLocalRepositoryResult(winrt::Microsoft::Windows::DevHome::SDK::ILocalRepository const& repository);
+        GetLocalRepositoryResult(winrt::hresult const& e, hstring const& displayMessage, hstring const& diagnosticText);
         winrt::Microsoft::Windows::DevHome::SDK::ILocalRepository Repository();
         winrt::Microsoft::Windows::DevHome::SDK::ProviderOperationResult Result();
 

--- a/tools/DevInsights/DevHome.DevInsights/Controls/ExternalToolsManagementButton.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Controls/ExternalToolsManagementButton.cs
@@ -14,7 +14,7 @@ using Microsoft.UI.Xaml.Media;
 
 namespace DevHome.DevInsights.Controls;
 
-internal sealed class ExternalToolsManagementButton : Button
+internal sealed class ExternalToolsManagementButton : AppBarButton
 {
     private const string UnregisterButtonGlyph = "\uECC9";
 

--- a/tools/DevInsights/DevHome.DevInsights/Controls/ProcessSelectionButton.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Controls/ProcessSelectionButton.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Input;
 
 namespace DevHome.DevInsights.Controls;
 
-public class ProcessSelectionButton : Button
+public class ProcessSelectionButton : AppBarButton
 {
     public ProcessSelectionButton()
     {

--- a/tools/DevInsights/DevHome.DevInsights/Styles/CommandBarStyle.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Styles/CommandBarStyle.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:DevHome.DevInsights.Styles">
 
     <!-- This is a copy/paste of the stock Command Bar template found in generic.xaml, with a small change to the "More Items" button to change the icon from an ellipse to a tools icon.
-         You can search for CHANGES HERE FOR Dev Insights for the change -->
+         You can search for CHANGES HERE FOR Dev Insights for the change, #767 -->
     <Style x:Key="CustomCommandBar" TargetType="CommandBar" BasedOn="{StaticResource CommandBarRevealStyle}">
         <Setter Property="Template">
             <Setter.Value>
@@ -764,11 +764,12 @@
                                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.EffectiveOverflowButtonVisibility}">
 
                                 <!-- CHANGES HERE FOR Dev Insights -->
-                                <FontIcon x:Name="EllipsisIcon"
-                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                            FontSize="{StaticResource SubtitleTextBlockFontSize}"
-                                            Glyph="&#xEC7A;"
-                                            Margin="0 -7 0 0"/>
+                                <FontIcon 
+                                    x:Name="EllipsisIcon"
+                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                    FontSize="16"
+                                    Glyph="&#xEC7A;"
+                                    Margin="0 -7 0 0"/>
 
                             </Button>
                             <Rectangle x:Name="HighContrastBorder"

--- a/tools/DevInsights/DevHome.DevInsights/Views/BarWindowHorizontal.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Views/BarWindowHorizontal.xaml
@@ -37,7 +37,13 @@
 
             <StackPanel Orientation="Horizontal" Grid.Column="1">
                 <Image Source="/Images/di.ico" Height="16" Width="16" Margin="8,2,0,0" VerticalAlignment="Center"/>
-                <TextBlock x:Uid="Title" Style="{StaticResource CaptionTextBlockStyle}" Margin="6,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" />
+                <TextBlock 
+                    x:Uid="Title" 
+                    Style="{StaticResource CaptionTextBlockStyle}" 
+                    Margin="6,0,0,0" 
+                    HorizontalAlignment="Left" 
+                    VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="TitleTextBlock"/>
             </StackPanel>
             <StackPanel x:Name="ChromeButtonPanel" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,1,0" Background="Transparent" Grid.Column="1" SizeChanged="{x:Bind SetRegionsForTitleBar}" LayoutUpdated="{x:Bind TitlebarLayoutUpdate}">
                 <Button
@@ -48,7 +54,8 @@
                     Command="{x:Bind _viewModel.ToggleSnapCommand}"
                     HorizontalAlignment="Left"
                     IsEnabled="{x:Bind _viewModel.IsSnappingEnabled, Mode=OneWay}"
-                    ToolTipService.ToolTip="{x:Bind _viewModel.CurrentSnapToolTip, Mode=OneWay}">
+                    ToolTipService.ToolTip="{x:Bind _viewModel.CurrentSnapToolTip, Mode=OneWay}"
+                    AutomationProperties.AutomationId="SnapButton">
                     <TextBlock x:Name="SnapButtonText" Text="{x:Bind _viewModel.CurrentSnapButtonText, Mode=OneWay}"/>
                 </Button>
                 <Button
@@ -56,8 +63,9 @@
                      Style="{StaticResource ChromeButton}"
                      FontSize="{StaticResource CaptionTextBlockFontSize}"
                      Command="{x:Bind _viewModel.RotateLayoutCommand}"
-                     HorizontalAlignment="Left">
-                    <TextBlock x:Name="RotateLayoutButtonText" Text="&#xe8b4;" />
+                     HorizontalAlignment="Left"
+                    AutomationProperties.AutomationId="RotateLayoutButton">
+                    <TextBlock x:Name="RotateLayoutButtonText" Text="&#xe8b4;"/>
                 </Button>
                 <Button
                      x:Uid="ExpandCollapseLayoutButton"
@@ -65,8 +73,9 @@
                      FontSize="{StaticResource CaptionTextBlockFontSize}"
                      Command="{x:Bind _viewModel.ToggleExpandedContentVisibilityCommand}"
                      HorizontalAlignment="Left"
-                     ToolTipService.ToolTip="{x:Bind _viewModel.CurrentExpandToolTip, Mode=OneWay}">
-                    <TextBlock x:Name="ExpandCollapseLayoutButtonText" />
+                     ToolTipService.ToolTip="{x:Bind _viewModel.CurrentExpandToolTip, Mode=OneWay}"
+                    AutomationProperties.AutomationId="ExpandCollapseLayoutButton">
+                    <TextBlock x:Name="ExpandCollapseLayoutButtonText"/>
                 </Button>
             </StackPanel>
         </Grid>
@@ -97,10 +106,11 @@
                     Content="&#xe179;" 
                     FontFamily="{StaticResource SymbolThemeFontFamily}" 
                     FontSize="{StaticResource SubtitleTextBlockFontSize}"
-                    Margin="0,-4,0,0">
+                    Margin="0,-4,0,0"
+                    AutomationProperties.AutomationId="ProcessChooserButton">
                 </local:ProcessSelectionButton>
                 <AppBarElementContainer>
-                    <TextBlock x:Uid="ProcessesLabel" x:Name="ProcessesLabel" Margin="0,6,0,0"/>
+                    <TextBlock x:Uid="ProcessesLabel" x:Name="ProcessesLabel" Margin="0,6,0,0" AutomationProperties.AutomationId="ProcessLabel"/>
                 </AppBarElementContainer>
             </CommandBar>
 
@@ -110,7 +120,10 @@
                     <StackPanel Orientation="Horizontal">
                         <StackPanel.ContextFlyout>
                             <MenuFlyout>
-                                <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
+                                <MenuFlyoutItem 
+                                    x:Uid="DetachMenuItem" 
+                                    Command="{x:Bind _viewModel.DetachFromProcessCommand}"
+                                    AutomationProperties.AutomationId="DetachMenuItem">
                                     <MenuFlyoutItem.Icon>
                                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
                                     </MenuFlyoutItem.Icon>
@@ -123,8 +136,13 @@
                             Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" 
                             ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" 
                             Height="20" 
-                            Width="20"/>
-                        <TextBlock x:Uid="AppName" Text="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="8,8,8,0"/>
+                            Width="20"
+                            AutomationProperties.AutomationId="AppIcon"/>
+                        <TextBlock 
+                            x:Uid="AppName" 
+                            Text="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" 
+                            Margin="8,8,8,0"
+                            AutomationProperties.AutomationId="AppName"/>
                     </StackPanel>
                 </AppBarElementContainer>
 
@@ -136,7 +154,8 @@
                             FontFamily="{StaticResource SymbolThemeFontFamily}"
                             FontSize="{StaticResource TitleLargeTextBlockFontSize}"
                             Margin="0,-10,0,0"
-                            Padding="0"/>
+                            Padding="0"
+                            AutomationProperties.AutomationId="InsightsButton"/>
                         <controls:InfoBadge
                             VerticalAlignment="Bottom"
                             HorizontalAlignment="Right"
@@ -173,7 +192,10 @@
                                 <Setter Property="Margin" Value="8,0,8,0"/>
                             </Style>
                         </StackPanel.Resources>
-                        <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}"/>
+                        <TextBlock 
+                            x:Uid="AppCPUUsage" 
+                            Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" 
+                            AutomationProperties.AutomationId="AppCPUUsage"/>
                     </StackPanel>
                 </AppBarElementContainer>
             </CommandBar>
@@ -190,9 +212,18 @@
                                 <Setter Property="Margin" Value="8,0,8,0"/>
                             </Style>
                         </StackPanel.Resources>
-                        <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}"/>
-                        <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}"/>
-                        <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"/>
+                        <TextBlock 
+                            x:Uid="SystemCPUUsage" 
+                            Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}"
+                            AutomationProperties.AutomationId="SystemCPUUsage"/>
+                        <TextBlock 
+                            x:Uid="SystemMemUsage" 
+                            Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}"
+                            AutomationProperties.AutomationId="SystemMemUsage"/>
+                        <TextBlock 
+                            x:Uid="SystemDiskUsage" 
+                            Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"
+                            AutomationProperties.AutomationId="SystemDiskUsage"/>
                     </StackPanel>
                 </AppBarElementContainer>
             </CommandBar>

--- a/tools/DevInsights/DevHome.DevInsights/Views/BarWindowHorizontal.xaml
+++ b/tools/DevInsights/DevHome.DevInsights/Views/BarWindowHorizontal.xaml
@@ -72,90 +72,130 @@
         </Grid>
 
         <Grid Grid.Row="1">
+            <Grid.Resources>
+                <Style TargetType="TextBlock">
+                    <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
+                    <Setter Property="Margin" Value="8,12,8,0"/>
+                </Style>
+                <Style TargetType="AppBarButton">
+                    <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
+                </Style>
+            </Grid.Resources>
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition x:Name="ToolColumn" Width="*"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <StackPanel x:Name="AllControls" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left" Background="Transparent" >
-                <StackPanel.Resources>
-                    <Style TargetType="TextBlock">
-                        <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}"/>
-                        <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}"/>
-                    </Style>
-                    <Style TargetType="Button">
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="Background" Value="Transparent"/>
-                    </Style>
-                    <Style TargetType="local:ExternalToolsManagementButton">
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="Background" Value="Transparent"/>
-                    </Style>
-                    <Style TargetType="local:ProcessSelectionButton">
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="Background" Value="Transparent"/>
-                    </Style>
-                </StackPanel.Resources>
-
-                <!-- Process Chooser area -->
-                <StackPanel Orientation="Horizontal" Visibility="{x:Bind _viewModel.IsProcessChooserVisible, Mode=OneWay}" Margin="0,0,0,0" >
-                    <local:ProcessSelectionButton x:Uid="ProcessChooserButton" Command="{x:Bind _viewModel.ProcessChooserCommand}" VerticalAlignment="Center">
-                        <TextBlock Text="&#xe179;"/>
-                    </local:ProcessSelectionButton>
-                    <TextBlock x:Uid="ProcessesLabel" x:Name="ProcessesLabel" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
-                </StackPanel>
-
-                <!-- Per App controls -->
-                <StackPanel Orientation="Horizontal" Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}" Spacing="10" Margin="10,0,0,0">
-                    <StackPanel.ContextFlyout>
-                        <MenuFlyout>
-                            <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                        </MenuFlyout>
-                    </StackPanel.ContextFlyout>
-                    <Image x:Name="AppIcon" HorizontalAlignment="Center" Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Height="20" Width="20" />
-                    <TextBlock x:Uid="AppName" Text="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
-                    <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center" />
-                </StackPanel>
-
-                <!-- Insights button -->
-                <Button x:Uid="InsightsButton" x:Name="InsightsButton" Command="{x:Bind _viewModel.ShowInsightsPageCommand}" Margin="10,0,0,0">
-                    <Grid>
-                        <TextBlock Text="&#xE946;" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
-                        <controls:InfoBadge
-                            VerticalAlignment="Top"
-                            HorizontalAlignment="Right"
-                            Margin="16,0,0,0"
-                            MinWidth="16"
-                            MinHeight="16"
-                            Value="{x:Bind _viewModel.UnreadInsightsCount, Mode=OneWay}"
-                            Opacity="{x:Bind _viewModel.InsightsBadgeOpacity, Mode=OneWay}"
-                            Style="{StaticResource SuccessValueInfoBadgeStyle}">
-                        </controls:InfoBadge>
-                    </Grid>
-                </Button>
-
-                <CommandBar>
-                    <AppBarSeparator/>
-                </CommandBar>
-            </StackPanel>
-
-            <CommandBar x:Name="MyCommandBar" Style="{StaticResource CustomCommandBar}" HorizontalAlignment="Left" IsDynamicOverflowEnabled="False" DefaultLabelPosition="Collapsed" Grid.Column="1" />
-
-            <CommandBar Grid.Column="2" >
-                <AppBarSeparator/>
+            <!-- Process Chooser area -->
+            <CommandBar Visibility="{x:Bind _viewModel.IsProcessChooserVisible, Mode=OneWay}">
+                <local:ProcessSelectionButton 
+                    x:Uid="ProcessChooserButton" 
+                    Command="{x:Bind _viewModel.ProcessChooserCommand}"
+                    Content="&#xe179;" 
+                    FontFamily="{StaticResource SymbolThemeFontFamily}" 
+                    FontSize="{StaticResource SubtitleTextBlockFontSize}"
+                    Margin="0,-4,0,0">
+                </local:ProcessSelectionButton>
+                <AppBarElementContainer>
+                    <TextBlock x:Uid="ProcessesLabel" x:Name="ProcessesLabel" Margin="0,6,0,0"/>
+                </AppBarElementContainer>
             </CommandBar>
 
-            <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Column="3" Spacing="10" Margin="0 0 10 0">
-                <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
-                <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}" FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
-                <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"  FontFamily="Segoe UI" FontSize="{StaticResource CaptionTextBlockFontSize}" VerticalAlignment="Center"/>
-            </StackPanel>
+            <CommandBar Grid.Column="1" OverflowButtonVisibility="Collapsed">
+                <!-- Per App controls -->
+                <AppBarElementContainer Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel.ContextFlyout>
+                            <MenuFlyout>
+                                <MenuFlyoutItem x:Uid="DetachMenuItem" Command="{x:Bind _viewModel.DetachFromProcessCommand}">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE894;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                            </MenuFlyout>
+                        </StackPanel.ContextFlyout>
+                        <Image 
+                            x:Name="AppIcon" 
+                            Margin="8,8,0,0"
+                            Source="{x:Bind _viewModel.ApplicationIcon, Mode=OneWay}" 
+                            ToolTipService.ToolTip="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" 
+                            Height="20" 
+                            Width="20"/>
+                        <TextBlock x:Uid="AppName" Text="{x:Bind _viewModel.ApplicationName, Mode=OneWay}" Margin="8,8,8,0"/>
+                    </StackPanel>
+                </AppBarElementContainer>
+
+                <!-- Insights button -->
+                <AppBarButton x:Uid="InsightsButton" x:Name="InsightsButton" Command="{x:Bind _viewModel.ShowInsightsPageCommand}" MinWidth="68">
+                    <Grid Padding="0">
+                        <TextBlock 
+                            Text="&#xE946;" 
+                            FontFamily="{StaticResource SymbolThemeFontFamily}"
+                            FontSize="{StaticResource TitleLargeTextBlockFontSize}"
+                            Margin="0,-10,0,0"
+                            Padding="0"/>
+                        <controls:InfoBadge
+                            VerticalAlignment="Bottom"
+                            HorizontalAlignment="Right"
+                            Margin="22,8,0,0"
+                            MinWidth="36"
+                            MinHeight="36"
+                            Padding="0"
+                            Style="{StaticResource SuccessValueInfoBadgeStyle}"
+                            FontFamily="Segoe UI"
+                            Value="{x:Bind _viewModel.UnreadInsightsCount, Mode=OneWay}"
+                            Opacity="{x:Bind _viewModel.InsightsBadgeOpacity, Mode=OneWay}"/>
+                    </Grid>
+                </AppBarButton>
+            </CommandBar>
+
+            <!-- Tools -->
+            <CommandBar 
+                x:Name="ToolsCommandBar"
+                Grid.Column="2"
+                Style="{StaticResource CustomCommandBar}" 
+                HorizontalAlignment="Left" 
+                IsDynamicOverflowEnabled="False" 
+                DefaultLabelPosition="Collapsed"/>
+
+            <!-- App resource usage-->
+            <CommandBar Grid.Column="3" Visibility="{x:Bind _viewModel.IsAppBarVisible, Mode=OneWay}">
+                <AppBarSeparator/>
+                <AppBarElementContainer>
+                    <StackPanel x:Name="AppResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,10,0,0">
+                        <StackPanel.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontFamily" Value="Segoe UI"/>
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
+                                <Setter Property="Margin" Value="8,0,8,0"/>
+                            </Style>
+                        </StackPanel.Resources>
+                        <TextBlock x:Uid="AppCPUUsage" Text="{x:Bind _viewModel.AppCpuUsage, Mode=OneWay}"/>
+                    </StackPanel>
+                </AppBarElementContainer>
+            </CommandBar>
+
+            <!-- System resource usage-->
+            <CommandBar Grid.Column="4">
+                <AppBarSeparator/>
+                <AppBarElementContainer>
+                    <StackPanel x:Name="SystemResourceStackPanel" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,10,0,0">
+                        <StackPanel.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="FontFamily" Value="Segoe UI"/>
+                                <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}"/>
+                                <Setter Property="Margin" Value="8,0,8,0"/>
+                            </Style>
+                        </StackPanel.Resources>
+                        <TextBlock x:Uid="SystemCPUUsage" Text="{x:Bind _viewModel.SystemCpuUsage, Mode=OneWay}"/>
+                        <TextBlock x:Uid="SystemMemUsage" Text="{x:Bind _viewModel.SystemRamUsage, Mode=OneWay}"/>
+                        <TextBlock x:Uid="SystemDiskUsage" Text="{x:Bind _viewModel.SystemDiskUsage, Mode=OneWay}"/>
+                    </StackPanel>
+                </AppBarElementContainer>
+            </CommandBar>
 
         </Grid>
 

--- a/tools/DevInsights/DevHome.DevInsights/Views/BarWindowHorizontal.xaml.cs
+++ b/tools/DevInsights/DevHome.DevInsights/Views/BarWindowHorizontal.xaml.cs
@@ -215,11 +215,11 @@ public partial class BarWindowHorizontal : WindowEx
         // If a tool is pinned, we'll add it to the primary commands list.
         if (tool.IsPinned)
         {
-            MyCommandBar.PrimaryCommands.Add(primaryCommandButton);
+            ToolsCommandBar.PrimaryCommands.Add(primaryCommandButton);
         }
 
         // We'll always add all tools to the secondary commands list.
-        MyCommandBar.SecondaryCommands.Add(secondaryCommandButton);
+        ToolsCommandBar.SecondaryCommands.Add(secondaryCommandButton);
 
         tool.PropertyChanged += (sender, args) =>
         {
@@ -236,11 +236,11 @@ public partial class BarWindowHorizontal : WindowEx
 
                 if (tool.IsPinned)
                 {
-                    MyCommandBar.PrimaryCommands.Add(primaryCommandButton);
+                    ToolsCommandBar.PrimaryCommands.Add(primaryCommandButton);
                 }
                 else
                 {
-                    MyCommandBar.PrimaryCommands.Remove(primaryCommandButton);
+                    ToolsCommandBar.PrimaryCommands.Remove(primaryCommandButton);
                 }
             }
         };
@@ -257,8 +257,8 @@ public partial class BarWindowHorizontal : WindowEx
         };
 
         // This should be at the top of the secondary command list
-        MyCommandBar.SecondaryCommands.Insert(0, manageToolsButton);
-        MyCommandBar.SecondaryCommands.Insert(1, new AppBarSeparator());
+        ToolsCommandBar.SecondaryCommands.Insert(0, manageToolsButton);
+        ToolsCommandBar.SecondaryCommands.Insert(1, new AppBarSeparator());
     }
 
     private MenuFlyoutItem CreatePinMenuItem(Tool tool, PinOption pinOption)
@@ -310,10 +310,10 @@ public partial class BarWindowHorizontal : WindowEx
                     if (oldItem.IsPinned)
                     {
                         // Find this item in the command bar
-                        AppBarButton? pinnedButton = MyCommandBar.PrimaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
+                        AppBarButton? pinnedButton = ToolsCommandBar.PrimaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
                         if (pinnedButton is not null)
                         {
-                            MyCommandBar.PrimaryCommands.Remove(pinnedButton);
+                            ToolsCommandBar.PrimaryCommands.Remove(pinnedButton);
                         }
                         else
                         {
@@ -321,10 +321,10 @@ public partial class BarWindowHorizontal : WindowEx
                         }
                     }
 
-                    AppBarButton? button = MyCommandBar.SecondaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
+                    AppBarButton? button = ToolsCommandBar.SecondaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Tag == oldItem);
                     if (button is not null)
                     {
-                        MyCommandBar.SecondaryCommands.Remove(button);
+                        ToolsCommandBar.SecondaryCommands.Remove(button);
                     }
                     else
                     {


### PR DESCRIPTION
## Summary of the pull request
Previously, we used a mix of different UI element types for the various parts of the toolbar, and this resulted in inconsistencies in how the controls look and behave. I moved everything into CommandBars, using AppBarButtons and AppBarElementContainers throughout. Including setting the base class for our custom buttons to be AppBarButton. Now all the buttons have the same shape/size/visual focus behavior, etc.

As part of this, moved the per-app CPU usage item to a new per-app resource panel alongside the system-wide resource panel. When we complete the user-selection work on resource items generally, we can continue to use these 2 panels.

Closes #3673 