### PR TITLE
Unsubscribe from OnExtensionsChanged when unloading Extensions page

### DIFF
--- a/DevHome.sln
+++ b/DevHome.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.vsconfig = .vsconfig
 		Directory.Build.props = Directory.Build.props
 		Solution.props = Solution.props
+		ToolingVersions.props = ToolingVersions.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevHome", "src\DevHome.csproj", "{60E0FD98-5396-436D-BAB7-187A853A5DC6}"

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/ViewModels/ExtensionLibraryViewModel.cs
@@ -51,9 +51,6 @@ public partial class ExtensionLibraryViewModel : ObservableObject
         _extensionService = extensionService;
         _dispatcherQueue = dispatcherQueue;
 
-        extensionService.OnExtensionsChanged -= OnExtensionsChanged;
-        extensionService.OnExtensionsChanged += OnExtensionsChanged;
-
         StorePackagesList = new();
         InstalledPackagesList = new();
     }
@@ -69,6 +66,21 @@ public partial class ExtensionLibraryViewModel : ObservableObject
     {
         await GetInstalledPackagesAndExtensionsAsync();
         GetAvailablePackages();
+
+        if (_extensionService != null)
+        {
+            _extensionService.OnExtensionsChanged -= OnExtensionsChanged;
+            _extensionService.OnExtensionsChanged += OnExtensionsChanged;
+        }
+    }
+
+    [RelayCommand]
+    public void Unloaded()
+    {
+        if (_extensionService != null)
+        {
+            _extensionService.OnExtensionsChanged -= OnExtensionsChanged;
+        }
     }
 
     private async void OnExtensionsChanged(object? sender, EventArgs e)

--- a/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
+++ b/tools/ExtensionLibrary/DevHome.ExtensionLibrary/Views/ExtensionLibraryView.xaml
@@ -15,6 +15,9 @@
         <ic:EventTriggerBehavior EventName="Loaded">
             <ic:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand}" />
         </ic:EventTriggerBehavior>
+        <ic:EventTriggerBehavior EventName="Unloaded">
+            <ic:InvokeCommandAction Command="{x:Bind ViewModel.UnloadedCommand}" />
+        </ic:EventTriggerBehavior>
     </i:Interaction.Behaviors>
 
     <Page.Resources>


### PR DESCRIPTION
## Summary of the pull request
We saw a crash when the extensions list updated, even though we weren't on the Extensions page. When leaving the page, we should unsubscribe from extension events, since we don't want to respond to them if there's no UI to update. Also, move subscribing out of the constructor and into the Loaded event.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3859
- [ ] Tests added/passed
- [ ] Documentation updated
