### PR TITLE
Update creation so Dev Home no longer brings up the wsl.exe window during creation

### DIFF
--- a/extensions/WSLExtension/Constants.cs
+++ b/extensions/WSLExtension/Constants.cs
@@ -30,6 +30,9 @@ public static class Constants
     // Wsl registry location for registered distributions.
     public const string WslRegistryLocation = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss";
 
+    // Registry location for app paths
+    public const string AppPathsRegistryLocation = @"Software\Microsoft\Windows\CurrentVersion\App Paths";
+
     // Wsl registry data names within a distribution location.
     public const string PackageFamilyRegistryName = "PackageFamilyName";
     public const string DistributionRegistryName = "DistributionName";
@@ -49,8 +52,13 @@ public static class Constants
     // Arguments to terminate all wsl sessions for a specific distribution using wsl.exe
     public const string TerminateDistributionArgs = "--terminate {0}";
 
-    // Arguments to download, install and register a wsl distribution.
-    public const string InstallDistributionArgs = "--install --distribution {0}";
+    // Arguments to installs and Register a wsl distribution using the distributions
+    // <launcher>.exe executable file. Where <launcher> is the WSL distributions name.
+    // See: https://github.com/microsoft/WSL-DistroLauncher?tab=readme-ov-file#contents
+    // for more information on the launcher executable. Using --root allows us to register
+    // the distribution without the command line session being hung waiting for the user to
+    // create a new username and password.
+    public const string InstallAndRegisterDistributionArgs = "install --root";
 
     // Arguments to list of all running distributions on a machine using wsl.exe
     public const string ListAllRunningDistributions = "--list --running";

--- a/extensions/WSLExtension/Contracts/IWslManager.cs
+++ b/extensions/WSLExtension/Contracts/IWslManager.cs
@@ -39,10 +39,11 @@ public interface IWslManager
     /// </summary>
     void LaunchDistribution(string distributionName);
 
-    /// <summary> Installs a new WSL distribution.
-    /// This is a wrapper for <see cref="IWslServicesMediator.InstallDistribution(string)"/>
-    /// </summary>
-    void InstallDistribution(string distributionName);
+    /// <summary> Installs a new WSL distribution from the Microsoft store. /// </summary>
+    public Task InstallDistributionPackageAsync(
+        DistributionDefinition definition,
+        Action<string>? statusUpdateCallback,
+        CancellationToken cancellationToken);
 
     /// <summary> Terminates all sessions for a new WSL distribution.
     /// This is a wrapper for <see cref="IWslServicesMediator.TerminateDistribution(string)"/>

--- a/extensions/WSLExtension/Contracts/IWslManager.cs
+++ b/extensions/WSLExtension/Contracts/IWslManager.cs
@@ -39,7 +39,7 @@ public interface IWslManager
     /// </summary>
     void LaunchDistribution(string distributionName);
 
