### PR TITLE
Fix accessibility issue for Hyperlinks in machine configurations summary page

### DIFF
--- a/src/App.xaml
+++ b/src/App.xaml
@@ -10,6 +10,7 @@
                 <ResourceDictionary Source="/Styles/Feedback_ThemeResources.xaml" />
                 <ResourceDictionary Source="/Styles/FontFamilies.xaml" />
                 <ResourceDictionary Source="/Styles/FontSizes.xaml" />
+                <ResourceDictionary Source="/Styles/HyperlinkButton.xaml" />
                 <ResourceDictionary Source="/Styles/LayoutSizes.xaml" />
                 <ResourceDictionary Source="/Styles/TextBlock.xaml" />
                 <ResourceDictionary Source="/Styles/Thickness.xaml" />

--- a/src/DevHome.csproj
+++ b/src/DevHome.csproj
@@ -61,6 +61,7 @@
     <None Remove="Assets\WhatsNewPage\DarkTheme\ExtensionsBig.png" />
     <None Remove="Assets\WhatsNewPage\LightTheme\Extensions.png" />
     <None Remove="Assets\WhatsNewPage\LightTheme\ExtensionsBig.png" />
+    <None Remove="Styles\HyperlinkButton.xaml" />
     <None Remove="Styles\WindowTitleBar_ThemeResources.xaml" />
   </ItemGroup>
 
@@ -122,6 +123,9 @@
     <None Update="NavConfig.jsonc">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="Styles\HyperlinkButton.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="Styles\WindowTitleBar_ThemeResources.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Styles/HyperlinkButton.xaml
+++ b/src/Styles/HyperlinkButton.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style
+        x:Key="HyperlinkButtonWithWrappedAndUnderlinedTextStyle"
+        TargetType="HyperlinkButton">
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock
+                        Text="{Binding}"
+                        TextWrapping="Wrap"
+                        TextDecorations="Underline" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryNextSteps.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Summary/SummaryNextSteps.xaml
@@ -48,9 +48,6 @@
             Grid.Row="1"
             IsTabStop="false"
             XYFocusKeyboardNavigation="Enabled">
-            <Grid.Resources>
-                <Style BasedOn="{StaticResource TextBlockButtonStyle}" TargetType="HyperlinkButton" />
-            </Grid.Resources>
             <Grid.RowDefinitions>
                 <RowDefinition />
                 <RowDefinition />
@@ -59,25 +56,29 @@
                 <RowDefinition />
             </Grid.RowDefinitions>
             <TextBlock
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_NextSteps"
+                x:Uid="SummaryPage_NextSteps"
                 Grid.Row="0"
                 Padding="0,20,0,25"
                 Foreground="{ThemeResource TextFillColorSecondary}"
                 Style="{ThemeResource BodyStrongTextBlockStyle}" />
             <HyperlinkButton
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_SetUpAnotherProject"
+                Style="{StaticResource HyperlinkButtonWithWrappedAndUnderlinedTextStyle}"
+                x:Uid="SummaryPage_SetUpAnotherProject"
                 Grid.Row="1"
                 Command="{Binding GoToMainPageCommand}" />
             <HyperlinkButton
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ChangeDevHomeSettings"
+                Style="{StaticResource HyperlinkButtonWithWrappedAndUnderlinedTextStyle}"
+                x:Uid="SummaryPage_ChangeDevHomeSettings"
                 Grid.Row="2"
                 Command="{Binding GoToDevHomeSettingsCommand}" />
             <HyperlinkButton
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_ChangeDeveloperSettingsInWindows"
+                Style="{StaticResource HyperlinkButtonWithWrappedAndUnderlinedTextStyle}"
+                x:Uid="SummaryPage_ChangeDeveloperSettingsInWindows"
                 Grid.Row="3"
                 Command="{Binding GoToForDevelopersSettingsPageCommand}" />
             <HyperlinkButton
-                x:Uid="ms-resource:///DevHome.SetupFlow/Resources/SummaryPage_LearnMoreAboutDevHome"
+                Style="{StaticResource HyperlinkButtonWithWrappedAndUnderlinedTextStyle}"
+                x:Uid="SummaryPage_LearnMoreAboutDevHome"
                 Grid.Row="4"
                 Command="{Binding LearnMoreCommand}" />
         </Grid>


### PR DESCRIPTION
## Summary of the pull request
The last page for every machine configuration flow (except QuickStart Playground) is the summary page. The page contains 4 hyperlink buttons that either leads the user to another page in Dev Home or the For Developers Windows settings page. There are two accessibility issue with this link:

1. Hyperlinks without an underline violates MAS 1.4.1 (See W3 orgs description [here](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Basically, we shouldn't only use color to convey information. The underline helps to convey that the text is a HyperLink. 
2. When a user increases their display scaling or text size scaling to 200%+ the hyperlink for the text "Change developer settings in windows" is cut off. 

Changes:

- Added a new HyperlinkButton style that allows the text within the HyperlinkButton to be wrapped and underlined.
- Removed the ms-resource part of the x:Uid strings in the HyperlinkButtons on the summary page as they are not needed.

**BEFORE CHANGES**
Video of showing scaling at 200% (Notice the hyperlinks have not underline and the "Change developer settings in windows" text is cut off. I start off the video using scaling at 200%:


https://github.com/user-attachments/assets/310ef8e1-d64f-469d-8e6d-8a9016f7701a

**AFTER CHANGES**
Video showing scaling at text scaling at 200% - Links are now underlined and the "Change developer settings in windows" text is now wrapped:

https://github.com/user-attachments/assets/961b0169-fa76-4231-b4d8-2cb4e039bfcf

video showing text scaling at 225%

https://github.com/user-attachments/assets/a04c010b-21cc-4a65-9d39-9ebf2b05a6a0



## References and relevant issues
Fixes:
https://task.ms/50454382
https://task.ms/52330843

## Detailed description of the pull request / Additional comments

When looking at the summary page, it looks like the elements are strictly contained in the uniform grid used for the entire page. So, that's why when resizing the page in the "After changes" video the text wraps even though from the users perspective it looks like there is still a lot of space for the text to flow without needing to wrap. I looked into this, and there needs to be a bigger change in how the summary page works in order to allow this to happen. Instead of strictly placing different user controls in quadrants of the uniformed grid we should be allowing these quadrants to freely expand and be resized based on the available space around them. I'll create an issue for this.

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
