### PR TITLE
Launch from SSH widget to Terminal if available

### DIFF
--- a/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
@@ -149,12 +150,26 @@ internal sealed class SSHWalletWidget : CoreWidget
         var cmd = new Process();
         cmd.StartInfo = new ProcessStartInfo
         {
-            FileName = "cmd.exe",
-            Arguments = $"/k \"ssh {args.Data}\"",
+            FileName = "wt.exe",
+            Arguments = $"ssh {args.Data}",
             UseShellExecute = true,
         };
 
-        cmd.Start();
+        try
+        {
+            cmd.Start();
+        }
+        catch (Win32Exception win32Ex)
+        {
+            Log.Error(win32Ex, "Failed to start wt.exe. Falling back to cmd.exe.");
+            cmd.StartInfo = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments = $"/k \"ssh {args.Data}\"",
+                UseShellExecute = true,
+            };
+            cmd.Start();
+        }
     }
 
     private void HandleCheckPath(WidgetActionInvokedArgs args)


### PR DESCRIPTION
## Summary of the pull request
Try launching via Terminal first. If Terminal isn't available, fall back to cmd. Uses the default profile. In the future, we could potentially give users the option to set a profile per-widget.

## Validation steps performed
Validated locally.

## PR checklist
- [ ] Closes #1936
- [ ] Tests added/passed
- [ ] Documentation updated
