### PR TITLE
Git command line changes for WSL

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration/Helpers/GitCommandRunnerResultInfo.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Helpers/GitCommandRunnerResultInfo.cs
@@ -19,18 +19,21 @@ public class GitCommandRunnerResultInfo
 
     public string? Arguments { get; set; }
 
+    public int? ProcessExitCode { get; set; }
+
     public GitCommandRunnerResultInfo(ProviderOperationStatus status, string? output)
     {
         Status = status;
         Output = output;
     }
 
-    public GitCommandRunnerResultInfo(ProviderOperationStatus status, string? displayMessage, string? diagnosticText, Exception? ex, string? args)
+    public GitCommandRunnerResultInfo(ProviderOperationStatus status, string? displayMessage, string? diagnosticText, Exception? ex, string? args, int? processExitCode)
     {
         Status = status;
         DisplayMessage = displayMessage;
         DiagnosticText = diagnosticText;
         Ex = ex;
         Arguments = args;
+        ProcessExitCode = processExitCode;
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Helpers/GitCommandRunnerResultInfo.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Helpers/GitCommandRunnerResultInfo.cs
@@ -27,9 +27,10 @@ public class GitCommandRunnerResultInfo
         Output = output;
     }
 
-    public GitCommandRunnerResultInfo(ProviderOperationStatus status, string? displayMessage, string? diagnosticText, Exception? ex, string? args, int? processExitCode)
+    public GitCommandRunnerResultInfo(ProviderOperationStatus status, string? output, string? displayMessage, string? diagnosticText, Exception? ex, string? args, int? processExitCode)
     {
         Status = status;
+        Output = output;
         DisplayMessage = displayMessage;
         DiagnosticText = diagnosticText;
         Ex = ex;

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitLogCache.cs
@@ -1,32 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using LibGit2Sharp;
 using Serilog;
 
 namespace FileExplorerGitIntegration.Models;
 
-// LibGit2Sharp.CommitEnumerator are not reusable as they do not provide a way to reuse libgit2's revwalk object
-// LibGit2's prepare_walk() does the expensive work of traversing and caching the commit graph
-// Unfortunately LibGit2Sharp.CommitEnumerator.Reset() method resets the revwalk, but does not reinitialize the sort/push/hide options
-// This leaves all that work wasted only to be done again.
-// Furthermore, LibGit2 revwalk initialization takes locks on internal data, which causes contention in multithreaded scenarios as threads
-// all scramble to initialize and re-initialize their own revwalk objects.
-// Ideally, LibGit2Sharp improves the API to allow reusing the revwalk object, but that seems unlikely to happen soon.
 internal sealed class CommitLogCache
 {
-    private readonly List<Commit> _commits = new();
     private readonly string _workingDirectory;
 
     // For now, we'll use the command line to get the last commit for a file, on demand.
-    // In the future we may use some sort of heuristic to determine if we should use the command line or not.
-    private readonly bool _preferCommandLine = true;
-    private readonly bool _useCommandLine;
     private readonly GitDetect _gitDetect = new();
     private readonly bool _gitInstalled;
 
@@ -34,40 +17,10 @@ internal sealed class CommitLogCache
 
     private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(CommitLogCache));
 
-    public CommitLogCache(Repository repo)
+    public CommitLogCache(string workingDirectory)
     {
-        _workingDirectory = repo.Info.WorkingDirectory;
-
-        // Use the command line to get the last commit for a file, on demand.
-        // PRO: If Git is installed, this will always succeed, and in a somewhat predictable amount of time.
-        //      Doesn't consume memory for the entire commit log.
-        // CON: Spawning a process for each file may be slower than walking to recent commits.
-        //      Does not work if Git isn't installed.
-        if (_preferCommandLine)
-        {
-            _gitInstalled = _gitDetect.DetectGit();
-            _useCommandLine = _gitInstalled;
-        }
-
-        if (!_useCommandLine)
-        {
-            // Greedily get the entire commit log for simplicity.
-            // PRO: No syncronization needed for the enumerator.
-            // CON: May take longer for the initial load and use more memory.
-            // For reference, I tested on my dev machine on a repo with an *large* number of commits
-            // https://github.com/python/cpython with > 120k commits. This was a one-time cost of 2-3 seconds, but also
-            // consumed several hundred MB of memory.
-            // Unfortunately, loading an *enormous* repo with 1M+ commits consumes a multiple GBs of memory.
-
-            // For smaller repos this method is faster, but the memory consumption is prohibitive on the huge ones.
-            // Additionally, virtualized repos (aka GVFS) may show the entire commit log, but each commit's tree isn't always hydrated.
-            // As a result, GVFS repos often fail to find the last commit for a file if it is older than some unknown threshold.
-
-            // Often, but not always, the root folder has some boilerplate/doc/config that rarely changes
-            // Therefore, populating the last commit for each file in the root folder often requires a large portion of the commit history anyway.
-            // This somewhat blunts the appeal of trying to load this incrementally.
-            _commits.AddRange(repo.Commits);
-        }
+        _workingDirectory = workingDirectory;
+        _gitInstalled = _gitDetect.DetectGit();
     }
 
     public CommitWrapper? FindLastCommit(string relativePath)
@@ -77,15 +30,7 @@ internal sealed class CommitLogCache
             return cachedCommit;
         }
 
