### PR TITLE
Prevent Dev Home crashing when widgets don't supply icons or screenshots

### DIFF
--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetIconService.cs
@@ -5,15 +5,12 @@ using System.Threading.Tasks;
 using DevHome.Dashboard.ComSafeWidgetObjects;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace DevHome.Dashboard.Services;
 
 public interface IWidgetIconService
 {
     public void RemoveIconsFromCache(string definitionId);
-
-    public Task<BitmapImage> GetIconFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme);
 
     public Task<Brush> GetBrushForWidgetIconAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/IWidgetScreenshotService.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using DevHome.Dashboard.ComSafeWidgetObjects;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Media;
 
 namespace DevHome.Dashboard.Services;
 
@@ -12,5 +12,5 @@ public interface IWidgetScreenshotService
 {
     public void RemoveScreenshotsFromCache(string definitionId);
 
-    public Task<BitmapImage> GetScreenshotFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme actualTheme);
+    public Task<Brush> GetBrushForWidgetScreenshotAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme);
 }

--- a/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Services/WidgetIconService.cs
@@ -38,7 +38,7 @@ public class WidgetIconService : IWidgetIconService
         _widgetDarkIconCache.TryRemove(definitionId, out _);
     }
 
-    public async Task<BitmapImage> GetIconFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme)
+    private async Task<BitmapImage> GetIconFromCacheAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme)
     {
         var widgetDefinitionId = widgetDefinition.Id;
         BitmapImage bitmapImage;
@@ -75,11 +75,24 @@ public class WidgetIconService : IWidgetIconService
 
     public async Task<Brush> GetBrushForWidgetIconAsync(ComSafeWidgetDefinition widgetDefinition, ElementTheme theme)
     {
-        var image = await GetIconFromCacheAsync(widgetDefinition, theme);
+        var image = new BitmapImage();
+        try
+        {
+            image = await GetIconFromCacheAsync(widgetDefinition, theme);
+        }
+        catch (System.IO.FileNotFoundException fileNotFoundEx)
+        {
+            _log.Warning(fileNotFoundEx, $"Widget icon missing for widget definition {widgetDefinition.DisplayTitle}");
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"Failed to get widget icon for widget definition {widgetDefinition.DisplayTitle}");
+        }
 
         var brush = new ImageBrush
         {
             ImageSource = image,
+            Stretch = Stretch.Uniform,
         };
 
         return brush;

--- a/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
+++ b/tools/Dashboard/DevHome.Dashboard/ViewModels/AddWidgetViewModel.cs
@@ -41,14 +41,10 @@ public partial class AddWidgetViewModel : ObservableObject
     public async Task SetWidgetDefinition(ComSafeWidgetDefinition selectedWidgetDefinition)
     {
         _selectedWidgetDefinition = selectedWidgetDefinition;
-        var bitmap = await _widgetScreenshotService.GetScreenshotFromCacheAsync(selectedWidgetDefinition, _themeSelectorService.GetActualTheme());
 
         WidgetDisplayTitle = selectedWidgetDefinition.DisplayTitle;
         WidgetProviderDisplayTitle = selectedWidgetDefinition.ProviderDefinitionDisplayName;
-        WidgetScreenshot = new ImageBrush
-        {
-            ImageSource = bitmap,
-        };
+        WidgetScreenshot = await _widgetScreenshotService.GetBrushForWidgetScreenshotAsync(selectedWidgetDefinition, _themeSelectorService.GetActualTheme());
         PinButtonVisibility = true;
     }
 
@@ -68,11 +64,7 @@ public partial class AddWidgetViewModel : ObservableObject
         {
             // Update the preview image for the selected widget.
             var theme = _themeSelectorService.GetActualTheme();
-            var bitmap = await _widgetScreenshotService.GetScreenshotFromCacheAsync(_selectedWidgetDefinition, theme);
-            WidgetScreenshot = new ImageBrush
-            {
-                ImageSource = bitmap,
-            };
+            WidgetScreenshot = await _widgetScreenshotService.GetBrushForWidgetScreenshotAsync(_selectedWidgetDefinition, theme);
         }
     }
 }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -117,7 +117,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
                 {
                     if (widgetDef.ProviderDefinitionId.Equals(providerDef.Id, StringComparison.Ordinal))
                     {
-                        var subItemContent = await BuildWidgetNavItem(widgetDef);
+                        var subItemContent = await BuildWidgetNavItemAsync(widgetDef);
                         var enable = !IsSingleInstanceAndAlreadyPinned(widgetDef, [.. comSafeCurrentlyPinnedWidgets]);
                         var subItem = new NavigationViewItem
                         {
@@ -148,12 +148,12 @@ public sealed partial class AddWidgetDialog : ContentDialog
         }
     }
 
-    private async Task<Grid> BuildWidgetNavItem(ComSafeWidgetDefinition widgetDefinition)
+    private async Task<Grid> BuildWidgetNavItemAsync(ComSafeWidgetDefinition widgetDefinition)
     {
-        return await BuildNavItem(widgetDefinition);
+        return await BuildNavItemAsync(widgetDefinition);
     }
 
-    private async Task<Grid> BuildNavItem(ComSafeWidgetDefinition widgetDefinition)
+    private async Task<Grid> BuildNavItemAsync(ComSafeWidgetDefinition widgetDefinition)
     {
         var itemContent = new Grid
         {
@@ -265,7 +265,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
             {
                 if (widgetItem.Tag is ComSafeWidgetDefinition widgetDefinition)
                 {
-                    widgetItem.Content = await BuildNavItem(widgetDefinition);
+                    widgetItem.Content = await BuildNavItemAsync(widgetDefinition);
                 }
             }
         }

--- a/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
+++ b/tools/Dashboard/DevHome.Dashboard/Views/AddWidgetDialog.xaml.cs
@@ -150,11 +150,10 @@ public sealed partial class AddWidgetDialog : ContentDialog
 
     private async Task<Grid> BuildWidgetNavItem(ComSafeWidgetDefinition widgetDefinition)
     {
-        var image = await _widgetIconService.GetIconFromCacheAsync(widgetDefinition, ActualTheme);
-        return BuildNavItem(image, widgetDefinition.DisplayTitle);
+        return await BuildNavItem(widgetDefinition);
     }
 
-    private Grid BuildNavItem(BitmapImage image, string text)
+    private async Task<Grid> BuildNavItem(ComSafeWidgetDefinition widgetDefinition)
     {
         var itemContent = new Grid
         {
@@ -165,32 +164,26 @@ public sealed partial class AddWidgetDialog : ContentDialog
             },
         };
 
-        if (image is not null)
-        {
-            var itemSquare = new Rectangle()
-            {
-                Width = 16,
-                Height = 16,
-                Margin = new Thickness(0, 0, 8, 0),
-                Fill = new ImageBrush
-                {
-                    ImageSource = image,
-                    Stretch = Stretch.Uniform,
-                },
-            };
-            Grid.SetColumn(itemSquare, 0);
+        var imageBrush = await _widgetIconService.GetBrushForWidgetIconAsync(widgetDefinition, ActualTheme);
 
-            itemContent.Children.Add(itemSquare);
-        }
+        var itemSquare = new Rectangle()
+        {
+            Width = 16,
+            Height = 16,
+            Margin = new Thickness(0, 0, 8, 0),
+            Fill = imageBrush,
+        };
+
+        Grid.SetColumn(itemSquare, 0);
+        itemContent.Children.Add(itemSquare);
 
         var itemText = new TextBlock()
         {
-            Text = text,
+            Text = widgetDefinition.DisplayTitle,
             TextWrapping = TextWrapping.Wrap,
             VerticalAlignment = VerticalAlignment.Center,
         };
         Grid.SetColumn(itemText, 1);
-
         itemContent.Children.Add(itemText);
 
         return itemContent;
@@ -272,8 +265,7 @@ public sealed partial class AddWidgetDialog : ContentDialog
             {
                 if (widgetItem.Tag is ComSafeWidgetDefinition widgetDefinition)
                 {
-                    var image = await _widgetIconService.GetIconFromCacheAsync(widgetDefinition, ActualTheme);
-                    widgetItem.Content = BuildNavItem(image, widgetDefinition.DisplayTitle);
+                    widgetItem.Content = await BuildNavItem(widgetDefinition);
                 }
             }
         }


### PR DESCRIPTION
## Summary of the pull request
Widget providers are required to supply icons and screenshots. However, if they don't, Dev Home shouldn't crash.
Simplify icon and screenshot services by just returning a brush. If we can't get the image to put in the brush, the image just won't show up.

## References and relevant issues
Related to #2482

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
