### PR TITLE
Disable Quickstart Playground after the experimental feature is turned off 

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -38,7 +38,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase, IDisposable
 {
     private readonly ILogger _log = Log.ForContext("SourceContext", nameof(MainPageViewModel));
 
-    private const string QuickstartPlaygroundFlowFeatureName = "QuickstartPlayground";
+    internal const string QuickstartPlaygroundFlowFeatureName = "QuickstartPlayground";
 
     private readonly IHost _host;
     private readonly IWinGet _winget;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/MainPageViewModel.cs
@@ -104,7 +104,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase, IDisposable
         _host.GetService<IExperimentationService>().ExperimentalFeatures.FirstOrDefault(f => string.Equals(f.Id, QuickstartPlaygroundFlowFeatureName, StringComparison.Ordinal))!.PropertyChanged += ExperimentalFeaturesViewModel_PropertyChanged;
 
         // Hack around this by setting the property explicitly based on the state of the feature.
-        EnableQuickstartPlayground = _host.GetService<IExperimentationService>().ExperimentalFeatures.FirstOrDefault(f => string.Equals(f.Id, QuickstartPlaygroundFlowFeatureName, StringComparison.Ordinal))!.IsEnabled;
+        EnableQuickstartPlayground = _host.GetService<IExperimentationService>().IsFeatureEnabled(QuickstartPlaygroundFlowFeatureName);
     }
 
     // Create a PropertyChanged handler that we will add to the ExperimentalFeaturesViewModel
@@ -113,7 +113,7 @@ public partial class MainPageViewModel : SetupPageViewModelBase, IDisposable
     {
         if (e.PropertyName == nameof(ExperimentalFeature.IsEnabled))
         {
-            EnableQuickstartPlayground = _host.GetService<IExperimentationService>().ExperimentalFeatures.FirstOrDefault(f => string.Equals(f.Id, QuickstartPlaygroundFlowFeatureName, StringComparison.Ordinal))!.IsEnabled;
+            EnableQuickstartPlayground = _host.GetService<IExperimentationService>().IsFeatureEnabled(QuickstartPlaygroundFlowFeatureName);
         }
     }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -614,7 +614,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     [RelayCommand]
     private void OnLoaded()
     {
-        var isEnabled = _experimentationService.IsFeatureEnabled("QuickstartPlayground");
+        var isEnabled = _experimentationService.IsFeatureEnabled(MainPageViewModel.QuickstartPlaygroundFlowFeatureName);
         if (!isEnabled)
         {
             var setupFlow = Application.Current.GetService<SetupFlowViewModel>();

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -614,7 +614,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     [RelayCommand]
     private void OnLoaded()
     {
-        var isEnabled = _experimentationService.ExperimentalFeatures.FirstOrDefault(f => string.Equals(f.Id, "QuickstartPlayground", StringComparison.Ordinal))!.IsEnabled;
+        var isEnabled = _experimentationService.IsFeatureEnabled("QuickstartPlayground");
         if (!isEnabled)
         {
             var setupFlow = Application.Current.GetService<SetupFlowViewModel>();

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/SetupFlowViewModel.cs
@@ -115,6 +115,11 @@ public partial class SetupFlowViewModel : ObservableObject
         _log.Information($"Terminating Setup flow by caller [{callerNameForTelemetry}]. ActivityId={Orchestrator.ActivityId}");
         TelemetryFactory.Get<ITelemetry>().Log("SetupFlow_Termination", LogLevel.Critical, new EndFlowEvent(callerNameForTelemetry), relatedActivityId: Orchestrator.ActivityId);
 
+        ResetToMainPage();
+    }
+
+    public void ResetToMainPage()
+    {
         Orchestrator.ReleaseRemoteOperationObject();
         _host.GetService<IDevDriveManager>().RemoveAllDevDrives();
         _packageProvider.Clear();

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
@@ -9,7 +9,15 @@
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:ctcontrols="using:CommunityToolkit.WinUI.Controls"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     mc:Ignorable="d">
+
+    <i:Interaction.Behaviors>
+        <ic:EventTriggerBehavior EventName="Loaded">
+            <ic:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand}" />
+        </ic:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
 
     <setupFlowBehaviors:SetupFlowNavigationBehavior.NextTemplate>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
## Summary of the pull request
User will no longer be allowed to interact or see the QSP UI in the machine configuration tab after the user has disabled the QSP experimental feature in settings 

## References and relevant issues
Resolves issue #3233 

## Detailed description of the pull request / Additional comments
With my changes, when the quickstartplaygroundviewmodel is loaded, it will check for the value of whether quickstartplayground experimental feature is enabled. If it's not, it will cancel out of the current setup flow and go back to the desired main page. 

The reason why this issue is happening is the experiment service doesn't have an event that it sends out to tell subscribers that an experiments state has changed. The setup flow's viewmodel and orchestrator are singletons, so what ever flow the user currently selects, will stay on the screen. since there is no event nothing happens. 

I think ideally, we wanted a more generic experimental feature solution where we could add an event to the experimentation service that the setup flow subscribes to, that when triggered, if the experiment is a flow in the setup flow, then we cancel out of the flow and go back to the machine setup flow page. However, with the current way that machine config is setup with its navigation and flow pages, it makes it more difficult to achieve that. Thus, for this PR, it will address specifically the qsp issue. 

Also currently, with my solution, there is a one frame that flashes when the qsp view model is navigating back to the machine config main page. 

## Validation steps performed
locally built and verified 

## PR checklist
- [ ] Closes #3233
- [ ] Tests added/passed
- [ ] Documentation updated
