### PR TITLE
Propagate error info from Hyper-V manager to the callers and telemetry for configuration operation

### DIFF
--- a/extensions/HyperVExtension/src/HyperVExtension.HostGuestCommunication/ApplyConfigurationResult.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension.HostGuestCommunication/ApplyConfigurationResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Xml.Serialization;
+
 namespace HyperVExtension.HostGuestCommunication;
 
 // Helper class to convert from the DevSetupEngine COM types to the .NET types and use them
@@ -55,15 +57,18 @@ public class ApplyConfigurationResult
     {
     }
 
-    public ApplyConfigurationResult(int resultCode, string? resultDescription = null)
+    public ApplyConfigurationResult(int resultCode, string? resultDescription = null, string? resultDiagnosticText = null)
     {
         ResultCode = resultCode;
         ResultDescription = resultDescription ?? string.Empty;
+        ResultDiagnosticText = resultDiagnosticText ?? string.Empty;
     }
 
     public int ResultCode { get; set; }
 
     public string ResultDescription { get; set; } = string.Empty;
+
+    public string ResultDiagnosticText { get; set; } = string.Empty;
 
     public OpenConfigurationSetResult? OpenConfigurationSetResult { get; set; }
 

--- a/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/ApplyConfigurationOperation.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/CommunicationWithGuest/ApplyConfigurationOperation.cs
@@ -192,7 +192,7 @@ public sealed class ApplyConfigurationOperation : IApplyConfigurationOperation, 
                 return new SDK.ApplyConfigurationResult(sdkOpenConfigurationSetResult, sdkApplyConfigurationSetResult);
             }
 
-            var hresultException = new HResultException(completionStatus.ResultCode);
+            var hresultException = new HResultException(completionStatus.ResultCode, completionStatus.ResultDiagnosticText);
 
             return new SDK.ApplyConfigurationResult(hresultException, completionStatus.ResultDescription, hresultException.Message);
         }

--- a/extensions/HyperVExtension/src/HyperVExtension/Exceptions/HyperVManagerException.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Exceptions/HyperVManagerException.cs
@@ -5,13 +5,15 @@ namespace HyperVExtension.Exceptions;
 
 public class HyperVManagerException : Exception
 {
-    public HyperVManagerException(string? message)
+    public HyperVManagerException(string? message, int hresult = 0)
         : base(message)
     {
+        HResult = hresult;
     }
 
     public HyperVManagerException(string? message, Exception? innerException)
     : base(message, innerException)
     {
+        HResult = innerException?.HResult ?? 0;
     }
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/HyperVVirtualMachine.cs
@@ -621,7 +621,10 @@ public class HyperVVirtualMachine : IComputeSystem
             var startResult = Start(string.Empty);
             if (startResult.Result.Status == ProviderOperationStatus.Failure)
             {
-                return operation.CompleteOperation(new HostGuestCommunication.ApplyConfigurationResult(startResult.Result.ExtendedError.HResult, startResult.Result.DisplayMessage));
+                return operation.CompleteOperation(new HostGuestCommunication.ApplyConfigurationResult(
+                    startResult.Result.ExtendedError.HResult,
+                    startResult.Result.DisplayMessage,
+                    startResult.Result.DiagnosticText));
             }
 
             using var guestSession = new GuestKvpSession(Guid.Parse(Id));

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/IPowerShellSession.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/IPowerShellSession.cs
@@ -37,4 +37,7 @@ public interface IPowerShellSession
 
     /// <summary> Gets the error messages associated with this instance of the PowerShell session. </summary>
     public string GetErrorMessages();
+
+    /// <summary> Gets the first error HRESULT associated with this instance of the PowerShell session. </summary>
+    public int GetErrorFirstHResult();
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/PowerShellResult.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/PowerShellResult.cs
@@ -14,4 +14,7 @@ public class PowerShellResult : PowerShellResultBase
 
     /// <inheritdoc cref="PowerShellResultBase.CommandOutputErrorMessage"/>
     public override string CommandOutputErrorMessage { get; set; } = string.Empty;
+
+    /// <inheritdoc cref="PowerShellResultBase.CommandOutputErrorFirstHresult"/>
+    public override int CommandOutputErrorFirstHResult { get; set; }
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Models/PowerShellResultBase.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Models/PowerShellResultBase.cs
@@ -22,4 +22,12 @@ public abstract class PowerShellResultBase
     /// in the PowerShell runspace. This is used for logging and debugging purposes.
     /// </remark>
     public abstract string CommandOutputErrorMessage { get; set; }
+
+    /// <summary> Gets or sets HRESULT from the first error return by PowerShell. </summary>
+    /// <remark>
+    /// This is the error HRESULT that is returned when the command returns an error
+    /// in the PowerShell runspace. PowerShell can return a list of exceptions. This is the HRESULT
+    /// from the first exception in the list. This is used for logging and debugging purposes.
+    /// </remark>
+    public abstract int CommandOutputErrorFirstHResult { get; set; }
 }

--- a/extensions/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Services/HyperVManager.cs
@@ -9,6 +9,7 @@ using HyperVExtension.Helpers;
 using HyperVExtension.Models;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Windows.Win32.Foundation;
 
 namespace HyperVExtension.Services;
 
