### PR TITLE
Have DevHome launch with F5

### DIFF
--- a/src/Properties/launchsettings.json
+++ b/src/Properties/launchsettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DevHome (Package)": {
       "commandName": "MsixPackage",
-      "doNotLaunchApp": true,
+      "doNotLaunchApp": false,
       "nativeDebugging": false
     },
     "DevHome (Unpackaged)": {


### PR DESCRIPTION
## Summary of the pull request

I accidentally checked in a change to DevHome's debug launch profile that caused DevHome to not launch when doing F5. This reverts that change.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
