### PR TITLE
[Dev Home]: Keyboard focus goes missing on closing 'Select Folder' window using keyboard

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.WinUI.Controls;
 using DevHome.Common.Contracts;
 using DevHome.Common.Extensions;
 using DevHome.Common.Models;
@@ -158,7 +158,7 @@ public partial class FileExplorerViewModel : ObservableObject
     }
 
     [RelayCommand]
-    public async Task<string> AddFolderClick()
+    public async Task<string> AddFolderClick(object sender)
     {
         StorageFolder? repoRootFolder = null;
         if (IsFeatureEnabled)
@@ -187,6 +187,7 @@ public partial class FileExplorerViewModel : ObservableObject
                 }
             });
             RefreshTrackedRepositories();
+            AdjustFocus(sender);
         }
 
         return repoRootFolder == null ? string.Empty : repoRootFolder.Path;
@@ -291,5 +292,18 @@ public partial class FileExplorerViewModel : ObservableObject
         }
 
         await LocalSettingsService!.SaveSettingAsync("ShowRepositoryStatus", value);
+    }
+
+    private void AdjustFocus(object sender)
+    {
+        var addRepositoryCard = sender as SettingsCard;
+        if (addRepositoryCard != null)
+        {
+            addRepositoryCard.IsTabStop = true;
+            _log.Debug($"AddRepositoryCard IsEnabled: {addRepositoryCard.IsEnabled}");
+            _log.Debug($"AddRepositoryCard Visibility: {addRepositoryCard.Visibility}");
+            bool isFocusSet = addRepositoryCard.Focus(FocusState.Keyboard);
+            _log.Information($"Set focus to add reposiotry card result: {isFocusSet}");
+        }
     }
 }

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -15,11 +15,13 @@
             Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"/>
         <ctControls:SettingsCard
             x:Uid="AddRepositoriesCard"
+            x:Name="AddRepositoriesCard"
             Grid.Column="1">
             <Button 
                 x:Uid="AddFolderButton"
                 Style="{ThemeResource AccentButtonStyle}" 
-                Command="{x:Bind ViewModel.AddFolderClickCommand}" />
+                Command="{x:Bind ViewModel.AddFolderClickCommand}"
+                CommandParameter="{Binding ElementName=AddRepositoriesCard}"/>
         </ctControls:SettingsCard>
         <ItemsRepeater 
             Name="ItemsRepeaterForAllRepoPaths" 


### PR DESCRIPTION
## Summary of the pull request
This PR fixes the following bug: 
-  "Keyboard focus goes missing on closing 'Select Folder' window using keyboard. On invoking 'Close' button in 'Select Folder' window, focus is nowhere visible and on hitting tab/shift+ tab also focus is not visible anywhere."

## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/53872961

## Detailed description of the pull request / Additional comments
During testing, it was observed that focus is also lost when a folder is chosen and the File Explorer window closes. 
The fix in this PR ensures that focus is readjusted to the relevant parent UI control after any interaction with File Explorer.

## Validation steps performed
Local Build
Unit Tests
Manual testing of fix to confirm focus is regained after the File Explorer window closes

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
