### PR TITLE
GitExecute changes for WSL

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FileExplorerGitIntegration.Models;
+
+namespace FileExplorerGitIntegration.UnitTest;
+
+[TestClass]
+public class WslIntegratorUnitTests
+{
+    [TestMethod]
+    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo")]
+    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo")]
+    [DataRow("\\wsl$\\Ubuntu\\home\\user\\repo")]
+    [DataRow("\\wsl.localhost\\Ubuntu\\home\\user\\repo")]
+    [DataRow("\\wsl.localhost\\Debian\\home\\user\\repo")]
+    [DataRow("\\wsl$\\kali-linux\\home\\user\\repo")]
+    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo")]
+    [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo")]
+    public void IsWSLRepoPositiveTests(string repositoryPath)
+    {
+        Assert.IsTrue(WslIntegrator.IsWSLRepo(repositoryPath));
+    }
+
+    [TestMethod]
+    [DataRow("C:\\Users\\foo\\bar")]
+    [DataRow("\\wsl$*\\Ubuntu\\home\\user\\repo")]
+    [DataRow("D:\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo")]
+    [DataRow("\\wsl.test\\Ubuntu\\home\\user\\repo")]
+    public void IsWslRepoNegativeTests(string repositoryPath)
+    {
+        Assert.IsFalse(WslIntegrator.IsWSLRepo(repositoryPath));
+    }
+
+    [TestMethod]
+    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "Ubuntu-20.04")]
+    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "Ubuntu-20.04")]
+    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "Debian")]
+    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "kali-linux")]
+    [DataRow("\\wsl.localhost\\UbuntuTest\\home\\user\\testRepo", "")]
+    [DataRow("\\wsl$\\InvalidDistribution\\home\\user\\testRepo", "")]
+    public void GetDistributionName(string repositoryPath, string value)
+    {
+        var distributionName = WslIntegrator.GetWslDistributionName(repositoryPath);
+        Assert.AreEqual(value, distributionName);
+    }
+
+    [TestMethod]
+    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "cd /home/user/repo && git ")]
+    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "cd /home/user/repo && git ")]
+    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "cd /home/user/repo && git ")]
+    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "cd /home/user/repo && git ")]
+    [DataRow("C:\\Users\\foo\\bar", "")]
+    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo", "cd /home/user/testRepo && git ")]
+    [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo", "cd /home/user/testRepo && git ")]
+    public void GetArgumentPrefixForWslTest(string repositoryPath, string value)
+    {
+        var prefix = WslIntegrator.GetArgumentPrefixForWsl(repositoryPath);
+        Assert.AreEqual(value, prefix);
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using FileExplorerGitIntegration.Models;
 
 namespace FileExplorerGitIntegration.UnitTest;
@@ -52,21 +53,21 @@ public class WslIntegratorUnitTests
     }
 
     [TestMethod]
-    [DataRow("C:\\Distribution\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("", "Value cannot be null")]
-    [DataRow("\\wsl$", "Failed to get the distribution name from the repository path")]
-    public void GetDistributionNameNegativeTest(string repositoryPath, string value)
+    [DataRow("C:\\Distribution\\home\\user\\testRepo")]
+    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo")]
+    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo")]
+    [DataRow("")]
+    [DataRow("\\wsl$")]
+    public void GetDistributionNameNegativeTest(string repositoryPath)
     {
-        try
+        Trace.Listeners.Clear();
+        if (string.IsNullOrEmpty(repositoryPath))
         {
-            var distributionName = WslIntegrator.GetWslDistributionName(repositoryPath);
-            Assert.AreEqual(value, distributionName);
+            Assert.ThrowsException<ArgumentNullException>(() => WslIntegrator.GetWslDistributionName(repositoryPath));
         }
-        catch (Exception ex)
+        else
         {
-            Assert.IsTrue(ex.Message.Contains(value));
+            Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetWslDistributionName(repositoryPath));
         }
     }
 
@@ -84,20 +85,20 @@ public class WslIntegratorUnitTests
     }
 
     [TestMethod]
-    [DataRow("C:\\Distribution\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("", "Value cannot be null")]
-    public void GetWorkingDirectoryNegativeTest(string repositoryPath, string value)
+    [DataRow("C:\\Distribution\\home\\user\\testRepo")]
+    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo")]
+    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo")]
+    [DataRow("")]
+    public void GetWorkingDirectoryNegativeTest(string repositoryPath)
     {
-        try
+        Trace.Listeners.Clear();
+        if (string.IsNullOrEmpty(repositoryPath))
         {
-            var workingDir = WslIntegrator.GetWorkingDirectory(repositoryPath);
-            Assert.AreEqual(value, workingDir);
+            Assert.ThrowsException<ArgumentNullException>(() => WslIntegrator.GetWorkingDirectory(repositoryPath));
         }
-        catch (Exception ex)
+        else
         {
-            Assert.IsTrue(ex.Message.Contains(value));
+            Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetWorkingDirectory(repositoryPath));
         }
     }
 
@@ -106,7 +107,6 @@ public class WslIntegratorUnitTests
     [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "-d Ubuntu-20.04 git ")]
     [DataRow("\\wsl$\\Debian\\home\\user\\repo", "-d Debian git ")]
     [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "-d kali-linux git ")]
