### PR TITLE
Update Microsoft Store service to allow callers to set their own package install timeout

### DIFF
--- a/services/DevHome.Services.Core/Contracts/IMicrosoftStoreService.cs
+++ b/services/DevHome.Services.Core/Contracts/IMicrosoftStoreService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Store.Preview.InstallControl;
 using Windows.Foundation;
@@ -37,4 +38,11 @@ public interface IMicrosoftStoreService
     /// <param name="packageId">Target package id</param>
     /// <returns>True if package was installed, false otherwise</returns>
     public Task<bool> TryInstallPackageAsync(string packageId);
+
+    /// <summary>
+    /// Install a package from the store.
+    /// </summary>
+    /// <param name="packageId">Target package id</param>
+    /// <param name="timeout">Amount of time the operation should wait before cancelling the task.</param>
+    public Task InstallPackageAsync(string packageId, TimeSpan timeout);
 }

--- a/services/DevHome.Services.Core/Services/MicrosoftStoreService.cs
+++ b/services/DevHome.Services.Core/Services/MicrosoftStoreService.cs
@@ -19,7 +19,6 @@ namespace DevHome.Services.Core.Services;
 public class MicrosoftStoreService : IMicrosoftStoreService
 {
     private readonly AppInstallManager _appInstallManager;
-    private readonly TimeSpan _storeInstallTimeout = TimeSpan.FromMinutes(1);
     private readonly ILogger _logger;
 
     public event TypedEventHandler<AppInstallManager, AppInstallManagerItemEventArgs> ItemCompleted
@@ -82,17 +81,11 @@ public class MicrosoftStoreService : IMicrosoftStoreService
         {
             var installTask = InstallPackageAsync(packageId);
 
-            // Wait for a maximum of StoreInstallTimeout (60 seconds).
-            var completedTask = await Task.WhenAny(installTask, Task.Delay(_storeInstallTimeout));
+            await installTask;
 
-            if (completedTask.Exception != null)
+            if (installTask.Exception != null)
             {
-                throw completedTask.Exception;
-            }
-
-            if (completedTask != installTask)
-            {
-                throw new TimeoutException("Store Install task did not finish in time.");
+                throw installTask.Exception;
             }
 
             return true;


### PR DESCRIPTION
## Summary of the pull request
Now that the Wsl extension uses the Microsoft store service in Dev Home to download and install Wsl distributions. I noticed from some of the telemetry and a failure I was getting that the Microsoft Store service has an arbitrary timeout of 1 minute. A download and install of an app could take longer than a minute especially if there are other updates happening that makes the download go to the pending state.

The Microsoft Store Service in Dev Home uses [this](https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.store.preview.installcontrol.appinstallmanager.startappinstallasync?view=winrt-26100#windows-applicationmodel-store-preview-installcontrol-appinstallmanager-startappinstallasync(system-string-system-string-system-boolean-system-boolean))

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
