### PR TITLE
Fix crash in SimpleTextInsights

### DIFF
--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Controls/InsightForMissingFileProcessTerminationControl.xaml
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Controls/InsightForMissingFileProcessTerminationControl.xaml
@@ -14,7 +14,7 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <TextBox Text="{x:Bind Text, Mode=OneWay}" AutomationProperties.AutomationId="ContentTextBock" VerticalAlignment="Center" Style="{StaticResource ReadOnlyTextBox}" />
+        <TextBox Text="{x:Bind Text, Mode=OneWay}" AutomationProperties.AutomationId="ContentTextBock" VerticalAlignment="Center" Style="{StaticResource ReadOnlyTextBox}" TextWrapping="Wrap"/>
         <local:ElevatedButtonControl Text="{x:Bind ElevationButtonTextString}" Grid.Column="1" Margin="20 0 0 0" Command="{x:Bind Command, Mode=OneWay}" AutomationProperties.Name="{x:Bind ElevationButtonTextString}" >
             <ToolTipService.ToolTip>
                 <ToolTip Content="{x:Bind ElevationButtonToolTipString}" />

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Pages/WinLogsPage.xaml
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Pages/WinLogsPage.xaml
@@ -99,7 +99,15 @@
                 <toolkit:DataGridTemplateColumn x:Uid="LogMessageColumn" Width="*" ClipboardContentBinding="{Binding Message}" >
                     <toolkit:DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBox Text="{Binding Message}" SelectedText="{Binding SelectedText, Mode=TwoWay}" IsReadOnly="True"/>
+                            <TextBox
+                                Text="{Binding Message}"
+                                SelectedText="{Binding SelectedText, Mode=TwoWay}"
+                                IsReadOnly="True"
+                                TextWrapping="Wrap"
+                                MaxHeight="100"
+                                VerticalAlignment="Top"
+                                AcceptsReturn="True"
+                                ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                         </DataTemplate>
                     </toolkit:DataGridTemplateColumn.CellTemplate>
                 </toolkit:DataGridTemplateColumn>

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/Strings/en-us/Resources.resw
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/Strings/en-us/Resources.resw
@@ -1283,7 +1283,7 @@ Dump File creation time: {1}</value>
     <comment>Title of an insight informing the user of a reason why a process exited</comment>
   </data>
   <data name="InsightProcessExitMissingDependencies" xml:space="preserve">
-    <value>Process {0} (pid: {1,6}) exited with error code {2}. Enabling loader snaps and trying to launch the process again can help diagnose why the app exited.</value>
+    <value>Process {0} (pid: {1,6}) exited with error code {2}. To help diagnose this issue, enable loader snaps and try to launch the process again.</value>
     <comment>{Locked="{0}, "{1,6}", "{2}"} Formatted string informing the user the process name {0}, the Process ID {1}, the exit code {2} of a process.</comment>
   </data>
   <data name="InsightProcessExitMissingDependenciesIdentifiedTitle" xml:space="preserve">

--- a/tools/DevDiagnostics/DevHome.DevDiagnostics/ViewModels/WinLogsPageViewModel.cs
+++ b/tools/DevDiagnostics/DevHome.DevDiagnostics/ViewModels/WinLogsPageViewModel.cs
@@ -173,13 +173,17 @@ public partial class WinLogsPageViewModel : ObservableObject, IDisposable
 
     private void FindPattern(string message)
     {
-        var newInsight = InsightsHelper.FindPattern(message);
-        if (newInsight is not null)
+        var newInsightTask = InsightsHelper.FindPattern(message, _dispatcher);
+        if (newInsightTask is not null)
         {
-            _dispatcher.TryEnqueue(() =>
+            var newInsight = newInsightTask.Result;
+            if (newInsight is not null)
             {
-                _insightsService.AddInsight(newInsight);
-            });
+                _dispatcher.TryEnqueue(() =>
+                {
+                    _insightsService.AddInsight(newInsight);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request

We were creating the control on the wrong thread. Now we queue the creation onto the UI thread, and wait for this to complete.

Also fixed the loader snaps insights text to wrap.
Also fixed the windows logs row text to wrap (but set to a maximum height, with a scrollbar that kicks in if needed).

Closes #3852 
Closes #3851 
Closes #3812 