-        CommitWrapper? result;
-        if (_useCommandLine)
-        {
-            result = FindLastCommitUsingCommandLine(relativePath);
-        }
-        else
-        {
-            result = FindLastCommitUsingLibGit2Sharp(relativePath);
-        }
+        var result = FindLastCommitUsingCommandLine(relativePath);
 
         if (result != null)
         {
@@ -129,55 +74,5 @@ internal sealed class CommitLogCache
         DateTimeOffset authorWhen = DateTimeOffset.Parse(parts[3], null, System.Globalization.DateTimeStyles.RoundtripKind);
         string sha = parts[4];
         return new CommitWrapper(message, authorName, authorEmail, authorWhen, sha);
-    }
-
-    private CommitWrapper? FindLastCommitUsingLibGit2Sharp(string relativePath)
-    {
-        var checkedFirstCommit = false;
-        foreach (var currentCommit in _commits)
-        {
-            // Now that CommitLogCache is caching the result of the revwalk, the next piece that is most expensive
-            // is obtaining relativePath's TreeEntry from the Tree (e.g. currentTree[relativePath].
-            // Digging into the git shows that number of directory entries and/or directory depth may play a factor.
-            // There may also be a lot of redundant lookups happening here, so it may make sense to do some LRU caching.
-            var currentTree = currentCommit.Tree;
-            var currentTreeEntry = currentTree[relativePath];
-            if (currentTreeEntry == null)
-            {
-                if (checkedFirstCommit)
-                {
-                    continue;
-                }
-                else
-                {
-                    // If this file isn't present in the most recent commit, then it's of no interest
-                    return null;
-                }
-            }
-
-            checkedFirstCommit = true;
-            var parents = currentCommit.Parents;
-            var count = parents.Count();
-            if (count == 0)
-            {
-                return new CommitWrapper(currentCommit);
-            }
-            else if (count > 1)
-            {
-                // Multiple parents means a merge. Ignore.
-                continue;
-            }
-            else
-            {
-                var parentTree = parents.First();
-                var parentTreeEntry = parentTree[relativePath];
-                if (parentTreeEntry == null || parentTreeEntry.Target.Id != currentTreeEntry.Target.Id)
-                {
-                    return new CommitWrapper(currentCommit);
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/CommitWrapper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using LibGit2Sharp;
-
 internal sealed class CommitWrapper
 {
     public string MessageShort { get; private set; }
@@ -14,15 +12,6 @@ internal sealed class CommitWrapper
     public DateTimeOffset AuthorWhen { get; private set; }
 
     public string Sha { get; private set; }
-
-    public CommitWrapper(Commit commit)
-    {
-        MessageShort = commit.MessageShort;
-        AuthorName = commit.Author.Name;
-        AuthorEmail = commit.Author.Email;
-        AuthorWhen = commit.Author.When;
-        Sha = commit.Sha;
-    }
 
     public CommitWrapper(string messageShort, string authorName, string authorEmail, DateTimeOffset authorWhen, string sha)
     {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExeceutableConfigOptions.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExeceutableConfigOptions.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace FileExplorerGitIntegration.Models;
 
 public partial class GitExecutableConfigOptions

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -46,7 +46,7 @@ public class GitExecute
                 if (process.ExitCode != 0)
                 {
                     Log.Error("Execute Git process exited unsuccessfully with exit code {ExitCode}", process.ExitCode);
-                    return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Execute Git process exited unsuccessfully", string.Empty, null, arguments, process.ExitCode);
+                    return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, output, "Execute Git process exited unsuccessfully", string.Empty, null, arguments, process.ExitCode);
                 }
 
                 return new GitCommandRunnerResultInfo(ProviderOperationStatus.Success, output);
@@ -54,13 +54,13 @@ public class GitExecute
             else
             {
                 Log.Error("Failed to start the Git process: process is null");
-                return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Git process is null", string.Empty, new InvalidOperationException("Failed to start the Git process: process is null"), null, null);
+                return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, null, "Git process is null", string.Empty, new InvalidOperationException("Failed to start the Git process: process is null"), null, null);
             }
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to invoke Git with arguments: {Argument}", arguments);
-            return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Failed to invoke Git with arguments", string.Empty, ex, arguments, null);
+            return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, null, "Failed to invoke Git with arguments", string.Empty, ex, arguments, null);
         }
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics;
 using FileExplorerGitIntegration.Helpers;
 using Microsoft.Windows.DevHome.SDK;

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitExecute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using FileExplorerGitIntegration.Helpers;
 using Microsoft.Windows.DevHome.SDK;
@@ -41,18 +42,25 @@ public class GitExecute
 
                 // Add timeout for 1 minute
                 process.WaitForExit(TimeSpan.FromMinutes(1));
+
+                if (process.ExitCode != 0)
+                {
+                    Log.Error("Execute Git process exited unsuccessfully with exit code {ExitCode}", process.ExitCode);
+                    return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Execute Git process exited unsuccessfully", string.Empty, null, arguments, process.ExitCode);
+                }
+
                 return new GitCommandRunnerResultInfo(ProviderOperationStatus.Success, output);
             }
             else
             {
                 Log.Error("Failed to start the Git process: process is null");
-                return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Git process is null", string.Empty, new InvalidOperationException("Failed to start the Git process: process is null"), null);
+                return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Git process is null", string.Empty, new InvalidOperationException("Failed to start the Git process: process is null"), null, null);
             }
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to invoke Git with arguments: {Argument}", arguments);
-            return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Failed to invoke Git with arguments", string.Empty, ex, arguments);
+            return new GitCommandRunnerResultInfo(ProviderOperationStatus.Failure, "Failed to invoke Git with arguments", string.Empty, ex, arguments, null);
         }
     }
 }

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepository.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
-using LibGit2Sharp;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Foundation.Collections;
@@ -15,7 +14,7 @@ public sealed class GitLocalRepository : ILocalRepository
 {
     private readonly RepositoryCache? _repositoryCache;
 
-    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(GitLocalRepository));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(GitLocalRepository));
 
     public string RootFolder
     {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepositoryProviderFactory.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepositoryProviderFactory.cs
@@ -36,12 +36,12 @@ public class GitLocalRepositoryProviderFactory : ILocalRepositoryProvider
         }
         catch (ArgumentException ex)
         {
-            _log.Error("GitLocalRepositoryProviderFactory", "Failed to create GitLocalRepository", ex);
+            _log.Error(ex, "GitLocalRepositoryProviderFactory: Failed to create GitLocalRepository");
             return new GetLocalRepositoryResult(ex, _stringResource.GetLocalized("RepositoryNotFound"), $"Message: {ex.Message} and HRESULT: {ex.HResult}");
         }
         catch (Exception ex)
         {
-            _log.Error("GitLocalRepositoryProviderFactory", "Failed to create GitLocalRepository", ex);
+            _log.Error(ex, "GitLocalRepositoryProviderFactory: Failed to create GitLocalRepository");
             if (ex.Message.Contains("not owned by current user") || ex.Message.Contains("detected dubious ownership in repository"))
             {
                 return new GetLocalRepositoryResult(ex, _stringResource.GetLocalized("RepositoryNotOwnedByCurrentUser"), $"Message: {ex.Message} and HRESULT: {ex.HResult}");

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepositoryProviderFactory.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitLocalRepositoryProviderFactory.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.InteropServices;
 using DevHome.Common.Services;
-using LibGit2Sharp;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 
@@ -35,10 +34,10 @@ public class GitLocalRepositoryProviderFactory : ILocalRepositoryProvider
         {
             return new GetLocalRepositoryResult(new GitLocalRepository(rootPath, _repositoryCache));
         }
-        catch (RepositoryNotFoundException libGitEx)
+        catch (ArgumentException ex)
         {
-            _log.Error("GitLocalRepositoryProviderFactory", "Failed to create GitLocalRepository", libGitEx);
-            return new GetLocalRepositoryResult(libGitEx, _stringResource.GetLocalized("RepositoryNotFound"), $"Message: {libGitEx.Message} and HRESULT: {libGitEx.HResult}");
+            _log.Error("GitLocalRepositoryProviderFactory", "Failed to create GitLocalRepository", ex);
+            return new GetLocalRepositoryResult(ex, _stringResource.GetLocalized("RepositoryNotFound"), $"Message: {ex.Message} and HRESULT: {ex.HResult}");
         }
         catch (Exception ex)
         {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitRepositoryStatus.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitRepositoryStatus.cs
@@ -11,6 +11,18 @@ internal sealed class GitRepositoryStatus
     private readonly Dictionary<string, SubmoduleStatus> _submoduleEntries = new();
     private readonly Dictionary<FileStatus, List<GitStatusEntry>> _statusEntries = new();
 
+    public string BranchName { get; set; } = string.Empty;
+
+    public bool IsHeadDetached { get; set; }
+
+    public string UpstreamBranch { get; set; } = string.Empty;
+
+    public int AheadBy { get; set; }
+
+    public int BehindBy { get; set; }
+
+    public string Sha { get; set; } = string.Empty;
+
     public GitRepositoryStatus()
     {
         _statusEntries.Add(FileStatus.NewInIndex, new List<GitStatusEntry>());

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryCache.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using LibGit2Sharp;
 using Serilog;
 
 namespace FileExplorerGitIntegration.Models;
@@ -11,7 +10,7 @@ namespace FileExplorerGitIntegration.Models;
 internal sealed class RepositoryCache : IDisposable
 {
     private readonly ConcurrentDictionary<string, RepositoryWrapper> _repositoryCache = new();
-    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(RepositoryCache));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(RepositoryCache));
     private bool _disposedValue;
 
     public RepositoryWrapper GetRepository(string rootFolder)

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -76,7 +76,7 @@ internal sealed class RepositoryWrapper : IDisposable
         if (validateGitRootRepo.Status != ProviderOperationStatus.Success)
         {
             _log.Error(validateGitRootRepo.Ex, "Failed to validate the git root repository using GitExecute");
-            throw validateGitRootRepo.Ex ?? new InvalidOperationException();
+            throw validateGitRootRepo.Ex ?? new InvalidOperationException(validateGitRootRepo.ProcessExitCode?.ToString(CultureInfo.InvariantCulture) ?? "Unknown error encountered during validation of git repository");
         }
 
         var output = validateGitRootRepo.Output;
@@ -120,13 +120,13 @@ internal sealed class RepositoryWrapper : IDisposable
         var result = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), _workingDirectory, "rev-parse HEAD");
         if (result.Status != ProviderOperationStatus.Success)
         {
-            throw result.Ex ?? new InvalidOperationException();
+            throw result.Ex ?? new InvalidOperationException(result.ProcessExitCode?.ToString(CultureInfo.InvariantCulture) ?? "Unknown error while obtaining HEAD commit");
         }
 
         string? head = result.Output?.Trim();
         if (string.IsNullOrEmpty(head))
         {
-            throw new InvalidOperationException("Git command output is null and/or the repository has no commits");
+            throw new InvalidOperationException("Git command output is null or the repository has no commits");
         }
 
         if (_head != null && _commits != null)

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/RepositoryWrapper.cs
@@ -47,7 +47,7 @@ internal sealed class RepositoryWrapper : IDisposable
     public RepositoryWrapper(string rootFolder)
     {
         _gitDetect.DetectGit();
-        IsValidGitRepository(rootFolder);
+        ValidateGitRepositoryRootPath(rootFolder);
         _workingDirectory = string.Concat(rootFolder, Path.DirectorySeparatorChar.ToString());
         _statusCache = new StatusCache(rootFolder);
 
@@ -70,7 +70,7 @@ internal sealed class RepositoryWrapper : IDisposable
         _submoduleStatusUntracked = _stringResource.GetLocalized("SubmoduleStatusUntracked");
     }
 
-    public void IsValidGitRepository(string rootFolder)
+    public void ValidateGitRepositoryRootPath(string rootFolder)
     {
         var validateGitRootRepo = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), rootFolder, "rev-parse --show-toplevel");
         if (validateGitRootRepo.Status != ProviderOperationStatus.Success)
