### PR TITLE
update environments telemetry to add hresults

### DIFF
--- a/common/Environments/Models/CreateComputeSystemOperation.cs
+++ b/common/Environments/Models/CreateComputeSystemOperation.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DevHome.Common.Environments.Helpers;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Common.TelemetryEvents.SetupFlow.Environments;
 using DevHome.Telemetry;
 using Microsoft.Windows.DevHome.SDK;
@@ -127,11 +128,14 @@ public class CreateComputeSystemOperation : IDisposable
                 Completed?.Invoke(this, CreateComputeSystemResult);
             }
 
-            var (displayMessage, diagnosticText, telemetryStatus) = ComputeSystemHelpers.LogResult(CreateComputeSystemResult?.Result, _log);
+            var (_, _, telemetryStatus) = ComputeSystemHelpers.LogResult(CreateComputeSystemResult?.Result, _log);
+            var telemetryResult = new TelemetryResult(CreateComputeSystemResult?.Result);
+            var providerId = ProviderDetails.ComputeSystemProvider.Id;
+
             TelemetryFactory.Get<ITelemetry>().Log(
                 "Environment_Creation_Event",
                 LogLevel.Critical,
-                new EnvironmentCreationEvent(ProviderDetails.ComputeSystemProvider.Id, telemetryStatus, displayMessage, diagnosticText),
+                new EnvironmentCreationEvent(ProviderDetails.ComputeSystemProvider.Id, telemetryStatus, telemetryResult),
                 _activityId);
 
             RemoveEventHandlers();

--- a/common/NativeMethods.txt
+++ b/common/NativeMethods.txt
@@ -18,3 +18,4 @@ GetWindowRect
 GetMonitorInfo
 SetWindowPos
 MonitorFromWindow
+E_INVALIDARG

--- a/common/TelemetryEvents/Environments/EnvironmentOperationEvent.cs
+++ b/common/TelemetryEvents/Environments/EnvironmentOperationEvent.cs
@@ -28,29 +28,29 @@ public class EnvironmentOperationEvent : EventBase
 
     public string? DiagnosticText { get; }
 
+    public int HResult { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EnvironmentOperationEvent"/> class.
     /// </summary>
     /// <param name="status">The status of the compute system operation</param>
     /// <param name="computeSystemOperation">An enum representing the compute system operation that was invoked</param>
     /// <param name="providerId">The Id of the compute system provider that owns the compute system that is being launched</param>
-    /// <param name="additionalContext">The context in which the operation is running as. E.g the Pin to start operation can be for Pinning or Unpinning</param>
-    /// <param name="displayMessage">Associated error text that was displayed to the user</param>
-    /// <param name="diagnosticText">Associated error text for the operation</param>
+    /// <param name="result">Associated telemtry result for the operation</param>
     public EnvironmentOperationEvent(
         EnvironmentsTelemetryStatus status,
         ComputeSystemOperations computeSystemOperation,
         string providerId,
-        string? additionalContext = null,
-        string? displayMessage = null,
-        string? diagnosticText = null)
+        TelemetryResult result,
+        string? additionalContext = null)
     {
         Status = status.ToString();
         OperationName = computeSystemOperation.ToString();
         ProviderId = providerId;
+        HResult = result.HResult;
+        DisplayMessage = result.DisplayMessage;
+        DiagnosticText = result.DiagnosticText;
         AdditionalContext = additionalContext;
-        DisplayMessage = displayMessage;
-        DiagnosticText = diagnosticText;
     }
 
     public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)

--- a/common/TelemetryEvents/SetupFlow/Environments/EnvironmentCreationEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/Environments/EnvironmentCreationEvent.cs
@@ -31,18 +31,24 @@ public class EnvironmentCreationEvent : EventBase
 
     public string? DiagnosticText { get; }
 
