### PR TITLE
Remove "locked" statement for DevHome for resources in WSL Extension

### DIFF
--- a/extensions/WSLExtension/Strings/en-US/Resources.resw
+++ b/extensions/WSLExtension/Strings/en-US/Resources.resw
@@ -168,7 +168,7 @@
   </data>
   <data name="VirtualMachinePlatformNotInstalled" xml:space="preserve">
     <value>The Virtual Machine Platform feature is needed for the WSL extension to function properly. The feature can be enabled in Dev Home's Windows customization page, under the virtualization feature management option. Enabling the feature will require a reboot. For more information on WSL requirements visit aka.ms/wslinstall</value>
-    <comment>{Locked="Windows", "WSL", "aka.ms/wslinstall", "Dev Home"} Text message to display when the virtual machine platform Windows optional component is not enabled.</comment>
+    <comment>{Locked="Windows", "WSL", "aka.ms/wslinstall"} Text message to display when the virtual machine platform Windows optional component is not enabled.</comment>
   </data>
   <data name="AppInstallPending" xml:space="preserve">
     <value>Installation of the {0} package is pending</value>


### PR DESCRIPTION
## Summary of the pull request

We were locking "Dev Home" as a non-localizable string in the WSL Extension, and Dev Home as been determined to be localizable.

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes internal MS bug [Bug 53944102](https://microsoft.visualstudio.com/OS/_workitems/edit/53944102): Locver: Apps: DevHome: Dev rule locks term "Dev Home" that is approved for localization in Term Studio
- [ ] Tests added/passed
- [ ] Documentation updated
