### PR TITLE
Hyper-V extension: Check guest OS version before apply configuration.

### DIFF
--- a/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpChannel.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpChannel.cs
@@ -50,7 +50,9 @@ internal sealed class GuestKvpChannel : IDisposable
 
         // Try to remove all parts of the message first just in case if previous communication session was
         // abruptly terminates and we got old messages not removed.
-        for (var i = 0; i < numberOfParts; i++)
+        // The key format is DevSetup{<number>}-<index>-<total> where index starts from 1.
+        // Best effort. Log error if failed, but don't throw.
+        for (var i = 1; i <= numberOfParts; i++)
         {
             RemoveKvpItem($"{kvpNameStart}{i}{kvpNameEnd}");
         }

--- a/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpChannel.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpChannel.cs
@@ -237,17 +237,17 @@ internal sealed class GuestKvpChannel : IDisposable
 
     private Dictionary<string, string> ReadGuestKvps()
     {
-        return MessageHelper.MergeMessageParts(ReadRawGuestKvps());
+        return MessageHelper.MergeMessageParts(ReadGuestExchangeItems());
     }
 
-    private Dictionary<string, string> ReadRawGuestKvps()
+    private Dictionary<string, string> ReadRawGuestKvps(string itemsType)
     {
         Dictionary<string, string> guestKvps = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         using var collection = _vmWmi.GetRelated("Msvm_KvpExchangeComponent");
         foreach (ManagementObject kvpExchangeComponent in collection)
         {
-            foreach (var exchangeDataItem in (string[])kvpExchangeComponent["GuestExchangeItems"])
+            foreach (var exchangeDataItem in (string[])kvpExchangeComponent[itemsType])
             {
                 XPathDocument xpathDoc = new XPathDocument(XmlReader.Create(new StringReader(exchangeDataItem)));
                 XPathNavigator navigator = xpathDoc.CreateNavigator();
@@ -267,6 +267,16 @@ internal sealed class GuestKvpChannel : IDisposable
         }
 
         return guestKvps;
+    }
+
+    private Dictionary<string, string> ReadGuestExchangeItems()
+    {
+        return ReadRawGuestKvps("GuestExchangeItems");
+    }
+
+    public Dictionary<string, string> ReadGuestProperties()
+    {
+        return ReadRawGuestKvps("GuestIntrinsicExchangeItems");
     }
 
     public void CleanUp()

--- a/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpSession.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/GuestKvpSession.cs
@@ -70,6 +70,11 @@ internal sealed class GuestKvpSession : IDisposable
         return result;
     }
 
+    public Dictionary<string, string> ReadGuestProperties()
+    {
+        return _channel.ReadGuestProperties();
+    }
+
     public void Dispose()
     {
         Dispose(true);

--- a/extensions/HyperVExtension/src/HyperVExtension/Constants.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Constants.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Windows.Win32.System.Diagnostics.Debug;
+
 namespace HyperVExtension;
 
 internal sealed class Constants
@@ -29,7 +31,7 @@ internal sealed class Constants
 
     public static string SystemRootPath { get; } = Path.GetPathRoot(Environment.SystemDirectory)!;
 
-    public static int GuestPlatformIdWindows { get; } = (int)Windows.Win32.System.Diagnostics.Debug.VER_PLATFORM.VER_PLATFORM_WIN32_NT;
+    public static int GuestPlatformIdWindows { get; } = (int)VER_PLATFORM.VER_PLATFORM_WIN32_NT;
 
     public static Version MinWindowsVersionForApplyConfiguration { get; } = new Version(10, 0, 19041, 0);
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Constants.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Constants.cs
@@ -28,4 +28,8 @@ internal sealed class Constants
     public const string HyperVTemplatesSubPath = @"HyperVExtension\Templates";
 
     public static string SystemRootPath { get; } = Path.GetPathRoot(Environment.SystemDirectory)!;
+
+    public static int GuestPlatformIdWindows { get; } = (int)Windows.Win32.System.Diagnostics.Debug.VER_PLATFORM.VER_PLATFORM_WIN32_NT;
+
+    public static Version MinWindowsVersionForApplyConfiguration { get; } = new Version(10, 0, 19041, 0);
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsOperationNotSupportedException.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsOperationNotSupportedException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using HyperVExtension.Common;
+using Windows.Win32.Foundation;
+
+namespace HyperVExtension.Exceptions;
+
+internal sealed class GuestOsOperationNotSupportedException : GuestOsVersionException
+{
+    public GuestOsOperationNotSupportedException(IStringResource stringResource, Dictionary<string, string>? guestOsProperties)
+        : base(stringResource.GetLocalized("GuestOsOperationNotSupported"), guestOsProperties)
+    {
+        HResult = HRESULT.E_NOTSUPPORTED;
+    }
+}

--- a/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsOperationNotSupportedException.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsOperationNotSupportedException.cs
@@ -9,7 +9,7 @@ namespace HyperVExtension.Exceptions;
 internal sealed class GuestOsOperationNotSupportedException : GuestOsVersionException
 {
     public GuestOsOperationNotSupportedException(IStringResource stringResource, Dictionary<string, string>? guestOsProperties)
-        : base(stringResource.GetLocalized("GuestOsOperationNotSupported"), guestOsProperties)
+        : base(stringResource.GetLocalized("GuestOsOperationNotSupported", $"Windows {Constants.MinWindowsVersionForApplyConfiguration}"), guestOsProperties)
     {
         HResult = HRESULT.E_NOTSUPPORTED;
     }

--- a/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsVersionException.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsVersionException.cs
@@ -64,6 +64,11 @@ internal class GuestOsVersionException : Exception
             }
         }
 