-    [DataRow("C:\\Users\\foo\\bar", "")]
     [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
     [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
     [DataRow("\\wsl.localhost\\CustomDistribution\\home\\user\\testRepo", "-d CustomDistribution git ")]
@@ -117,18 +117,19 @@ public class WslIntegratorUnitTests
     }
 
     [TestMethod]
-    [DataRow("", "Value cannot be null")]
-    [DataRow("\\wsl.localhost", "Failed to get the distribution name from the repository path")]
-    public void GetArgumentPrefixForWslNegativeTest(string repositoryPath, string value)
+    [DataRow("")]
+    [DataRow("\\wsl.localhost")]
+    [DataRow("C:\\Users\\foo\\bar")]
+    public void GetArgumentPrefixForWslNegativeTest(string repositoryPath)
     {
-        try
+        Trace.Listeners.Clear();
+        if (string.IsNullOrEmpty(repositoryPath))
         {
-            var prefix = WslIntegrator.GetArgumentPrefixForWsl(repositoryPath);
-            Assert.AreEqual(value, prefix);
+            Assert.ThrowsException<ArgumentNullException>(() => WslIntegrator.GetArgumentPrefixForWsl(repositoryPath));
         }
-        catch (Exception ex)
+        else
         {
-            Assert.IsTrue(ex.Message.Contains(value));
+            Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetArgumentPrefixForWsl(repositoryPath));
         }
     }
 

--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
@@ -34,6 +34,8 @@ public class WslIntegratorUnitTests
     [DataRow(@"D:\wsl.localhost\Ubuntu-20.04\home\user\repo")]
     [DataRow(@"\\wsl.test\Ubuntu\home\user\repo")]
     [DataRow("")]