@@ -136,7 +137,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to get VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to get VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // If we found the VM there should only be one psObject in the list.
@@ -146,7 +149,9 @@ public class HyperVManager : IHyperVManager, IDisposable
                 return _hyperVVirtualMachineFactory(psObject);
             }
 
-            throw new HyperVManagerException($"Unable to get VM with Id {vmId} due to PowerShell returning a null PsObject");
+            throw new HyperVManagerException(
+                $"Unable to get VM with Id {vmId} due to PowerShell returning a null PsObject",
+                HRESULT.E_UNEXPECTED);
         }
         finally
         {
@@ -188,7 +193,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to stop VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to stop VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // The VM will be the returned object since we used the "PassThru" parameter.
@@ -229,7 +236,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to start VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to start VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // The VM will be the returned object since we used the "PassThru" parameter.
@@ -270,7 +279,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to pause VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to pause VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // The VM will be the returned object since we used the "PassThru" parameter.
@@ -313,7 +324,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to resume VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to resume VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // The VM will be the returned object since we used the "PassThru" parameter.
@@ -356,7 +369,9 @@ public class HyperVManager : IHyperVManager, IDisposable
             var result = _powerShellService.Execute(commandLineStatements, PipeType.PipeOutput);
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to remove VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to remove VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // The VM will be the returned object since we used the "PassThru" parameter.
@@ -544,7 +559,7 @@ public class HyperVManager : IHyperVManager, IDisposable
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
                 throw new HyperVManagerException(
-                    $"Unable to create a new checkpoint for VM with Id: {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                    $"Unable to create a new checkpoint for VM with Id: {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}", result.CommandOutputErrorFirstHResult);
             }
 
             var newCheckpoint = result.PsObjects.FirstOrDefault();
@@ -587,7 +602,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
             if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
             {
-                throw new HyperVManagerException($"Unable to start VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}");
+                throw new HyperVManagerException(
+                    $"Unable to start VM with Id {vmId} due to PowerShell error: {result.CommandOutputErrorMessage}",
+                    result.CommandOutputErrorFirstHResult);
             }
 
             // The VM will be the returned object since we used the "PassThru" parameter.
@@ -644,7 +661,9 @@ public class HyperVManager : IHyperVManager, IDisposable
 
         if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
         {
-            throw new HyperVManagerException($"Unable to get Local Hyper-V host: {result.CommandOutputErrorMessage}");
+            throw new HyperVManagerException(
+                $"Unable to get Local Hyper-V host: {result.CommandOutputErrorMessage}",
+                result.CommandOutputErrorFirstHResult);
         }
 
         // return the host object. It should be the only object in the list.
@@ -668,7 +687,9 @@ public class HyperVManager : IHyperVManager, IDisposable
         var result = _powerShellService.Execute(statementBuilderForNewVm, PipeType.None);
         if (!string.IsNullOrEmpty(result.CommandOutputErrorMessage))
         {
-            throw new HyperVManagerException($"Unable to create the virtual machine: {result.CommandOutputErrorMessage}");
+            throw new HyperVManagerException(
+                $"Unable to create the virtual machine: {result.CommandOutputErrorMessage}",
+                result.CommandOutputErrorFirstHResult);
         }
 
         var returnedPsObject = result.PsObjects.First();

--- a/extensions/HyperVExtension/src/HyperVExtension/Services/PowerShellService.cs
+++ b/extensions/HyperVExtension/src/HyperVExtension/Services/PowerShellService.cs
@@ -49,11 +49,13 @@ public class PowerShellService : IPowerShellService, IDisposable
                 _powerShellSession.ClearSession();
                 var psObjectList = ExecuteStatements(commandLineStatements, pipeType);
                 var commandOutputErrorMessage = _powerShellSession.GetErrorMessages();
+                var hresult = _powerShellSession.GetErrorFirstHResult();
 
                 return new PowerShellResult
                 {
                     PsObjects = psObjectList,
                     CommandOutputErrorMessage = commandOutputErrorMessage,
+                    CommandOutputErrorFirstHResult = hresult,
                 };
             }
         }

--- a/extensions/HyperVExtension/test/HyperVExtension/Mocks/PowerShellSessionMock.cs
+++ b/extensions/HyperVExtension/test/HyperVExtension/Mocks/PowerShellSessionMock.cs
@@ -45,4 +45,10 @@ public class PowerShellSessionMock : IPowerShellSession
     {
         return ErrorText;
     }
+
+    /// <inheritdoc cref="IPowerShellSession.GetErrorFirstHResult"/>
+    public int GetErrorFirstHResult()
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
## Summary of the pull request
Propagate more error info returned as a result of Hyper-V operations to higher levels and telemetry.

We were losing some error info returned by PowerShell for Hyper-V operations, making it harder to diagnose the failures. This PR adds more diagnostic info to telemetry.

## References and relevant issues
#3662 

## Detailed description of the pull request / Additional comments
I haven't seen a useful HRESULT in exceptions returned by PowerShell, however error description can be useful and can have error codes embedded into the text.

## Validation steps performed
Tested by forcing Hyper-V/PowerShell to return errors when trying to execute Configure Environment operation.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