+    public int HResult { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EnvironmentCreationEvent"/> class.
     /// </summary>
     /// <param name="providerId">The Id of the compute system provider that initiated the creation operation</param>
     /// <param name="status">The status of the creation operation</param>
-    /// <param name="diagnosticText">Associated error text for the operation</param>
-    public EnvironmentCreationEvent(string providerId, EnvironmentsTelemetryStatus status, string? displayMessage = null, string? diagnosticText = null)
+    /// <param name="result">Associated telemetry result for the operation</param>
+    public EnvironmentCreationEvent(
+        string providerId,
+        EnvironmentsTelemetryStatus status,
+        TelemetryResult result)
     {
         ProviderId = providerId;
         Status = status.ToString();
-        DisplayMessage = displayMessage;
-        DiagnosticText = diagnosticText;
+        HResult = result.HResult;
+        DisplayMessage = result.DisplayMessage;
+        DiagnosticText = result.DiagnosticText;
     }
 
     // Inherited but unused.

--- a/common/TelemetryEvents/SetupFlow/Environments/EnvironmentLaunchEvent.cs
+++ b/common/TelemetryEvents/SetupFlow/Environments/EnvironmentLaunchEvent.cs
@@ -22,18 +22,24 @@ public class EnvironmentLaunchEvent : EventBase
 
     public string? DiagnosticText { get; }
 
+    public int HResult { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EnvironmentLaunchEvent"/> class.
     /// </summary>
     /// <param name="providerId">The Id of the compute system provider that owns the compute system that is being launched</param>
     /// <param name="status">The status of the launch operation</param>
-    /// <param name="diagnosticText">Associated error text for the operation</param>
-    public EnvironmentLaunchEvent(string providerId, EnvironmentsTelemetryStatus status, string? displayMessage = null, string? diagnosticText = null)
+    /// <param name="result">Associated telemetry result for the operation</param>
+    public EnvironmentLaunchEvent(
+        string providerId,
+        EnvironmentsTelemetryStatus status,
+        TelemetryResult result)
     {
         ProviderId = providerId;
         Status = status.ToString();
-        DisplayMessage = displayMessage;
-        DiagnosticText = diagnosticText;
+        HResult = result.HResult;
+        DisplayMessage = result.DisplayMessage;
+        DiagnosticText = result.DiagnosticText;
     }
 
     // Inherited but unused.

--- a/common/TelemetryEvents/TelemetryResult.cs
+++ b/common/TelemetryEvents/TelemetryResult.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Windows.DevHome.SDK;
+
+namespace DevHome.Common.TelemetryEvents;
+
+public class TelemetryResult
+{
+    private const int SuccessHResult = 0;
+
+    private const int InvalidArgHResult = unchecked((int)0x80070057);
+
+    public int HResult { get; private set; }
+
+    public ProviderOperationStatus Status { get; private set; }
+
+    public string? DisplayMessage { get; private set; }
+
+    public string? DiagnosticText { get; private set; }
+
+    public TelemetryResult(ProviderOperationResult? result)
+    {
+        UpdateProperties(result);
+    }
+
+    public TelemetryResult(int hResult, string displayMessage, string diagnosticText)
+    {
+        HResult = hResult;
+        Status = ProviderOperationStatus.Failure;
+        DisplayMessage = displayMessage;
+        DiagnosticText = diagnosticText;
+    }
+
+    public TelemetryResult()
+    {
+        HResult = SuccessHResult;
+        Status = ProviderOperationStatus.Success;
+    }
+
+    private void UpdateProperties(ProviderOperationResult? result)
+    {
+        if (result == null)
+        {
+            // The extension provided us with a null ProviderOperationResult,
+            // so the telemetry should state this explicitly.
+            Status = ProviderOperationStatus.Failure;
+            DiagnosticText = "ProviderOperationResult was null";
+            DisplayMessage = "ProviderOperationResult was null";
+            return;
+        }
+
+        Status = result.Status;
+        DiagnosticText = result.DiagnosticText;
+        DisplayMessage = result.DisplayMessage;
+        HResult = SuccessHResult;
+
+        if (Status == ProviderOperationStatus.Failure)
+        {
+            HResult = result.ExtendedError.HResult;
+        }
+    }
+}

--- a/common/TelemetryEvents/TelemetryResult.cs
+++ b/common/TelemetryEvents/TelemetryResult.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT License.
 
 using Microsoft.Windows.DevHome.SDK;
+using Windows.Win32.Foundation;
 
 namespace DevHome.Common.TelemetryEvents;
 
 public class TelemetryResult
 {
     private const int SuccessHResult = 0;
-
-    private const int InvalidArgHResult = unchecked((int)0x80070057);
 
     public int HResult { get; private set; }
 
@@ -45,6 +44,7 @@ public class TelemetryResult
             // The extension provided us with a null ProviderOperationResult,
             // so the telemetry should state this explicitly.
             Status = ProviderOperationStatus.Failure;
+            HResult = HRESULT.E_INVALIDARG;
             DiagnosticText = "ProviderOperationResult was null";
             DisplayMessage = "ProviderOperationResult was null";
             return;

--- a/docs/tools/common/TelemetryResult.md
+++ b/docs/tools/common/TelemetryResult.md
@@ -1,0 +1,43 @@
+# TelemetryResult
+Used to extract data from a `ProviderOperationResult` object returned by an SDK method or wrapper class. This can also be used as a general class to store error information that can be sent in a telemetry payload.
+
+## Properties
+| Property | Type | Description |
+| -------- | -------- | -------- |
+| HResult | Integer | HRESULT code returned by an operation to Dev Home or an extension.
+| Status | ProviderOperationStatus | Enum used to dictate whether an  operation succeeded or failed.  |
+| DisplayMessage | String? | Optional display message returned to the user from an interaction with Dev Home. This may be localized. |
+| DiagnosticText | String? | Optional diagnostic text return by an operation. This can be used to gain insights into errors that occur in an extension, after an operation is initiated by Dev Home. |
+
+## Usage
+#### ComputeSystemViewModel.cs
+```C#
+// Using the parameterless constructor. This is optional. Most events in Dev Home only care about the result of the operation and not that the operation started.
+var startLaunchEvent = new EnvironmentLaunchEvent(
+    ComputeSystemProviderId,
+    EnvironmentsTelemetryStatus.Started,
+    new TelemetryResult());
+
+// Send the telemetry stating that the operation has started.
+TelemetryFactory.Get<ITelemetry>().Log(
+    "Environment_Launch_Event",
+    LogLevel.Critical,
+    startLaunchEvent);
+
+// It's good practise to wrap the out of proc COM object in a wrapper class and return the associated SDK result. Exceptions caught by the wrapper can then be used to return an SDK result that indicates that the operation failed.
+var launchResponse = await ComputeSystemWrapper.ConnectAsync(string.Empty);
+
+// ... Handle any post operation logic..
+
+// Use the TelemetryResult to extract data from the ProviderOperationResult, so it can be used in an Event payload.
+var endLaunchEvent = new EnvironmentLaunchEvent(
+    ComputeSystemProviderId,
+    telemetryStatusBasedOnResponse,
+    new TelemetryResult(launchResponse?.Result));
+
+// Operation is completed and the payload for ending the event can be sent.
+TelemetryFactory.Get<ITelemetry>().Log(
+    "Environment_Launch_Event",
+    LogLevel.Critical,
+    endLaunchEvent);
+```

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -138,7 +138,9 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
             ShouldShowDotOperations = false;
             ShouldShowSplitButton = false;
 
-            RegisterForAllOperationMessages(DataExtractor.FillDotButtonOperations(ComputeSystem, _mainWindow), DataExtractor.FillLaunchButtonOperations(_provider, ComputeSystem, _configurationAction));
+            RegisterForAllOperationMessages(
+                DataExtractor.FillDotButtonOperations(ComputeSystem, _mainWindow),
+                DataExtractor.FillLaunchButtonOperations(_provider, ComputeSystem, _configurationAction));
 
             _ = Task.Run(async () =>
             {
@@ -319,25 +321,25 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     {
         _mainWindow.DispatcherQueue.TryEnqueue(() =>
         {
-        var data = message.Value;
-        IsOperationInProgress = true;
-        ShouldShowLaunchOperation = false;
-        var providerId = ComputeSystem.AssociatedProviderId.Value;
+            var data = message.Value;
+            IsOperationInProgress = true;
+            ShouldShowLaunchOperation = false;
+            var providerId = ComputeSystem.AssociatedProviderId.Value;
 
-        _log.Information($"operation '{data.ComputeSystemOperation}' starting for Compute System: {Name}");
+            _log.Information($"operation '{data.ComputeSystemOperation}' starting for Compute System: {Name}");
 
-        var telemetryPayload = new EnvironmentOperationEvent(
-            EnvironmentsTelemetryStatus.Started,
-            data.ComputeSystemOperation,
-            providerId,
-            new TelemetryResult(),
-            data.AdditionalContext);
+            var telemetryPayload = new EnvironmentOperationEvent(
+                EnvironmentsTelemetryStatus.Started,
+                data.ComputeSystemOperation,
+                providerId,
+                new TelemetryResult(),
+                data.AdditionalContext);
 
-        TelemetryFactory.Get<ITelemetry>().Log(
-            "Environment_OperationInvoked_Event",
-            LogLevel.Critical,
-            telemetryPayload,
-            relatedActivityId: message.Value.ActivityId);
+            TelemetryFactory.Get<ITelemetry>().Log(
+                "Environment_OperationInvoked_Event",
+                LogLevel.Critical,
+                telemetryPayload,
+                relatedActivityId: message.Value.ActivityId);
         });
     }
 

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -327,11 +327,11 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
         _log.Information($"operation '{data.ComputeSystemOperation}' starting for Compute System: {Name}");
 
         var telemetryPayload = new EnvironmentOperationEvent(
-                EnvironmentsTelemetryStatus.Started,
-                data.ComputeSystemOperation,
-                providerId,
-                new TelemetryResult(),
-                data.AdditionalContext);
+            EnvironmentsTelemetryStatus.Started,
+            data.ComputeSystemOperation,
+            providerId,
+            new TelemetryResult(),
+            data.AdditionalContext);
 
         TelemetryFactory.Get<ITelemetry>().Log(
             "Environment_OperationInvoked_Event",

--- a/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
+++ b/tools/Environments/DevHome.Environments/ViewModels/ComputeSystemViewModel.cs
@@ -14,6 +14,7 @@ using DevHome.Common.Environments.Helpers;
 using DevHome.Common.Environments.Models;
 using DevHome.Common.Environments.Services;
 using DevHome.Common.Services;
+using DevHome.Common.TelemetryEvents;
 using DevHome.Common.TelemetryEvents.Environments;
 using DevHome.Common.TelemetryEvents.SetupFlow.Environments;
 using DevHome.Environments.Helpers;
@@ -274,15 +275,16 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
             TelemetryFactory.Get<ITelemetry>().Log(
                 "Environment_Launch_Event",
                 LogLevel.Critical,
-                new EnvironmentLaunchEvent(ComputeSystem.AssociatedProviderId.Value, EnvironmentsTelemetryStatus.Started));
+                new EnvironmentLaunchEvent(ComputeSystem.AssociatedProviderId.Value, EnvironmentsTelemetryStatus.Started, new TelemetryResult()));
 
             var operationResult = await ComputeSystem.ConnectAsync(string.Empty);
 
-            var (displayMessage, diagnosticText, telemetryStatus) = ComputeSystemHelpers.LogResult(operationResult?.Result, _log);
+            var (displayMessage, _, telemetryStatus) = ComputeSystemHelpers.LogResult(operationResult?.Result, _log);
+            var telemetryResult = new TelemetryResult(operationResult?.Result);
             TelemetryFactory.Get<ITelemetry>().Log(
                 "Environment_Launch_Event",
                 LogLevel.Critical,
-                new EnvironmentLaunchEvent(ComputeSystem.AssociatedProviderId.Value, telemetryStatus, displayMessage, diagnosticText));
+                new EnvironmentLaunchEvent(ComputeSystem.AssociatedProviderId.Value, telemetryStatus, telemetryResult));
 
             if (telemetryStatus == EnvironmentsTelemetryStatus.Failed)
             {
@@ -317,18 +319,25 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
     {
         _mainWindow.DispatcherQueue.TryEnqueue(() =>
         {
-            var data = message.Value;
-            IsOperationInProgress = true;
-            ShouldShowLaunchOperation = false;
-            var providerId = ComputeSystem.AssociatedProviderId.Value;
+        var data = message.Value;
+        IsOperationInProgress = true;
+        ShouldShowLaunchOperation = false;
+        var providerId = ComputeSystem.AssociatedProviderId.Value;
 
-            _log.Information($"operation '{data.ComputeSystemOperation}' starting for Compute System: {Name}");
+        _log.Information($"operation '{data.ComputeSystemOperation}' starting for Compute System: {Name}");
 
-            TelemetryFactory.Get<ITelemetry>().Log(
-                "Environment_OperationInvoked_Event",
-                LogLevel.Measure,
-                new EnvironmentOperationEvent(EnvironmentsTelemetryStatus.Started, data.ComputeSystemOperation, providerId, data.AdditionalContext),
-                relatedActivityId: message.Value.ActivityId);
+        var telemetryPayload = new EnvironmentOperationEvent(
+                EnvironmentsTelemetryStatus.Started,
+                data.ComputeSystemOperation,
+                providerId,
+                new TelemetryResult(),
+                data.AdditionalContext);
+
+        TelemetryFactory.Get<ITelemetry>().Log(
+            "Environment_OperationInvoked_Event",
+            LogLevel.Critical,
+            telemetryPayload,
+            relatedActivityId: message.Value.ActivityId);
         });
     }
 
@@ -345,11 +354,12 @@ public partial class ComputeSystemViewModel : ComputeSystemCardBase, IRecipient<
             _log.Information($"operation '{data.ComputeSystemOperation}' completed for Compute System: {Name}");
 
             var providerId = ComputeSystem.AssociatedProviderId.Value;
-            var (displayMessage, diagnosticText, telemetryStatus) = ComputeSystemHelpers.LogResult(data.OperationResult.Result, _log);
+            var (displayMessage, _, telemetryStatus) = ComputeSystemHelpers.LogResult(data.OperationResult.Result, _log);
+            var telemetryResult = new TelemetryResult(data.OperationResult.Result);
             TelemetryFactory.Get<ITelemetry>().Log(
                 "Environment_OperationInvoked_Event",
-                LogLevel.Measure,
-                new EnvironmentOperationEvent(telemetryStatus, data.ComputeSystemOperation, providerId, data.AdditionalContext, displayMessage, diagnosticText),
+                LogLevel.Critical,
+                new EnvironmentOperationEvent(telemetryStatus, data.ComputeSystemOperation, providerId, telemetryResult, data.AdditionalContext),
                 relatedActivityId: message.Value.ActivityId);
         });
     }

--- a/tools/SetupFlow/DevHome.SetupFlow/Exceptions/SDKApplyConfigurationSetResultException.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Exceptions/SDKApplyConfigurationSetResultException.cs
@@ -16,4 +16,10 @@ public class SDKApplyConfigurationSetResultException : Exception
     : base(message)
     {
     }
+
+    public SDKApplyConfigurationSetResultException(string message, int hResult)
+    : base(message)
+    {
+        HResult = hResult;
+    }
 }


### PR DESCRIPTION
## Summary of the pull request

Although we capture the error messaging, we don't capture the HResult error codes. Capturing these will provide us with more information that we can use to filter out noisy data a bit easier.

Changes:

1. Added a `TelemetryResult` class that extracts data from the `ProviderOperationResult` so this doesn't have to be done by all the other telemetry classes.
2. Added an HResult integer property for the `EnvironmentOperationEvent`, `EnvironmentCreationEvent` and the `EnvironmentLaunchEvent` classes. These also now take a `TelemetryResult`  in their constructors to get the error information.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

I used the TraceView++ app to confirm that the events are now submitting the HResults, that are received by the operations in their payload.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
