### PR TITLE
Detect if the current process is elevated in Dashboard

### DIFF
--- a/common/Helpers/RuntimeHelper.cs
+++ b/common/Helpers/RuntimeHelper.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.Security;
+using static DevHome.Common.Helpers.RuntimeHelper;
 
 namespace DevHome.Common.Helpers;
 
@@ -33,6 +37,35 @@ public static class RuntimeHelper
     {
         var identity = WindowsIdentity.GetCurrent();
         return identity.Owner?.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid) ?? false;
+    }
+
+    // Determine whether the current process is running elevated in a split token session
+    // will not return true if UAC is disabled and the user is running as administrator by default
+    public static unsafe bool IsCurrentProcessRunningElevated()
+    {
+        HANDLE tokenHandle;
+        if (!PInvoke.OpenProcessToken(PInvoke.GetCurrentProcess(), TOKEN_ACCESS_MASK.TOKEN_QUERY, &tokenHandle))
+        {
+            throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        try
+        {
+            TOKEN_ELEVATION_TYPE elevationType;
+            uint elevationTypeSize = (uint)Unsafe.SizeOf<TOKEN_ELEVATION_TYPE>();
+            uint returnLength;
+
+            if (!PInvoke.GetTokenInformation(tokenHandle, TOKEN_INFORMATION_CLASS.TokenElevationType, &elevationType, elevationTypeSize, &returnLength))
+            {
+                throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return elevationType == TOKEN_ELEVATION_TYPE.TokenElevationTypeFull;
+        }
+        finally
+        {
+            PInvoke.CloseHandle(tokenHandle);
+        }
     }
 
     public static void VerifyCurrentProcessRunningAsAdmin()

--- a/common/NativeMethods.txt
+++ b/common/NativeMethods.txt
@@ -11,6 +11,9 @@ GetWindowLong
 WINDOW_EX_STYLE
 SHLoadIndirectString
 StrFormatByteSizeEx
+OpenProcessToken
+GetTokenInformation
+GetCurrentProcess
 SFBS_FLAGS
 MAX_PATH
 GetDpiForWindow
@@ -19,3 +22,4 @@ GetMonitorInfo
 SetWindowPos
 MonitorFromWindow
 E_INVALIDARG
+TOKEN_ELEVATION_TYPE

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/DashboardViewModel.cs
@@ -46,8 +46,8 @@ public partial class DashboardViewModel : ObservableObject
         return (widgetCount == 0 && !isLoading && HasWidgetServiceInitialized) ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    public bool IsRunningAsAdmin()
+    public bool IsRunningElevated()
     {
-        return RuntimeHelper.IsCurrentProcessRunningAsAdmin();
+        return RuntimeHelper.IsCurrentProcessRunningElevated();
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/DashboardView.xaml.cs
@@ -195,8 +195,8 @@ public partial class DashboardView : ToolPage, IDisposable
 
     private async Task<bool> ValidateDashboardState()
     {
-        // Ensure we're not running as admin. Display an error and don't allow using the Dashboard if we are.
-        if (ViewModel.IsRunningAsAdmin())
+        // Ensure we're not running elevated. Display an error and don't allow using the Dashboard if we are.
+        if (ViewModel.IsRunningElevated())
         {
             _log.Error($"Dev Home is running as admin, can't show Dashboard");
             RunningAsAdminMessageStackPanel.Visibility = Visibility.Visible;


### PR DESCRIPTION
## Summary of the pull request
Detect if the current process is elevated instead of whether the user… is in the administrator group for showing the Dashboard
If the user is running in a split token session (typical behavior for an administrator account with UAC enabled) the Widgets provider is running non-elevated and COM callbacks running in Dev Home(elevated) will not work.

However, if the user is running with UAC disabled and running everything as administrator by default Widgets service will also be running with the same token.

This change switches from detecting whether Dev Home is running as a user with the administrator SID to a check that determines if there is a split token for elevation.  

For an account with UAC enabled Widgets will still not work:
![image](https://github.com/user-attachments/assets/8bcb3eea-b768-4dc4-92fd-a16ecad63420)

However, for a device with UAC disabled running as admin they work:
![image](https://github.com/user-attachments/assets/285df3f5-9117-4022-b9cf-63ee89366baa)

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
