### PR TITLE
Remove ClCompile from csproj

### DIFF
--- a/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
+++ b/extensionsdk/Microsoft.Windows.DevHome.SDK.Lib/Microsoft.Windows.DevHome.SDK.Lib.csproj
@@ -18,13 +18,6 @@
       <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
   </PropertyGroup>
 
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
-      <SpectreMitigation>Spectre</SpectreMitigation>
-    </ClCompile>
-  </ItemDefinitionGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This item doesn't do anything in a csproj. It only applies to C++.