@@ -124,9 +124,9 @@ internal sealed class RepositoryWrapper : IDisposable
         }
 
         string? head = result.Output?.Trim();
-        if (head == null)
+        if (string.IsNullOrEmpty(head))
         {
-            throw new InvalidOperationException("Git command output is null.");
+            throw new InvalidOperationException("Git command output is null and/or the repository has no commits");
         }
 
         if (_head != null && _commits != null)

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/StatusCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/StatusCache.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Data;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Threading.Channels;
 using LibGit2Sharp;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
 using Windows.Win32;
@@ -25,7 +23,7 @@ internal sealed class StatusCache : IDisposable
     private readonly ReaderWriterLockSlim _statusLock = new();
     private readonly GitDetect _gitDetect = new();
     private readonly bool _gitInstalled;
-    private readonly Serilog.ILogger _log = Log.ForContext("SourceContext", nameof(StatusCache));
+    private readonly ILogger _log = Log.ForContext("SourceContext", nameof(StatusCache));
 
     private GitRepositoryStatus? _status;
     private bool _disposedValue;
@@ -199,7 +197,23 @@ internal sealed class StatusCache : IDisposable
         //                       Disclaimer: I'm not sure how far back porcelain=v2 is supported, but I'm pretty sure it's at least 3-4 years.
         //                       There could be old Git installations that predate it.
         // -z                  : Terminate filenames and entries with NUL instead of space/LF. This helps us deal with filenames containing spaces.
