### PR TITLE
Fix multi user extension login for setup environment and create environment flows

### DIFF
--- a/common/Renderers/DevHomeChoiceSetWithDynamicRefresh.cs
+++ b/common/Renderers/DevHomeChoiceSetWithDynamicRefresh.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
+using CommunityToolkit.WinUI.Helpers;
 using DevHome.Common.DevHomeAdaptiveCards.CardModels;
 using DevHome.Common.DevHomeAdaptiveCards.InputValues;
 using Microsoft.UI.Xaml;
@@ -85,10 +86,14 @@ public partial class DevHomeChoiceSetWithDynamicRefresh : IAdaptiveElementRender
         comboBox.ItemsSource = listOfComboBoxItems;
         comboBox.SelectedIndex = int.TryParse(choiceSet.Value, out var selectedIndex) ? selectedIndex : UnSelectedIndex;
 
-        // Setup event handlers
-        comboBox.SelectionChanged += RefreshCardOnSelectionChanged;
-        comboBox.Unloaded += RemoveEventHandler;
-        comboBox.Loaded += AddEventHandlers;
+        // Setup selection changed weak event handler
+        var selectionChangedWeakRef = new WeakEventListener<ComboBox, object, SelectionChangedEventArgs>(comboBox)
+        {
+            OnEventAction = (instance, source, args) => RefreshCardOnSelectionChanged(instance, args),
+            OnDetachAction = (weakEventListener) => comboBox.SelectionChanged -= weakEventListener.OnEvent,
+        };
+
+        comboBox.SelectionChanged += selectionChangedWeakRef.OnEvent;
 
         // Use the choiceSets Id as the name of the combo box.
         comboBox.Name = choiceSet.Id;
@@ -222,24 +227,6 @@ public partial class DevHomeChoiceSetWithDynamicRefresh : IAdaptiveElementRender
             {
                 UpdateComboBoxWithDynamicData(parentComboBox, comboBoxToUpdate);
             }
-        }
-    }
-
-    private void RemoveEventHandler(object sender, object args)
-    {
-        if (sender is ComboBox parentComboBox)
-        {
-            parentComboBox.SelectionChanged -= RefreshCardOnSelectionChanged;
-            parentComboBox.Unloaded -= RemoveEventHandler;
-        }
-    }
-
-    private void AddEventHandlers(object sender, object args)
-    {
-        if (sender is ComboBox parentComboBox)
-        {
-            parentComboBox.SelectionChanged += RefreshCardOnSelectionChanged;
-            parentComboBox.Unloaded += RemoveEventHandler;
         }
     }
 

--- a/common/Renderers/DevHomeChoiceSetWithDynamicRefresh.cs
+++ b/common/Renderers/DevHomeChoiceSetWithDynamicRefresh.cs
@@ -88,6 +88,7 @@ public partial class DevHomeChoiceSetWithDynamicRefresh : IAdaptiveElementRender
         // Setup event handlers
         comboBox.SelectionChanged += RefreshCardOnSelectionChanged;
         comboBox.Unloaded += RemoveEventHandler;
+        comboBox.Loaded += AddEventHandlers;
 
         // Use the choiceSets Id as the name of the combo box.
         comboBox.Name = choiceSet.Id;
@@ -230,11 +231,15 @@ public partial class DevHomeChoiceSetWithDynamicRefresh : IAdaptiveElementRender
         {
             parentComboBox.SelectionChanged -= RefreshCardOnSelectionChanged;
             parentComboBox.Unloaded -= RemoveEventHandler;
-            _childChoiceSetDataForOnParentSelectionChanged.Remove(parentComboBox);
-            if (_choiceSetParentIdToChildIdMap.TryGetValue(parentComboBox.Name, out var childComboBoxId))
-            {
-                _choiceSetIdToUIElementMap.Remove(childComboBoxId);
-            }
+        }
+    }
+
+    private void AddEventHandlers(object sender, object args)
+    {
+        if (sender is ComboBox parentComboBox)
+        {
+            parentComboBox.SelectionChanged += RefreshCardOnSelectionChanged;
+            parentComboBox.Unloaded += RemoveEventHandler;
         }
     }
 

