### PR TITLE
Fix DevDiagnostics startup issue - Don't PInvoke into CoImpersonateClient

### DIFF
--- a/service/DevHome.Service/DevHomeService.cs
+++ b/service/DevHome.Service/DevHomeService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace DevHome.Service.Runtime;
@@ -10,10 +11,12 @@ public class DevHomeService : IDevHomeService
 {
     public DevHomeService()
     {
-        ComHelpers.VerifyCaller();
+        Process myCaller = ComHelpers.GetClientProcess();
+
+        ComHelpers.VerifyCaller(myCaller);
 
         // Track our caller process
-        ServiceLifetimeController.RegisterProcess(ComHelpers.GetClientProcess());
+        ServiceLifetimeController.RegisterProcess(myCaller);
     }
 
     public int GetNumber()

--- a/service/DevHome.Service/NativeMethods.txt
+++ b/service/DevHome.Service/NativeMethods.txt
@@ -1,5 +1,3 @@
-CoImpersonateClient
-CoRevertToSelf
 CoInitializeEx
 CoInitializeSecurity
 CoGetCallContext
@@ -7,6 +5,8 @@ CoRegisterClassObject
 CoResumeClassObjects
 GetPackageFullNameFromToken
 I_RpcBindingInqLocalClientPID
+OpenProcess
+OpenProcessToken
 CLASS_E_NOAGGREGATION
 E_ACCESSDENIED
 E_NOINTERFACE


### PR DESCRIPTION
## Summary of the pull request

DevDiagnostics, on a retail build without a debugger attached, was failing to launch due to missing method exceptions. This was due to the CLR being unable to a load assemblies and types when impersonating a medium IL caller in its NT service.

In retrospect, doing an impersonation in C# is a really bad idea(tm), so I've updated the caller validation code to not require it.

## References and relevant issues

## Detailed description of the pull request / Additional comments

(Some of this is drawn from my old and possibly incorrect information)

In Debug builds (and builds where the debugger is attached), the CLR will JIT/load all of the types and assemblies when the code initially enters a function. Presumably this is why this bug didn't repro in day-to-day development.

On retail builds, it appears the CLR is loading types and assemblies on demand. In this case, we'd impersonate the caller of the service (a medium IL process), and then call a few more functions. Under the covers the CLR would trying to load types/assemblies to be able to call those functions, but it was running in a medium IL context, and thus would fail to load files into a system service.

The change removes the impersonation code, so the CLR has the permissions to do whatever it needs.

My goal is to make failures involving the NT service more easily diagnosible, but for this PR, I just wanted to fix the bug.

## Validation steps performed

## PR checklist
- [ ] Closes #3773 
- [ ] Tests added/passed
- [ ] Documentation updated