-        var result = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), workingDirectory, "--no-optional-locks status --porcelain=v2 -z");
+        var result = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), workingDirectory, "--no-optional-locks status --porcelain=v2 --branch -z");
+        if (result.Status != ProviderOperationStatus.Success)
+        {
+            return null;
+        }
+
+        return result.Output;
+    }
+
+    private string? RetrieveBranchInformation(string workingDirectory)
+    {
+        // Options fully explained at https://git-scm.com/docs/git-branch
+        // --no-optional-locks : Since this we are essentially running in the background, don't take any optional git locks
+        //                       that could interfere with the user's work. This means calling "branch" won't auto-update the
+        //                       index to make future "branch" calls faster, but it's better to be unintrusive.
+        // --show--current     : Show the current branch name. This is the only option we care about.
+        var result = GitExecute.ExecuteGitCommand(_gitDetect.GitConfiguration.ReadInstallPath(), workingDirectory, "--no-optional-locks branch --show-current");
         if (result.Status != ProviderOperationStatus.Success)
         {
             return null;
@@ -234,6 +248,7 @@ internal sealed class StatusCache : IDisposable
     {
         var repoStatus = new GitRepositoryStatus();
         ParseStatus(RetrieveStatusFromDirectory(_workingDirectory), repoStatus);
+        ParseBranchInformation(RetrieveBranchInformation(_workingDirectory), repoStatus);
         return repoStatus;
     }
 
@@ -292,11 +307,48 @@ internal sealed class StatusCache : IDisposable
                 var filePath = Path.Combine(relativeDir, line.Substring(2)).Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 repoStatus.Add(filePath, new GitStatusEntry(filePath, FileStatus.NewInWorkdir));
             }
+            else if (line.StartsWith("# branch.oid ", StringComparison.Ordinal))
+            {
+                // For porcelain=v2, the branch status line has the following format:
+                //   # branch.oid <sha>
+                // For now, we only care about the <sha>.
+                repoStatus.Sha = line.Substring(13);
+            }
+            else if (line.StartsWith("# branch.ab ", StringComparison.Ordinal))
+            {
+                // For porcelain=v2, the branch status line has the following format:
+                //   # branch.ab +<ahead> -<behind>
+                // For now, we only care about the <ahead> and <behind>.
+                var pieces = line.Split(' ', 4);
+                var aheadBy = int.Parse(pieces[2][1..], CultureInfo.InvariantCulture);
+                var behindBy = int.Parse(pieces[3][1..], CultureInfo.InvariantCulture);
+                repoStatus.AheadBy = aheadBy;
+                repoStatus.BehindBy = behindBy;
+            }
+            else if (line.StartsWith("# branch.upstream ", StringComparison.Ordinal))
+            {
+                // For porcelain=v2, the branch status line has the following format:
+                //   # branch.upstream <upstream>
+                // For now, we only care about the <upstream>.
+                repoStatus.UpstreamBranch = line.Substring(17);
+            }
             else
             {
                 _log.Warning($"Encountered unexpected line in ParseStatus: {line}");
             }
         }
