### PR TITLE
Fix Dashboard crash when widgets runtime isn't present

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Helpers/WidgetHelpers.cs
@@ -19,8 +19,8 @@ internal sealed class WidgetHelpers
 {
     public const string WebExperiencePackPackageId = "9MSSGKG348SP";
     public const string WebExperiencePackageFamilyName = "MicrosoftWindows.Client.WebExperience_cw5n1h2txyewy";
-    public const string WidgetPlatformRuntimePackageId = "9N3RK8ZV2ZR8";
-    public const string WidgetPlatformRuntimePackageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
+    public const string WidgetsPlatformRuntimePackageId = "9N3RK8ZV2ZR8";
+    public const string WidgetsPlatformRuntimePackageFamilyName = "Microsoft.WidgetsPlatformRuntime_8wekyb3d8bbwe";
 
     public static readonly string[] DefaultWidgetDefinitionIds =
     {

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -38,7 +38,11 @@ public class WidgetServiceService : IWidgetServiceService
 
     public WidgetServiceStates GetWidgetServiceState()
     {
+        var isWindows11String = RuntimeHelper.IsOnWindows11 ? "Windows 11" : "Windows 10";
+        _log.Information($"Checking for WidgetService on {isWindows11String}");
+
         // First check for the WidgetsPlatformRuntime package. If it's installed and has a valid state, we return that state.
+        _log.Information("Checking for WidgetsPlatformRuntime...");
         var package = GetWidgetsPlatformRuntimePackage();
         _widgetServiceState = ValidatePackage(package);
         if (_widgetServiceState == WidgetServiceStates.MeetsMinVersion ||
@@ -48,6 +52,7 @@ public class WidgetServiceService : IWidgetServiceService
         }
 
         // If the WidgetsPlatformRuntime package is not installed or not high enough version, check for the WebExperience package.
+        _log.Information("Checking for WebExperiencePack...");
         package = GetWebExperiencePackPackage();
         _widgetServiceState = ValidatePackage(package);
 
@@ -87,24 +92,25 @@ public class WidgetServiceService : IWidgetServiceService
 
     private WidgetServiceStates ValidatePackage(Package package)
     {
-        var isWindows11String = RuntimeHelper.IsOnWindows11 ? "Windows 11" : "Windows 10";
-        _log.Information($"Validating package {package.DisplayName} on {isWindows11String}");
-
+        WidgetServiceStates packageStatus;
         if (package == null)
         {
-            return WidgetServiceStates.NotAtMinVersion;
+            packageStatus = WidgetServiceStates.NotAtMinVersion;
         }
         else if (package.Status.VerifyIsOK())
         {
-            return WidgetServiceStates.MeetsMinVersion;
+            packageStatus = WidgetServiceStates.MeetsMinVersion;
         }
         else if (package.Status.Servicing == true)
         {
-            return WidgetServiceStates.Updating;
+            packageStatus = WidgetServiceStates.Updating;
         }
         else
         {
-            return WidgetServiceStates.NotOK;
+            packageStatus = WidgetServiceStates.NotOK;
         }
+
+        _log.Information($"ValidatePackage found {packageStatus}");
+        return packageStatus;
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -38,8 +38,8 @@ public class WidgetServiceService : IWidgetServiceService
 
     public WidgetServiceStates GetWidgetServiceState()
     {
-        // First check for the WidgetPlatformRuntime package. If it's installed and has a valid state, we return that state.
-        var package = GetWidgetPlatformRuntimePackage();
+        // First check for the WidgetsPlatformRuntime package. If it's installed and has a valid state, we return that state.
+        var package = GetWidgetsPlatformRuntimePackage();
         _widgetServiceState = ValidatePackage(package);
         if (_widgetServiceState == WidgetServiceStates.MeetsMinVersion ||
             _widgetServiceState == WidgetServiceStates.Updating)
@@ -47,7 +47,7 @@ public class WidgetServiceService : IWidgetServiceService
             return _widgetServiceState;
         }
 
-        // If the WidgetPlatformRuntime package is not installed or not high enough version, check for the WebExperience package.
+        // If the WidgetsPlatformRuntime package is not installed or not high enough version, check for the WebExperience package.
         package = GetWebExperiencePackPackage();
         _widgetServiceState = ValidatePackage(package);
 
@@ -57,8 +57,8 @@ public class WidgetServiceService : IWidgetServiceService
     public async Task<bool> TryInstallingWidgetService()
     {
         _log.Information("Try installing widget service...");
-        var installedSuccessfully = await _msStoreService.TryInstallPackageAsync(WidgetHelpers.WidgetPlatformRuntimePackageId);
-        _widgetServiceState = ValidatePackage(GetWidgetPlatformRuntimePackage());
+        var installedSuccessfully = await _msStoreService.TryInstallPackageAsync(WidgetHelpers.WidgetsPlatformRuntimePackageId);
+        _widgetServiceState = ValidatePackage(GetWidgetsPlatformRuntimePackage());
         _log.Information($"InstalledSuccessfully == {installedSuccessfully}, {_widgetServiceState}");
         return installedSuccessfully;
     }
@@ -77,11 +77,11 @@ public class WidgetServiceService : IWidgetServiceService
         return packages.First();
     }
 
-    private Package GetWidgetPlatformRuntimePackage()
+    private Package GetWidgetsPlatformRuntimePackage()
     {
         var minSupportedVersion = new Version(1, 0, 0, 0);
 
-        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetPlatformRuntimePackageFamilyName, (minSupportedVersion, null));
+        var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetsPlatformRuntimePackageFamilyName, (minSupportedVersion, null));
         return packages.First();
     }
 

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -560,7 +560,7 @@ public partial class DashboardView : ToolPage, IDisposable
         }
         else
         {
-            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetPlatformRuntimePackageId}"));
+            await Windows.System.Launcher.LaunchUriAsync(new($"ms-windows-store://pdp/?productid={WidgetHelpers.WidgetsPlatformRuntimePackageId}"));
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
If a widget service check returned null, we'd crash when trying to log the result. Change logging to prevent that crash.

Also fix name to match package: Widget**s**PlatformRuntime

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3816
- [ ] Tests added/passed
- [ ] Documentation updated
