### PR TITLE
prevent the more options button in environments cards from being cut off when text is scaled to 200%

### DIFF
--- a/common/Environments/Styles/HorizontalCardStyles.xaml
+++ b/common/Environments/Styles/HorizontalCardStyles.xaml
@@ -126,6 +126,7 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Width" Value="36" />
         <Setter Property="Height" Value="36" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     </Style>
 

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -66,6 +66,7 @@
                 <Grid>
                     <Button
                         x:Uid="MoreOptionsButton"
+                        Padding="0"
                         Style="{StaticResource HorizontalThreeDotsStyle}">
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}"/>
@@ -79,6 +80,7 @@
                 <Grid>
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}"
+                        Padding="0"
                         x:Uid="MoreOptionsButton">
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}" />

--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -66,7 +66,6 @@
                 <Grid>
                     <Button
                         x:Uid="MoreOptionsButton"
-                        Padding="0"
                         Style="{StaticResource HorizontalThreeDotsStyle}">
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}"/>
@@ -80,7 +79,6 @@
                 <Grid>
                     <Button
                         Style="{StaticResource HorizontalThreeDotsStyle}"
-                        Padding="0"
                         x:Uid="MoreOptionsButton">
                         <Button.Flyout>
                             <customControls:CardFlyout ItemsViewModels="{x:Bind DotOperations, Mode=OneWay}" />


### PR DESCRIPTION
## Summary of the pull request
When text is scaled at 200 percent the horizontal 3 dots button on the environment cards appear to be cutoff. This is an accessibility issue. Issue happens because as the scale of the text increases, the text bleeds into the buttons padding causing it to looks as if it was clipped/missing a dot character.

Changes:

- Remove the padding from the button as it is not needed for this button

**Before changes:**

<img width="1151" alt="before no padding change" src="https://github.com/user-attachments/assets/63e645ac-4b5b-49e0-b50e-f3625fe58873">


**After changes**
<img width="1151" alt="After padding changes" src="https://github.com/user-attachments/assets/3e68ad94-30f1-4c31-b539-5601ae266c8d">

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #3760 3760
- [ ] Tests added/passed
- [ ] Documentation updated