+    [DataRow(@"\wsl.localhost\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"wsl$\Ubuntu-20.04\home\user\repo")]
     public void IsWslRepoNegativeTests(string repositoryPath)
     {
         Assert.IsFalse(WslIntegrator.IsWSLRepo(repositoryPath));
@@ -58,6 +60,8 @@ public class WslIntegratorUnitTests
     [DataRow(@"wslg\Ubuntu-18.04\wsl.localhost\home\user\testRepo")]
     [DataRow("")]
     [DataRow(@"\\wsl$")]
+    [DataRow(@"\wsl.localhost\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"wsl$\Ubuntu-20.04\home\user\repo")]
     public void GetDistributionNameNegativeTest(string repositoryPath)
     {
         Trace.Listeners.Clear();
@@ -82,6 +86,8 @@ public class WslIntegratorUnitTests
     [DataRow(@"\\Ubuntu-18.04\wsl$\home\user\testRepo")]
     [DataRow(@"wslg\Ubuntu-18.04\wsl.localhost\home\user\testRepo")]
     [DataRow("")]
+    [DataRow(@"\wsl.localhost\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"wsl$\Ubuntu-20.04\home\user\repo")]
     public void GetWorkingDirectoryNegativeTest(string repositoryPath)
     {
         Trace.Listeners.Clear();
@@ -106,6 +112,8 @@ public class WslIntegratorUnitTests
     [DataRow("")]
     [DataRow(@"\\wsl.localhost")]
     [DataRow(@"C:\Users\foo\bar")]
+    [DataRow(@"\wsl.localhost\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"wsl$\Ubuntu-20.04\home\user\repo")]
     public void GetArgumentPrefixForWslNegativeTest(string repositoryPath)
     {
         Trace.Listeners.Clear();

--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
@@ -17,16 +17,22 @@ public class WslIntegratorUnitTests
     [DataRow("\\wsl$\\kali-linux\\home\\user\\repo")]
     [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo")]
     [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo")]
+    [DataRow("\\WSL.LOCALHOST\\Ubuntu-18.04\\home\\user\\testRepo")]
+    [DataRow("\\WSL$\\Ubuntu-18.04\\home\\user\\testRepo")]
+    [DataRow("\\WsL.loCaLHoST\\Ubuntu-18.04\\home\\user\\testRepo")]
+    [DataRow("\\WsL$\\Ubuntu-18.04\\home\\user\\testRepo")]
     public void IsWSLRepoPositiveTests(string repositoryPath)
     {
         Assert.IsTrue(WslIntegrator.IsWSLRepo(repositoryPath));
     }
 
     [TestMethod]
+    [DataRow("//wsl$//kali-linux//home//user//repo")]
     [DataRow("C:\\Users\\foo\\bar")]
     [DataRow("\\wsl$*\\Ubuntu\\home\\user\\repo")]
     [DataRow("D:\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo")]
     [DataRow("\\wsl.test\\Ubuntu\\home\\user\\repo")]
+    [DataRow("")]
     public void IsWslRepoNegativeTests(string repositoryPath)
     {
         Assert.IsFalse(WslIntegrator.IsWSLRepo(repositoryPath));
@@ -37,25 +43,93 @@ public class WslIntegratorUnitTests
     [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "Ubuntu-20.04")]
     [DataRow("\\wsl$\\Debian\\home\\user\\repo", "Debian")]
     [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "kali-linux")]
-    [DataRow("\\wsl.localhost\\UbuntuTest\\home\\user\\testRepo", "")]
-    [DataRow("\\wsl$\\InvalidDistribution\\home\\user\\testRepo", "")]
-    public void GetDistributionName(string repositoryPath, string value)
+    [DataRow("\\wsl.localhost\\UbuntuTest\\home\\user\\testRepo", "UbuntuTest")]
+    [DataRow("\\wsl$\\CustomDistribution\\home\\user\\testRepo", "CustomDistribution")]
+    public void GetDistributionNamePositiveTest(string repositoryPath, string value)
     {
         var distributionName = WslIntegrator.GetWslDistributionName(repositoryPath);
         Assert.AreEqual(value, distributionName);
     }
 
     [TestMethod]
-    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "cd /home/user/repo && git ")]
-    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "cd /home/user/repo && git ")]
-    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "cd /home/user/repo && git ")]
-    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "cd /home/user/repo && git ")]
+    [DataRow("C:\\Distribution\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
+    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
+    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
+    [DataRow("", "")]
+    [DataRow("\\wsl$", "")]
+    public void GetDistributionNameNegativeTest(string repositoryPath, string value)
+    {
+        try
+        {
+            var distributionName = WslIntegrator.GetWslDistributionName(repositoryPath);
+            Assert.AreEqual(value, distributionName);
+        }
+        catch (Exception ex)
+        {
+            Assert.IsTrue(ex.Message.Contains(value));
+        }
+    }
+
+    [TestMethod]
+    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", @"\\wsl$\Ubuntu-20.04\home\user\repo")]
+    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", @"\\wsl$\Ubuntu-20.04\home\user\repo")]
+    [DataRow("\\wsl$\\Debian\\home\\user\\repo", @"\\wsl$\Debian\home\user\repo")]
+    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", @"\\wsl$\kali-linux\home\user\repo")]
+    [DataRow("\\wsl.localhost\\customDistribution\\home\\user\\testRepo", @"\\wsl$\customDistribution\home\user\testRepo")]
+    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\dir1\\dir2\\DIR3\\testRepo", @"\\wsl$\Ubuntu-18.04\home\user\dir1\dir2\DIR3\testRepo")]
+    public void GetWorkingDirectoryPositiveTest(string repositoryPath, string value)
+    {
+        var workingDirPath = WslIntegrator.GetWorkingDirectory(repositoryPath);
+        Assert.AreEqual(value, workingDirPath);
+    }
+
+    [TestMethod]
+    [DataRow("C:\\Distribution\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
+    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
+    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
+    [DataRow("", "")]
+    public void GetWorkingDirectoryNegativeTest(string repositoryPath, string value)
+    {
+        try
+        {
+            var workingDir = WslIntegrator.GetWorkingDirectory(repositoryPath);
+            Assert.AreEqual(value, workingDir);
+        }
+        catch (Exception ex)
+        {
+            Assert.IsTrue(ex.Message.Contains(value));
+        }
+    }
+
+    [TestMethod]
+    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "-d Ubuntu-20.04 git ")]
+    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "-d Ubuntu-20.04 git ")]
+    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "-d Debian git ")]
+    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "-d kali-linux git ")]
     [DataRow("C:\\Users\\foo\\bar", "")]
-    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo", "cd /home/user/testRepo && git ")]
-    [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo", "cd /home/user/testRepo && git ")]
+    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
+    [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
+    [DataRow("", "")]
+    [DataRow("\\wsl.localhost\\CustomDistribution\\home\\user\\testRepo", "-d CustomDistribution git ")]
     public void GetArgumentPrefixForWslTest(string repositoryPath, string value)
     {
         var prefix = WslIntegrator.GetArgumentPrefixForWsl(repositoryPath);
         Assert.AreEqual(value, prefix);
+    }
+
+    [TestMethod]
+    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "/home/user/repo")]
+    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "/home/user/repo")]
+    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "/home/user/repo")]
+    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "/home/user/repo")]
+    [DataRow("\\WSL.LOCALHOST\\UBUNTU-18.04\\HOME\\USER\\TESTREPO", "/HOME/USER/TESTREPO")]
+    [DataRow("\\WSL$\\UBUNTU-18.04\\HOME\\USER\\TESTREPO", "/HOME/USER/TESTREPO")]
+    [DataRow("\\WSL.LOCALHOST\\UBUNTU-18.04\\HoME\\USeR\\TeSTREpO", "/HoME/USeR/TeSTREpO")]
+    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\dir1\\dir2\\dir3\\dir4\\repo", "/home/user/dir1/dir2/dir3/dir4/repo")]
+    [DataRow("", "")]
+    public void GetNormalizedLinuxPathTest(string repositoryPath, string value)
+    {
+        var normalizedPath = WslIntegrator.GetNormalizedLinuxPath(repositoryPath);
+        Assert.AreEqual(value, normalizedPath);
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
@@ -10,29 +10,29 @@ namespace FileExplorerGitIntegration.UnitTest;
 public class WslIntegratorUnitTests
 {
     [TestMethod]
-    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo")]
-    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo")]
-    [DataRow("\\wsl$\\Ubuntu\\home\\user\\repo")]
-    [DataRow("\\wsl.localhost\\Ubuntu\\home\\user\\repo")]
-    [DataRow("\\wsl.localhost\\Debian\\home\\user\\repo")]
-    [DataRow("\\wsl$\\kali-linux\\home\\user\\repo")]
-    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo")]
-    [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo")]
-    [DataRow("\\WSL.LOCALHOST\\Ubuntu-18.04\\home\\user\\testRepo")]
-    [DataRow("\\WSL$\\Ubuntu-18.04\\home\\user\\testRepo")]
-    [DataRow("\\WsL.loCaLHoST\\Ubuntu-18.04\\home\\user\\testRepo")]
-    [DataRow("\\WsL$\\Ubuntu-18.04\\home\\user\\testRepo")]
+    [DataRow(@"\\wsl$\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"\\wsl$\Ubuntu\home\user\repo")]
+    [DataRow(@"\\wsl.localhost\Ubuntu\home\user\repo")]
+    [DataRow(@"\\wsl.localhost\Debian\home\user\repo")]
+    [DataRow(@"\\wsl$\kali-linux\home\user\repo")]
+    [DataRow(@"\\wsl$\Ubuntu-18.04\home\user\testRepo")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-18.04\home\user\testRepo")]
+    [DataRow(@"\\WSL.LOCALHOST\Ubuntu-18.04\home\user\testRepo")]
+    [DataRow(@"\\WSL$\Ubuntu-18.04\home\user\testRepo")]
+    [DataRow(@"\\WsL.loCaLHoST\Ubuntu-18.04\home\user\testRepo")]
+    [DataRow(@"\\WsL$\Ubuntu-18.04\home\user\testRepo")]
     public void IsWSLRepoPositiveTests(string repositoryPath)
     {
         Assert.IsTrue(WslIntegrator.IsWSLRepo(repositoryPath));
     }
 
     [TestMethod]
-    [DataRow("//wsl$//kali-linux//home//user//repo")]
-    [DataRow("C:\\Users\\foo\\bar")]
-    [DataRow("\\wsl$*\\Ubuntu\\home\\user\\repo")]
-    [DataRow("D:\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo")]
-    [DataRow("\\wsl.test\\Ubuntu\\home\\user\\repo")]
+    [DataRow(@"//wsl$/kali-linux/home/user/repo")]
+    [DataRow(@"C:\Users\foo\bar")]
+    [DataRow(@"\\wsl$*\Ubuntu\home\user\repo")]
+    [DataRow(@"D:\wsl.localhost\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"\\wsl.test\Ubuntu\home\user\repo")]
     [DataRow("")]
     public void IsWslRepoNegativeTests(string repositoryPath)
     {
@@ -40,12 +40,12 @@ public class WslIntegratorUnitTests
     }
 
     [TestMethod]
-    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "Ubuntu-20.04")]
-    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "Ubuntu-20.04")]
-    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "Debian")]
-    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "kali-linux")]
-    [DataRow("\\wsl.localhost\\UbuntuTest\\home\\user\\testRepo", "UbuntuTest")]
-    [DataRow("\\wsl$\\CustomDistribution\\home\\user\\testRepo", "CustomDistribution")]
+    [DataRow(@"\\wsl$\Ubuntu-20.04\home\user\repo", "Ubuntu-20.04")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-20.04\home\user\repo", "Ubuntu-20.04")]
+    [DataRow(@"\\wsl$\Debian\home\user\repo", "Debian")]
+    [DataRow(@"\\wsl.localhost\kali-linux\home\user\repo", "kali-linux")]
+    [DataRow(@"\\wsl.localhost\UbuntuTest\home\user\testRepo", "UbuntuTest")]
+    [DataRow(@"\\wsl$\CustomDistribution\home\user\testRepo", "CustomDistribution")]
     public void GetDistributionNamePositiveTest(string repositoryPath, string value)
     {
         var distributionName = WslIntegrator.GetWslDistributionName(repositoryPath);
@@ -53,31 +53,24 @@ public class WslIntegratorUnitTests
     }
 
     [TestMethod]
-    [DataRow("C:\\Distribution\\home\\user\\testRepo")]
-    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo")]
-    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo")]
+    [DataRow(@"C:\Distribution\home\user\testRepo")]
+    [DataRow(@"\\Ubuntu-18.04\wsl$\home\user\testRepo")]
+    [DataRow(@"wslg\Ubuntu-18.04\wsl.localhost\home\user\testRepo")]
     [DataRow("")]
-    [DataRow("\\wsl$")]
+    [DataRow(@"\\wsl$")]
     public void GetDistributionNameNegativeTest(string repositoryPath)
     {
         Trace.Listeners.Clear();
-        if (string.IsNullOrEmpty(repositoryPath))
-        {
-            Assert.ThrowsException<ArgumentNullException>(() => WslIntegrator.GetWslDistributionName(repositoryPath));
-        }
-        else
-        {
-            Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetWslDistributionName(repositoryPath));
-        }
+        Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetWslDistributionName(repositoryPath));
     }
 
     [TestMethod]
