### PR TITLE
Fixed Clipboard Monitor text size and window width

### DIFF
--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Controls/ClipboardMonitorControl.xaml
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Controls/ClipboardMonitorControl.xaml
@@ -32,7 +32,6 @@
                 <Setter Property="IsReadOnly" Value="True"/>
                 <Setter Property="VerticalAlignment" Value="Center"/>
                 <Setter Property="Margin" Value="0 2 0 0"/>
-                <Setter Property="Height" Value="25"/>
             </Style>
         </Grid.Resources>
         <TextBlock x:Uid="HexLabelTextBlock" Grid.Column="1" AutomationProperties.AutomationId="HexLabel"/>

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Helpers/Tool.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Helpers/Tool.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DevHome.Common.Extensions;
 using DevHome.DevDiagnostics.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -71,6 +72,10 @@ public abstract partial class Tool : ObservableObject
         ToolLaunchOptions options = new();
         options.TargetProcessId = TargetAppData.Instance.TargetProcess?.Id;
         options.TargetHWnd = TargetAppData.Instance.HWnd;
+
+        var barWindow = Application.Current.GetService<PrimaryWindow>().DBarWindow;
+        options.ParentWindow = barWindow;
+
         InvokeTool(options);
     }
 

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Views/ClipboardMonitoringWindow.xaml.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Views/ClipboardMonitoringWindow.xaml.cs
@@ -10,7 +10,7 @@ public sealed partial class ClipboardMonitoringWindow : WindowEx
 {
     public ClipboardMonitoringWindow()
     {
-        this.InitializeComponent();
+        InitializeComponent();
         Title = CommonHelper.GetLocalizedString("ClipboardMonitorWindowTitle");
     }
 }


### PR DESCRIPTION
## Summary of the pull request
Removed the unnecessary height restriction on the text, and set the window width to the same as the parent BarWindow width. The code was already in place to base the window size/position off the parent window, but the parent window wasn't getting set.

Closes #3693 
Closes #3700 