-    /// <summary> Installs a new WSL distribution from the Microsoft store. /// </summary>
+    /// <summary> Installs a new WSL distribution from the Microsoft store.</summary>
     public Task InstallDistributionPackageAsync(
         DistributionDefinition definition,
         Action<string>? statusUpdateCallback,

--- a/extensions/WSLExtension/Contracts/IWslServicesMediator.cs
+++ b/extensions/WSLExtension/Contracts/IWslServicesMediator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Windows.ApplicationModel;
 using WSLExtension.Models;
 
 namespace WSLExtension.Contracts;
@@ -31,8 +32,8 @@ public interface IWslServicesMediator
     /// <summary> Launches a new WSL process with the provided distribution. </summary>
     void LaunchDistribution(string distributionName);
 
-    /// <summary> Installs and registers a new distribution on the machine. </summary>
-    void InstallDistribution(string distributionName);
+    /// <summary> Installs and registers a distribution on the machine. </summary>
+    void InstallAndRegisterDistribution(Package distributionPackage);
 
     /// <summary> Terminates all running WSL sessions for the provided distribution on the machine. </summary>
     void TerminateDistribution(string distributionName);

--- a/extensions/WSLExtension/DevHomeProviders/WslProvider.cs
+++ b/extensions/WSLExtension/DevHomeProviders/WslProvider.cs
@@ -72,10 +72,16 @@ public class WslProvider : IComputeSystemProvider
                 deserializedObject as WslInstallationUserInput ?? throw new InvalidOperationException($"Json deserialization failed for input Json: {inputJson}");
 
             var definitions = _wslManager.GetAllDistributionsAvailableToInstallAsync().GetAwaiter().GetResult();
-            return new WslInstallDistributionOperation(
-                definitions[wslInstallationUserInput.SelectedDistributionIndex],
-                _stringResource,
-                _wslManager);
+
+            // Make sure the distribution the user selected is still available.
+            var definition = definitions.SingleOrDefault(definition => definition.IsSameDistribution(wslInstallationUserInput.NewEnvironmentName));
+
+            if (definition == null)
+            {
+                throw new InvalidOperationException($"Couldn't find selected distribution with input {inputJson}");
+            }
+
+            return new WslInstallDistributionOperation(definition, _stringResource, _wslManager);
         }
         catch (Exception ex)
         {

--- a/extensions/WSLExtension/DistributionDefinitions/DistributionDefinition.cs
+++ b/extensions/WSLExtension/DistributionDefinitions/DistributionDefinition.cs
@@ -35,4 +35,19 @@ public class DistributionDefinition
     public string PackageFamilyName { get; set; } = string.Empty;
 
     public string Publisher { get; set; } = string.Empty;
+
+    public bool IsSameDistribution(string name)
+    {
+        // Both name and friendly name should not be empty or null in the WSL distribution
+        // json.
+        if (string.IsNullOrEmpty(Name) || string.IsNullOrEmpty(FriendlyName))
+        {
+            return false;
+        }
+
+        // For distributions retrieved from the WSL distribution Json, both the name and
+        // friendly names are unique.
+        return Name.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+            FriendlyName.Equals(name, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/extensions/WSLExtension/Exceptions/AppExecutionAliasNotFoundException.cs
+++ b/extensions/WSLExtension/Exceptions/AppExecutionAliasNotFoundException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WSLExtension.Exceptions;
+
+public class AppExecutionAliasNotFoundException : Exception
+{
+    public AppExecutionAliasNotFoundException(string? message)
+        : base(message)
+    {
+    }
+}

--- a/extensions/WSLExtension/Models/WslProcessData.cs
+++ b/extensions/WSLExtension/Models/WslProcessData.cs
@@ -32,7 +32,7 @@ public class WslProcessData
 
     public bool ExitedSuccessfully()
     {
-        return ExitCode == WslExeExitSuccess && string.IsNullOrEmpty(StdError);
+        return ExitCode == WslExeExitSuccess;
     }
 
     public override string ToString()

--- a/extensions/WSLExtension/Services/WslManager.cs
+++ b/extensions/WSLExtension/Services/WslManager.cs
@@ -33,7 +33,11 @@ public class WslManager : IWslManager, IDisposable
 
     private readonly IStringResource _stringResource;
 
+    private readonly object _distributionInstallLock = new();
+
     private readonly SemaphoreSlim _wslKernelPackageInstallLock = new(1, 1);
+
+    private readonly HashSet<string> _distributionsBeingInstalled = new();
 
     public event EventHandler<HashSet<string>>? DistributionStateSyncEventHandler;
 
@@ -90,15 +94,25 @@ public class WslManager : IWslManager, IDisposable
         var registeredDistributionsMap = await GetInformationOnAllRegisteredDistributionsAsync();
         var distributionsToListOnCreationPage = new List<DistributionDefinition>();
         _distributionDefinitionsMap ??= await _definitionHelper.GetDistributionDefinitionsAsync();
-        foreach (var distributionDefinition in _distributionDefinitionsMap.Values)
-        {
-            // filter out distribution definitions already registered on machine.
-            if (registeredDistributionsMap.TryGetValue(distributionDefinition.Name, out var _))
-            {
-                continue;
-            }
 
-            distributionsToListOnCreationPage.Add(distributionDefinition);
+        lock (_distributionInstallLock)
+        {
+            foreach (var distributionDefinition in _distributionDefinitionsMap.Values)
+            {
+                // filter out distribution definitions already registered on machine.
+                if (registeredDistributionsMap.TryGetValue(distributionDefinition.Name, out var _))
+                {
+                    continue;
+                }
+
+                // filter out distributions that are currently being installed/registered.
+                if (_distributionsBeingInstalled.Contains(distributionDefinition.Name))
+                {
+                    continue;
+                }
+
+                distributionsToListOnCreationPage.Add(distributionDefinition);
+            }
         }
 
         // Sort the list by distribution name in ascending order before sending it.
@@ -138,10 +152,58 @@ public class WslManager : IWslManager, IDisposable
         _wslServicesMediator.LaunchDistribution(distributionName);
     }
 
-    /// <inheritdoc cref="IWslManager.InstallDistribution"/>
-    public void InstallDistribution(string distributionName)
+    /// <inheritdoc cref="IWslManager.InstallDistributionPackageAsync"/>
+    public async Task InstallDistributionPackageAsync(
+        DistributionDefinition definition,
+        Action<string>? statusUpdateCallback,
+        CancellationToken cancellationToken)
     {
-        _wslServicesMediator.InstallDistribution(distributionName);
+        lock (_distributionInstallLock)
+        {
+            if (_distributionsBeingInstalled.Contains(definition.Name))
+            {
+                throw new InvalidOperationException("Distribution already being installed");
+            }
+
+            _distributionsBeingInstalled.Add(definition.Name);
+        }
+
+        try
+        {
+            statusUpdateCallback?.Invoke(_stringResource.GetLocalized("DistributionPackageInstallationCheck", definition.FriendlyName));
+            if (!_packageHelper.IsPackageInstalled(definition.PackageFamilyName))
+            {
+                // Install it from the store.
+                statusUpdateCallback?.Invoke(_stringResource.GetLocalized("DistributionPackageInstallationStart", definition.FriendlyName));
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!await _microsoftStoreService.TryInstallPackageAsync(definition.StoreAppId))
+                {
+                    throw new InvalidDataException($"Failed to install the {definition.Name} package");
+                }
+            }
+            else
+            {
+                statusUpdateCallback?.Invoke(_stringResource.GetLocalized("DistributionPackageAlreadyInstalled", definition.FriendlyName));
+            }
+
+            var package = _packageHelper.GetPackageFromPackageFamilyName(definition.PackageFamilyName);
+            if (package == null)
+            {
+                throw new InvalidDataException($"Couldn't find the {definition.Name} package");
+            }
+
+            statusUpdateCallback?.Invoke(_stringResource.GetLocalized("WSLWaitingToCompleteRegistration", definition.FriendlyName));
+            cancellationToken.ThrowIfCancellationRequested();
+            _wslServicesMediator.InstallAndRegisterDistribution(package);
+            statusUpdateCallback?.Invoke(_stringResource.GetLocalized("WSLRegistrationCompletedSuccessfully", definition.FriendlyName));
+        }
+        finally
+        {
+            lock (_distributionInstallLock)
+            {
+                _distributionsBeingInstalled.Remove(definition.Name);
+            }
+        }
     }
 
     /// <inheritdoc cref="IWslManager.TerminateDistribution"/>
@@ -228,6 +290,21 @@ public class WslManager : IWslManager, IDisposable
     private void OnInstallChanged(object sender, AppInstallManagerItemEventArgs args)
     {
         var installItem = args.Item;
+        var installationStatus = installItem.GetCurrentStatus();
+        var itemInstallState = installationStatus.InstallState;
+
+        lock (_distributionInstallLock)
+        {
+            if (_distributionsBeingInstalled.Contains(installItem.ProductId))
+            {
+                if (itemInstallState == AppInstallState.Completed ||
+                    itemInstallState == AppInstallState.Canceled ||
+                    itemInstallState == AppInstallState.Error)
+                {
+                    _distributionsBeingInstalled.Remove(installItem.ProductId);
+                }
+            }
+        }
 
         WslInstallationEventHandler?.Invoke(this, installItem);
     }

--- a/extensions/WSLExtension/Strings/en-US/Resources.resw
+++ b/extensions/WSLExtension/Strings/en-US/Resources.resw
@@ -130,10 +130,6 @@
     <value>Starting the creation process for {0}</value>
     <comment>{Locked="{0}"} Text for when a user starts the creation process for a specific wsl distribution. {0} is the name of the distribution</comment>
   </data>
-  <data name="WSLWaitingToCompleteInstallation" xml:space="preserve">
-    <value>Waiting for {0}'s installation to complete</value>
-    <comment>{Locked="{0}"} Text message to display when a wsl distribution is installing. {0} is the name of the distribution</comment>
-  </data>
   <data name="WSLWaitingToCompleteRegistration" xml:space="preserve">
     <value>Waiting for the Windows Subsystem for Linux service to register {0}. This may take a few minutes.</value>
     <comment>{Locked="Windows", "Linux", "{0}"} Text to display when a specific wsl distribution is being registered. {0} is the name of the distribution</comment>
@@ -141,10 +137,6 @@
   <data name="WSLInstallationFailedWithException" xml:space="preserve">
     <value>Unable to install and register {0} due to error: {1}. Try using wsl.exe to install it manually. See aka.ms/wslinstall</value>
     <comment>{Locked="{0}", "{1}", "wsl.exe", "aka.ms/wslinstall"} Text message to display when the extension failed to install a wsl distribution. {0} is the name of the distribution and {1} is the error message.</comment>
-  </data>
- <data name="WSLInstallationFailedTimeOut" xml:space="preserve">
-    <value>Installation timed out, unable to install and register {0}. Try using wsl.exe to install manually. See aka.ms/wslinstall</value>
-    <comment>{Locked="{0}", "{wsl.exe}", "{aka.ms/wslinstall}"} Text message to display when the extension failed to install a wsl distribution. {0} is the name of the distribution</comment>
   </data>
   <data name="InstallingWslKernelPackage" xml:space="preserve">
     <value>The Windows Subsystem for Linux kernel package is not installed. Starting installation.</value>
@@ -154,9 +146,25 @@
     <value>Checking if the Windows Subsystem for Linux kernel package is installed</value>
     <comment>{Locked="Windows", "Linux"}</comment>
   </data>
+  <data name="DistributionPackageAlreadyInstalled" xml:space="preserve">
+    <value>The {0} package is already installed. Attempting to register it with the Windows Subsystem for Linux service.</value>
+    <comment>{Locked="{0}", "Windows", "Linux"} Text to display when a specific wsl distribution package is already installed. {0} is the name of the distribution</comment>
+  </data>
+  <data name="DistributionPackageInstallationCheck" xml:space="preserve">
+    <value>Checking if the {0} package is already installed</value>
+    <comment>{Locked="{0}"} Text to display when the extension checks the users system to confirm if a specific wsl distribution package is already installed. {0} is the name of the distribution</comment>
+  </data>
+  <data name="DistributionPackageInstallationStart" xml:space="preserve">
+    <value>The {0} package is not installed. Starting store installation.</value>
+    <comment>{Locked="{0}"} Text to display when a specific wsl distribution package is not installed. {0} is the name of the distribution</comment>
+  </data>
   <data name="WSLInstallationCompletedSuccessfully" xml:space="preserve">
     <value>Successfully installed {0}</value>
     <comment>{Locked="{0}"} Text to display when the extension successfully installs a specific wsl distribution package onto a users machine. {0} is the name of the distribution</comment>
+  </data>
+  <data name="WSLRegistrationCompletedSuccessfully" xml:space="preserve">
+    <value>Successfully registered {0}</value>
+    <comment>{Locked="{0}"} Text to display when the extension successfully registers a specific wsl distribution. {0} is the name of the distribution</comment>
   </data>
   <data name="VirtualMachinePlatformNotInstalled" xml:space="preserve">
     <value>The Virtual Machine Platform feature is needed for the WSL extension to function properly. The feature can be enabled in Dev Home's Windows customization page, under the virtualization feature management option. Enabling the feature will require a reboot. For more information on WSL requirements visit aka.ms/wslinstall</value>
@@ -213,5 +221,9 @@
   <data name="WslKernelPackageInstalled" xml:space="preserve">
     <value>The Windows Subsystem for Linux kernel package is installed</value>
     <comment>{Locked="Windows", "Linux"} Text to display when the wsl package is installed.</comment>
+  </data>
+  <data name="WSLRegistrationFailedDueToNoAppExAlias" xml:space="preserve">
+    <value>Failed to register {0} with the Windows Subsystem for Linux service due its app execution alias being turned off or missing. Please open the Windows Settings app and navigate to the app execution alias page to toggle the setting on for {0}, then try again.</value>
+    <comment>{Locked="{0}", "{Windows}", "Linux"} Text to display when the registration of a specific wsl distribution failed due to its app execution alias setting being turned off. {0} is the name of the distribution.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the pull request
This is a follow up PR to #3743 . Before that change we were using `wsl.exe --install <distribution name>`  to both install the WSL kernel package, and the distribution the user selected. Now, after this change the WSL extension itself will install the WSL kernel package from the store, but we still let wsl.exe do the downloading, installing and registering of the distribution package from the store. With this change all three of those tasks will now be done by the WSL extension. This provides us better flexibility and the user no longer sees a disconnected terminal Window outside of Dev Home. Everything from downloading, installing and registering the distribution will happen within Dev Home itself.

Here is a video of me installing the Debian distribution **BEFORE** my changes

https://github.com/user-attachments/assets/ca1109bb-8585-4a80-bcdb-9259af1a27c3

Here is a video of me installing the Debian distribution **AFTER** my changes

https://github.com/user-attachments/assets/451cb496-71d5-483e-8dcd-ac20c53722f5

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
