### PR TITLE
Fix truncated text of Sync environments button

### DIFF
--- a/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
+++ b/tools/Environments/DevHome.Environments/Views/LandingPage.xaml
@@ -294,7 +294,7 @@
                     x:Uid="SyncEnvironmentsButton"
                     Command="{x:Bind ViewModel.SyncButtonCommand}"
                     Margin="0 3 0 0"
-                    Width="110">
+                    MinWidth="110">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="16" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72C;"/>
                         <TextBlock x:Uid="SyncButtonTextBlock" />


### PR DESCRIPTION
## Summary of the pull request

This fixes truncated text on the "Sync" button on the Environments landing page when the UI is localized in German:

![image](https://github.com/user-attachments/assets/54a14a26-0af1-4273-966f-0f94d10df4ad)

The full button text should read "Synchronisieren".

## References and relevant issues

## Detailed description of the pull request / Additional comments

## Validation steps performed

## PR checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
