### PR TITLE
Speed up package search

### DIFF
--- a/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using DevHome.Services.WindowsPackageManager.Contracts;
@@ -79,6 +80,29 @@ internal sealed class WinGetPackage : IWinGetPackage
     {
         var uriOptions = string.IsNullOrEmpty(installVersion) ? null : new WinGetPackageUriOptions(installVersion);
         return new(CatalogName, Id, uriOptions);
+    }
+
+    /// <summary>
+    /// Copies the packages from out-of-proc to in-proc.
+    /// </summary>
+    /// <param name="logger">Logger</param>
+    /// <param name="packageFinder">Package finder</param>
+    /// <param name="packagesOutOfProc">Packages to copy</param>
+    /// <returns>List of in-proc packages</returns>
+    public static List<IWinGetPackage> FromOutOfProc(
+        ILogger logger,
+        IWinGetPackageFinder packageFinder,
+        IList<CatalogPackage> packagesOutOfProc)
+    {
+        var perfTimer = Stopwatch.StartNew();
+        logger.LogDebug($"Copying {packagesOutOfProc.Count} packages from out-of-proc to in-proc");
+        var packagesInProc = packagesOutOfProc
+            .AsParallel()
+            .AsOrdered()
+            .Select(p => new WinGetPackage(logger, p, packageFinder.IsElevationRequired(p)))
+            .ToList<IWinGetPackage>();
+        logger.LogDebug($"Finished copying {packagesOutOfProc.Count} packages from out-of-proc to in-proc in: {perfTimer.ElapsedMilliseconds} ms");
+        return packagesInProc;
     }
 
     private PackageVersionInfo GetPackageVersionInfo(CatalogPackage package)

--- a/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Models/WinGetPackage.cs
@@ -94,6 +94,7 @@ internal sealed class WinGetPackage : IWinGetPackage
         IWinGetPackageFinder packageFinder,
         IList<CatalogPackage> packagesOutOfProc)
     {
+        // Copy packages from out-of-process in parallel to enhance the performance
         var perfTimer = Stopwatch.StartNew();
         logger.LogDebug($"Copying {packagesOutOfProc.Count} packages from out-of-proc to in-proc");
         var packagesInProc = packagesOutOfProc

--- a/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetGetPackageOperation.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetGetPackageOperation.cs
@@ -65,13 +65,8 @@ internal sealed class WinGetGetPackageOperation : IWinGetGetPackageOperation
                     // Get packages from the catalog
                     var catalog = await _protocolParser.ResolveCatalogAsync(firstParsedUri);
                     var packagesOutOfProc = await _packageFinder.GetPackagesAsync(catalog, packageIds);
-                    var packagesInProc = packagesOutOfProc
-                        .AsParallel()
-                        .AsOrdered()
-                        .Select(p => new WinGetPackage(_logger, p, _packageFinder.IsElevationRequired(p)))
-                        .ToList<IWinGetPackage>();
-                    packagesInProc
-                        .ForEach(p => _packageCache.TryAddPackage(_protocolParser.CreatePackageUri(p), p));
+                    var packagesInProc = WinGetPackage.FromOutOfProc(_logger, _packageFinder, packagesOutOfProc);
+                    packagesInProc.ForEach(p => _packageCache.TryAddPackage(_protocolParser.CreatePackageUri(p), p));
                     return packagesInProc;
                 }));
             }

--- a/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetGetPackageOperation.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetGetPackageOperation.cs
@@ -66,6 +66,8 @@ internal sealed class WinGetGetPackageOperation : IWinGetGetPackageOperation
                     var catalog = await _protocolParser.ResolveCatalogAsync(firstParsedUri);
                     var packagesOutOfProc = await _packageFinder.GetPackagesAsync(catalog, packageIds);
                     var packagesInProc = packagesOutOfProc
+                        .AsParallel()
+                        .AsOrdered()
                         .Select(p => new WinGetPackage(_logger, p, _packageFinder.IsElevationRequired(p)))
                         .ToList<IWinGetPackage>();
                     packagesInProc

--- a/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetSearchOperation.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetSearchOperation.cs
@@ -41,6 +41,8 @@ internal sealed class WinGetSearchOperation : IWinGetSearchOperation
             var searchCatalog = await _catalogConnector.GetCustomSearchCatalogAsync();
             var results = await _packageFinder.SearchAsync(searchCatalog, query, limit);
             return results
+                .AsParallel()
+                .AsOrdered()
                 .Select(p => new WinGetPackage(_logger, p, _packageFinder.IsElevationRequired(p)))
                 .ToList<IWinGetPackage>();
         });

--- a/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetSearchOperation.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Services/Operations/WinGetSearchOperation.cs
@@ -40,11 +40,7 @@ internal sealed class WinGetSearchOperation : IWinGetSearchOperation
         {
             var searchCatalog = await _catalogConnector.GetCustomSearchCatalogAsync();
             var results = await _packageFinder.SearchAsync(searchCatalog, query, limit);
-            return results
-                .AsParallel()
-                .AsOrdered()
-                .Select(p => new WinGetPackage(_logger, p, _packageFinder.IsElevationRequired(p)))
-                .ToList<IWinGetPackage>();
+            return WinGetPackage.FromOutOfProc(_logger, _packageFinder, results);
         });
     }
 }

--- a/services/DevHome.Services.WindowsPackageManager/Services/WinGetPackageFinder.cs
+++ b/services/DevHome.Services.WindowsPackageManager/Services/WinGetPackageFinder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Services.WindowsPackageManager.COM;
@@ -154,7 +155,13 @@ internal sealed class WinGetPackageFinder : IWinGetPackageFinder
     private async Task<IList<CatalogPackage>> GetPackagesInternalAsync(WinGetCatalog catalog, FindPackagesOptions options)
     {
         _logger.LogInformation($"Performing search on catalog {catalog.GetDescriptiveName()}");
+        _logger.LogDebug($"Calling WinGet COM API {nameof(PackageCatalog.FindPackagesAsync)}");
+
+        // Find packages using WinGet COM API
+        var perfTimer = Stopwatch.StartNew();
         var findResult = await catalog.Catalog.FindPackagesAsync(options);
+        perfTimer.Stop();
+
         if (findResult.Status != FindPackagesResultStatus.Ok)
         {
             _logger.LogError($"Failed to find packages with status {findResult.Status}");
@@ -170,7 +177,7 @@ internal sealed class WinGetPackageFinder : IWinGetPackageFinder
         }
 
         _logger.LogInformation($"Found {result.Count} results from catalog {catalog.GetDescriptiveName()} [{string.Join(", ", result.Select(p => p.Id))}]");
-
+        _logger.LogDebug($"Finished calling WinGet COM API {nameof(PackageCatalog.FindPackagesAsync)} with {result.Count} results in {perfTimer.ElapsedMilliseconds} ms");
         return result;
     }
 }


### PR DESCRIPTION
## Summary of the pull request

Code changes in this PR allows copying packages from out-of-proc to in-proc in parallel offering x1.44 speedup on average per search query. Those values are based on 28 data points executed before and after the change.

⚠️ Those numbers may be different on different machines and depends on hardware and software variables.

  | Before (ms) | After (ms) | Speedup
-- | -- | -- | --
SUM | 46,613 | 32,272 | 1.444379
AVG | 1,726 | 1,195 | 1.444379

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #3655
- [ ] Tests added/passed
- [ ] Documentation updated
