### PR TITLE
Really fix Dashboard crash when widgets runtime isn't present 

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -79,7 +79,13 @@ public class WidgetServiceService : IWidgetServiceService
             WidgetHelpers.WebExperiencePackageFamilyName,
             (minSupportedVersion400, version500),
             (minSupportedVersion500, null));
-        return packages.First();
+
+        if (packages.Any())
+        {
+            return packages.First();
+        }
+
+        return null;
     }
 
     private Package GetWidgetsPlatformRuntimePackage()
@@ -87,7 +93,12 @@ public class WidgetServiceService : IWidgetServiceService
         var minSupportedVersion = new Version(1, 0, 0, 0);
 
         var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetsPlatformRuntimePackageFamilyName, (minSupportedVersion, null));
-        return packages.First();
+        if (packages.Any())
+        {
+            return packages.First();
+        }
+
+        return null;
     }
 
     private WidgetServiceStates ValidatePackage(Package package)

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetServiceService.cs
@@ -79,13 +79,7 @@ public class WidgetServiceService : IWidgetServiceService
             WidgetHelpers.WebExperiencePackageFamilyName,
             (minSupportedVersion400, version500),
             (minSupportedVersion500, null));
-
-        if (packages.Any())
-        {
-            return packages.First();
-        }
-
-        return null;
+        return packages.FirstOrDefault();
     }
 
     private Package GetWidgetsPlatformRuntimePackage()
@@ -93,12 +87,7 @@ public class WidgetServiceService : IWidgetServiceService
         var minSupportedVersion = new Version(1, 0, 0, 0);
 
         var packages = _packageDeploymentService.FindPackagesForCurrentUser(WidgetHelpers.WidgetsPlatformRuntimePackageFamilyName, (minSupportedVersion, null));
-        if (packages.Any())
-        {
-            return packages.First();
-        }
-
-        return null;
+        return packages.FirstOrDefault();
     }
 
     private WidgetServiceStates ValidatePackage(Package package)


### PR DESCRIPTION
## Summary of the pull request
#3819 wasn't a sufficient fix because we were still calling .First() on a potentially empty list. Instead, check if there's anything in the list and return null if there isn't.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3816
- [ ] Tests added/passed
- [ ] Documentation updated
