### PR TITLE
fix environment deletion dialog to respect theme changes

### DIFF
--- a/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
+++ b/tools/Environments/DevHome.Environments/Strings/en-us/Resources.resw
@@ -265,19 +265,19 @@
     <value>Manage environments:</value>
     <comment>Header text for the cards that in the UI that are not being created.</comment>
   </data>
-  <data name="DeleteEnviroment_CancelButton" xml:space="preserve">
+  <data name="DeleteEnvironment_CancelButton" xml:space="preserve">
     <value>Cancel</value>
     <comment>Text for the cancel button of the delete environment confirmation popup.</comment>
   </data>
-  <data name="DeleteEnviroment_ConfirmButton" xml:space="preserve">
+  <data name="DeleteEnvironment_ConfirmButton" xml:space="preserve">
     <value>Delete</value>
     <comment>Text for the delete confirmation button of the delete environment confirmation popup.</comment>
   </data>
-  <data name="DeleteEnviroment_Content" xml:space="preserve">
+  <data name="DeleteEnvironment_Content" xml:space="preserve">
     <value>Choosing to delete your environment will remove it permanently.</value>
     <comment>Text for the content of the delete environment confirmation popup.</comment>
   </data>
-  <data name="DeleteEnviroment_Title" xml:space="preserve">
+  <data name="DeleteEnvironment_Title" xml:space="preserve">
     <value>Do you want to delete your environment?</value>
     <comment>Text for the title of the delete environment confirmation popup.</comment>
   </data>

--- a/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using DevHome.Common.Environments.Models;
+using DevHome.Common.Extensions;
 using DevHome.Common.Services;
+using DevHome.Contracts.Services;
 using DevHome.Environments.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -142,18 +144,20 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
         // Show confirmation popup in case of delete
         if (ComputeSystemOperation == ComputeSystemOperations.Delete)
         {
-            ContentDialog noWifiDialog = new ContentDialog
+            var themeService = Application.Current.GetService<IThemeSelectorService>();
+            var deletionContentDialog = new ContentDialog
             {
                 Title = _stringResource.GetLocalized("DeleteEnviroment_Title"),
                 Content = _stringResource.GetLocalized("DeleteEnviroment_Content"),
                 PrimaryButtonText = _stringResource.GetLocalized("DeleteEnviroment_ConfirmButton"),
                 SecondaryButtonText = _stringResource.GetLocalized("DeleteEnviroment_CancelButton"),
                 XamlRoot = _mainWindow?.Content.XamlRoot,
+                RequestedTheme = themeService.Theme,
             };
 
             _mainWindow?.DispatcherQueue?.TryEnqueue(async () =>
             {
-                var result = await noWifiDialog.ShowAsync();
+                var result = await deletionContentDialog.ShowAsync();
 
                 // Delete the enviroment after confirmation
                 if (result == ContentDialogResult.Primary)

--- a/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/OperationsViewModel.cs
@@ -147,10 +147,10 @@ public partial class OperationsViewModel : IEquatable<OperationsViewModel>
             var themeService = Application.Current.GetService<IThemeSelectorService>();
             var deletionContentDialog = new ContentDialog
             {
-                Title = _stringResource.GetLocalized("DeleteEnviroment_Title"),
-                Content = _stringResource.GetLocalized("DeleteEnviroment_Content"),
-                PrimaryButtonText = _stringResource.GetLocalized("DeleteEnviroment_ConfirmButton"),
-                SecondaryButtonText = _stringResource.GetLocalized("DeleteEnviroment_CancelButton"),
+                Title = _stringResource.GetLocalized("DeleteEnvironment_Title"),
+                Content = _stringResource.GetLocalized("DeleteEnvironment_Content"),
+                PrimaryButtonText = _stringResource.GetLocalized("DeleteEnvironment_ConfirmButton"),
+                SecondaryButtonText = _stringResource.GetLocalized("DeleteEnvironment_CancelButton"),
                 XamlRoot = _mainWindow?.Content.XamlRoot,
                 RequestedTheme = themeService.Theme,
             };


### PR DESCRIPTION
## Summary of the pull request
fixes accessibility issue where we weren't respecting the app's theme when launching the "Delete environment" dialog. To do this, we'll now use Dev Homes theme service to get the current theme of the app, and use that as the requested theme for the dialog. 

**Before:**

https://github.com/user-attachments/assets/842a0768-607b-4526-9047-499c82159f29


**After**

https://github.com/user-attachments/assets/2016c01c-d35b-4b80-9bb7-a0b83365a22e


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #3753
- [ ] Tests added/passed
- [ ] Documentation updated
