### PR TITLE
[Dev Home][File Explorer][Version Control Selection Dropdown] Dropdown selector should include "Unassigned" as an option

### DIFF
--- a/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
+++ b/tools/Customization/DevHome.Customization/ViewModels/FileExplorerViewModel.cs
@@ -292,4 +292,11 @@ public partial class FileExplorerViewModel : ObservableObject
 
         await LocalSettingsService!.SaveSettingAsync("ShowRepositoryStatus", value);
     }
+
+    public void UnassignSourceControlProviderFromRepository(string repositoryRootPath)
+    {
+        ExtraFolderPropertiesWrapper.Unregister(repositoryRootPath);
+        RepoTracker.ModifySourceControlProviderForTrackedRepository(_unassigned, repositoryRootPath);
+        RefreshTrackedRepositories();
+    }
 }

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
@@ -43,6 +43,7 @@ public sealed partial class AddRepositoriesView : UserControl
     {
         if (sender is MenuFlyout menuFlyout)
         {
+            var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
             menuFlyout.Items.Clear();
 
             foreach (var extension in ViewModel.ExtensionService.GetInstalledExtensionsAsync(ProviderType.LocalRepository).Result)
@@ -54,14 +55,13 @@ public sealed partial class AddRepositoriesView : UserControl
                 };
                 menuItem.Click += AssignSourceControlProviderButton_Click;
 
-                var stringResource = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources");
                 ToolTipService.SetToolTip(menuItem, stringResource.GetLocalized("PrefixForDevHomeVersion", extension.PackageDisplayName));
                 menuFlyout.Items.Add(menuItem);
             }
 
             var unassignMenuItem = new MenuFlyoutItem
             {
-                Text = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources").GetLocalized("MenuFlyoutUnregisteredRepository_Content"),
+                Text = stringResource.GetLocalized("MenuFlyoutUnregisteredRepository_Content"),
             };
             unassignMenuItem.Click += UnassignFolderButton_Click;
             menuFlyout.Items.Add(unassignMenuItem);

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
@@ -58,6 +58,23 @@ public sealed partial class AddRepositoriesView : UserControl
                 ToolTipService.SetToolTip(menuItem, stringResource.GetLocalized("PrefixForDevHomeVersion", extension.PackageDisplayName));
                 menuFlyout.Items.Add(menuItem);
             }
+
+            var unassignMenuItem = new MenuFlyoutItem
+            {
+                Text = new StringResource("DevHome.Customization.pri", "DevHome.Customization/Resources").GetLocalized("MenuFlyoutUnregisteredRepository_Content"),
+            };
+            unassignMenuItem.Click += UnassignFolderButton_Click;
+            menuFlyout.Items.Add(unassignMenuItem);
+        }
+    }
+
+    public void UnassignFolderButton_Click(object sender, RoutedEventArgs e)
+    {
+        // Extract relevant data from view and give to view model for unassign
+        MenuFlyoutItem menuItem = (MenuFlyoutItem)sender;
+        if (menuItem.DataContext is RepositoryInformation repoInfo)
+        {
+            ViewModel.UnassignSourceControlProviderFromRepository(repoInfo.RepositoryRootPath);
         }
     }
 


### PR DESCRIPTION
## Summary of the pull request
This PR adds a menu item that allows a user to unassign the repository root folder from the source control provider currently selected.

## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/54238855/

## Detailed description of the pull request / Additional comments
![image](https://github.com/user-attachments/assets/d425610d-6ef3-4043-bae7-6a4d4601f79a)

## Validation steps performed
Build
Unit tests
Manual testing of "Unassigned" menu item

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
