### PR TITLE
Reset AdaptiveCardFlowNavigator when machine configuration ends a flow

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Models/AdaptiveCardFlowNavigator.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/AdaptiveCardFlowNavigator.cs
@@ -31,7 +31,7 @@ public class AdaptiveCardFlowNavigator
     /// <see cref="_nextButtonAdaptiveCardId"/> and <see cref="_previousButtonAdaptiveCardId"/> in order for
     /// Dev Home to know which buttons in the adaptive card Json moves the flow forward and backwards.
     /// </remarks>
-    public DevHomeActionSet DevHomeActionSetRenderer { get; } = new(TopLevelCardActionSetVisibility.Hidden);
+    public DevHomeActionSet DevHomeActionSetRenderer { get; private set; } = new(TopLevelCardActionSetVisibility.Hidden);
 
     /// <summary>
     /// Performs the validation work needed to navigate to the next page in an adaptive card. This is used
@@ -66,5 +66,10 @@ public class AdaptiveCardFlowNavigator
     public bool IsActionInvokerAvailable()
     {
         return DevHomeActionSetRenderer.ActionButtonInvoker != null;
+    }
+
+    public void ResetFlowNavigator()
+    {
+        DevHomeActionSetRenderer = new(TopLevelCardActionSetVisibility.Hidden);
     }
 }

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -120,6 +120,7 @@ public partial class SetupFlowViewModel : ObservableObject
         _packageProvider.Clear();
         EndSetupFlow(null, EventArgs.Empty);
 
+        Orchestrator.AdaptiveCardFlowNavigator.ResetFlowNavigator();
         Orchestrator.FlowPages = new List<SetupPageViewModelBase> { _mainPageViewModel };
     }
 


### PR DESCRIPTION
## Summary of the pull request
Fixes issue where after an adaptive card wizard like flow, the set up flow orchestrator still believes it's in an adaptive card flow the next time the user starts another flow. This prevents regular flows that don't use an adaptive card wizard like experience from moving past the review page. This is because the review page expects to receive data telling it whether there was an error or not from the extension, when the user clicks the primary button for the page. In this case it's the "Set up" button. See: 
https://github.com/microsoft/devhome/blob/31bfc0375bccebfd1a38f546c4148d3c761cdcbb/tools/SetupFlow/DevHome.SetupFlow/ViewModels/ReviewViewModel.cs#L192

Video Before fix:

You'll see I start off the creation process for a Hyper-V VM (This starts an adaptive card wizard flow). Then I start the flow for setting up an environment (this does not start an adaptive card wizard flow). You'll see when I get to the end that I am unable to click the "Set up" button.

https://github.com/user-attachments/assets/c4da4e31-6054-482d-b436-d1b0a062ef5c


Video After fix:

In this video I create a WSL distribution using the creation flow, which starts the adaptive card wizard like experience. Then after that I show that I am able to go past the review page in the set up environment flow, which does not start an adaptive card wizard flow. 


https://github.com/user-attachments/assets/7efcc160-3e61-4dd8-84ed-858d8f322809


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #3785 3785
- [ ] Tests added/passed
- [ ] Documentation updated
