### PR TITLE
[FE + Version Control] Accessibility Insights Fast Pass: Section 508 502.3.1: (DevHome/button '') The Name property must not contain any characters in the private Unicode range. 

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -485,7 +485,7 @@
     <value>Close</value>
     <comment>Text for a button to close a content dialog</comment>
   </data>
-  <data name="MoreOptionsButton.AutomationProperties.Name" xml:space="preserve">
+  <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>More Options</value>
     <comment>Text for the more options button on the setting card for the Add Repositories UI</comment>
   </data>

--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -483,6 +483,10 @@
   </data>
   <data name="CloseButtonText" xml:space="preserve">
     <value>Close</value>
-    <comment>Text for a button to close a content dialog.</comment>
+    <comment>Text for a button to close a content dialog</comment>
+  </data>
+  <data name="MoreOptionsButton.AutomationProperties.Name" xml:space="preserve">
+    <value>More Options</value>
+    <comment>Text for the more options button on the setting card for the Add Repositories UI</comment>
   </data>
 </root>

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -49,7 +49,7 @@
                                 </DropDownButton.Flyout>
                             </DropDownButton>
                             <Button 
-                                x:Name="MoreOptionsButton"
+                                x:Uid="MoreOptionsButton"
                                 Content="&#xe712;"
                                 Height="36" 
                                 MinWidth="36"


### PR DESCRIPTION
## Summary of the pull request
The PR fixes an accessibility issue in the Add Repositories UI under the Windows Customization File Explorer page.  

## References and relevant issues
https://github.com/microsoft/devhome/issues/3665

## Detailed description of the pull request / Additional comments
An accessible name was declared for the button through AutomationProperties.Name. 

## Validation steps performed
Local Build
Ensured that the issue no longer reproduces after the fix is applied using the Accessibility Insights for Windows tool. Some screenshots below: 

Without fix the issue is identified in the tool: 
![image](https://github.com/user-attachments/assets/805e8f5a-3872-4b1a-8ef2-a5eccedf50d9)

With fix, the issue no longer appears 
![image](https://github.com/user-attachments/assets/760eb25d-c8fe-447b-98ae-13cfaa54c992)


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
