### PR TITLE
Fix race condition when storing GitConfiguration to disk

### DIFF
--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitConfiguration.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitConfiguration.cs
@@ -16,7 +16,7 @@ public class GitConfiguration : IDisposable
 
     private string GitExeInstallPath { get; set; } = string.Empty;
 
-    private readonly object _fileLock = new();
+    private static readonly object _fileLock = new();
 
     private readonly ILogger _log = Log.ForContext<GitDetect>();
 


### PR DESCRIPTION
## Summary of the pull request
The `GitConfiguration` class is thread-safe, but it still resulted in multiple threads trying to store the configuration file concurrently. This concurrent access mostly hit when browsing to a folder in File Explorer for the first time in the Git extension process life, as multiple threads tried to perform the initial Git detection concurrently. Making the `_fileLock` field static ensures that only one thread can access the file at a time.

## Validation steps performed
Prior to fix, when using a debug build, multiple file IO exceptions were logged in the git integration console window when first browsing to a registered folder. After fix, these IO exceptions are no longer encountered.

## PR checklist
- [x] Closes #3685 
