### PR TITLE
[File Explorer Source Control Integration] Craftsmanship Bug Fixes

### DIFF
--- a/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
+++ b/tools/Customization/DevHome.Customization/Views/AddRepositoriesView.xaml
@@ -16,6 +16,7 @@
         <ctControls:SettingsCard
             x:Uid="AddRepositoriesCard"
             x:Name="AddRepositoriesCard"
+            Margin="{ThemeResource SettingsCardMargin}"
             Grid.Column="1">
             <Button 
                 x:Uid="AddFolderButton"
@@ -32,7 +33,7 @@
                     <ctControls:SettingsCard 
                         Header="{Binding RepositoryRootPath}"
                         Description="{Binding SourceControlProviderDisplayName}"
-                        Margin="0">
+                        Margin="{ThemeResource SettingsCardMargin}">
                         <ctControls:SettingsCard.HeaderIcon>
                             <FontIcon 
                                 FontFamily="{StaticResource SymbolThemeFontFamily}" 

--- a/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
+++ b/tools/Customization/DevHome.Customization/Views/FileExplorerPage.xaml
@@ -6,7 +6,8 @@
     xmlns:behaviors="using:DevHome.Common.Behaviors"
     xmlns:views="using:DevHome.Customization.Views"
     behaviors:NavigationViewHeaderBehavior.HeaderTemplate="{StaticResource BreadcrumbBarDataTemplate}"
-    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}">
+    behaviors:NavigationViewHeaderBehavior.HeaderContext="{x:Bind ViewModel}"
+    HighContrastAdjustment="None">
 
     <ScrollViewer VerticalAlignment="Top" VerticalScrollBarVisibility="Auto">
         <Grid>


### PR DESCRIPTION
## Summary of the pull request
This PR fixes the background behind button labels in "Night Sky" theme and adjusts the padding between the settings card for repository root paths. 

## References and relevant issues
https://microsoft.visualstudio.com/OS/_workitems/edit/54238809/
https://microsoft.visualstudio.com/OS/_workitems/edit/54238904/

## Detailed description of the pull request / Additional comments

## Validation steps performed
Local Build 
Manual Validation of UI to ensure issues are resolved
![image](https://github.com/user-attachments/assets/aacc08e0-40f0-4dbb-8c33-357c82921232)

![image](https://github.com/user-attachments/assets/b9feafe7-75cd-4751-868e-d13de8e5abc9)


## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