-    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", @"\\wsl$\Ubuntu-20.04\home\user\repo")]
-    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", @"\\wsl$\Ubuntu-20.04\home\user\repo")]
-    [DataRow("\\wsl$\\Debian\\home\\user\\repo", @"\\wsl$\Debian\home\user\repo")]
-    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", @"\\wsl$\kali-linux\home\user\repo")]
-    [DataRow("\\wsl.localhost\\customDistribution\\home\\user\\testRepo", @"\\wsl$\customDistribution\home\user\testRepo")]
-    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\dir1\\dir2\\DIR3\\testRepo", @"\\wsl$\Ubuntu-18.04\home\user\dir1\dir2\DIR3\testRepo")]
+    [DataRow(@"\\wsl$\Ubuntu-20.04\home\user\repo", @"\\wsl$\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-20.04\home\user\repo", @"\\wsl$\Ubuntu-20.04\home\user\repo")]
+    [DataRow(@"\\wsl$\Debian\home\user\repo", @"\\wsl$\Debian\home\user\repo")]
+    [DataRow(@"\\wsl.localhost\kali-linux\home\user\repo", @"\\wsl$\kali-linux\home\user\repo")]
+    [DataRow(@"\\wsl.localhost\customDistribution\home\user\testRepo", @"\\wsl$\customDistribution\home\user\testRepo")]
+    [DataRow(@"\\wsl$\Ubuntu-18.04\home\user\dir1\dir2\DIR3\testRepo", @"\\wsl$\Ubuntu-18.04\home\user\dir1\dir2\DIR3\testRepo")]
     public void GetWorkingDirectoryPositiveTest(string repositoryPath, string value)
     {
         var workingDirPath = WslIntegrator.GetWorkingDirectory(repositoryPath);
@@ -85,31 +78,24 @@ public class WslIntegratorUnitTests
     }
 
     [TestMethod]
