### PR TITLE
DevDiagnostics - Fix crash when removing multiple tools at once

### DIFF
--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Controls/EditToolsControl.xaml.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Controls/EditToolsControl.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using DevHome.Common.Extensions;
 using DevHome.DevDiagnostics.Helpers;
 using Microsoft.UI.Xaml;
@@ -21,13 +22,22 @@ public sealed partial class EditToolsControl : UserControl
 
     private void UnregisterToolButton_Click(object sender, RoutedEventArgs e)
     {
-        var selectedItems = ToolsDataGrid.SelectedItems;
-        for (var i = selectedItems.Count - 1; i >= 0; i--)
+        List<ExternalTool> toolsToRemove = new();
+
+        // First, grab all the tools we want to remove. The grid seems to have some unexpected behavior
+        // with its list of selected items when you start removing them.
+        foreach (var item in ToolsDataGrid.SelectedItems)
         {
-            if (selectedItems[i] is ExternalTool tool)
+            if (item is ExternalTool tool)
             {
-                _externalTools.RemoveExternalTool(tool);
+                toolsToRemove.Add(tool);
             }
+        }
+
+        // And now remove all of the tools
+        foreach (var tool in toolsToRemove)
+        {
+            _externalTools.RemoveExternalTool(tool);
         }
 
         EnableUnregisterButton();


### PR DESCRIPTION
## Summary of the pull request

In the "Edit or unregister existing tools" page, you can select and remove multiple tools at once. We did this by walking through all of the selected tools (in reverse index order) and removing them 1 by 1. However, we're seeing some strange behavior from the grid control where, if you have 3 items selected and remove one of those selected items, the grid control will report only 1 item selected (expected to be 2). The code doesn't expect this, and we end up running off the end of the array.

This updates the code to collect all of the selected tools and puts them into a list first, and then removes them. It doesn't matter what the grid control does with its selected items array in this case.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3826 
- [ ] Tests added/passed
- [ ] Documentation updated
