### PR TITLE
Make DevDiagnostics experimental again

### DIFF
--- a/settings/DevHome.Settings/Strings/en-us/Resources.resw
+++ b/settings/DevHome.Settings/Strings/en-us/Resources.resw
@@ -553,6 +553,14 @@
     <value>Quiet background processes allows you to free up resources while developing</value>
     <comment>Inline description of the Quiet background processes experimental feature on the 'Settings -&gt; Experiments' page where you enable it.</comment>
   </data>
+  <data name="DevDiagnosticsExperiment_Name" xml:space="preserve">
+    <value>Dev Diagnostics</value>
+    <comment>Name of experimental feature 'Dev Diagnostics' on the 'Settings -&gt; Experiments' page where you enable it.</comment>
+  </data>
+  <data name="DevDiagnosticsExperiment_Description" xml:space="preserve">
+    <value>Dev Diagnostics is a utility to provide deeper insights into your applications</value>
+    <comment>Inline description of the Dev Diagnostics experimental feature on the 'Settings -&gt; Experiments' page where you enable it.</comment>
+  </data>
   <data name="QuickstartPlayground_Name" xml:space="preserve">
     <value>Quickstart Playground</value>
     <comment>Locked="{Quickstart Playground}" Title text for the Quickstart Playground feature.</comment>

--- a/src/NavConfig.jsonc
+++ b/src/NavConfig.jsonc
@@ -132,6 +132,30 @@
       }
     },
     {
+      "identity": "DevDiagnosticsExperiment",
+      "enabledByDefault": false,
+      "buildTypeOverrides": [
+        {
+          "buildType": "dev",
+          "enabledByDefault": true,
+          "visible": true
+        },
+        {
+          "buildType": "canary",
+          "enabledByDefault": true,
+          "visible": true
+        },
+        {
+          "buildType": "stable",
+          "enabledByDefault": false,
+          "visible": true
+        }
+      ],
+      "openPage": {
+        "key": "DevHome.Utilities.ViewModels.UtilitiesMainPageViewModel"
+      }
+    },
+    {
       "identity": "RepositoryManagementExperiment",
       "enabledByDefault": false,
       "buildTypeOverrides": [

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/DDApp.xaml.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/DDApp.xaml.cs
@@ -108,6 +108,26 @@ public partial class App : Application, IApp
         Environment.FailFast(e.Message, e.Exception);
     }
 
+    internal static bool IsFeatureEnabled()
+    {
+        var isEnabled = false;
+
+        ApplicationData.Current.LocalSettings.Values.TryGetValue($"ExperimentalFeature_DevDiagnosticsExperiment", out var isEnabledObj);
+        if (isEnabledObj is not null && isEnabledObj is string isEnabledValue)
+        {
+            isEnabled = isEnabledValue == "true";
+        }
+        else
+        {
+#if DEBUG
+            // Override on debug builds to be enabled by default
+            isEnabled = true;
+#endif
+        }
+
+        return isEnabled;
+    }
+
     internal static ITelemetry Logger => TelemetryFactory.Get<ITelemetry>();
 
     internal static void LogTimeTaken(string eventName, uint timeTakenMilliseconds, Guid? relatedActivityId = null) => Logger.LogTimeTaken(eventName, timeTakenMilliseconds, relatedActivityId);

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Program.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Program.cs
@@ -172,6 +172,13 @@ public static class Program
         else if (e.Kind == Microsoft.Windows.AppLifecycle.ExtendedActivationKind.StartupTask)
         {
             // Start the app in the background to handle the startup task and register the hotkey
+            if (wasFirstActivation && !App.IsFeatureEnabled())
+            {
+                // Exit the process if PI Expermental feature is not enabled and its the first activation in the process
+                Log.Information("Experimental feature is not enabled. Exiting the process.");
+                Process.GetCurrentProcess().Kill(false);
+            }
+
             // Don't show the bar window for startup task activations.
             return;
         }

--- a/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
+++ b/tools/Utilities/src/ViewModels/UtilitiesMainPageViewModel.cs
@@ -50,7 +50,7 @@ public partial class UtilitiesMainPageViewModel : ObservableObject
                 SupportsLaunchAsAdmin = Microsoft.UI.Xaml.Visibility.Visible,
                 UtilityAutomationId = "DevHome.EnvironmentVariables",
             },
-            new(Path.Combine(appExAliasAbsFolderPath, "DevHome.DevDiagnostics.exe"))
+            new(Path.Combine(appExAliasAbsFolderPath, "DevHome.DevDiagnostics.exe"), experimentationService, "DevDiagnosticsExperiment")
             {
                 Title = stringResource.GetLocalized("DevDiagnosticsTitle"),
                 Description = stringResource.GetLocalized("DevDiagnosticsDesc"),


### PR DESCRIPTION
## Summary of the pull request

With some of the internal changes happening, moving DevDiagnostics back to experimental until we get further clarity.

This is ultimately a revert of

https://github.com/microsoft/devhome/pull/3734

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