+        if (InnerException != null)
+        {
+            message.Append(CultureInfo.InvariantCulture, $"{Environment.NewLine}{InnerException}.");
+        }
+
         return message.ToString();
     }
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsVersionException.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsVersionException.cs
@@ -12,7 +12,7 @@ namespace HyperVExtension.Exceptions;
 internal class GuestOsVersionException : Exception
 {
     public GuestOsVersionException(IStringResource stringResource, Exception innerException, Dictionary<string, string>? guestOsProperties)
-        : base(stringResource.GetLocalized("FailedToDetermineGuestOsVersion"), innerException)
+        : base(stringResource.GetLocalized("FailedToDetermineGuestOsVersion", $"Windows {Constants.MinWindowsVersionForApplyConfiguration}"), innerException)
     {
         HResult = innerException.HResult;
         GuestOsProperties = guestOsProperties;

--- a/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsVersionException.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Exceptions/GuestOsVersionException.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Management.Automation;
+using System.Text;
+using HyperVExtension.Common;
+using HyperVExtension.Helpers;
+
+namespace HyperVExtension.Exceptions;
+
+internal class GuestOsVersionException : Exception
+{
+    public GuestOsVersionException(IStringResource stringResource, Exception innerException, Dictionary<string, string>? guestOsProperties)
+        : base(stringResource.GetLocalized("FailedToDetermineGuestOsVersion"), innerException)
+    {
+        HResult = innerException.HResult;
+        GuestOsProperties = guestOsProperties;
+    }
+
+    protected GuestOsVersionException(string message, Dictionary<string, string>? guestOsProperties)
+        : base(message)
+    {
+        GuestOsProperties = guestOsProperties;
+    }
+
+    public Dictionary<string, string>? GuestOsProperties { get; }
+
+    public override string ToString()
+    {
+        StringBuilder message = new();
+        message.Append(CultureInfo.InvariantCulture, $"{Message}.");
+        if (InnerException != null)
+        {
+            message.Append(CultureInfo.InvariantCulture, $" {InnerException}.");
+        }
+
+        if (GuestOsProperties != null)
+        {
+            GuestOsProperties.TryGetValue(HyperVStrings.OSPlatformId, out var osPlatformId);
+            GuestOsProperties.TryGetValue(HyperVStrings.OSVersion, out var osVersion);
+            GuestOsProperties.TryGetValue(HyperVStrings.OSName, out var osName);
+            if ((osPlatformId != null) ||
+                (osVersion != null) ||
+                (osName != null))
+            {
+                message.Append(" (");
+                if (osPlatformId != null)
+                {
+                    message.Append(CultureInfo.InvariantCulture, $"{HyperVStrings.OSPlatformId} = {osPlatformId}");
+                }
+
+                if (osVersion != null)
+                {
+                    message.Append(CultureInfo.InvariantCulture, $", {HyperVStrings.OSVersion} = {osVersion}");
+                }
+
+                if (osName != null)
+                {
+                    message.Append(CultureInfo.InvariantCulture, $", {HyperVStrings.OSName} = {osName}");
+                }
+
+                message.Append(')');
+            }
+        }
+
+        return message.ToString();
+    }
+}

--- a/extensions/HyperVExtension/src/HyperVExtension/Helpers/HyperVStrings.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Helpers/HyperVStrings.cs
@@ -101,4 +101,9 @@ public static class HyperVStrings
     public const string StartingState = "Starting";
     public const string StoppingState = "Stopping";
     public const string ResumingState = "Resuming";
+
+    // Hyper-V properties readable from GuestIntrinsicExchangeItems
+    public const string OSPlatformId = "OSPlatformId";
+    public const string OSVersion = "OSVersion";
+    public const string OSName = "OSName";
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -817,6 +817,7 @@ public class HyperVVirtualMachine : IComputeSystem
 
         try
         {
+            // The dictionary returned from GetOsVersionInfo is case-insensitive, so the keys are not case-sensitive.
             osVersionInfo = GetOsVersionInfo(guestSession);
             var osPlatformId = int.Parse(osVersionInfo[HyperVStrings.OSPlatformId], CultureInfo.InvariantCulture);
             if (osPlatformId == Constants.GuestPlatformIdWindows)

--- a/extensions/HyperVExtension/src/HyperVExtension/NativeMethods.txt
+++ b/extensions/HyperVExtension/src/HyperVExtension/NativeMethods.txt
@@ -1,5 +1,7 @@
 ﻿GetCurrentPackageFullName
 WIN32_ERROR
+E_UNEXPECTED
+E_NOTSUPPORTED
 E_FAIL
 E_ABORT
 S_OK
@@ -8,3 +10,4 @@ SFBS_FLAGS
 StrFormatByteSizeEx
 SetForegroundWindow
 GetDiskFreeSpaceEx
+VER_PLATFORM

--- a/extensions/HyperVExtension/src/HyperVExtension/Strings/en-US/Resources.resw
+++ b/extensions/HyperVExtension/src/HyperVExtension/Strings/en-US/Resources.resw
@@ -206,12 +206,12 @@
     <comment>Error text to tell the user that an error happened while trying to read virtual machine's OS properties.</comment>
   </data>
   <data name="FailedToDetermineGuestOsVersion" xml:space="preserve">
-    <value>Failed to determine guest OS version</value>
-    <comment>Error text to tell the user that an error happened while trying to determine virtual machine's OS version.</comment>
+    <value>Failed to determine guest OS version. The operation requires {0}</value>
+    <comment>Error text to tell the user that an error happened while trying to determine virtual machine's OS version. The {0} parameter will indicate the required OS version.</comment>
   </data>
   <data name="GuestOsOperationNotSupported" xml:space="preserve">
-    <value>This operation is not supported for the guest OS</value>
-    <comment>Error text to tell the user that an operation is not supported for the virtual machine's OS version.</comment>
+    <value>This operation is not supported for the guest OS. The operation requires {0}</value>
+    <comment>Error text to tell the user that an operation is not supported for the virtual machine's OS version. The {0} parameter will indicate the required OS version.</comment>
   </data>
   <data name="VmCredentialRequest.CancelText" xml:space="preserve">
     <value>Cancel</value>

--- a/extensions/HyperVExtension/src/HyperVExtension/Strings/en-US/Resources.resw
+++ b/extensions/HyperVExtension/src/HyperVExtension/Strings/en-US/Resources.resw
@@ -201,6 +201,18 @@
     <value>Unable to start the operation because it is already in progress</value>
     <comment>Error text to tell the user that the process to create the virtual machine is already in progress.</comment>
   </data>
+  <data name="FailedToReadGuestOsProperties" xml:space="preserve">
+    <value>Failed to read guest OS properties</value>
+    <comment>Error text to tell the user that an error happened while trying to read virtual machine's OS properties.</comment>
+  </data>
+  <data name="FailedToDetermineGuestOsVersion" xml:space="preserve">
+    <value>Failed to determine guest OS version</value>
+    <comment>Error text to tell the user that an error happened while trying to determine virtual machine's OS version.</comment>
+  </data>
+  <data name="GuestOsOperationNotSupported" xml:space="preserve">
+    <value>This operation is not supported for the guest OS</value>
+    <comment>Error text to tell the user that an operation is not supported for the virtual machine's OS version.</comment>
+  </data>
   <data name="VmCredentialRequest.CancelText" xml:space="preserve">
     <value>Cancel</value>
     <comment>Cancel button text in the dialog to enter Hyper-V VM admin credential.</comment>


### PR DESCRIPTION
## Summary of the pull request
This change adds a check for the guest OS platform and version in "apply configuration" operation for a Hyper-V VM. If VM is not a Windows VM 19041+ the operation will be aborted with "This operation is not supported for the guest OS" message.

We should disable configure environment operation in UI for VMs that don't support it. The work will be in a separate change. (This implementation of getting guest OS version requires the VM to be running, not good for UX where VMs are in a not running state)

Fix an off-by-one bug that was causing #3664.
 
## References and relevant issues
#3662
#3663
#3664

## Detailed description of the pull request / Additional comments

## Validation steps performed
Tested with Windows and Ubuntu OS's.

## PR checklist
- [ ] Closes #3664
- [ ] Tests added/passed
- [ ] Documentation updated
