### PR TITLE
[File Explorer Git Integration] Trim version control properties to 80 chars.

### DIFF
--- a/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
+++ b/tools/Customization/DevHome.FileExplorerSourceControlIntegration/SourceControlProvider.cs
@@ -117,11 +117,14 @@ public class SourceControlProvider :
 
         // Trim any string properties to 80 characters
         var result = repository.GetProperties(properties, relativePath);
-        foreach (var key in result.Keys)
+        foreach (var key in result.Keys.ToList())
         {
             if (result[key] is string str)
             {
-                result[key] = str[..80];
+                if (str.Length > 80)
+                {
+                    result[key] = str[..80];
+                }
             }
         }
 


### PR DESCRIPTION
## Summary of the pull request
Trim version control properties to a "reasonable" length, so as to avoid bombarding File Explorer with massively long strings that adversely affect the user experience.

## Detailed description of the pull request / Additional comments
Also combined the property filtering logic into a single method used by both property sources.

## PR checklist
- [ ] Closes #3603 
- [ ] Tests passed
