### PR TITLE
Telemetry for detecting git

### DIFF
--- a/common/TelemetryEvents/GitExtension/GitDetectEvent.cs
+++ b/common/TelemetryEvents/GitExtension/GitDetectEvent.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using DevHome.Telemetry;
+using Microsoft.Diagnostics.Telemetry;
+using Microsoft.Diagnostics.Telemetry.Internal;
+
+namespace DevHome.Common.TelemetryEvents.GitExtension;
+
+// How git.exe was located
+public enum GitDetectStatus
+{
+    // git.exe was not found on the system
+    NotFound,
+
+    // In the PATH environment variable
+    PathEnvironmentVariable,
+
+    // Probed well-known registry keys to find a Git install location
+    RegistryProbe,
+
+    // Probed well-known folders under Program Files [(x86)]
+    ProgramFiles,
+}
+
+[EventData]
+public class GitDetectEvent : EventBase
+{
+    public override PartA_PrivTags PartA_PrivTags => PrivTags.ProductAndServicePerformance;
+
+    public string Status { get; }
+
+    public string Version { get; }
+
+    public GitDetectEvent(GitDetectStatus status, string version)
+    {
+        Status = status.ToString();
+        Version = version;
+    }
+
+    public override void ReplaceSensitiveStrings(Func<string, string> replaceSensitiveStrings)
+    {
+        // This event so far has no sensitive strings
+    }
+}

--- a/extensions/GitExtension/FileExplorerGitIntegration/Models/GitDetect.cs
+++ b/extensions/GitExtension/FileExplorerGitIntegration/Models/GitDetect.cs
@@ -128,7 +128,7 @@ public class GitDetect
         var result = GitExecute.ExecuteGitCommand(path, string.Empty, "--version");
         if (result.Status == ProviderOperationStatus.Success && result.Output != null && result.Output.Contains("git version"))
         {
-            return new DetectInfo { Found = true, Version = result.Output.Replace("git version", string.Empty) };
+            return new DetectInfo { Found = true, Version = result.Output.Replace("git version", string.Empty).TrimEnd() };
         }
 
         return new DetectInfo { Found = false, Version = string.Empty };


### PR DESCRIPTION
## Summary of the pull request
Adds telemetry to log if and where git.exe was detected.

Stores one of four statuses:
- Detected by running "git.exe" and relying on the `PATH` environment variable
- Detected by probing well-known registry keys
- Detected by probing well-known folders under Program Files [(x86)]
- Not found