### PR TITLE
Fix environment  card text colors for high contrast users

### DIFF
--- a/common/Environments/Styles/HorizontalCardStyles.xaml
+++ b/common/Environments/Styles/HorizontalCardStyles.xaml
@@ -201,7 +201,7 @@
         x:Key="CardBodyStateTextBlockStyle"
         BasedOn="{StaticResource CaptionTextBlockStyle}"
         TargetType="TextBlock">
-        <Setter Property="Foreground" Value="{ThemeResource TextFillColorTertiaryBrush}" />
+        <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}" />
         <Setter Property="TextTrimming" Value="CharacterEllipsis" />
     </Style>
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/SetupTargetView.xaml
@@ -145,13 +145,13 @@
                         VerticalAlignment="Center">
                         <TextBlock
                             Text="{x:Bind DisplayName, Mode=OneWay}"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                             Margin=" 0 0 0 0"
                             IsTextSelectionEnabled="True"/>
                         <TextBlock
                             Margin="7 0 0 0"
                             Text="{x:Bind FormattedDeveloperId, Mode=OneWay}"
-                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                             Style="{ThemeResource BodyTextBlockStyle}"
                             IsTextSelectionEnabled="True"/>
                     </StackPanel>


### PR DESCRIPTION
## Summary of the pull request
Currently there a couple places on the environment pages where we use the `TextFillColorTertiaryBrush` Win UI color brush. However, this brush does not provide a good enough contrast ratio when used in high contrast mode. This is an accessibility issue. Looking at the Win UI gallery guidance, we should actually be using the `TextFillColorPrimaryBrush` for text that is at rest  (See Win UI gallery apps color section for text). This PR updates these usages of `TextFillColorTertiaryBrush` to `TextFillColorPrimaryBrush`. 

Before:
_Before - setup environments page_
<img width="508" alt="Before - setup environments page" src="https://github.com/user-attachments/assets/f61b8e90-b3db-43dd-ad4b-ad53aac63740">
_Before - environments page_
<img width="462" alt="Before - environments page" src="https://github.com/user-attachments/assets/c17042f2-008f-46ea-a94a-ef1611dd5f68">

After:
_After - setup environments page_
<img width="452" alt="After - environment setup page" src="https://github.com/user-attachments/assets/4714bf7a-4116-4924-898c-a85fee777fec">

_After changes - environments page_
<img width="460" alt="After changes - environments page" src="https://github.com/user-attachments/assets/f401d376-da3b-4f28-8c18-88e664c2f3aa">


## References and relevant issues
 Accessibility internal bugs:
https://task.ms/49714932
https://task.ms/50453683

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #3809 
- [ ] Tests added/passed
- [ ] Documentation updated