-    [DataRow("C:\\Distribution\\home\\user\\testRepo")]
-    [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo")]
-    [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo")]
+    [DataRow(@"C:\Distribution\home\user\testRepo")]
+    [DataRow(@"\\Ubuntu-18.04\wsl$\home\user\testRepo")]
+    [DataRow(@"wslg\Ubuntu-18.04\wsl.localhost\home\user\testRepo")]
     [DataRow("")]
     public void GetWorkingDirectoryNegativeTest(string repositoryPath)
     {
         Trace.Listeners.Clear();
-        if (string.IsNullOrEmpty(repositoryPath))
-        {
-            Assert.ThrowsException<ArgumentNullException>(() => WslIntegrator.GetWorkingDirectory(repositoryPath));
-        }
-        else
-        {
-            Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetWorkingDirectory(repositoryPath));
-        }
+        Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetWorkingDirectory(repositoryPath));
     }
 
     [TestMethod]
-    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "-d Ubuntu-20.04 git ")]
-    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "-d Ubuntu-20.04 git ")]
-    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "-d Debian git ")]
-    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "-d kali-linux git ")]
-    [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
-    [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
-    [DataRow("\\wsl.localhost\\CustomDistribution\\home\\user\\testRepo", "-d CustomDistribution git ")]
+    [DataRow(@"\\wsl$\Ubuntu-20.04\home\user\repo", "-d Ubuntu-20.04 git ")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-20.04\home\user\repo", "-d Ubuntu-20.04 git ")]
+    [DataRow(@"\\wsl$\Debian\home\user\repo", "-d Debian git ")]
+    [DataRow(@"\\wsl.localhost\kali-linux\home\user\repo", "-d kali-linux git ")]
+    [DataRow(@"\\wsl$\Ubuntu-18.04\home\user\testRepo", "-d Ubuntu-18.04 git ")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-18.04\home\user\testRepo", "-d Ubuntu-18.04 git ")]
+    [DataRow(@"\\wsl.localhost\CustomDistribution\home\user\testRepo", "-d CustomDistribution git ")]
     public void GetArgumentPrefixForWslPositiveTest(string repositoryPath, string value)
     {
         var prefix = WslIntegrator.GetArgumentPrefixForWsl(repositoryPath);
@@ -118,30 +104,23 @@ public class WslIntegratorUnitTests
 
     [TestMethod]
     [DataRow("")]
-    [DataRow("\\wsl.localhost")]
-    [DataRow("C:\\Users\\foo\\bar")]
+    [DataRow(@"\\wsl.localhost")]
+    [DataRow(@"C:\Users\foo\bar")]
     public void GetArgumentPrefixForWslNegativeTest(string repositoryPath)
     {
         Trace.Listeners.Clear();
-        if (string.IsNullOrEmpty(repositoryPath))
-        {
-            Assert.ThrowsException<ArgumentNullException>(() => WslIntegrator.GetArgumentPrefixForWsl(repositoryPath));
-        }
-        else
-        {
-            Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetArgumentPrefixForWsl(repositoryPath));
-        }
+        Assert.ThrowsException<ArgumentException>(() => WslIntegrator.GetArgumentPrefixForWsl(repositoryPath));
     }
 
     [TestMethod]
-    [DataRow("\\wsl$\\Ubuntu-20.04\\home\\user\\repo", "/home/user/repo")]
-    [DataRow("\\wsl.localhost\\Ubuntu-20.04\\home\\user\\repo", "/home/user/repo")]
-    [DataRow("\\wsl$\\Debian\\home\\user\\repo", "/home/user/repo")]
-    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\repo", "/home/user/repo")]
-    [DataRow("\\WSL.LOCALHOST\\UBUNTU-18.04\\HOME\\USER\\TESTREPO", "/HOME/USER/TESTREPO")]
-    [DataRow("\\WSL$\\UBUNTU-18.04\\HOME\\USER\\TESTREPO", "/HOME/USER/TESTREPO")]
-    [DataRow("\\WSL.LOCALHOST\\UBUNTU-18.04\\HoME\\USeR\\TeSTREpO", "/HoME/USeR/TeSTREpO")]
-    [DataRow("\\wsl.localhost\\kali-linux\\home\\user\\dir1\\dir2\\dir3\\dir4\\repo", "/home/user/dir1/dir2/dir3/dir4/repo")]
+    [DataRow(@"\\wsl$\Ubuntu-20.04\home\user\repo", "/home/user/repo")]
+    [DataRow(@"\\wsl.localhost\Ubuntu-20.04\home\user\repo", "/home/user/repo")]
+    [DataRow(@"\\wsl$\Debian\home\user\repo", "/home/user/repo")]
+    [DataRow(@"\\wsl.localhost\kali-linux\home\user\repo", "/home/user/repo")]
+    [DataRow(@"\\WSL.LOCALHOST\UBUNTU-18.04\HOME\USER\TESTREPO", "/HOME/USER/TESTREPO")]
+    [DataRow(@"\\WSL$\UBUNTU-18.04\HOME\USER\TESTREPO", "/HOME/USER/TESTREPO")]
+    [DataRow(@"\\WSL.LOCALHOST\UBUNTU-18.04\HoME\USeR\TeSTREpO", "/HoME/USeR/TeSTREpO")]
+    [DataRow(@"\\wsl.localhost\kali-linux\home\user\dir1\dir2\dir3\dir4\repo", "/home/user/dir1/dir2/dir3/dir4/repo")]
     [DataRow("", "")]
     public void GetNormalizedLinuxPathTest(string repositoryPath, string value)
     {

--- a/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration.UnitTest/WslIntegratorUnitTests.cs
@@ -55,8 +55,8 @@ public class WslIntegratorUnitTests
     [DataRow("C:\\Distribution\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
     [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
     [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("", "")]
-    [DataRow("\\wsl$", "")]
+    [DataRow("", "Value cannot be null")]
+    [DataRow("\\wsl$", "Failed to get the distribution name from the repository path")]
     public void GetDistributionNameNegativeTest(string repositoryPath, string value)
     {
         try
@@ -87,7 +87,7 @@ public class WslIntegratorUnitTests
     [DataRow("C:\\Distribution\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
     [DataRow("\\Ubuntu-18.04\\wsl$\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
     [DataRow("wslg\\Ubuntu-18.04\\wsl.localhost\\home\\user\\testRepo", "the repository path must be a valid wsl path")]
-    [DataRow("", "")]
+    [DataRow("", "Value cannot be null")]
     public void GetWorkingDirectoryNegativeTest(string repositoryPath, string value)
     {
         try
@@ -109,12 +109,27 @@ public class WslIntegratorUnitTests
     [DataRow("C:\\Users\\foo\\bar", "")]
     [DataRow("\\wsl$\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
     [DataRow("\\wsl.localhost\\Ubuntu-18.04\\home\\user\\testRepo", "-d Ubuntu-18.04 git ")]
-    [DataRow("", "")]
     [DataRow("\\wsl.localhost\\CustomDistribution\\home\\user\\testRepo", "-d CustomDistribution git ")]
-    public void GetArgumentPrefixForWslTest(string repositoryPath, string value)
+    public void GetArgumentPrefixForWslPositiveTest(string repositoryPath, string value)
     {
         var prefix = WslIntegrator.GetArgumentPrefixForWsl(repositoryPath);
         Assert.AreEqual(value, prefix);
+    }
+
+    [TestMethod]
+    [DataRow("", "Value cannot be null")]
+    [DataRow("\\wsl.localhost", "Failed to get the distribution name from the repository path")]
+    public void GetArgumentPrefixForWslNegativeTest(string repositoryPath, string value)
+    {
+        try
+        {
+            var prefix = WslIntegrator.GetArgumentPrefixForWsl(repositoryPath);
+            Assert.AreEqual(value, prefix);
+        }
+        catch (Exception ex)
+        {
+            Assert.IsTrue(ex.Message.Contains(value));
+        }
     }
 
     [TestMethod]

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -15,16 +15,25 @@ public class GitExecute
     {
         try
         {
-            var processStartInfo = new ProcessStartInfo
+            var processStartInfo = new ProcessStartInfo();
+            var wslArgument = WslIntegrator.GetArgumentPrefixForWsl(repositoryDirectory);
+            if (wslArgument == string.Empty)
             {
-                FileName = gitApplication,
-                Arguments = arguments,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                WorkingDirectory = repositoryDirectory ?? string.Empty,
-                StandardOutputEncoding = System.Text.Encoding.UTF8,
-            };
+                processStartInfo.FileName = gitApplication;
+                processStartInfo.Arguments = arguments;
+                processStartInfo.WorkingDirectory = repositoryDirectory ?? string.Empty;
+            }
+            else
+            {
+                Log.Information("Wsl.exe will be invoked to obtain property information from git");
+                processStartInfo.FileName = "wsl.exe";
+                processStartInfo.Arguments = string.Concat(wslArgument, arguments);
+            }
+
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.CreateNoWindow = true;
+            processStartInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
 
             using var process = Process.Start(processStartInfo);
             if (process != null)

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -16,8 +16,7 @@ public class GitExecute
         try
         {
             var processStartInfo = new ProcessStartInfo();
-            var wslArgument = WslIntegrator.GetArgumentPrefixForWsl(repositoryDirectory);
-            if (wslArgument == string.Empty)
+            if (!WslIntegrator.IsWSLRepo(repositoryDirectory))
             {
                 processStartInfo.FileName = gitApplication;
                 processStartInfo.Arguments = arguments;
@@ -27,7 +26,7 @@ public class GitExecute
             {
                 Log.Information("Wsl.exe will be invoked to obtain property information from git");
                 processStartInfo.FileName = "wsl";
-                processStartInfo.Arguments = string.Concat(wslArgument, arguments);
+                processStartInfo.Arguments = string.Concat(WslIntegrator.GetArgumentPrefixForWsl(repositoryDirectory), arguments);
                 processStartInfo.WorkingDirectory = WslIntegrator.GetWorkingDirectory(repositoryDirectory);
             }
 

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -21,13 +21,14 @@ public class GitExecute
             {
                 processStartInfo.FileName = gitApplication;
                 processStartInfo.Arguments = arguments;
-                processStartInfo.WorkingDirectory = repositoryDirectory ?? string.Empty;
+                processStartInfo.WorkingDirectory = repositoryDirectory;
             }
             else
             {
                 Log.Information("Wsl.exe will be invoked to obtain property information from git");
-                processStartInfo.FileName = "wsl.exe";
+                processStartInfo.FileName = "wsl";
                 processStartInfo.Arguments = string.Concat(wslArgument, arguments);
+                processStartInfo.WorkingDirectory = WslIntegrator.GetWorkingDirectory(repositoryDirectory);
             }
 
             processStartInfo.RedirectStandardOutput = true;

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
@@ -45,27 +45,27 @@ public class WslIntegrator
         if (string.IsNullOrEmpty(repositoryPath))
         {
             _log.Debug("The repository path is empty");
-            return string.Empty;
+            throw new ArgumentNullException(nameof(repositoryPath));
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
 
         // Parse the repository path to get the distribution name
         string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
-        if (pathParts.Length >= 1)
+        if (pathParts.Length > 1)
         {
             return pathParts[1];
         }
 
         _log.Debug("Failed to get the distribution name from the repository path");
-        return string.Empty;
+        throw new ArgumentException("Failed to get the distribution name from the repository path");
     }
 
     public static string GetWorkingDirectory(string repositoryPath)
     {
         if (string.IsNullOrEmpty(repositoryPath))
         {
-            return string.Empty;
+            throw new ArgumentNullException(nameof(repositoryPath));
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
@@ -106,11 +106,6 @@ public class WslIntegrator
         }
 
         var distributionName = GetWslDistributionName(repositoryPath);
-        if (distributionName == string.Empty)
-        {
-            _log.Debug("Failed to get the distribution name from the repository path");
-            return string.Empty;
-        }
 
         string argumentPrefix = $"-d {distributionName} git ";
         return argumentPrefix;

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
@@ -49,6 +49,10 @@ public class WslIntegrator
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
+        if (!IsWSLRepo(repositoryPath))
+        {
+            throw new ArgumentException($"Not a valid WSL path: {repositoryPath}");
+        }
 
         // Parse the repository path to get the distribution name
         string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
@@ -69,6 +73,10 @@ public class WslIntegrator
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
+        if (!IsWSLRepo(repositoryPath))
+        {
+            throw new ArgumentException($"Not a valid WSL path: {repositoryPath}");
+        }
 
         string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
 
@@ -99,15 +107,17 @@ public class WslIntegrator
 
     public static string GetArgumentPrefixForWsl(string repositoryPath)
     {
-        if (!IsWSLRepo(repositoryPath))
+        if (string.IsNullOrEmpty(repositoryPath))
         {
-            _log.Debug("The repository path is not a WSL path");
-            return string.Empty;
+            throw new ArgumentNullException(nameof(repositoryPath));
         }
 
-        var distributionName = GetWslDistributionName(repositoryPath);
+        Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
+        if (!IsWSLRepo(repositoryPath))
+        {
+            throw new ArgumentException($"Not a valid WSL path: {repositoryPath}");
+        }
 
-        string argumentPrefix = $"-d {distributionName} git ";
-        return argumentPrefix;
+        return $"-d {GetWslDistributionName(repositoryPath)} git ";
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
@@ -15,13 +15,19 @@ public class WslIntegrator
     {
         if (string.IsNullOrEmpty(repositoryPath))
         {
-            _log.Debug("The repository path is empty");
+            _log.Debug($"The repository path is empty");
+            return false;
+        }
+
+        if (!repositoryPath.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase))
+        {
+            _log.Debug($"The repository path is not in the expected format: {repositoryPath}");
             return false;
         }
 
         if (repositoryPath.Contains(Path.AltDirectorySeparatorChar))
         {
-            _log.Debug("The repository path is not in the expected format");
+            _log.Debug($"The repository path is not in the expected format: {repositoryPath}");
             return false;
         }
 
@@ -45,7 +51,7 @@ public class WslIntegrator
         if (string.IsNullOrEmpty(repositoryPath))
         {
             _log.Debug("The repository path is empty");
-            throw new ArgumentNullException(nameof(repositoryPath));
+            throw new ArgumentException("Repository path is empty");
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
@@ -61,7 +67,7 @@ public class WslIntegrator
             return pathParts[1];
         }
 
-        _log.Debug("Failed to get the distribution name from the repository path");
+        _log.Debug($"Failed to get the distribution name from the repository path: {repositoryPath}");
         throw new ArgumentException("Failed to get the distribution name from the repository path");
     }
 
@@ -69,7 +75,7 @@ public class WslIntegrator
     {
         if (string.IsNullOrEmpty(repositoryPath))
         {
-            throw new ArgumentNullException(nameof(repositoryPath));
+            throw new ArgumentException("Repository path is empty");
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");
@@ -109,7 +115,7 @@ public class WslIntegrator
     {
         if (string.IsNullOrEmpty(repositoryPath))
         {
-            throw new ArgumentNullException(nameof(repositoryPath));
+            throw new ArgumentException("Repository path is empty");
         }
 
         Debug.Assert(IsWSLRepo(repositoryPath), "the repository path must be a valid wsl path");

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace FileExplorerGitIntegration.Models;
+
+public class WslIntegrator
+{
+    private static readonly string[] _wslPathPrefixes = { "wsl$", "wsl.localhost" };
+
+    // For more information on distributions, see https://github.com/microsoft/WSL/blob/master/distributions/DistributionInfo.json
+    private static readonly string[] _wslDistributions =
+    {
+        "Ubuntu", "Debian", "kali-linux", "Ubuntu-18.04", "Ubuntu-20.04", "Ubuntu-22.04", "Ubuntu-24.04", "OracleLinux_7_9", "OracleLinux_8_7", "OracleLinux_9_1",
+        "openSUSE-Leap-15.6", "SUSE-Linux-Enterprise-15-SP5", "SUSE-Linux-Enterprise-15-SP6", "openSUSE-Tumbleweed",
+    };
+
+    public static bool IsWSLRepo(string repositoryPath)
+    {
+        if (string.IsNullOrEmpty(repositoryPath))
+        {
+            return false;
+        }
+
+        string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+
+        // Check if the repository path contains any of the WSL path prefixes
+        foreach (string prefix in _wslPathPrefixes)
+        {
+            if (pathParts[0].Equals(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static string GetWslDistributionName(string repositoryPath)
+    {
+        if (string.IsNullOrEmpty(repositoryPath))
+        {
+            return string.Empty;
+        }
+
+        // Parse the repository path to get the distribution name
+        string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+        if (pathParts.Length >= 1)
+        {
+            foreach (string distribution in _wslDistributions)
+            {
+                if (pathParts[1].Equals(distribution, StringComparison.OrdinalIgnoreCase))
+                {
+                    return distribution;
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+
+    public static string GetWorkingDirectoryPath(string repositoryPath)
+    {
+        if (string.IsNullOrEmpty(repositoryPath))
+        {
+            return string.Empty;
+        }
+
+        string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+        var workingDirPath = string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Skip(2));
+        workingDirPath = workingDirPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        workingDirPath = workingDirPath.Insert(0, Path.AltDirectorySeparatorChar.ToString());
+        return workingDirPath;
+    }
+
+    public static string GetArgumentPrefixForWsl(string repositoryPath)
+    {
+        if (!IsWSLRepo(repositoryPath))
+        {
+            return string.Empty;
+        }
+
+        if (GetWslDistributionName(repositoryPath) == string.Empty)
+        {
+            return string.Empty;
+        }
+
+        var workingDirectoryPath = GetWorkingDirectoryPath(repositoryPath);
+
+        string argumentPrefix = $"cd {workingDirectoryPath} && git ";
+        return argumentPrefix;
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/WslIntegrator.cs
@@ -8,7 +8,7 @@ namespace FileExplorerGitIntegration.Models;
 
 public class WslIntegrator
 {
-    private static readonly string[] _wslPathPrefixes = { "wsl$", "wsl.localhost" };
+    private static readonly string[] _wslPathPrefixes = { @"\\wsl$\", @"\\wsl.localhost\" };
     private static readonly ILogger _log = Log.ForContext<WslIntegrator>();
 
     public static bool IsWSLRepo(string repositoryPath)
@@ -19,24 +19,16 @@ public class WslIntegrator
             return false;
         }
 
-        if (!repositoryPath.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase))
-        {
-            _log.Debug($"The repository path is not in the expected format: {repositoryPath}");
-            return false;
-        }
-
         if (repositoryPath.Contains(Path.AltDirectorySeparatorChar))
         {
             _log.Debug($"The repository path is not in the expected format: {repositoryPath}");
             return false;
         }
 
-        string[] pathParts = repositoryPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
-
         // Check if the repository path contains any of the WSL path prefixes
         foreach (string prefix in _wslPathPrefixes)
         {
-            if (pathParts[0].Equals(prefix, StringComparison.OrdinalIgnoreCase))
+            if (repositoryPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }


### PR DESCRIPTION
## Summary of the pull request
This PR modifies the arguments used while starting a process inside GitExecute to accommodate obtaining git information for WSL repositories. 

## References and relevant issues

## Detailed description of the pull request / Additional comments
This PR adds: 
- WSLIntegrator model class: parses WSL paths to extract relevant information and arguments 
- WSLIntegratorUnitTests: unit tests for WSLIntegrator

This PR modifies GitExecute to invoke wsl.exe with the expected arguments to obtain git information for registered wsl repository paths. 


## Validation steps performed
Package build
Unit Tests
Manual testing including registration of repositories inside Dev Home for the git extension


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
