### PR TITLE
Add in Chat UI to Quickstart Playground

### DIFF
--- a/common/Environments/Converters/PromptStatusToGenerateButtonStyle.cs
+++ b/common/Environments/Converters/PromptStatusToGenerateButtonStyle.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace DevHome.Common.Environments.Converters;
+
+/// <summary>
+/// Converter to convert the PromptStatus bool value to a style that will be used by the GenerateButton.
+/// </summary>
+public class PromptStatusToGenerateButtonStyle : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        bool validStatus = (bool)value;
+
+        switch (validStatus)
+        {
+            case true:
+                return Application.Current.Resources["AccentButtonStyle"] as Style;
+            case false:
+                return Application.Current.Resources["DefaultButtonStyle"] as Style;
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/common/Environments/Converters/PromptStatusToSubmitButtonStyle.cs
+++ b/common/Environments/Converters/PromptStatusToSubmitButtonStyle.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace DevHome.Common.Environments.Converters;
+
+/// <summary>
+/// Converter to convert the PromptStatus bool value to a style that will be used by the SubmitButton.
+/// </summary>
+public class PromptStatusToSubmitButtonStyle : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        bool validStatus = (bool)value;
+
+        switch (validStatus)
+        {
+            case true:
+                return Application.Current.Resources["DefaultButtonStyle"] as Style;
+            case false:
+                return Application.Current.Resources["AccentButtonStyle"] as Style;
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Models/ExtensionWrapper.cs
+++ b/src/Models/ExtensionWrapper.cs
@@ -27,7 +27,7 @@ public class ExtensionWrapper : IExtensionWrapper
         [typeof(ISettingsProvider)] = ProviderType.Settings,
         [typeof(IFeaturedApplicationsProvider)] = ProviderType.FeaturedApplications,
         [typeof(IComputeSystemProvider)] = ProviderType.ComputeSystem,
-        [typeof(IQuickStartProjectProvider)] = ProviderType.QuickStartProject,
+        [typeof(IQuickStartProjectProvider2)] = ProviderType.QuickStartProject,
         [typeof(ILocalRepositoryProvider)] = ProviderType.LocalRepository,
     };
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Models/QuickStartProjectProvider.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Models/QuickStartProjectProvider.cs
@@ -11,7 +11,7 @@ using Windows.Storage;
 namespace DevHome.SetupFlow.Models;
 
 /// <summary>
-/// Wrapper class for the IQuickStartProjectProvider interface that can be used throughout the application.
+/// Wrapper class for the IQuickStartProjectProvider2 interface that can be used throughout the application.
 /// Note: Additional methods added to this class should be wrapped in try/catch blocks to ensure that
 /// exceptions don't bubble up to the caller as the methods are cross proc COM calls.
 /// </summary>
@@ -21,7 +21,7 @@ public sealed class QuickStartProjectProvider
 
     private readonly string _errorString;
 
-    private readonly IQuickStartProjectProvider _quickStartProjectProvider;
+    private readonly IQuickStartProjectProvider2 _quickStartProjectProvider;
 
     public string PackageFullName { get; }
 
@@ -34,7 +34,7 @@ public sealed class QuickStartProjectProvider
     public string[] SamplePrompts { get; }
 
     public QuickStartProjectProvider(
-        IQuickStartProjectProvider quickStartProjectProvider,
+        IQuickStartProjectProvider2 quickStartProjectProvider,
         ISetupFlowStringResource setupFlowStringResource,
         string packageFullName)
     {
@@ -72,6 +72,21 @@ public sealed class QuickStartProjectProvider
         catch (Exception ex)
         {
             TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundProjectGenerationOperation", ex, activityId);
+            _log.Error(ex, $"CreateProjectGenerationOperation for: {this} failed due to exception");
+            return null;
+        }
+    }
+
+    public IQuickStartChatStyleGenerationOperation CreateChatStyleGenerationOperation(string prompt)
+    {
+        try
+        {
+            TelemetryFactory.Get<ITelemetry>().LogCritical("QuickstartPlaygroundCreateChatStyleGenerationOperation");
+            return _quickStartProjectProvider.CreateChatStyleGenerationOperation(prompt);
+        }
+        catch (Exception ex)
+        {
+            TelemetryFactory.Get<ITelemetry>().LogException("QuickstartPlaygroundCreateChatStyleGenerationOperation", ex);
             _log.Error(ex, $"CreateProjectGenerationOperation for: {this} failed due to exception");
             return null;
         }

--- a/tools/SetupFlow/DevHome.SetupFlow/Services/QuickStartProjectService.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Services/QuickStartProjectService.cs
@@ -33,7 +33,7 @@ public sealed class QuickStartProjectService : IQuickStartProjectService
         {
             try
             {
-                var quickStartProjectProviders = (await extension.GetListOfProvidersAsync<IQuickStartProjectProvider>()).ToList();
+                var quickStartProjectProviders = (await extension.GetListOfProvidersAsync<IQuickStartProjectProvider2>()).ToList();
                 foreach (var quickStartProjectProvider in quickStartProjectProviders)
                 {
                     if (quickStartProjectProvider != null)
@@ -44,7 +44,7 @@ public sealed class QuickStartProjectService : IQuickStartProjectService
             }
             catch (Exception ex)
             {
-                _log.Error(ex, $"Failed to get {nameof(IQuickStartProjectProvider)} provider from '{extension.PackageFullName}'");
+                _log.Error(ex, $"Failed to get {nameof(IQuickStartProjectProvider2)} provider from '{extension.PackageFullName}'");
             }
         }
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
+++ b/tools/SetupFlow/DevHome.SetupFlow/Strings/en-us/Resources.resw
@@ -1919,6 +1919,14 @@
     <value>Generate project</value>
     <comment>Tooltip for the generate button on the QuickstartPlayground page</comment>
   </data>
+  <data name="QuickstartPlaygroundSubmitButton.Content" xml:space="preserve">
+    <value>Submit</value>
+    <comment>Label for the submit button on the QuickstartPlayground page</comment>
+  </data>
+  <data name="QuickstartPlaygroundSubmitButtonTooltip.Content" xml:space="preserve">
+    <value>Submit prompt</value>
+    <comment>Tooltip for the submit button on the QuickstartPlayground page</comment>
+  </data>
   <data name="QuickstartPlaygroundLaunchDropDownButton.Content" xml:space="preserve">
     <value>Open in Editor</value>
     <comment>Drop down button to launch QuickstartPlayground project</comment>

--- a/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/ViewModels/QuickstartPlaygroundViewModel.cs
@@ -190,8 +190,6 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     [NotifyCanExecuteChangedFor(nameof(LaunchProjectHostCommand), nameof(SaveProjectCommand))]
     private bool _enableProjectButtons = false;
 
-    private int _stepCounter;
-
     public QuickstartPlaygroundViewModel(
         ISetupFlowStringResource stringResource,
         IQuickStartProjectService quickStartProjectService,
@@ -471,7 +469,7 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
     [RelayCommand(CanExecute = nameof(CanGenerateCodespace))]
     public async Task GenerateCodespace()
     {
-        if (CustomPrompt != null && CustomPrompt != string.Empty && ActiveQuickstartSelection != null)
+        if (!string.IsNullOrEmpty(CustomPrompt) && ActiveQuickstartSelection != null)
         {
             try
             {
@@ -600,7 +598,6 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
 
     public async Task GenerateChatStyleCompetions(string message)
     {
-        _stepCounter++;
         if (ActiveQuickstartSelection != null)
         {
             _quickStartChatStyleGeneration = ActiveQuickstartSelection.CreateChatStyleGenerationOperation(message);
@@ -663,7 +660,6 @@ public partial class QuickstartPlaygroundViewModel : SetupPageViewModelBase
             PromptTextBoxPlaceholder = StringResource.GetLocalized("QuickstartPlaygroundGenerationPromptPlaceholder");
             ReferenceSampleUri = null;
             ChatMessages.Clear();
-            _stepCounter = 0;
 
             SetupChat();
 

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml
@@ -7,6 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:setupFlowBehaviors="using:DevHome.SetupFlow.Behaviors"
+    xmlns:devEnvConverters="using:DevHome.Common.Environments.Converters"
     xmlns:controls="using:DevHome.SetupFlow.Controls"
     xmlns:ctcontrols="using:CommunityToolkit.WinUI.Controls"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
@@ -49,6 +50,82 @@
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/SetupFlowStyles.xaml" />
                 <ResourceDictionary Source="ms-appx:///DevHome.SetupFlow/Styles/QuickstartStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <DataTemplate x:Key="ChatResponseMessageTemplate" x:DataType="viewmodels:ChatStyleMessage">
+                <Grid Height="Auto"
+			Margin="4"
+			HorizontalAlignment="Left">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="1"
+				Padding="16,8,16,8"
+				CornerRadius="16">
+                        <StackPanel.Background>
+                            <SolidColorBrush Color="WhiteSmoke" />
+                        </StackPanel.Background>
+                        <Border Padding="8,4,8,4"
+									CornerRadius="4">
+                            <Border.Background>
+                                <SolidColorBrush Opacity="0.2"
+							Color="WhiteSmoke" />
+                            </Border.Background>
+                            <StackPanel Orientation="Horizontal"
+										Spacing="8">
+                                <TextBlock MaxWidth="400"
+									FontFamily="Segoe Fluent"
+									FontSize="12"
+									IsTextSelectionEnabled="True"
+									Text="{x:Bind Name}"
+									TextWrapping="Wrap">
+                                    <TextBlock.Foreground>
+                                        <SolidColorBrush Color="Black" />
+                                    </TextBlock.Foreground>
+                                </TextBlock>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Grid>
+            </DataTemplate>
+            <DataTemplate x:Key="ChatRequestMessageTemplate" x:DataType="viewmodels:ChatStyleMessage">
+                <Grid Height="Auto"
+			Margin="4"
+			HorizontalAlignment="Right">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="1"
+				Padding="16,8,16,8"
+				CornerRadius="16">
+                        <StackPanel.Background>
+                            <SolidColorBrush Color="LightSkyBlue" />
+                        </StackPanel.Background>
+                        <Border Padding="8,4,8,4"
+						CornerRadius="4">
+                            <Border.Background>
+                                <SolidColorBrush Opacity="0.2"
+							Color="LightSkyBlue" />
+                            </Border.Background>
+                            <StackPanel Orientation="Horizontal"
+										Spacing="8">
+                                <TextBlock MaxWidth="400"
+								FontFamily="Segoe Fluent"
+								FontSize="12"
+								IsTextSelectionEnabled="True"
+								Text="{x:Bind Name}"
+								TextWrapping="Wrap">
+                                    <TextBlock.Foreground>
+                                        <SolidColorBrush Color="Black" />
+                                    </TextBlock.Foreground>
+                                </TextBlock>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Grid>
+            </DataTemplate>
+            <devEnvConverters:PromptStatusToSubmitButtonStyle x:Key="PromptStatusToSubmitButtonStyle"/>
+            <devEnvConverters:PromptStatusToGenerateButtonStyle x:Key="PromptStatusToGenerateButtonStyle"/>
         </ResourceDictionary>
     </UserControl.Resources>
     <controls:SetupShell Orchestrator="{x:Bind ViewModel.Orchestrator, Mode=OneWay}">
@@ -71,11 +148,6 @@
                                 <ColumnDefinition Width="1*"/>
                                 <ColumnDefinition Width="1*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock x:Uid="QuickstartPlaygroundPromptHeader"
-                                       Grid.Column="0"
-                                       VerticalAlignment="Center"
-                                       TextWrapping="WrapWholeWords"
-                                       Margin="10"/>
                             <ctcontrols:WrapPanel Grid.Column="1" 
                                         Orientation="Horizontal"
                                         HorizontalAlignment="Right" 
@@ -100,6 +172,30 @@
                                           TabIndex="1"/>
                             </ctcontrols:WrapPanel>
                         </Grid>
+                        <ScrollViewer
+								VerticalScrollBarVisibility="Auto"
+								HorizontalScrollBarVisibility="Auto"
+								BorderThickness="1"
+								CornerRadius="8"
+                            	Visibility="{x:Bind ViewModel.IsPromptGuidanceVisible, Mode=OneWay}"
+								Margin="10,0,10,10"
+								Padding="10"
+								Background="white"
+								MaxHeight="300">
+                            <Grid>
+                                <Grid.Resources>
+                                    <viewmodels:ChatMessageTemplateSelector x:Key="ChatMessageTemplateSelector"
+														ChatRequestMessageTemplate="{StaticResource ChatRequestMessageTemplate}"
+														ChatResponseMessageTemplate="{StaticResource ChatResponseMessageTemplate}" />
+                                </Grid.Resources>
+                                <ListView MinWidth="800"
+                                          MinHeight="200"
+                                          ItemsSource="{x:Bind ViewModel.ChatMessages, Mode=OneWay}"
+                                          ItemTemplateSelector="{StaticResource ChatMessageTemplateSelector}"
+                                          IsItemClickEnabled="False"
+                                          SelectionMode="None"/>
+                            </Grid>
+                        </ScrollViewer>
                         <ctcontrols:WrapPanel x:Name="ExamplePrompts"
                                               Orientation="Horizontal"
                                               Visibility="{x:Bind ViewModel.ShowExamplePrompts, Mode=OneWay}">
@@ -113,11 +209,6 @@
                                 Content="{x:Bind ViewModel.SamplePromptTwo, Mode=OneWay}"
                                 Style="{StaticResource SamplePromptStyle}"
                                 TabIndex="3"/>
-                            <Button Command="{x:Bind ViewModel.CopyExamplePromptCommand}" 
-                                CommandParameter="{Binding Content, RelativeSource={RelativeSource Self}}" 
-                                Content="{x:Bind ViewModel.SamplePromptThree, Mode=OneWay}"
-                                Style="{StaticResource SamplePromptStyle}" 
-                                TabIndex="4"/>
                         </ctcontrols:WrapPanel>
                         <Grid>
                             <Grid.RowDefinitions>
@@ -129,8 +220,8 @@
                                      PlaceholderText="{x:Bind ViewModel.PromptTextBoxPlaceholder, Mode=OneWay}"
                                      x:Name="CustomPrompt" 
                                      TextWrapping="Wrap"
-                                     AcceptsReturn="True" 
-                                     MinWidth="800"
+                                     KeyDown="CustomPrompt_KeyDown"
+									 MinWidth="1100"
                                      MinHeight="60"
                                      VerticalAlignment="Center"
                                      HorizontalAlignment="Stretch"
@@ -168,10 +259,21 @@
                                     </StackPanel>
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0 0 10 0">
-                                    <Button x:Uid="QuickstartPlaygroundGenerateButton"
-                                            x:Name="GenerateButton" 
+                                    <Button x:Uid="QuickstartPlaygroundSubmitButton"
+                                            x:Name="SubmitButton" 
                                             Margin="10 0 0 0"
-                                            Style="{ThemeResource AccentButtonStyle}"
+                                            Style="{x:Bind ViewModel.IsPromptValid, Converter={StaticResource PromptStatusToSubmitButtonStyle}, Mode=OneWay}"
+                                            Command="{x:Bind ViewModel.SubmitChatCommand}"
+                                            VerticalAlignment="Center"
+                                            TabIndex="6">
+                                        <ToolTipService.ToolTip>
+                                            <ToolTip x:Uid="QuickstartPlaygroundGenerateButtonTooltip"/>
+                                        </ToolTipService.ToolTip>
+                                    </Button>
+                                    <Button x:Uid="QuickstartPlaygroundGenerateButton"
+                                            x:Name="GenerateButton"
+                                            Margin="10 0 0 0"
+                                            Style="{x:Bind ViewModel.IsPromptValid, Converter={StaticResource PromptStatusToGenerateButtonStyle}, Mode=OneWay}"
                                             Command="{x:Bind ViewModel.GenerateCodespaceCommand}"
                                             VerticalAlignment="Center"
                                             TabIndex="6">

--- a/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
+++ b/tools/SetupFlow/DevHome.SetupFlow/Views/QuickstartPlaygroundView.xaml.cs
@@ -12,8 +12,10 @@ using DevHome.Contracts.Services;
 using DevHome.SetupFlow.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
+using Windows.System;
 
 namespace DevHome.SetupFlow.Views;
 
@@ -330,6 +332,32 @@ public sealed partial class QuickstartPlaygroundView : UserControl
         if (promptTextBox != null)
         {
             promptTextBox.SelectionStart = promptTextBox.Text.Length;
+        }
+    }
+
+    private async void CustomPrompt_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Enter)
+        {
+            ViewModel.ShowExamplePrompts = false;
+
+            var textBox = sender as TextBox;
+
+            if (textBox != null)
+            {
+                var message = textBox.Text;
+
+                if (message != null && message != string.Empty)
+                {
+                    ViewModel.ChatMessages.Add(new ChatStyleMessage
+                    {
+                        Name = message,
+                        Type = ChatStyleMessage.ChatMessageItemType.Request,
+                    });
+
+                    await ViewModel.GenerateChatStyleCompetions(message);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the pull request
https://github.com/microsoft/devhome/pull/3908 with the SDK changes needs to be merged in first
This adds the UI changes required for the chat style portion of Quickstart Playground, where the user can chat with the UI to refine the prompt before they generate a codespace.
## References and relevant issues

## Detailed description of the pull request / Additional comments
Video demo:
https://github.com/user-attachments/assets/a6753ad4-4cc6-4639-88d6-4dc00093deb8
![image](https://github.com/user-attachments/assets/5d7b2544-1f25-405c-b2ca-0b7a1a801370)## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
