### PR TITLE
Use localized strings for file and folder status

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/GitLocalRepositoryProviderUnitTests.cs
@@ -186,7 +186,7 @@ public class GitLocalRepositoryProviderUnitTests
         Assert.AreEqual(result[statusProperty], string.Empty);
         Assert.AreEqual(result[lastChangeMessageProperty], "Third a/a1");
         result = localRepo.GetProperties(properties, relativeToPath);
-        Assert.AreEqual(result[statusProperty], "Staged rename");
+        Assert.AreEqual(result[statusProperty], "Staged, Renamed");
         Assert.AreEqual(result[lastChangeMessageProperty], "Third a/a1");
 
         // Reset

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -174,9 +174,9 @@ internal sealed class RepositoryWrapper : IDisposable
         }
 
         var statusString = string.Empty;
-        bool staged = status.Status.HasFlag(FileStatus.NewInIndex) || status.Status.HasFlag(FileStatus.ModifiedInIndex) || status.Status.HasFlag(FileStatus.RenamedInIndex) || status.Status.HasFlag(FileStatus.TypeChangeInIndex);
-        bool modified = status.Status.HasFlag(FileStatus.ModifiedInWorkdir) || status.Status.HasFlag(FileStatus.TypeChangeInWorkdir);
-        bool renamed = status.Status.HasFlag(FileStatus.RenamedInIndex) || status.Status.HasFlag(FileStatus.RenamedInWorkdir);
+        var staged = status.Status.HasFlag(FileStatus.NewInIndex) || status.Status.HasFlag(FileStatus.ModifiedInIndex) || status.Status.HasFlag(FileStatus.RenamedInIndex) || status.Status.HasFlag(FileStatus.TypeChangeInIndex);
+        var modified = status.Status.HasFlag(FileStatus.ModifiedInWorkdir) || status.Status.HasFlag(FileStatus.TypeChangeInWorkdir);
+        var renamed = status.Status.HasFlag(FileStatus.RenamedInIndex) || status.Status.HasFlag(FileStatus.RenamedInWorkdir);
 
         if (staged)
         {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Strings/en-us/Resources.resw
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Strings/en-us/Resources.resw
@@ -121,4 +121,44 @@
     <value>Unable to get repository at the given root path</value>
     <comment>Error text for when the git extension is unable to obtain the repository given its root path</comment>
   </data>
+  <data name="FolderStatusBranch" xml:space="preserve">
+    <value>Branch: {0}</value>
+    <comment>Display the current Git branch</comment>
+  </data>
+  <data name="FolderStatusDetached" xml:space="preserve">
+    <value>Detached: {0}</value>
+    <comment>Display the commit id when the Git repo is in a detached state</comment>
+  </data>
+  <data name="FileStatusMergeConflict" xml:space="preserve">
+    <value>Merge conflict</value>
+    <comment>File status to display when its Git status is merge conflict</comment>
+  </data>
+  <data name="FileStatusUntracked" xml:space="preserve">
+    <value>Untracked</value>
+    <comment>File status to display when its Git status is untracked aka "new in the working dir"</comment>
+  </data>
+  <data name="FileStatusStaged" xml:space="preserve">
+    <value>Staged</value>
+    <comment>File status to display when its Git status has staged changes</comment>
+  </data>
+  <data name="FileStatusStagedRenamed" xml:space="preserve">
+    <value>Staged, Renamed</value>
+    <comment>File status to display when its Git status is renamed with staged changes</comment>
+  </data>
+  <data name="FileStatusStagedModified" xml:space="preserve">
+    <value>Staged, Modified</value>
+    <comment>File status to display when its Git status has staged changes and unstaged changes</comment>
+  </data>
+  <data name="FileStatusStagedRenamedModified" xml:space="preserve">
+    <value>Staged, Renamed, Modified</value>
+    <comment>File status to display when its Git status is renamed, and has both staged and unstaged changes</comment>
+  </data>
+  <data name="FileStatusModified" xml:space="preserve">
+    <value>Modified</value>
+    <comment>File status to display when its Git status has unstaged changes</comment>
+  </data>
+  <data name="FileStatusRenamedModified" xml:space="preserve">
+    <value>Renamed, Modified</value>
+    <comment>File status to display when its Git status is renamed with unstanged changes</comment>
+  </data>
 </root>

--- a/extensions/GitExtension/FileExplorerGitIntegration/Strings/en-us/Resources.resw
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Strings/en-us/Resources.resw
@@ -159,6 +159,7 @@
   </data>
   <data name="FileStatusRenamedModified" xml:space="preserve">
     <value>Renamed, Modified</value>
-    <comment>File status to display when its Git status is renamed with unstanged changes</comment>
+    <comment>File status to display when its Git status is renamed with unstaged changes</comment>
+
   </data>
 </root>

--- a/extensions/GitExtension/FileExplorerGitIntegration/Strings/en-us/Resources.resw
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Strings/en-us/Resources.resw
@@ -160,6 +160,5 @@
   <data name="FileStatusRenamedModified" xml:space="preserve">
     <value>Renamed, Modified</value>
     <comment>File status to display when its Git status is renamed with unstaged changes</comment>
-
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
The status strings we display show things like "Branch: ", "Modified", "Staged", etc. We need to localize these strings (and not localize things like git commit messages and such)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed
Ran private build against repositories and ran unit tests

## PR checklist
- [ ] Closes #3598 
- [ ] Tests added/passed
- [ ] Documentation updated
