### PR TITLE
'Sample configurations' Hyperlink hit target larger than hyperlink text

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/MainPageView.xaml
@@ -170,6 +170,9 @@
                                     <Hyperlink NavigateUri="https://aka.ms/dsc.yaml">
                                         <Run x:Uid="MainPage_ConfigurationFile_Description_Link" />
                                     </Hyperlink>
+                                    <!-- Empty Run to workaround Hyperlink's wide clickable area issue:
+                                        https://github.com/microsoft/microsoft-ui-xaml/issues/2618 -->
+                                    <Run />
                                 </TextBlock>
                             </ctControls:SettingsCard.Description>
                         </ctControls:SettingsCard>


### PR DESCRIPTION
## Summary of the pull request
Added a trailing <Run> tag to work around an issue with the hyperlink.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/1782a5aa-3705-4ec6-8020-1b9c595623f3" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/293c7a91-b4b7-4c21-a898-d78d7b5191e6" />
</td>
</tr>
</table>

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #2873
- [ ] Tests added/passed
- [ ] Documentation updated
