### PR TITLE
[File Explorer Source Control Integration] Accessibility bug fixes

### DIFF
--- a/tools/Customization/DevHome.Customization/Models/RepositoryInformation.cs
+++ b/tools/Customization/DevHome.Customization/Models/RepositoryInformation.cs
@@ -20,7 +20,7 @@ public class RepositoryInformation
 
     public string SourceControlProviderPackageDisplayName { get; }
 
-    public string RepoPathMapping { get; }
+    public string RepositoryPathMapping { get; }
 
     public int Position { get; }
 
@@ -33,7 +33,7 @@ public class RepositoryInformation
         var extension = GetExtension(classId);
         SourceControlProviderDisplayName = GetExtensionDisplayName(extension);
         SourceControlProviderPackageDisplayName = GetExtensionPackageDisplayName(extension);
-        RepoPathMapping = string.Concat(RepositoryRootPath, " ", SourceControlProviderDisplayName);
+        RepositoryPathMapping = string.Concat(RepositoryRootPath, " ", SourceControlProviderDisplayName);
         Position = position;
         Size = size;
     }

--- a/tools/Customization/DevHome.Customization/Models/RepositoryInformation.cs
+++ b/tools/Customization/DevHome.Customization/Models/RepositoryInformation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using DevHome.Common.Extensions;
@@ -21,13 +20,22 @@ public class RepositoryInformation
 
     public string SourceControlProviderPackageDisplayName { get; }
 
-    public RepositoryInformation(string rootpath, string classId)
+    public string RepoPathMapping { get; }
+
+    public int Position { get; }
+
+    public int Size { get; }
+
+    public RepositoryInformation(string rootpath, string classId, int position, int size)
     {
         RepositoryRootPath = rootpath;
         SourceControlProviderCLSID = classId;
         var extension = GetExtension(classId);
         SourceControlProviderDisplayName = GetExtensionDisplayName(extension);
         SourceControlProviderPackageDisplayName = GetExtensionPackageDisplayName(extension);
+        RepoPathMapping = string.Concat(RepositoryRootPath, " ", SourceControlProviderDisplayName);
+        Position = position;
+        Size = size;
     }
 
     private IExtensionWrapper? GetExtension(string classId)

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -70,11 +71,10 @@ public partial class FileExplorerViewModel : ObservableObject
         {
             TrackedRepositories.Clear();
             var repoCollection = RepoTracker.GetAllTrackedRepositories();
-            var position = 0;
-            foreach (KeyValuePair<string, string> data in repoCollection)
+            for (int position = 0; position < repoCollection.Count; position++)
             {
-                position++;
-                TrackedRepositories.Add(new RepositoryInformation(data.Key, data.Value, position, repoCollection.Count));
+                var data = repoCollection.ElementAt(position);
+                TrackedRepositories.Add(new RepositoryInformation(data.Key, data.Value, position + 1, repoCollection.Count));
             }
         }
     }

--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -70,9 +70,11 @@ public partial class FileExplorerViewModel : ObservableObject
         {
             TrackedRepositories.Clear();
             var repoCollection = RepoTracker.GetAllTrackedRepositories();
+            var position = 0;
             foreach (KeyValuePair<string, string> data in repoCollection)
             {
-                TrackedRepositories.Add(new RepositoryInformation(data.Key, data.Value));
+                position++;
+                TrackedRepositories.Add(new RepositoryInformation(data.Key, data.Value, position, repoCollection.Count));
             }
         }
     }

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -40,7 +40,7 @@
                             Orientation="Horizontal">
                             <DropDownButton 
                                 Content="{Binding SourceControlProviderDisplayName}"
-                                AutomationProperties.Name="{Binding RepoPathMapping}"
+                                AutomationProperties.Name="{Binding RepositoryPathMapping}"
                                 ToolTipService.ToolTip="{Binding SourceControlProviderPackageDisplayName}"
                                 AutomationProperties.PositionInSet="{Binding Position}"
                                 AutomationProperties.SizeOfSet="{Binding Size}">

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -17,7 +17,7 @@
             x:Uid="AddRepositoriesCard"
             Grid.Column="1">
             <Button 
-                x:Uid="AddFolderButton" 
+                x:Uid="AddFolderButton"
                 Style="{ThemeResource AccentButtonStyle}" 
                 Command="{x:Bind ViewModel.AddFolderClickCommand}" />
         </ctControls:SettingsCard>
@@ -40,7 +40,10 @@
                             Orientation="Horizontal">
                             <DropDownButton 
                                 Content="{Binding SourceControlProviderDisplayName}"
-                                ToolTipService.ToolTip="{Binding SourceControlProviderPackageDisplayName}">
+                                AutomationProperties.Name="{Binding RepoPathMapping}"
+                                ToolTipService.ToolTip="{Binding SourceControlProviderPackageDisplayName}"
+                                AutomationProperties.PositionInSet="{Binding Position}"
+                                AutomationProperties.SizeOfSet="{Binding Size}">
                                 <DropDownButton.Flyout>
                                     <MenuFlyout 
                                         Opening="SourceControlProviderMenuFlyout_Opening"
@@ -48,7 +51,9 @@
                                     </MenuFlyout>
                                 </DropDownButton.Flyout>
                             </DropDownButton>
-                            <Button 
+                            <Button
+                                AutomationProperties.PositionInSet="{Binding Position}"
+                                AutomationProperties.SizeOfSet="{Binding Size}"
                                 x:Uid="MoreOptionsButton"
                                 Content="&#xe712;"
                                 Height="36" 


### PR DESCRIPTION
## Summary of the pull request
This PR fixes two accessibility bugs for the File Explorer Page under Windows Customization. 

## References and relevant issues

## Detailed description of the pull request / Additional comments
The accessibility bugs that this PR resolves are: 
- On navigating to 'Unassigned' button (dropdown) or 'More options' button, narrator is not announcing position count for the list items. Arrow navigation is defined for 'Folder paths' so position count should be defined.
- On navigating to 'Unassigned' button (dropdown), narrator is announcing as 'Unassigned button collapsed' but it is not announcing its respective 'Folder path'.

## Validation steps performed
Used narrator to confirm that the following expected results were achieved: 
- Position count defined on navigating to the dropdown button or 'More options' button i.e. narrator announces if an item is one of two, two of four etc. 
- Narrator announces the associated folder path info on navigating to dropdown button 

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
