### PR TITLE
Remove NT service registration from Retail build of DevHome

### DIFF
--- a/src/Package.appxmanifest
+++ b/src/Package.appxmanifest
@@ -333,17 +333,6 @@
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>
-        <desktop6:Extension Category="windows.service" Executable="DevHome.Service.exe" EntryPoint="DevHome.Service.Service">
-          <desktop6:Service Name="DevHome.Service" StartupType="manual" StartAccount="localSystem" />
-        </desktop6:Extension>
-        <com2:Extension Category="windows.comServer">
-          <com2:ComServer>
-            <com3:ServiceServer ServiceName="DevHome.Service" LaunchAndActivationPermission="O:SYG:SYD:(A;;11;;;IU)">
-              <!-- Grant local activation rights to Interactive Users. -->
-              <com3:Class Id="E8D40232-20A1-4F3B-9C0C-AAA6538698C6" DisplayName="CLSID_DevHomeService" />
-            </com3:ServiceServer>
-          </com2:ComServer>
-        </com2:Extension>
       </Extensions>
     </Application>
     <Application Id="DevHome.DevDiagnostics" Executable="DevHome.DevDiagnostics.exe" EntryPoint="Windows.FullTrustApplication">
@@ -419,8 +408,6 @@
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
     <rescap:Capability Name="unvirtualizedResources" />
-    <rescap:Capability Name="packagedServices" />
-    <rescap:Capability Name="localSystemServices" />
   </Capabilities>
   <genTemplate:Metadata>
     <genTemplate:Item Name="generator" Value="Template Studio" />


### PR DESCRIPTION
## Summary of the pull request
Remove the NT service registration from the retail build of DevHome until we finish some bookkeeping tasks.

This will prevent DevDiagnostics from monitoring processes that failed to launch due to loader dependencies, but everything else should be fine.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

Built retail. Installed the build, confirmed no NT service was installed, and DevDiagnostics still launched properly.

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