+    }
+
+    private void ParseBranchInformation(string? branchInfo, GitRepositoryStatus repoStatus)
+    {
+        if (string.IsNullOrEmpty(branchInfo))
+        {
+            repoStatus.IsHeadDetached = true;
+            return;
+        }
+
+        repoStatus.BranchName = branchInfo.TrimEnd('\n');
+        repoStatus.IsHeadDetached = false;
     }
 
     private void ParseOrdinaryStatusEntry(

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/StatusCache.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/StatusCache.cs
@@ -312,7 +312,7 @@ internal sealed class StatusCache : IDisposable
                 // For porcelain=v2, the branch status line has the following format:
                 //   # branch.oid <sha>
                 // For now, we only care about the <sha>.
-                repoStatus.Sha = line.Substring(13);
+                repoStatus.Sha = line.Split(' ')[2];
             }
             else if (line.StartsWith("# branch.ab ", StringComparison.Ordinal))
             {
@@ -330,7 +330,7 @@ internal sealed class StatusCache : IDisposable
                 // For porcelain=v2, the branch status line has the following format:
                 //   # branch.upstream <upstream>
                 // For now, we only care about the <upstream>.
-                repoStatus.UpstreamBranch = line.Substring(17);
+                repoStatus.UpstreamBranch = line.Split(' ')[2];
             }
             else
             {

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/ThrottledTask.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/ThrottledTask.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
-
 namespace FileExplorerGitIntegration.Models;
 
 internal sealed class ThrottledTask


### PR DESCRIPTION
## Summary of the pull request

This PR contains the last set of changes to allow file explorer integration of a WSL git repository. It does this by using WSL command line to obtain all property information from git. 

## References and relevant issues
https://github.com/microsoft/devhome/issues/3829

## Detailed description of the pull request / Additional comments
This PR: 
- Uses git rev-parse --show-toplevel to validate a git repository instead of LibGit2Sharp.Repository()
- Uses git -no-optional-locks-branch --show-current to retrieve branch name, detached state
- Adds --branch to RetrieveStatusInformation to obtain branch sha, ahead by value, behind by value and upstream branch info
- Uses rev-parse HEAD to find head commit
- Removes CommitWrapper(LibGit2Sharp.Commit commit) constructor and removes FindLastCommitUsingLibGit2Sharp from CommitLogCache

_Note: This PR removes LibGit2Sharp usage where applicable and other unused library using statements. However, it does not completely clean usage of LibGit2Sharp library as the enum definitions from this library are being relied on such as FIleStatus etc. A separate bug has been created to track the complete removal of LibGit2Sharp from the git extension project (i.e. [Create custom enum definitions for FileStatus, SubmoduleStatus to remove LibGit2Sharp dependency from git extension project · Issue #3894 · microsoft/devhome (github.com)](https://github.com/microsoft/devhome/issues/3894)). This improvement is not blocking to this PR._ 

## Validation steps performed
Build of msix package
Unit Testing
Validation of functionality in VM
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/908ed3b4-4181-43f2-a96e-ee748a07cf00">



## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
