### PR TITLE
Respect app specific requested theme in customization dialogs

### DIFF
--- a/tools/Customization/DevHome.Customization/Views/ModifyFeaturesDialog.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/ModifyFeaturesDialog.xaml.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using DevHome.Common.Extensions;
+using DevHome.Contracts.Services;
 using DevHome.Customization.ViewModels;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Customization.Views;
@@ -15,6 +18,8 @@ public sealed partial class ModifyFeaturesDialog : ContentDialog
         ViewModel = new ModifyFeaturesDialogViewModel();
         this.InitializeComponent();
         this.DataContext = ViewModel;
+
+        RequestedTheme = Application.Current.GetService<IThemeSelectorService>().Theme;
     }
 
     private void OnCancelClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)

--- a/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/RestartDialog.xaml.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using DevHome.Common.Extensions;
 using DevHome.Common.Helpers;
+using DevHome.Contracts.Services;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace DevHome.Customization.Views;
@@ -11,6 +14,8 @@ public sealed partial class RestartDialog : ContentDialog
     public RestartDialog()
     {
         this.InitializeComponent();
+
+        RequestedTheme = Application.Current.GetService<IThemeSelectorService>().Theme;
     }
 
     private void OnRestartClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)


### PR DESCRIPTION
## Summary of the pull request
Set requested theme in modify features and restart dialog in Windows customization so that the Dev Home theme override is applied instead of the Windows system theme.

## References and relevant issues
#3749 

## Detailed description of the pull request / Additional comments

## Validation steps performed
Ensure Windows theme is set to light
Open Dev Home App.
Apply dark theme (Settings -> Preference -> Theme -> Dark).
Now Go to "Windows Customization" page (Select form the navigation options).
Select any of the options and click on "Apply" button.
Observe "Committing changes" pop up complies with Dev Home settings theme and not that of Windows, i.e. is Dark

## PR checklist
- [ ] Closes #3749 
- [ ] Tests added/passed
- [ ] Documentation updated