--- a/settings/DevHome.Settings/Assets/DarkHostConfig.json
+++ b/settings/DevHome.Settings/Assets/DarkHostConfig.json
@@ -4,7 +4,7 @@
       "fontFamily": "'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
       "fontSizes": {
         "small": 12,
-        "default": 12,
+        "default": 14,
         "medium": 14,
         "large": 18,
         "extraLarge": 26

--- a/settings/DevHome.Settings/Assets/LightHostConfig.json
+++ b/settings/DevHome.Settings/Assets/LightHostConfig.json
@@ -4,7 +4,7 @@
       "fontFamily": "'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif",
       "fontSizes": {
         "small": 12,
-        "default": 12,
+        "default": 14,
         "medium": 14,
         "large": 18,
         "extraLarge": 26

--- a/tools/SetupFlow/DevHome.SetupFlow/Converters/CreationStateKindToVisibilityConverter.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Converters/CreationStateKindToVisibilityConverter.cs
@@ -15,7 +15,7 @@ using Microsoft.UI.Xaml.Media;
 namespace DevHome.SetupFlow.Converters;
 
 /// <summary>
-/// Converter to convert the state of the EnvironmentCreationOptions page to a visibility enum.
+/// Converts the state of the EnvironmentCreationOptions page to a visibility enum.
 /// </summary>
 public class CreationStateKindToVisibilityConverter : IValueConverter
 {

--- a/tools/SetupFlow/DevHome.SetupFlow/Converters/CreationStateKindToVisibilityConverter.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Converters/CreationStateKindToVisibilityConverter.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevHome.Common.Environments.Models;
+using DevHome.SetupFlow.ViewModels.Environments;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+
+namespace DevHome.SetupFlow.Converters;
+
+/// <summary>
+/// Converter to convert the state of the EnvironmentCreationOptions page to a visibility enum.
+/// </summary>
+public class CreationStateKindToVisibilityConverter : IValueConverter
+{
+    private const string ProgressRingGridName = "ProgressRingGrid";
+
+    private const string AdaptiveCardGridName = "AdaptiveCardGrid";
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        var parameterString = (string)parameter;
+        var creationStateKind = (CreationPageStateKind)value;
+
+        if (parameterString.Equals(AdaptiveCardGridName, StringComparison.Ordinal))
+        {
+            return creationStateKind switch
+            {
+                CreationPageStateKind.InitialPageAdaptiveCardLoaded => Visibility.Visible,
+                _ => Visibility.Collapsed,
+            };
+        }
+
+        if (parameterString.Equals(ProgressRingGridName, StringComparison.Ordinal))
+        {
+            return creationStateKind switch
+            {
+                CreationPageStateKind.InitialPageAdaptiveCardLoading => Visibility.Visible,
+                CreationPageStateKind.OtherPageAdaptiveCardLoading => Visibility.Visible,
+                _ => Visibility.Collapsed,
+            };
+        }
+
+        return Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1820,6 +1820,10 @@
     <value>There was an error loading the data required to create {0} environments</value>
     <comment>Locked={"{0}"} Error text display when we are unable to retrieve the creation data for a Dev Home provider. {0} is the name of the provider</comment>
   </data>
+  <data name="ErrorLoadingCreationUIForDeveloperId" xml:space="preserve">
+    <value>There was an error loading {0} environments for '{1}'.</value>
+    <comment>Locked={"{0}", "{1}"} Error text to display when a Dev Home provider returns an error when returning environments for a specific user. {0} is the name of the provider and {1} is the users logon Id.</comment>
+  </data>
   <data name="EnvironmentCreationReviewTabTitle" xml:space="preserve">
     <value>Environment</value>
     <comment>Title for create environment review tab</comment>
@@ -2034,5 +2038,9 @@
   <data name="NoInternetConnectionDescription" xml:space="preserve">
     <value>Please check your network settings and try again.</value>
     <comment>Text displayed when there is no internet connection</comment>
+  </data>
+  <data name="EnvironmentSelectAccountHeader.Header" xml:space="preserve">
+    <value>Select an account</value>
+    <comment>Header text for combo box where the user can select an account</comment>
   </data>
 </root>

--- a/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Utilities/DevDriveUtil.cs
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using CommunityToolkit.Common;
 using Serilog;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Shell;
+using static CommunityToolkit.Common.Converters;
 
 namespace DevHome.SetupFlow.Utilities;
 
@@ -269,7 +269,7 @@ public static class DevDriveUtil
                 if (result != 0)
                 {
                     // fallback to using community toolkit which shows this unlocalized. In the form of 50 GB, 40 TB etc.
-                    return Converters.ToFileSizeString((long)sizeInBytes);
+                    return ToFileSizeString((long)sizeInBytes);
                 }
                 else
                 {

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemCardViewModel.cs
@@ -72,7 +72,12 @@ public partial class ComputeSystemCardViewModel : ObservableObject
         _dispatcherQueue = dispatcherQueue;
         _computeSystemManager = manager;
         ComputeSystemTitle = computeSystem.DisplayName.Value;
-        ComputeSystemAlternativeTitle = computeSystem.SupplementalDisplayName.Value;
+
+        if (!string.IsNullOrEmpty(computeSystem.SupplementalDisplayName.Value))
+        {
+            ComputeSystemAlternativeTitle = $"({computeSystem.SupplementalDisplayName.Value})";
+        }
+
         ComputeSystem = computeSystem;
         ComputeSystem.StateChanged += _computeSystemManager.OnComputeSystemStateChanged;
         _computeSystemManager.ComputeSystemStateChanged += OnComputeSystemStateChanged;

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemsListViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/ComputeSystemsListViewModel.cs
@@ -48,8 +48,6 @@ public partial class ComputeSystemsListViewModel : ObservableObject
 
     public AdvancedCollectionView ComputeSystemCardAdvancedCollectionView { get; private set; }
 
-    public Dictionary<DeveloperIdWrapper, ComputeSystemsResult> DevIdToComputeSystemMap { get; set; }
-
     public ComputeSystemProvider Provider { get; set; }
 
     public DeveloperIdWrapper CurrentDeveloperId { get; set; }
@@ -101,21 +99,22 @@ public partial class ComputeSystemsListViewModel : ObservableObject
         return AccessibilityName;
     }
 
-    public ComputeSystemsListViewModel(ComputeSystemsLoadedData loadedData)
+    public ComputeSystemsListViewModel(
+        ComputeSystemProviderDetails providerDetails,
+        KeyValuePair<DeveloperIdWrapper, ComputeSystemsResult> devIdComputeSystemPair)
     {
-        Provider = loadedData.ProviderDetails.ComputeSystemProvider;
-        DevIdToComputeSystemMap = loadedData.DevIdToComputeSystemMap;
-
-        // Get the first developerId and compute system result.
-        var devIdToResultKeyValuePair = DevIdToComputeSystemMap.FirstOrDefault();
-        CurrentResult = devIdToResultKeyValuePair.Value;
-        CurrentDeveloperId = devIdToResultKeyValuePair.Key;
+        Provider = providerDetails.ComputeSystemProvider;
+        CurrentResult = devIdComputeSystemPair.Value;
+        CurrentDeveloperId = devIdComputeSystemPair.Key;
 
         DisplayName = Provider.DisplayName;
 
         if ((CurrentResult != null) && (CurrentResult.ComputeSystems != null))
         {
-            ComputeSystems = CurrentResult.ComputeSystems.Select(computeSystem => new ComputeSystemCache(computeSystem)).ToList();
+            // Filter out compute systems that do not support configuration.
+            ComputeSystems = CurrentResult.ComputeSystems
+                .Where(computeSystem => computeSystem.SupportedOperations.HasFlag(ComputeSystemOperations.ApplyConfiguration))
+                .Select(computeSystem => new ComputeSystemCache(computeSystem)).ToList();
         }
 
         // Create a new AdvancedCollectionView for the ComputeSystemCards collection.

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/Environments/EnvironmentCreationOptionsViewModel.cs
@@ -250,7 +250,7 @@ public partial class EnvironmentCreationOptionsViewModel : SetupPageViewModelBas
                 var result = _extensionAdaptiveCardSession.Initialize(_extensionAdaptiveCard);
                 if (result.Status == ProviderOperationStatus.Failure)
                 {
-                    _log.Error(result.ExtendedError, $"Extension failed to generate adaptive card. DisplayMsg: {result.DisplayMessage}, DiagnosticMsg: {result.DiagnosticText}");
+                    _log.Error(result.ExtendedError, $"Extension failed to generate adaptive card. DisplayMessage: {result.DisplayMessage}, DiagnosticMessage: {result.DiagnosticText}");
                     SessionErrorTitle = _stringResource.GetLocalized("ErrorLoadingCreationUITitle", _curProviderDetails.ComputeSystemProvider.DisplayName);
                     SessionErrorMessage = result.DisplayMessage;
                     CanGoToNextPage = false;

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/EnvironmentCreationOptionsView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/Environments/EnvironmentCreationOptionsView.xaml
@@ -9,12 +9,16 @@
     xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
     xmlns:commonBehaviors="using:DevHome.Common.Behaviors"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
+    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:setupFlowConverters="using:DevHome.SetupFlow.Converters"
     Unloaded="ViewUnloaded"
     Loaded="ViewLoaded">
     <UserControl.Resources>
         <converters:BoolToVisibilityConverter x:Key="CollapsedWhenTrueBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
         <converters:EmptyObjectToObjectConverter x:Key="EmptyObjectToObjectConverter" NotEmptyValue="Visible" EmptyValue="Collapsed"/>
         <converters:EmptyObjectToObjectConverter x:Key="EmptyObjectToObjectVisibleWhenEmptyConverter" NotEmptyValue="Collapsed" EmptyValue="Visible"/>
+        <converters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible" />
+        <setupFlowConverters:CreationStateKindToVisibilityConverter x:Key="CreationStateKindToVisibilityConverter"/>
     </UserControl.Resources>
     <i:Interaction.Behaviors >
         <commonBehaviors:AutoFocusBehavior />
@@ -52,8 +56,9 @@
             Margin="{ThemeResource ContentPageMargin}"
             Grid.Row="1">
             <Grid>
-                 <Grid.RowDefinitions>
-                    <RowDefinition Height="auto"/>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
                     <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid
@@ -61,31 +66,75 @@
                     HorizontalAlignment="Stretch"
                     Visibility="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}">
                     <InfoBar
+                        Visibility="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
                         IsOpen="True"
                         Title="{x:Bind ViewModel.SessionErrorTitle, Mode=OneWay}"
                         Severity="Error"
-                        Message="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay}" >
+                        HorizontalAlignment="Stretch">
+                        <InfoBar.Content>
+                            <Grid>
+                                <!--- Textblock for when there is a title in the infobar -->
+                                <TextBlock
+                                    Visibility="{x:Bind ViewModel.SessionErrorTitle, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectConverter}}"
+                                    Padding="0 0 0 20"
+                                    Margin="0 -10 0 0"
+                                    Text="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay}"
+                                    IsTextSelectionEnabled="True"
+                                    TextWrapping="Wrap"/>
+
+                                <!--- Textblock for when there is no title in the infobar -->
+                                <TextBlock
+                                    Visibility="{x:Bind ViewModel.SessionErrorTitle, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectVisibleWhenEmptyConverter}}"
+                                    Padding="0 20 0 20"
+                                    Text="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay}"
+                                    IsTextSelectionEnabled="True"
+                                    TextWrapping="Wrap"/>
+                            </Grid>
+                            
+                        </InfoBar.Content>
                     </InfoBar>
                 </Grid>
+
+                <ComboBox
+                    Grid.Row="1"
+                    x:Name="AccountSelectionComboBox"
+                    x:Uid="EnvironmentSelectAccountHeader"
+                    Visibility="{x:Bind ViewModel.DeveloperIdWrappers, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}"
+                    ItemsSource="{x:Bind ViewModel.DeveloperIdWrappers, Mode=OneWay}"
+                    SelectedValue="{x:Bind ViewModel.SelectedDeveloperId, Mode=TwoWay}"
+                    DisplayMemberPath="LoginId"
+                    Margin="0 0 0 20"
+                    HorizontalAlignment="Left"
+                    MinWidth="250">
+                    <i:Interaction.Behaviors>
+                        <ic:EventTriggerBehavior EventName="SelectionChanged">
+                            <ic:InvokeCommandAction
+                                Command="{x:Bind ViewModel.DeveloperIdSelectedCommand, Mode=OneWay}"
+                                CommandParameter="{Binding SelectedValue, ElementName=AccountSelectionComboBox, Mode=OneWay}"/>
+                        </ic:EventTriggerBehavior>
+                    </i:Interaction.Behaviors>
+                </ComboBox>
 
                 <!--- Show the adaptive card on the page if its loaded. -15 Padding added as the adaptive card adds an extra 40px of padding on all sides -->
                 <!-- Set focus to this grid because it is the first container with selectable elements.-->
                 <Grid
-                    Grid.Row="1"
-                    Visibility="{x:Bind ViewModel.IsAdaptiveCardSessionLoaded, Mode=OneWay}"
+                    Grid.Row="2"
+                    Visibility="{x:Bind ViewModel.CreationPageState, Mode=OneWay, Converter={StaticResource CreationStateKindToVisibilityConverter}, ConverterParameter='AdaptiveCardGrid'}"
                     x:Name="AdaptiveCardGrid" 
-                    Padding="-15">
+                    Padding="-15"
+                    HorizontalAlignment="Left">
                     <i:Interaction.Behaviors>
                         <behaviors:FocusBehavior/>
                     </i:Interaction.Behaviors>
                 </Grid>
 
                 <Grid
-                    Grid.Row="1"
+                    Grid.Row="2"
+                    x:Name="ProgressRingGrid"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     ColumnSpacing="10"
-                    Visibility="{x:Bind ViewModel.IsAdaptiveCardSessionLoaded, Mode=OneWay, Converter={StaticResource CollapsedWhenTrueBoolToVisibilityConverter}}">
+                    Visibility="{x:Bind ViewModel.CreationPageState, Mode=OneWay, Converter={StaticResource CreationStateKindToVisibilityConverter}, ConverterParameter='ProgressRingGrid'}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="auto"/>
                         <ColumnDefinition Width="auto"/>
@@ -96,7 +145,7 @@
                         IsActive="True"
                         Width="20"
                         Height="20"/>
-                    <TextBlock 
+                    <TextBlock
                         Visibility="{x:Bind ViewModel.SessionErrorMessage, Mode=OneWay, Converter={StaticResource EmptyObjectToObjectVisibleWhenEmptyConverter}}"
                         Grid.Column="1" Text="{x:Bind ViewModel.AdaptiveCardLoadingMessage, Mode=OneWay}" />
                 </Grid>


### PR DESCRIPTION
## Summary of the pull request
Update setup target and create environment flows to allow an extension with multiple logged in developerIds to show their environments. Before this change both places use to use the first DeveloperId it find from the extension to query for environments. This caused an issue for extensions like the azure extension where the user might be logged in using a work or school account as well as a personal MSA account. 


Changes:

- noticed that we remove the event handlers in `DevHomeChoiceSetWithDynamicRefresh.cs` when the combo boxes unload. But we don't add them back on load which is probably how this issue #3638 occurred. So I updated it to prevent that from happening.
- noticed the text were too small in the adaptive card. Updated the default text size in the host config to be size 14 which looks like its also the default for win ui in general.
- For the setup environment flow:
  - In `ComputeSystemsListViewModel` we  now filter out compute systems that don't support environments in its constructor.
  -  Updated `SetupTargetViewModel.cs`'s `UpdateListViewModelList` method to create a `ComputeSystemsListViewModel` for each developerId that returns a list of compute systems. 
  - Added parentheses over the alternate title for the compute system when it appears in the UI so it looks like it does in the environments page.
- For the create environment flow:
  - I removed the booleans which were used to update the state of the page e.g `IsAdaptiveCardSessionLoaded` to be enums, now that there are multiple states the initial creation page that shows the adaptive card can be in. A converter was created to allow controls to be visible/collapsed depending on the state of the initial creation page. 
    - Note: For background on how the create environment flow works. There is only one `ExtensionAdaptiveCardSession2` object. The `EnvironmentCreationOptionsViewModel` that holds it sends the adaptive card to different views depending on the state of the flow. 
  - Added a Combo box so the user can select an account 

**Video of me showing how the create environment flow works with multiple users logged into the Azure extension:**

https://github.com/user-attachments/assets/f1dd9b0b-b9ff-4700-986a-56982ba7fae8

**Video of me showing that users can now see all their dev boxes when multiple users are logged in. In this scenario I don't have access to DevBoxes on my secondary msa, but you can see that doesn't prevent us from showing others**

https://github.com/user-attachments/assets/4e3590f9-56ad-4cde-979d-f8240ea99a6b


## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [x] Closes #3677
- [x] Closes #3638
- [ ] Tests added/passed
- [ ] Documentation updated
