### PR TITLE
Only show end task setting on Windows 11

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/GeneralSystemViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/GeneralSystemViewModel.cs
@@ -41,6 +41,8 @@ public partial class GeneralSystemViewModel : ObservableObject
 
     public bool CanModifyLongPaths => _isUserAdministrator && !ModifyLongPathsCommand.IsRunning;
 
+    public bool ShowEndTaskOnTaskBarSetting => RuntimeHelper.IsOnWindows11;
+
     public GeneralSystemViewModel(DispatcherQueue dispatcherQueue)
     {
         _dispatcherQueue = dispatcherQueue;

--- a/tools/Customization/DevHome.Customization/Views/GeneralSystemView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/GeneralSystemView.xaml
@@ -20,7 +20,7 @@
         <controls:SettingsCard x:Uid="LongPaths" Margin="{ThemeResource SettingsCardMargin}">
             <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.LongPathsEnabled, Mode=TwoWay}" IsEnabled="{x:Bind ViewModel.CanModifyLongPaths, Mode=OneWay}"/>
         </controls:SettingsCard>
-        <controls:SettingsCard x:Uid="EndTaskOnTaskBar" Margin="{ThemeResource SettingsCardMargin}">
+        <controls:SettingsCard x:Uid="EndTaskOnTaskBar" Margin="{ThemeResource SettingsCardMargin}" Visibility="{x:Bind ViewModel.ShowEndTaskOnTaskBarSetting }">
             <ToggleSwitch Grid.Column="1" IsOn="{x:Bind ViewModel.EndTaskOnTaskBarEnabled, Mode=TwoWay}" />
         </controls:SettingsCard>
     </StackPanel>


### PR DESCRIPTION
## Summary of the pull request
End task on task bar is not supported on Windows 10. This change sets the visibility of that setting to reference IsOnWindows11

## References and relevant issues
#3570

## Validation steps performed
Confirm that the setting is visible on Windows 11 and hidden on Windows 10

## PR checklist
- [ ] Closes #3570
- [ ] Tests added/passed
- [ ] Documentation updated
