### PR TITLE
DevDiagnostics - Don't treat every tool addition/removal as a dump analyzer

### DIFF
--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Models/WERAnalyzer.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Models/WERAnalyzer.cs
@@ -79,17 +79,20 @@ public class WERAnalyzer : IDisposable
         // with it.
         if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems is not null)
         {
+            List<Tool> newAnalysisTools = new();
+
             foreach (Tool tool in e.NewItems)
             {
                 if (tool.Type.HasFlag(ToolType.DumpAnalyzer))
                 {
                     _registeredAnalysisTools.Add(tool);
+                    newAnalysisTools.Add(tool);
                 }
             }
 
             foreach (var report in _werAnalysisReports)
             {
-                RunToolAnalysis(report, e.NewItems.Cast<Tool>().ToList());
+                RunToolAnalysis(report, newAnalysisTools);
             }
         }
 
@@ -101,11 +104,11 @@ public class WERAnalyzer : IDisposable
                 if (tool.Type.HasFlag(ToolType.DumpAnalyzer))
                 {
                     _registeredAnalysisTools.Remove(tool);
-                }
 
-                foreach (var report in _werAnalysisReports)
-                {
-                    report.RemoveToolAnalysis(tool);
+                    foreach (var report in _werAnalysisReports)
+                    {
+                        report.RemoveToolAnalysis(tool);
+                    }
                 }
             }
         }

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Pages/WERPage.xaml.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Pages/WERPage.xaml.cs
@@ -127,7 +127,7 @@ public sealed partial class WERPage : Page
         }
         else
         {
-            Debug.Assert(currentSelectedIndex == 0, "Expected only the first item would have a null tag");
+            Debug.Assert(currentSelectedIndex == 0 || currentSelectedIndex == -1, "Expected only the first item would have a null tag");
             WERInfo.Text = info.Report.Description;
         }
     }


### PR DESCRIPTION
## Summary of the pull request

Had an issue where any new tools being added or removed were always been treated like a dump analyzer. This would (rightfully so) trigger a bunch of asserts.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3817
- [ ] Tests added/passed
- [ ] Documentation updated
