### PR TITLE
Ensure 'learn more' link is visible when app install page is resized

### DIFF
--- a/tools/SetupFlow/DevHome.SetupFlow/Styles/AppManagement_ThemeResources.xaml
+++ b/tools/SetupFlow/DevHome.SetupFlow/Styles/AppManagement_ThemeResources.xaml
@@ -5,7 +5,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
-    xmlns:controls="using:DevHome.SetupFlow.Controls">
+    xmlns:controls="using:DevHome.SetupFlow.Controls"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls">
     <x:Double x:Key="AppManagementIconDisabledOpacity">0.4</x:Double>
 
     <!-- Package title style -->
@@ -30,7 +31,7 @@
                     <converters:BoolToObjectConverter x:Key="LearnMoreInstalledConverter">
                         <converters:BoolToObjectConverter.FalseValue>
                             <HyperlinkButton Name="LearnMoreButton" Command="{Binding LearnMoreCommand,Mode=OneWay}">
-                                <TextBlock x:Uid="ms-resource:///DevHome.SetupFlow/Resources/LearnMore"/>
+                                <TextBlock TextWrapping="NoWrap" x:Uid="ms-resource:///DevHome.SetupFlow/Resources/LearnMore"/>
                             </HyperlinkButton>
                         </converters:BoolToObjectConverter.FalseValue>
                         <converters:BoolToObjectConverter.TrueValue>
@@ -70,11 +71,11 @@
                     <TextBlock Name="Title" Style="{ThemeResource AppManagementPackageTitleTextBlock}" Text="{Binding PackageTitle}"/>
                 </controls:PackageDetailsSettingsCard.Header>
                 <controls:PackageDetailsSettingsCard.Description>
-                    <StackPanel Orientation="Horizontal" Spacing="3">
-                        <TextBlock Name="Version" Style="{ThemeResource AppManagementPackageDescriptionTextBlock}" Text="{Binding PackageShortDescription}"/>
+                    <ctControls:WrapPanel HorizontalSpacing="3">
+                        <TextBlock TextWrapping="NoWrap" Name="Version" Style="{ThemeResource AppManagementPackageDescriptionTextBlock}" Text="{Binding PackageShortDescription}"/>
                         <TextBlock Name="Divider" Style="{ThemeResource AppManagementPackageDescriptionTextBlock}">|</TextBlock>
                         <ContentControl IsTabStop="False" Content="{Binding IsInstalled, Converter={StaticResource LearnMoreInstalledConverter}}" />
-                    </StackPanel>
+                    </ctControls:WrapPanel>
                 </controls:PackageDetailsSettingsCard.Description>
                 <controls:PackageDetailsSettingsCard.HeaderIcon>
                     <ImageIcon AutomationProperties.Name="{Binding PackageTitle}" Name="Image" Source="{Binding Icon, Mode=OneWay}"/>


### PR DESCRIPTION
## Summary of the pull request

<table>
<tr><th>Before<br/><i>'Lear more' truncated</i></th><th>After<br/><i>'Lear more' on a new line</i></th></tr>

<tr>
<td><img src="https://github.com/user-attachments/assets/6e502758-075a-495f-88df-2e5b27ff68db" /></td>
<td><img src="https://github.com/user-attachments/assets/43490157-c989-4bc0-b7b3-97eefd500c1b" /></td>
</tr>
</table>

## References and relevant issues
- https://task.ms/53683675

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
