### PR TITLE
[File Explorer Source Control Integration] Accessibility Bug Fixes

### DIFF
--- a/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
+++ b/tools/Customization/DevHome.Customization/Strings/en-us/Resources.resw
@@ -441,9 +441,9 @@
     <value>Enable File Explorer Version Control Integration</value>
     <comment>The header for the settings card that allows user to enable or disable File Explorer Version Control Integration</comment>
   </data>
-  <data name="FileExplorerSettingsTextBlock.Text" xml:space="preserve">
+  <data name="FileExplorerVersionControlSettings.Text" xml:space="preserve">
     <value>File Explorer + Version Control</value>
-    <comment>The text for the File Explorer Settings toggle</comment>
+    <comment>Header text for a group of toggle controls to configure File Explorer Version Control Integration</comment>
   </data>
   <data name="ShowVersionControlInfoCard.Description" xml:space="preserve">
     <value>See version control columns for enhanced repositories like "Code Status", "Last Change Date", "Last Change Message"</value>
@@ -477,7 +477,7 @@
     <value>An exception was thrown while obtaining the repository from the local repository provider: </value>
     <comment>An error message when an exception is thrown while obtaining the repository from the local repository provider</comment>
   </data>
-   <data name="RegistrationErrorWithFileExplorer" xml:space="preserve">
+  <data name="RegistrationErrorWithFileExplorer" xml:space="preserve">
     <value>Failed to register repository root folder with File Explorer </value>
     <comment>An error message when the repository root folder cannot be registered with File Explorer</comment>
   </data>
@@ -488,5 +488,17 @@
   <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>More Options</value>
     <comment>Text for the more options button on the setting card for the Add Repositories UI</comment>
+  </data>
+  <data name="MoreOptionsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>More Options</value>
+    <comment>Tool tip for the more options button on the setting card for the Add Repositories UI</comment>
+  </data>
+  <data name="FileExplorerPage_FileExplorerVersionControlSettingsGroup.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>File Explorer + Version Control</value>
+    <comment>Narrator text for a group of toggle controls to configure File Explorer Version Control Integration</comment>
+  </data>
+  <data name="FileExplorerPage_AddRepositoriesGroup.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Add repositories</value>
+    <comment>Narrator text for the Add Repositories user experience in File Explorer source control integration</comment>
   </data>
 </root>

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -5,12 +5,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls" 
-    xmlns:viewmodels="using:DevHome.Customization.ViewModels"
+    xmlns:ctControls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 
-    <StackPanel>
-        <TextBlock 
+    <StackPanel
+        x:Uid="FileExplorerPage_AddRepositoriesGroup"
+        IsTabStop="True">
+        <TextBlock
             x:Uid="AddRepositoriesTextBlock"
             Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"/>
         <ctControls:SettingsCard

--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml.cs
@@ -8,6 +8,8 @@ using DevHome.Customization.Helpers;
 using DevHome.Customization.Models;
 using DevHome.Customization.ViewModels;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.DevHome.SDK;
 using Serilog;
@@ -87,6 +89,11 @@ public sealed partial class AddRepositoriesView : UserControl
             XamlRoot = xamlRoot,
             RequestedTheme = ActualTheme,
         };
+
+        // Set automation properties
+        AutomationProperties.SetName(errorDialog, stringResource.GetLocalized("AssignSourceControlErrorDialog_Title"));
+        AutomationProperties.SetHeadingLevel(errorDialog, AutomationHeadingLevel.Level1);
+
         _ = await errorDialog.ShowAsync();
     }
 

--- a/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/VersionControlIntegrationSettingsView.xaml
@@ -11,9 +11,10 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     mc:Ignorable="d">
 
-    <StackPanel>
+    <StackPanel
+        x:Uid="FileExplorerPage_FileExplorerVersionControlSettingsGroup">
         <TextBlock 
-            x:Uid="FileExplorerSettingsTextBlock"
+            x:Uid="FileExplorerVersionControlSettings"
             Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"/>
 
         <ctControls:SettingsCard


### PR DESCRIPTION
## Summary of the pull request
This PR contains accessibility bug fixes for the following issues: 
- Section headers 'File Explorer+ Version Control' and 'Add Repositories' are not announced by narrator in 'Windows Customization>> File explorer' page.
- "Error assigning source control provider" is not defined as heading.
- Tooltip is not defined for "More Options" button in Add repository group

## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/53873821
https://microsoft.visualstudio.com/OS/_workitems/edit/53874085
https://microsoft.visualstudio.com/OS/_workitems/edit/53874117

## Detailed description of the pull request / Additional comments

## Validation steps performed
Local Build
Unit Tests
Confirmed the tooltip appears for the "More Options" button in Add Repositories UI
Confirmed the following using narrator: 
- Narrator announces the section headers 'File Explorer+ Version Control' and 'Add Repositories' in 'Windows Customization>> File explorer' page.
- Narrator conveys the heading level for "Error assigning source control provider"


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
