### PR TITLE
SSH widget updates when config file changes

### DIFF
--- a/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
+++ b/extensions/CoreWidgetProvider/Widgets/SSHWalletWidget.cs
@@ -208,6 +208,7 @@ internal sealed class SSHWalletWidget : CoreWidget
         var options = new FileStreamOptions()
         {
             Access = FileAccess.Read,
+            Share = FileShare.ReadWrite,
         };
 
         using var reader = new StreamReader(ConfigFile, options);


### PR DESCRIPTION
## Summary of the pull request
The SSH widget was not updating when the config file changed because the widget did not allow outside processes to read or write to the file. 

This pull request modifies the SSHWalletWidget's `FileStreamOptions` to allow read/write sharing.

## References and relevant issues
Resolves #2672

## Detailed description of the pull request / Additional comments

Before: 
- SSH widget didn't update when its config file changed
- If multiple SSH widgets pointed to the same config file, a file is busy error arose in at least one of the widgets when the config file was updated

After:
- SSH widget updates when its config file changes
- Multiple SSH widgets pointing to the same config file update together when the config file changes

## Validation steps performed (locally)
- Created sample config file with two hosts
- Opened config file in text editor
- Added one (and multiple) SSH widgets to dashboard
- Repeatedly removed/added one host, saving after each change
- Found that with each save, SSH widget updated to reflect the config file

## PR checklist
- [X] Closes #2672 
- [ ] Tests added/passed
- [ ] Documentation updated
